### PR TITLE
Feature/gamepad c64

### DIFF
--- a/.github/workflows/dotnet-push-package.yml
+++ b/.github/workflows/dotnet-push-package.yml
@@ -16,7 +16,7 @@ env:
   #  PROJECT_FILE6: "src/libraries/Highbyte.DotNet6502.Impl.SilkNet/Highbyte.DotNet6502.Impl.SilkNet.csproj"
   #  PROJECT_FILE7: "src/libraries/Highbyte.DotNet6502.Impl.Skia/Highbyte.DotNet6502.Impl.Skia.csproj"
    CONFIGURATION: "Release"
-   VERSION: "0.12.0"  #Major.Minor[.Rev]
+   VERSION: "0.12.1"  #Major.Minor[.Rev]
    VERSION_SUFFIX: "-alpha"
    PACKAGE_REPO: "https://nuget.pkg.github.com/highbyte/index.json"
 

--- a/.github/workflows/sonarscan-dotnet.yml
+++ b/.github/workflows/sonarscan-dotnet.yml
@@ -32,7 +32,7 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: SonarScanner for .NET 7 with pull request decoration support
-        uses: highbyte/sonarscan-dotnet@v2.2.4
+        uses: highbyte/sonarscan-dotnet@v2.2.6
         with:
           # The key of the SonarQube project
           sonarProjectKey: highbyte_dotnet-6502

--- a/src/apps/Highbyte.DotNet6502.App.SkiaNative/ConfigUI/SilkNetImGuiC64Config.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SkiaNative/ConfigUI/SilkNetImGuiC64Config.cs
@@ -1,7 +1,7 @@
-using System.Linq;
 using System.Numerics;
+using Highbyte.DotNet6502.Impl.SilkNet.Commodore64.Input;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
-using static Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.C64Joystick;
+using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
 
 namespace Highbyte.DotNet6502.App.SkiaNative.ConfigUI;
 
@@ -20,13 +20,14 @@ public class SilkNetImGuiC64Config
     public bool Cancel { get; set; }
 
     private bool _isValidConfig = true;
+
     public bool IsValidConfig => _isValidConfig;
     private List<string>? _validationErrors;
 
     private const int POS_X = 50;
     private const int POS_Y = 50;
     private const int WIDTH = 400;
-    private const int HEIGHT = 380;
+    private const int HEIGHT = 550;
     //private static Vector4 s_informationColor = new Vector4(1.0f, 1.0f, 1.0f, 1.0f);
     private static Vector4 s_errorColor = new Vector4(1.0f, 0.0f, 0.0f, 1.0f);
     //private static Vector4 s_warningColor = new Vector4(0.5f, 0.8f, 0.8f, 1);
@@ -91,15 +92,22 @@ public class SilkNetImGuiC64Config
             _config!.SetROM(C64Config.CHARGEN_ROM_NAME, _chargenRomFile);
         }
 
-        ImGui.Text("Keyboard joystick 2");
-        var keyToJoystickMap = _config!.KeyboardJoystickMap;
         int joystick = 2;
+        ImGui.Text($"Joystick {joystick}");
         ImGui.BeginDisabled(disabled: true);
-        ImGui.LabelText("Up", $"{string.Join(",", keyToJoystickMap.GetMappedKeysForJoystickAction(joystick, C64JoystickAction.Up))}");
-        ImGui.LabelText("Down", $"{string.Join(",", keyToJoystickMap.GetMappedKeysForJoystickAction(joystick, C64JoystickAction.Down))}");
-        ImGui.LabelText("Left", $"{string.Join(",", keyToJoystickMap.GetMappedKeysForJoystickAction(joystick, C64JoystickAction.Left))}");
-        ImGui.LabelText("Right", $"{string.Join(",", keyToJoystickMap.GetMappedKeysForJoystickAction(joystick, C64JoystickAction.Right))}");
-        ImGui.LabelText("Fire", $"{string.Join(",", keyToJoystickMap.GetMappedKeysForJoystickAction(joystick, C64JoystickAction.Fire)).Replace(" ", "SPACE")}");
+        foreach (var mapKey in C64SilkNetGamepad.SilkNetGamePadToC64JoystickMap)
+        {
+            ImGui.LabelText($"{string.Join(",", mapKey.Key)}", $"{string.Join(",", mapKey.Value)}");
+        }
+        ImGui.EndDisabled();
+
+        ImGui.Text($"Keyboard Joystick {joystick}");
+        var keyToJoystickMap = _config!.KeyboardJoystickMap;
+        ImGui.BeginDisabled(disabled: true);
+        foreach (var mapKey in keyToJoystickMap.GetMap(joystick))
+        {
+            ImGui.LabelText($"{string.Join(",", mapKey.Key)}", $"{string.Join(",", mapKey.Value)}");
+        }
         ImGui.EndDisabled();
 
         if (_config!.IsDirty)

--- a/src/apps/Highbyte.DotNet6502.App.SkiaNative/SilkNetImGuiLogsPanel.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SkiaNative/SilkNetImGuiLogsPanel.cs
@@ -14,7 +14,7 @@ public class SilkNetImGuiLogsPanel : ISilkNetImGuiWindow
 
     private const int POS_X = 300;
     private const int POS_Y = 2;
-    private const int WIDTH = 800;
+    private const int WIDTH = 950;
     private const int HEIGHT = 600;
     private static Vector4 s_labelColor = new Vector4(0.7f, 0.7f, 0.7f, 1.0f);
     private static Vector4 s_informationColor = new Vector4(1.0f, 1.0f, 1.0f, 1.0f);

--- a/src/apps/Highbyte.DotNet6502.App.SkiaNative/SilkNetImGuiMenu.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SkiaNative/SilkNetImGuiMenu.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Numerics;
 using Highbyte.DotNet6502.App.SkiaNative.ConfigUI;
+using Highbyte.DotNet6502.Impl.SilkNet.Commodore64.Input;
 using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Commodore64;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;

--- a/src/apps/Highbyte.DotNet6502.App.SkiaWASM/Highbyte.DotNet6502.App.SkiaWASM.csproj
+++ b/src/apps/Highbyte.DotNet6502.App.SkiaWASM/Highbyte.DotNet6502.App.SkiaWASM.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="SkiaSharp.Views.Blazor" Version="2.88.6" />
     <PackageReference Include="PublishSPAforGitHubPages.Build" Version="2.1.0" />
     <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
+    <PackageReference Include="Toolbelt.Blazor.Gamepad" Version="8.0.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/apps/Highbyte.DotNet6502.App.SkiaWASM/Pages/Commodore64/C64ConfigUI.razor
+++ b/src/apps/Highbyte.DotNet6502.App.SkiaWASM/Pages/Commodore64/C64ConfigUI.razor
@@ -1,4 +1,5 @@
 ﻿@using Highbyte.DotNet6502.App.SkiaWASM.Skia
+@using Highbyte.DotNet6502.Impl.AspNet.Commodore64.Input;
 @using Highbyte.DotNet6502.Systems;
 @using Highbyte.DotNet6502.Systems.Commodore64.Config
 @using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
@@ -66,6 +67,28 @@ else
     </div>
 </div>
 
+
+<h2>Joystick</h2>
+@{
+    var gampadToJoystickMap = C64AspNetGamepad.AspNetGamePadToC64JoystickMap;
+    int joystick = 2;
+}
+<div class="table">
+    <div class="table-row">
+        <div class="table-cell twocol">Joystick @joystick action</div>
+        <div class="table-cell twocol">Gampad button</div>
+    </div>
+    @{
+        foreach (var mapKey in gampadToJoystickMap)
+        {
+            <div class="table-row">
+                <div class="table-cell twocol">@string.Join(",", mapKey.Value)</div>
+                <div class="table-cell twocol">@string.Join(",", mapKey.Key)</div>
+            </div>
+        }
+    }
+</div>
+
 <h2>Joystick keyboard</h2>
 @{
     var keyToJoystickMap = C64Config.KeyboardJoystickMap;
@@ -76,11 +99,11 @@ else
         <div class="table-cell twocol"><input @bind="C64Config.KeyboardJoystickEnabled" @bind:event="oninput" type="checkbox" id="keyboardJoystickEnabled" title="Enable Joystick Keyboard" /></div>
     </div>
     <div class="table-row">
-        <div class="table-cell twocol">Joystick 2 action</div>
+        <div class="table-cell twocol">Joystick @joystick action</div>
         <div class="table-cell twocol">Key</div>
     </div>
     @{
-        foreach (var mapKey in keyToJoystickMap.GetMap(2))
+        foreach (var mapKey in keyToJoystickMap.GetMap(joystick))
         {
             <div class="table-row">
                 <div class="table-cell twocol">@string.Join(",", mapKey.Value)</div>

--- a/src/apps/Highbyte.DotNet6502.App.SkiaWASM/Pages/Commodore64/C64ConfigUI.razor
+++ b/src/apps/Highbyte.DotNet6502.App.SkiaWASM/Pages/Commodore64/C64ConfigUI.razor
@@ -1,6 +1,7 @@
 ﻿@using Highbyte.DotNet6502.App.SkiaWASM.Skia
 @using Highbyte.DotNet6502.Systems;
 @using Highbyte.DotNet6502.Systems.Commodore64.Config
+@using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
 @using static Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.C64Joystick;
 @using static Highbyte.DotNet6502.App.SkiaWASM.Pages.Index
 
@@ -65,10 +66,9 @@ else
     </div>
 </div>
 
-<h2>Joystick #2 keyboard map</h2>
+<h2>Joystick keyboard</h2>
 @{
     var keyToJoystickMap = C64Config.KeyboardJoystickMap;
-    var joystick = 2;
 }
 <div class="table">
     <div class="table-row">
@@ -76,25 +76,18 @@ else
         <div class="table-cell twocol"><input @bind="C64Config.KeyboardJoystickEnabled" @bind:event="oninput" type="checkbox" id="keyboardJoystickEnabled" title="Enable Joystick Keyboard" /></div>
     </div>
     <div class="table-row">
-        <div class="table-cell twocol">Up:</div>
-        <div class="table-cell twocol">@string.Join(",", keyToJoystickMap.GetMappedKeysForJoystickAction(joystick, C64JoystickAction.Up))</div>
+        <div class="table-cell twocol">Joystick 2 action</div>
+        <div class="table-cell twocol">Key</div>
     </div>
-    <div class="table-row">
-        <div class="table-cell twocol">Down:</div>
-        <div class="table-cell twocol">@string.Join(",", keyToJoystickMap.GetMappedKeysForJoystickAction(joystick, C64JoystickAction.Down))</div>
-    </div>
-    <div class="table-row">
-        <div class="table-cell twocol">Left:</div>
-        <div class="table-cell twocol">@string.Join(",", keyToJoystickMap.GetMappedKeysForJoystickAction(joystick, C64JoystickAction.Left))</div>
-    </div>
-    <div class="table-row">
-        <div class="table-cell twocol">Right:</div>
-        <div class="table-cell twocol">@string.Join(",", keyToJoystickMap.GetMappedKeysForJoystickAction(joystick, C64JoystickAction.Right))</div>
-    </div>
-    <div class="table-row">
-        <div class="table-cell twocol">Fire:</div>
-        <div class="table-cell twocol">@string.Join(",", keyToJoystickMap.GetMappedKeysForJoystickAction(joystick, C64JoystickAction.Fire)).Replace(" ", "SPACE")</div>
-    </div>
+    @{
+        foreach (var mapKey in keyToJoystickMap.GetMap(2))
+        {
+            <div class="table-row">
+                <div class="table-cell twocol">@string.Join(",", mapKey.Value)</div>
+                <div class="table-cell twocol">@string.Join(",", mapKey.Key)</div>
+            </div>
+        }
+    }
 </div>
 
 <p></p>

--- a/src/apps/Highbyte.DotNet6502.App.SkiaWASM/Pages/Commodore64/C64Menu.razor
+++ b/src/apps/Highbyte.DotNet6502.App.SkiaWASM/Pages/Commodore64/C64Menu.razor
@@ -316,13 +316,12 @@
 
         // Send "list" + Enter to the keyboard buffer to immediately list the loaded program
         var c64Keyboard = c64.Cia.Keyboard;
-        // TODO after implementing C64 keyboard matrix scanning
-        // TODO: Bypass keyboard matrix scanning and send directly to keyboard buffer?
-        // c64Keyboard.KeyPressed(Petscii.CharToPetscii['l']);
-        // c64Keyboard.KeyPressed(Petscii.CharToPetscii['i']);
-        // c64Keyboard.KeyPressed(Petscii.CharToPetscii['s']);
-        // c64Keyboard.KeyPressed(Petscii.CharToPetscii['t']);
-        // c64Keyboard.KeyPressed(Petscii.CharToPetscii[(char)13]);
+        // Bypass keyboard matrix scanning and send directly to keyboard buffer?
+        c64Keyboard.InsertPetsciiCharIntoBuffer(Petscii.CharToPetscii['l']);
+        c64Keyboard.InsertPetsciiCharIntoBuffer(Petscii.CharToPetscii['i']);
+        c64Keyboard.InsertPetsciiCharIntoBuffer(Petscii.CharToPetscii['s']);
+        c64Keyboard.InsertPetsciiCharIntoBuffer(Petscii.CharToPetscii['t']);
+        c64Keyboard.InsertPetsciiCharIntoBuffer(Petscii.CharToPetscii[(char)13]);
 
         await Parent.OnStart(new());
     }

--- a/src/apps/Highbyte.DotNet6502.App.SkiaWASM/Pages/Commodore64/C64Menu.razor
+++ b/src/apps/Highbyte.DotNet6502.App.SkiaWASM/Pages/Commodore64/C64Menu.razor
@@ -65,16 +65,21 @@
     private string SYSTEM_NAME = C64.SystemName;
 
     // Note: The current config object (reference) is stored in this variable so that the UI can bind it's properties (not possible to use async call to _systemList.GetSystemConfig() in property )
-    private C64Config _c64Config => (C64Config)Parent.SystemConfig;
+    private C64Config? _c64Config => Parent.SystemConfig as C64Config;
+
 
     private bool JoystickKeyboardEnabled
     {
         get
         {
+            if (_c64Config == null)
+                return false;
             return _c64Config?.KeyboardJoystickEnabled ?? false;
         }
         set
         {
+            if (_c64Config == null)
+                return;
             _c64Config.KeyboardJoystickEnabled = value;
             if (Parent.CurrentEmulatorState != EmulatorState.Uninitialized)
             {

--- a/src/apps/Highbyte.DotNet6502.App.SkiaWASM/Pages/Index.razor.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SkiaWASM/Pages/Index.razor.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.AspNetCore.Components.Forms;
 using Blazored.LocalStorage;
 using Highbyte.DotNet6502.Logging.Console;
+using Toolbelt.Blazor.Gamepad;
 
 namespace Highbyte.DotNet6502.App.SkiaWASM.Pages;
 
@@ -120,6 +121,9 @@ public partial class Index
 
     [Inject]
     public DotNet6502ConsoleLoggerConfiguration LoggerConfiguration { get; set; }
+
+    [Inject]
+    public GamepadList GamepadList { get; set; }
 
     private ILogger<Index> _logger;
 
@@ -268,7 +272,7 @@ public partial class Index
 
         if (!_wasmHost.Initialized)
         {
-            await _wasmHost.Init(e.Surface.Canvas, grContext, _audioContext, Js!);
+            await _wasmHost.Init(e.Surface.Canvas, grContext, _audioContext, GamepadList, Js!);
         }
 
         //_emulatorRenderer.SetSize(e.Info.Width, e.Info.Height);

--- a/src/apps/Highbyte.DotNet6502.App.SkiaWASM/Program.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SkiaWASM/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Highbyte.DotNet6502.App.SkiaWASM;
 using Highbyte.DotNet6502.Logging.Console;
 using Blazored.LocalStorage;
+using Toolbelt.Blazor.Extensions.DependencyInjection;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
@@ -10,6 +11,7 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddBlazoredModal();
 builder.Services.AddBlazoredLocalStorage();
+builder.Services.AddGamepadList();
 
 builder.Logging.ClearProviders();
 builder.Logging.AddDotNet6502Console();

--- a/src/apps/Highbyte.DotNet6502.App.SkiaWASM/Skia/WasmHost.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SkiaWASM/Skia/WasmHost.cs
@@ -4,6 +4,7 @@ using Highbyte.DotNet6502.Impl.AspNet.JSInterop.BlazorWebAudioSync;
 using Highbyte.DotNet6502.Impl.Skia;
 using Highbyte.DotNet6502.Monitor;
 using Highbyte.DotNet6502.Systems;
+using Toolbelt.Blazor.Gamepad;
 
 namespace Highbyte.DotNet6502.App.SkiaWASM.Skia;
 
@@ -97,13 +98,13 @@ public class WasmHost : IDisposable
         Initialized = false;
     }
 
-    public async Task Init(SKCanvas canvas, GRContext grContext, AudioContextSync audioContext, IJSRuntime jsRuntime)
+    public async Task Init(SKCanvas canvas, GRContext grContext, AudioContextSync audioContext, GamepadList gamepadList, IJSRuntime jsRuntime)
     {
         _skCanvas = canvas;
         _grContext = grContext;
 
         _skiaRenderContext = new SkiaRenderContext(GetCanvas, GetGRContext);
-        InputHandlerContext = new AspNetInputHandlerContext(_loggerFactory);
+        InputHandlerContext = new AspNetInputHandlerContext(_loggerFactory, gamepadList);
         AudioHandlerContext = new WASMAudioHandlerContext(audioContext, jsRuntime, _initialMasterVolume);
 
         _systemList.InitContext(() => _skiaRenderContext, () => InputHandlerContext, () => AudioHandlerContext);

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Commodore64/Input/C64AspNetGamepad.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Commodore64/Input/C64AspNetGamepad.cs
@@ -1,0 +1,15 @@
+using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
+
+namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64.Input;
+
+public static class C64AspNetGamepad
+{
+    public static Dictionary<int[], C64JoystickAction[]> AspNetGamePadToC64JoystickMap = new()
+    {
+        { new[] { 0 }, new[] { C64JoystickAction.Fire } },
+        { new[] { 12 }, new[] { C64JoystickAction.Up} },
+        { new[] { 13 }, new[] { C64JoystickAction.Down } },
+        { new[] { 14 }, new[] { C64JoystickAction.Left } },
+        { new[] { 15 }, new[] { C64JoystickAction.Right } },
+    };
+}

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Highbyte.DotNet6502.Impl.AspNet.csproj
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Highbyte.DotNet6502.Impl.AspNet.csproj
@@ -30,6 +30,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.11" />
+    <PackageReference Include="Toolbelt.Blazor.Gamepad" Version="8.0.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/Highbyte.DotNet6502.Impl.NAudio/Commodore64/Audio/C64NAudioAudioHandler.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.NAudio/Commodore64/Audio/C64NAudioAudioHandler.cs
@@ -220,6 +220,7 @@ public class C64NAudioAudioHandler : IAudioHandler<C64, NAudioAudioHandlerContex
             formattedMsg = $"{msg}";
         }
 
-        _logger.LogDebug(formattedMsg);
+        //_logger.LogDebug(formattedMsg);
+        _logger.LogTrace(formattedMsg);
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.SilkNet/Commodore64/Input/C64SilkNetGamepad.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SilkNet/Commodore64/Input/C64SilkNetGamepad.cs
@@ -1,0 +1,16 @@
+using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
+
+namespace Highbyte.DotNet6502.Impl.SilkNet.Commodore64.Input;
+
+public static class C64SilkNetGamepad
+{
+
+    public static Dictionary<ButtonName[], C64JoystickAction[]> SilkNetGamePadToC64JoystickMap = new()
+    {
+        { new[] { ButtonName.A }, new[] { C64JoystickAction.Fire } },
+        { new[] { ButtonName.DPadUp }, new[] { C64JoystickAction.Up} },
+        { new[] { ButtonName.DPadDown }, new[] { C64JoystickAction.Down } },
+        { new[] { ButtonName.DPadLeft }, new[] { C64JoystickAction.Left } },
+        { new[] { ButtonName.DPadRight }, new[] { C64JoystickAction.Right } },
+    };
+}

--- a/src/libraries/Highbyte.DotNet6502.Impl.SilkNet/SilkNetInputHandlerContext.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SilkNet/SilkNetInputHandlerContext.cs
@@ -1,6 +1,8 @@
+using System.Linq;
 using System.Runtime.InteropServices;
 using Highbyte.DotNet6502.Systems;
 using Microsoft.Extensions.Logging;
+using Silk.NET.Input;
 using Silk.NET.SDL;
 
 namespace Highbyte.DotNet6502.Impl.SilkNet;
@@ -11,13 +13,18 @@ public class SilkNetInputHandlerContext : IInputHandlerContext
     private readonly ILogger<SilkNetInputHandlerContext> _logger;
     private static IInputContext s_inputcontext;
     public IInputContext InputContext => s_inputcontext;
+
+    // Keyboard
     private IKeyboard _primaryKeyboard;
     public IKeyboard PrimaryKeyboard => _primaryKeyboard;
-
     public HashSet<Key> KeysDown = new();
-
     private bool _capsLockKeyDownCaptured;
     private bool _capsLockOn;
+
+    // Gamepad
+    private IGamepad? _currentGamePad;
+    public IGamepad? CurrentGamePad => _currentGamePad;
+    public HashSet<ButtonName> GamepadButtonsDown = new();
 
     public bool Quit { get; private set; }
 
@@ -35,35 +42,125 @@ public class SilkNetInputHandlerContext : IInputHandlerContext
 
         s_inputcontext = _silkNetWindow.CreateInput();
 
-        // Silk.NET Input: Keyboard
         if (s_inputcontext == null)
             throw new Exception("Silk.NET Input Context not found.");
+
+        s_inputcontext.ConnectionChanged += ConnectionChanged;
+
+        // Silk.NET Input: Keyboard
         if (s_inputcontext.Keyboards != null && s_inputcontext.Keyboards.Count != 0)
             _primaryKeyboard = s_inputcontext.Keyboards[0];
         if (_primaryKeyboard == null)
             throw new Exception("Keyboard not found");
+        ListenForKeyboardInput();
 
-        ListenForKeyboardInput(enabled: true);
-
-    }
-
-    public void ListenForKeyboardInput(bool enabled)
-    {
-        if (enabled)
+        // Silk.NET Input: Gamepad
+        if (s_inputcontext.Gamepads != null && s_inputcontext.Gamepads.Count != 0)
         {
-            // Unregister any existing handlers to avoid duplicates
-            _primaryKeyboard.KeyUp -= KeyUp;
-            _primaryKeyboard.KeyDown -= KeyDown;
-
-            _primaryKeyboard.KeyUp += KeyUp;
-            _primaryKeyboard.KeyDown += KeyDown;
-
+            _currentGamePad = s_inputcontext.Gamepads[0];
+            ListenForGampadInput();
         }
         else
         {
-            _primaryKeyboard.KeyUp -= KeyUp;
-            _primaryKeyboard.KeyDown -= KeyDown;
+            _logger.LogInformation("No gamepads found.");
         }
+
+    }
+
+    private void ConnectionChanged(IInputDevice device, bool isConnected)
+    {
+        _logger.LogInformation($"Input Connection Changed: {device.Name} {device.Index} isConnected: {isConnected}");
+        if (device is IGamepad gamepad)
+        {
+            if (isConnected)
+            {
+                _currentGamePad = gamepad;
+                ListenForGampadInput();
+                _logger.LogInformation($"Current Gamepad is now: {device.Name} {device.Index}");
+            }
+            else
+            {
+                _currentGamePad = null;
+            }
+        }
+        //else if (device is IKeyboard keyboard)
+        //{
+        //    if (isConnected)
+        //    {
+        //        _primaryKeyboard = keyboard;
+        //        ListenForKeyboardInput();
+        //    }
+        //    else
+        //    {
+        //        _primaryKeyboard = null;
+        //    }
+        //}
+        //else
+        //{
+        //    _logger.LogWarning($"Unknown device type: {device.GetType().Name}");
+        //}   
+
+    }
+
+    private void ListenForGampadInput()
+    {
+        if (_currentGamePad == null)
+            return;
+
+        _currentGamePad.Deadzone = new Deadzone(0.05f, DeadzoneMethod.Traditional);
+
+        // Unregister any existing handlers to avoid duplicates
+        _currentGamePad.ButtonDown -= GamepadButtonDown;
+        _currentGamePad.ButtonUp -= GamepadButtonUp;
+        //_currentGamePad.ThumbstickMoved -= GamepadThumbstickMoved;
+        //_currentGamePad.TriggerMoved -= GamepadTriggerMoved;
+
+        _currentGamePad.ButtonDown += GamepadButtonDown;
+        _currentGamePad.ButtonUp += GamepadButtonUp;
+        //_currentGamePad.ThumbstickMoved += GamepadThumbstickMoved;
+        //_currentGamePad.TriggerMoved += GamepadTriggerMoved;
+    }
+
+    private void GamepadTriggerMoved(IGamepad gamepad, Trigger trigger)
+    {
+        _logger.LogDebug($"GamepadTriggerMoved: {trigger.Index}");
+    }
+
+    private void GamepadThumbstickMoved(IGamepad gamepad, Thumbstick thumbstick)
+    {
+        _logger.LogDebug($"GamepadThumbstickMoved: {thumbstick.Index} {thumbstick.X},{thumbstick.Y}");
+    }
+
+    private void GamepadButtonUp(IGamepad gamepad, Button button)
+    {
+        var buttonId = button.Name;
+        if (GamepadButtonsDown.Contains(buttonId))
+        {
+            _logger.LogDebug($"GamepadButtonUp: {button.Name} {button.Index} {button.Pressed}");
+            GamepadButtonsDown.Remove(buttonId);
+        }
+    }
+
+    private void GamepadButtonDown(IGamepad gamepad, Button button)
+    {
+        var buttonId = button.Name;
+        if (!GamepadButtonsDown.Contains(buttonId))
+        {
+            _logger.LogDebug($"GamepadButtonDown: {button.Name} {button.Index} {button.Pressed}");
+            GamepadButtonsDown.Add(buttonId);
+        }
+    }
+
+    public void ListenForKeyboardInput(bool enabled = true)
+    {
+        // Unregister any existing handlers to avoid duplicates
+        _primaryKeyboard.KeyUp -= KeyUp;
+        _primaryKeyboard.KeyDown -= KeyDown;
+
+        if (!enabled)
+            return;
+        _primaryKeyboard.KeyUp += KeyUp;
+        _primaryKeyboard.KeyDown += KeyDown;
     }
 
     private void KeyUp(IKeyboard keyboard, Key key, int scanCode)

--- a/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Config/C64KeyboardJoystickMap.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Config/C64KeyboardJoystickMap.cs
@@ -1,27 +1,26 @@
 using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
-using static Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.C64Joystick;
 
 namespace Highbyte.DotNet6502.Systems.Commodore64.Config;
 
 public class C64KeyboardJoystickMap
 {
-    public Dictionary<C64Key, C64JoystickAction> KeyToJoystick1Map = new()
+    private Dictionary<C64Key, C64JoystickAction> KeyToJoystick1Map = new()
     {
     };
-    public Dictionary<C64Key, C64JoystickAction> KeyToJoystick2Map = new()
+
+    private Dictionary<C64Key, C64JoystickAction> KeyToJoystick2Map = new()
     {
+            {C64Key.Space, C64JoystickAction.Fire},
             {C64Key.W, C64JoystickAction.Up},
             {C64Key.S, C64JoystickAction.Down},
             {C64Key.A, C64JoystickAction.Left},
-            {C64Key.D, C64JoystickAction.Right},
-            {C64Key.Space, C64JoystickAction.Fire},
+            {C64Key.D, C64JoystickAction.Right}
     };
 
-    public List<C64Key> GetMappedKeysForJoystickAction(int joystick, C64JoystickAction action)
+    public Dictionary<C64Key, C64JoystickAction> GetMap(int joystick)
     {
         if (joystick != 1 && joystick != 2)
             throw new ArgumentException($"Invalid joystick number: {joystick}");
-        var map = joystick == 1 ? KeyToJoystick1Map : KeyToJoystick2Map;
-        return map.Where(x => x.Value == action).Select(x => x.Key).ToList();
+        return joystick == 1 ? KeyToJoystick1Map : KeyToJoystick2Map;
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/TimerAndPeripheral/C64Joystick.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/TimerAndPeripheral/C64Joystick.cs
@@ -1,16 +1,20 @@
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Microsoft.Extensions.Logging;
 
 namespace Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
 
 public class C64Joystick
 {
+    private readonly ILogger<C64Joystick> _logger;
+
     public bool KeyboardJoystickEnabled { get; set; }
     public C64KeyboardJoystickMap KeyboardJoystickMap { get; private set; }
     public HashSet<C64JoystickAction> CurrentJoystick1Actions { get; private set; } = new();
     public HashSet<C64JoystickAction> CurrentJoystick2Actions { get; private set; } = new();
 
-    public C64Joystick(C64Config c64Config)
+    public C64Joystick(C64Config c64Config, ILoggerFactory loggerFactory)
     {
+        _logger = loggerFactory.CreateLogger<C64Joystick>();
         KeyboardJoystickEnabled = c64Config.KeyboardJoystickEnabled;
         KeyboardJoystickMap = c64Config.KeyboardJoystickMap;
     }
@@ -18,23 +22,27 @@ public class C64Joystick
     public void SetJoystick1Actions(HashSet<C64JoystickAction> joystickActions)
     {
         CurrentJoystick1Actions = joystickActions;
+        if (joystickActions.Count > 0)
+            _logger.LogTrace($"C64 joystick 1 pressed: {string.Join(",", joystickActions)}");
+
     }
 
     public void SetJoystick2Actions(HashSet<C64JoystickAction> joystickActions)
     {
         CurrentJoystick2Actions = joystickActions;
+        if (joystickActions.Count > 0)
+            _logger.LogTrace($"C64 joystick 2 pressed: {string.Join(",", joystickActions)}");
     }
-
-    /// <summary>
-    /// Possible joystick actions. More than one can be active at the same time.
-    /// The integer value corresponds to the bit position in the joystick register (set = not active, clear = active).
-    /// </summary>
-    public enum C64JoystickAction
-    {
-        Up = 0,
-        Down = 1,
-        Left = 2,
-        Right = 3,
-        Fire = 4
-    }
+}
+/// <summary>
+/// Possible joystick actions. More than one can be active at the same time.
+/// The integer value corresponds to the bit position in the joystick register (set = not active, clear = active).
+/// </summary>
+public enum C64JoystickAction
+{
+    Up = 0,
+    Down = 1,
+    Left = 2,
+    Right = 3,
+    Fire = 4
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/TimerAndPeripheral/C64Keyboard.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/TimerAndPeripheral/C64Keyboard.cs
@@ -145,6 +145,22 @@ public class C64Keyboard
     }
 
     /// <summary>
+    /// Inserts a PETSCII character directly into the keyboard buffer, bypassing keyboard matrix.
+    /// Can be useful when wanting to type Basic commands on behalf of the user.
+    /// </summary>
+    /// <param name="petsciiChar"></param>
+    public void InsertPetsciiCharIntoBuffer(byte petsciiChar)
+    {
+        // Address: 0x00c6: Keyboard buffer index
+        // Address: 0x0277 - 0x0280: Keyboard buffer
+        var bufferIndex = _c64.Mem[0x00c6];
+        if (bufferIndex >= 10)
+            return;
+        _c64.Mem[0x00c6]++;
+        _c64.Mem[(ushort)(0x0277 + bufferIndex)] = petsciiChar;
+    }
+
+    /// <summary>
     /// Move joystick based on keyboard input (if configured).
     /// </summary>
     private void HandleJoystickKeyboard()

--- a/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/TimerAndPeripheral/Cia.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/TimerAndPeripheral/Cia.cs
@@ -20,7 +20,7 @@ public class Cia
         _c64 = c64;
         CiaIRQ = new CiaIRQ();
         Keyboard = new C64Keyboard(c64, loggerFactory);
-        Joystick = new C64Joystick(c64Config);
+        Joystick = new C64Joystick(c64Config, loggerFactory);
 
         CiaTimers = new();
         CiaTimers.Add(CiaTimerType.Cia1_A, new CiaTimer(CiaTimerType.Cia1_A, IRQSource.TimerA, _c64));


### PR DESCRIPTION
Adds gamepad support in native and WASM client to control a joystick in C64.
- Native app uses gamepad support in Silk.NET library.
- WASM app uses JS interop to Browser Gamepad API via a Blazor 3rd party library.
