### PR TITLE
Feature/misc fixes

### DIFF
--- a/src/apps/Highbyte.DotNet6502.App.ConsoleMonitor/GlobalUsings.cs
+++ b/src/apps/Highbyte.DotNet6502.App.ConsoleMonitor/GlobalUsings.cs
@@ -1,2 +1,1 @@
 // If <ImplicitUsings>enable</ImplicitUsings> is added to the .csproj file, a bunch of standard .NET namespaces are added by default (and not needed to be added here).
-global using System.CommandLine;

--- a/src/apps/Highbyte.DotNet6502.App.SilkNetNative/ConfigUI/SilkNetImGuiC64Config.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SilkNetNative/ConfigUI/SilkNetImGuiC64Config.cs
@@ -1,18 +1,17 @@
 using System.Diagnostics;
 using System.Numerics;
 using Highbyte.DotNet6502.App.SilkNetNative.SystemSetup;
-using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
-using Microsoft.Extensions.Logging;
 
 namespace Highbyte.DotNet6502.App.SilkNetNative.ConfigUI;
 
 public class SilkNetImGuiC64Config
 {
     private readonly SilkNetImGuiMenu _mainMenu;
-    C64Config _config => (C64Config)_mainMenu.GetSelectedSystemConfig();
-    C64HostConfig _hostConfig => (C64HostConfig)_mainMenu.GetSelectedSystemHostConfig();
 
+    private C64Config _config => (C64Config)_mainMenu.GetSelectedSystemConfig();
+
+    private C64HostConfig _hostConfig => (C64HostConfig)_mainMenu.GetSelectedSystemHostConfig();
 
     private string? _romDirectory;
     private string? _kernalRomFile;
@@ -20,7 +19,7 @@ public class SilkNetImGuiC64Config
     private string? _chargenRomFile;
 
     private int _selectedRenderer = 0;
-    private string[] _availableRenderers = Enum.GetNames<C64HostRenderer>();
+    private readonly string[] _availableRenderers = Enum.GetNames<C64HostRenderer>();
     private bool _openGLFineScrollPerRasterLineEnabled;
 
     private bool _open;

--- a/src/apps/Highbyte.DotNet6502.App.SilkNetNative/ConfigUI/SilkNetImGuiGenericComputerConfig.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SilkNetNative/ConfigUI/SilkNetImGuiGenericComputerConfig.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Numerics;
+using Highbyte.DotNet6502.App.SilkNetNative.SystemSetup;
 using Highbyte.DotNet6502.Systems.Generic.Config;
 
 namespace Highbyte.DotNet6502.App.SilkNetNative.ConfigUI;
@@ -7,11 +8,14 @@ namespace Highbyte.DotNet6502.App.SilkNetNative.ConfigUI;
 public class SilkNetImGuiGenericComputerConfig
 {
     private readonly SilkNetImGuiMenu _mainMenu;
-    GenericComputerConfig _config => (GenericComputerConfig)_mainMenu.GetSelectedSystemConfig();
+
+    private GenericComputerConfig _config => (GenericComputerConfig)_mainMenu.GetSelectedSystemConfig();
+
+    private GenericComputerHostConfig _hostConfig => (GenericComputerHostConfig)_mainMenu.GetSelectedSystemHostConfig();
 
     private bool _open;
 
-    private string _programBinaryFile;
+    private string _programBinaryFile = default!;
 
     public bool IsValidConfig
     {
@@ -29,11 +33,10 @@ public class SilkNetImGuiGenericComputerConfig
         }
     }
     private List<string> _validationErrors = new();
-
-    static Vector4 s_InformationColor = new Vector4(1.0f, 1.0f, 1.0f, 1.0f);
-    static Vector4 s_ErrorColor = new Vector4(1.0f, 0.0f, 0.0f, 1.0f);
-    static Vector4 s_WarningColor = new Vector4(0.5f, 0.8f, 0.8f, 1);
-    static Vector4 s_OkButtonColor = new Vector4(0.0f, 0.6f, 0.0f, 1.0f);
+    //private static Vector4 s_informationColor = new Vector4(1.0f, 1.0f, 1.0f, 1.0f);
+    private static Vector4 s_errorColor = new Vector4(1.0f, 0.0f, 0.0f, 1.0f);
+    //private static Vector4 s_warningColor = new Vector4(0.5f, 0.8f, 0.8f, 1);
+    private static Vector4 s_okButtonColor = new Vector4(0.0f, 0.6f, 0.0f, 1.0f);
 
     public SilkNetImGuiGenericComputerConfig(SilkNetImGuiMenu mainMenu)
     {
@@ -122,7 +125,6 @@ public class SilkNetImGuiGenericComputerConfig
             ImGui.SameLine();
             ImGui.Text(_config!.Memory.Screen.DefaultBorderColor.ToString());
 
-
             // Memory - Input
             ImGui.Text("Memory - Input");
 
@@ -148,7 +150,7 @@ public class SilkNetImGuiGenericComputerConfig
             }
             if (!IsValidConfig)
             {
-                ImGui.PushStyleColor(ImGuiCol.Text, s_ErrorColor);
+                ImGui.PushStyleColor(ImGuiCol.Text, s_errorColor);
                 foreach (var error in _validationErrors)
                 {
                     ImGui.TextWrapped($"Error: {error}");
@@ -166,12 +168,12 @@ public class SilkNetImGuiGenericComputerConfig
 
             ImGui.SameLine();
             ImGui.BeginDisabled(disabled: !IsValidConfig);
-            ImGui.PushStyleColor(ImGuiCol.Button, s_OkButtonColor);
+            ImGui.PushStyleColor(ImGuiCol.Button, s_okButtonColor);
             if (ImGui.Button("Ok"))
             {
                 Debug.WriteLine("Ok pressed");
                 ImGui.CloseCurrentPopup();
-                _mainMenu.UpdateCurrentSystemConfig(_config, null);
+                _mainMenu.UpdateCurrentSystemConfig(_config, _hostConfig);
             }
             ImGui.PopStyleColor();
             ImGui.EndDisabled();

--- a/src/apps/Highbyte.DotNet6502.App.SilkNetNative/EmulatorConfig.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SilkNetNative/EmulatorConfig.cs
@@ -9,10 +9,10 @@ public class EmulatorConfig
 {
     public const string ConfigSectionName = "Highbyte.DotNet6502.SkiaConfig";
 
-    public string DefaultEmulator { get; set; }
-    public float DefaultDrawScale { get; set; }
+    public required string DefaultEmulator { get; set; }
+    public required float DefaultDrawScale { get; set; }
     public float CurrentDrawScale { get; set; }
-    public MonitorConfig? Monitor { get; set; }
+    public required MonitorConfig Monitor { get; set; }
 
     public Dictionary<string, IHostSystemConfig> HostSystemConfigs = new();
 

--- a/src/apps/Highbyte.DotNet6502.App.SilkNetNative/EmulatorConfig.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SilkNetNative/EmulatorConfig.cs
@@ -24,7 +24,7 @@ public class EmulatorConfig
     public void Validate(SystemList<SilkNetRenderContextContainer, SilkNetInputHandlerContext, NAudioAudioHandlerContext> systemList)
     {
         if (!systemList.Systems.Contains(DefaultEmulator))
-            throw new Exception($"Setting {nameof(DefaultEmulator)} value {DefaultEmulator} is not supported. Valid values are: {string.Join(',', systemList.Systems)}");
+            throw new DotNet6502Exception($"Setting {nameof(DefaultEmulator)} value {DefaultEmulator} is not supported. Valid values are: {string.Join(',', systemList.Systems)}");
         Monitor.Validate();
     }
 }

--- a/src/apps/Highbyte.DotNet6502.App.SilkNetNative/Program.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SilkNetNative/Program.cs
@@ -41,7 +41,8 @@ var c64HostConfig = new C64HostConfig
 var c64Setup = new C64Setup(loggerFactory, c64HostConfig);
 systemList.AddSystem(c64Setup);
 
-var genericComputerSetup = new GenericComputerSetup(loggerFactory);
+var genericComputerHostConfig = new GenericComputerHostConfig { };
+var genericComputerSetup = new GenericComputerSetup(loggerFactory, genericComputerHostConfig);
 systemList.AddSystem(genericComputerSetup);
 
 // TODO: Read options from appsettings.json
@@ -62,7 +63,7 @@ var emulatorConfig = new EmulatorConfig
     HostSystemConfigs = new Dictionary<string, IHostSystemConfig>
     {
         { C64.SystemName, c64HostConfig },
-        { GenericComputer.SystemName, null }
+        { GenericComputer.SystemName, genericComputerHostConfig}
     }
 };
 emulatorConfig.Validate(systemList);

--- a/src/apps/Highbyte.DotNet6502.App.SilkNetNative/Program.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SilkNetNative/Program.cs
@@ -39,10 +39,10 @@ var c64HostConfig = new C64HostConfig
     }
 };
 var c64Setup = new C64Setup(loggerFactory, c64HostConfig);
-await systemList.AddSystem(c64Setup);
+systemList.AddSystem(c64Setup);
 
 var genericComputerSetup = new GenericComputerSetup(loggerFactory);
-await systemList.AddSystem(genericComputerSetup);
+systemList.AddSystem(genericComputerSetup);
 
 // TODO: Read options from appsettings.json
 var emulatorConfig = new EmulatorConfig

--- a/src/apps/Highbyte.DotNet6502.App.SilkNetNative/SilkNetImGuiMenu.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SilkNetNative/SilkNetImGuiMenu.cs
@@ -1,6 +1,5 @@
 using System.Numerics;
 using AutoMapper;
-using Highbyte.DotNet6502.App.SilkNetNative;
 using Highbyte.DotNet6502.App.SilkNetNative.ConfigUI;
 using Highbyte.DotNet6502.App.SilkNetNative.SystemSetup;
 using Highbyte.DotNet6502.Systems;
@@ -38,12 +37,12 @@ public class SilkNetImGuiMenu : ISilkNetImGuiWindow
     public bool C64KeyboardJoystickEnabled;
     public int C64KeyboardJoystick;
     public int C64SelectedJoystick;
-    public string[] C64AvailableJoysticks;
+    public string[] C64AvailableJoysticks = [];
 
     private string SelectedSystemName => _silkNetWindow.SystemList.Systems.ToArray()[_selectedSystemItem];
 
-    private ISystemConfig? _originalSystemConfig;
-    private IHostSystemConfig? _originalHostSystemConfig;
+    private ISystemConfig _originalSystemConfig = default!;
+    private IHostSystemConfig _originalHostSystemConfig = default!;
 
     private SilkNetImGuiC64Config? _c64ConfigUI;
     private SilkNetImGuiGenericComputerConfig? _genericComputerConfigUI;
@@ -62,7 +61,6 @@ public class SilkNetImGuiMenu : ISilkNetImGuiWindow
 
         _mapper = mapper;
         _logger = loggerFactory.CreateLogger<SilkNetImGuiMenu>();
-
 
         ISystemConfig systemConfig = GetSelectedSystemConfig();
         if (systemConfig is C64Config c64Config)
@@ -477,36 +475,27 @@ public class SilkNetImGuiMenu : ISilkNetImGuiWindow
     }
     internal IHostSystemConfig GetSelectedSystemHostConfig()
     {
-        if (!_silkNetWindow.EmulatorConfig.HostSystemConfigs.ContainsKey(SelectedSystemName))
-            return null;
         return _silkNetWindow.EmulatorConfig.HostSystemConfigs[SelectedSystemName];
     }
 
     internal void RememberOriginalConfigs()
     {
         _originalSystemConfig = (ISystemConfig)GetSelectedSystemConfig().Clone();
-
-        var hostSystemConfig = (IHostSystemConfig)GetSelectedSystemHostConfig();
-        if (hostSystemConfig != null)
-            _originalHostSystemConfig = (IHostSystemConfig)GetSelectedSystemHostConfig().Clone();
+        _originalHostSystemConfig = (IHostSystemConfig)GetSelectedSystemHostConfig().Clone();
     }
     internal void RestoreOriginalConfigs()
     {
         UpdateCurrentSystemConfig(_originalSystemConfig, _originalHostSystemConfig);
     }
 
-    internal void UpdateCurrentSystemConfig(ISystemConfig config, IHostSystemConfig? hostSystemConfig)
+    internal void UpdateCurrentSystemConfig(ISystemConfig config, IHostSystemConfig hostSystemConfig)
     {
         // Update the system config
         _silkNetWindow.SystemList.ChangeCurrentSystemConfig(SelectedSystemName, config);
 
         // Update the existing host system config, it is referenced from different objects (thus we cannot replace it with a new one).
-        if (hostSystemConfig != null)
-        {
-            var org = _silkNetWindow.EmulatorConfig.HostSystemConfigs[SelectedSystemName];
-            if (org != null && hostSystemConfig != null)
-                _mapper.Map(hostSystemConfig, org);
-        }
+        var orgHostSystemConfig = _silkNetWindow.EmulatorConfig.HostSystemConfigs[SelectedSystemName];
+        _mapper.Map(hostSystemConfig, orgHostSystemConfig);
     }
     public void Run()
     {
@@ -527,5 +516,4 @@ public class SilkNetImGuiMenu : ISilkNetImGuiWindow
     {
         Visible = false;
     }
-
 }

--- a/src/apps/Highbyte.DotNet6502.App.SilkNetNative/SilkNetImgUIMonitor.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SilkNetNative/SilkNetImgUIMonitor.cs
@@ -1,9 +1,6 @@
-using System.Diagnostics;
 using System.Numerics;
 using Highbyte.DotNet6502.Monitor;
 using Highbyte.DotNet6502.Systems;
-using ImGuiNET;
-using NativeFileDialogSharp;
 
 namespace Highbyte.DotNet6502.App.SilkNetNative;
 
@@ -30,17 +27,15 @@ public class SilkNetImGuiMonitor : ISilkNetImGuiWindow
     private const int POS_Y = 2;
     private const int WIDTH = 750;
     private const int HEIGHT = 642;
-    const int MONITOR_CMD_LINE_LENGTH = 200;
+    private const int MONITOR_CMD_LINE_LENGTH = 200;
+    private static Vector4 s_informationColor = new Vector4(1.0f, 1.0f, 1.0f, 1.0f);
+    private static Vector4 s_errorColor = new Vector4(1.0f, 0.0f, 0.0f, 1.0f);
+    private static Vector4 s_warningColor = new Vector4(0.5f, 0.8f, 0.8f, 1);
+    private static Vector4 s_statusColor = new Vector4(0.7f, 0.7f, 0.7f, 1.0f);
 
-    static Vector4 s_InformationColor = new Vector4(1.0f, 1.0f, 1.0f, 1.0f);
-    static Vector4 s_ErrorColor = new Vector4(1.0f, 0.0f, 0.0f, 1.0f);
-    static Vector4 s_WarningColor = new Vector4(0.5f, 0.8f, 0.8f, 1);
+    private readonly bool _autoScroll = true;
 
-    static Vector4 s_StatusColor = new Vector4(0.7f, 0.7f, 0.7f, 1.0f);
-
-    private bool _autoScroll = true;
-
-    public event EventHandler<bool> MonitorStateChange;
+    public event EventHandler<bool>? MonitorStateChange;
     protected virtual void OnMonitorStateChange(bool monitorEnabled)
     {
         var handler = MonitorStateChange;
@@ -99,10 +94,10 @@ public class SilkNetImGuiMonitor : ISilkNetImGuiWindow
             {
                 textColor = cmd.Severity switch
                 {
-                    MessageSeverity.Information => s_InformationColor,
-                    MessageSeverity.Warning => s_WarningColor,
-                    MessageSeverity.Error => s_ErrorColor,
-                    _ => s_InformationColor
+                    MessageSeverity.Information => s_informationColor,
+                    MessageSeverity.Warning => s_warningColor,
+                    MessageSeverity.Error => s_errorColor,
+                    _ => s_informationColor
                 };
                 ImGui.PushStyleColor(ImGuiCol.Text, textColor);
                 ImGui.Text(cmd.Message);
@@ -126,11 +121,8 @@ public class SilkNetImGuiMonitor : ISilkNetImGuiWindow
                 if (ImGui.GetScrollY() >= ImGui.GetScrollMaxY())
                     ImGui.SetScrollHereY(1.0f); // 0.0f:top, 0.5f:center, 1.0f:bottom
             }
-
         }
         ImGui.EndChild();
-
-
 
         if (_setFocusOnInput)
         {
@@ -161,12 +153,12 @@ public class SilkNetImGuiMonitor : ISilkNetImGuiWindow
             return;
 
         // CPU status
-        ImGui.PushStyleColor(ImGuiCol.Text, s_StatusColor);
+        ImGui.PushStyleColor(ImGuiCol.Text, s_statusColor);
         ImGui.Text($"CPU: {OutputGen.GetProcessorState(_silkNetNativeMonitor.Cpu, includeCycles: true)}");
         ImGui.PopStyleColor();
 
         // System status
-        ImGui.PushStyleColor(ImGuiCol.Text, s_StatusColor);
+        ImGui.PushStyleColor(ImGuiCol.Text, s_statusColor);
         foreach (var sysInfoRow in _silkNetNativeMonitor.System.SystemInfo)
         {
             ImGui.Text($"SYS: {sysInfoRow}");

--- a/src/apps/Highbyte.DotNet6502.App.SilkNetNative/SilkNetWindow.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SilkNetNative/SilkNetWindow.cs
@@ -228,7 +228,7 @@ public class SilkNetWindow
     public void SetCurrentSystem(string systemName)
     {
         if (EmulatorState != EmulatorState.Uninitialized)
-            throw new Exception("Internal error. Cannot change system while running");
+            throw new DotNet6502Exception("Internal error. Cannot change system while running");
 
         _currentSystemName = systemName;
 
@@ -260,7 +260,7 @@ public class SilkNetWindow
             return;
 
         if (!_systemList.IsValidConfig(_currentSystemName).Result)
-            throw new Exception("Internal error. Cannot start emulator if current system config is invalid.");
+            throw new DotNet6502Exception("Internal error. Cannot start emulator if current system config is invalid.");
 
         // Only create a new instance of SystemRunner if we previously has not started (so resume after pause works).
         if (EmulatorState == EmulatorState.Uninitialized)
@@ -429,7 +429,7 @@ public class SilkNetWindow
         _inputContext = _window.CreateInput();
         // Listen to key to enable monitor
         if (_inputContext.Keyboards == null || _inputContext.Keyboards.Count == 0)
-            throw new Exception("Keyboard not found");
+            throw new DotNet6502Exception("Keyboard not found");
         var primaryKeyboard = _inputContext.Keyboards[0];
 
         // Listen to special key that will show/hide overlays for monitor/stats

--- a/src/apps/Highbyte.DotNet6502.App.SilkNetNative/SilkNetWindow.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SilkNetNative/SilkNetWindow.cs
@@ -32,7 +32,7 @@ public class SilkNetWindow
 
     private readonly DotNet6502InMemLogStore _logStore;
     private readonly DotNet6502InMemLoggerConfiguration _logConfig;
-    private string _currentSystemName;
+    private string _currentSystemName = default!;
     private readonly bool _defaultAudioEnabled;
     private float _defaultAudioVolumePercent;
     private readonly ILoggerFactory _loggerFactory;
@@ -65,41 +65,40 @@ public class SilkNetWindow
     private readonly PerSecondTimedStat _renderFps = InstrumentationBag.Add<PerSecondTimedStat>($"{HostStatRootName}-OnRenderFPS");
 
     // Render context container for SkipSharp (surface/canvas) and SilkNetOpenGl
-    private SilkNetRenderContextContainer _silkNetRenderContextContainer;
+    private SilkNetRenderContextContainer _silkNetRenderContextContainer = default!;
     // SilkNet input handling
-    private SilkNetInputHandlerContext _silkNetInputHandlerContext;
+    private SilkNetInputHandlerContext _silkNetInputHandlerContext = default!;
     // NAudio audio handling
-    private NAudioAudioHandlerContext _naudioAudioHandlerContext;
+    private NAudioAudioHandlerContext _naudioAudioHandlerContext = default!;
 
     // Emulator    
-    private SystemRunner? _systemRunner;
+    private SystemRunner _systemRunner = default!;
     public SystemRunner SystemRunner => _systemRunner!;
 
     // Monitor
-    private SilkNetImGuiMonitor _monitor;
+    private SilkNetImGuiMonitor _monitor = default!;
     public SilkNetImGuiMonitor Monitor => _monitor;
 
     // Instrumentations panel
-    private SilkNetImGuiStatsPanel _statsPanel;
+    private SilkNetImGuiStatsPanel _statsPanel = default!;
     public SilkNetImGuiStatsPanel StatsPanel => _statsPanel;
 
     // Logs panel
-    private SilkNetImGuiLogsPanel _logsPanel;
+    private SilkNetImGuiLogsPanel _logsPanel = default!;
     public SilkNetImGuiLogsPanel LogsPanel => _logsPanel;
 
     // Menu
-    private SilkNetImGuiMenu _menu;
+    private SilkNetImGuiMenu _menu = default!;
     private bool _statsWasEnabled = false;
-    private bool _logsWasEnabled = false;
+    //private bool _logsWasEnabled = false;
 
-    readonly List<ISilkNetImGuiWindow> _imGuiWindows = new List<ISilkNetImGuiWindow>();
+    private readonly List<ISilkNetImGuiWindow> _imGuiWindows = new List<ISilkNetImGuiWindow>();
     private bool _atLeastOneImGuiWindowHasFocus => _imGuiWindows.Any(x => x.Visible && x.WindowIsFocused);
 
     // GL and other ImGui resources
-    private GL _gl;
-    private IInputContext _inputContext;
-    private ImGuiController _imGuiController;
-
+    private GL _gl = default!;
+    private IInputContext _inputContext = default!;
+    private ImGuiController _imGuiController = default!;
 
     public SilkNetWindow(
         EmulatorConfig emulatorConfig,
@@ -268,12 +267,11 @@ public class SilkNetWindow
 
         _monitor.Init(_systemRunner!);
 
-        _systemRunner!.AudioHandler.StartPlaying();
+        _systemRunner.AudioHandler.StartPlaying();
 
         EmulatorState = EmulatorState.Running;
 
         _logger.LogInformation($"System started: {_currentSystemName}");
-
     }
 
     public void Pause()
@@ -281,7 +279,7 @@ public class SilkNetWindow
         if (EmulatorState == EmulatorState.Paused || EmulatorState == EmulatorState.Uninitialized)
             return;
 
-        _systemRunner!.AudioHandler.PausePlaying();
+        _systemRunner.AudioHandler.PausePlaying();
         EmulatorState = EmulatorState.Paused;
 
         _logger.LogInformation($"System paused: {_currentSystemName}");
@@ -293,7 +291,7 @@ public class SilkNetWindow
             return;
         if (EmulatorState == EmulatorState.Running)
             Pause();
-        _systemRunner = null;
+        _systemRunner = default!;
         EmulatorState = EmulatorState.Uninitialized;
         Start();
     }
@@ -302,7 +300,7 @@ public class SilkNetWindow
     {
         if (EmulatorState == EmulatorState.Running)
             Pause();
-        _systemRunner = null;
+        _systemRunner = default!;
         SetUninitializedWindow();
         InitRendering();
 
@@ -326,7 +324,7 @@ public class SilkNetWindow
         {
             using (_inputTime.Measure())
             {
-                _systemRunner!.ProcessInput();
+                _systemRunner.ProcessInput();
             }
         }
 
@@ -371,13 +369,12 @@ public class SilkNetWindow
             using (_renderTime.Measure())
             {
                 // Render emulator system screen
-                _systemRunner!.Draw();
+                _systemRunner.Draw();
 
                 // Flush the SkiaSharp Context
                 _silkNetRenderContextContainer.SkiaRenderContext.GetGRContext().Flush();
             }
             emulatorRendered = true;
-
 
             // SilkNet windows are what's known as "double-buffered". In essence, the window manages two buffers.
             // One is rendered to while the other is currently displayed by the window.
@@ -529,9 +526,7 @@ public class SilkNetWindow
         if (_menu.Visible)
             _menu.Disable();
         else
-        {
             _menu.Enable();
-        }
     }
 
     public void ToggleStatsPanel()
@@ -557,8 +552,8 @@ public class SilkNetWindow
 
         if (_logsPanel.Visible)
         {
+            //_logsWasEnabled = true;
             _logsPanel.Disable();
-            _logsWasEnabled = false;
         }
         else
         {
@@ -584,6 +579,5 @@ public class SilkNetWindow
         {
             _monitor.Enable();
         }
-
     }
 }

--- a/src/apps/Highbyte.DotNet6502.App.SilkNetNative/SystemSetup/C64Setup.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SilkNetNative/SystemSetup/C64Setup.cs
@@ -25,7 +25,7 @@ public class C64Setup : SystemConfigurer<SilkNetRenderContextContainer, SilkNetI
         _c64HostConfig = c64HostConfig;
     }
 
-    public async Task<ISystemConfig> GetNewConfig(string configurationVariant)
+    public Task<ISystemConfig> GetNewConfig(string configurationVariant)
     {
         var c64Config = new C64Config
         {
@@ -66,13 +66,15 @@ public class C64Setup : SystemConfigurer<SilkNetRenderContextContainer, SilkNetI
         };
 
         //c64Config.Validate();
-        return c64Config;
+        return Task.FromResult<ISystemConfig>(c64Config);
     }
 
-    public async Task PersistConfig(ISystemConfig systemConfig)
+    public Task PersistConfig(ISystemConfig systemConfig)
     {
         var c64Config = (C64Config)systemConfig;
         // TODO: Persist settings to file
+
+        return Task.CompletedTask;
     }
 
     public ISystem BuildSystem(ISystemConfig systemConfig)

--- a/src/apps/Highbyte.DotNet6502.App.SilkNetNative/SystemSetup/GenericComputerHostConfig.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SilkNetNative/SystemSetup/GenericComputerHostConfig.cs
@@ -1,0 +1,14 @@
+using Highbyte.DotNet6502.Systems;
+
+namespace Highbyte.DotNet6502.App.SilkNetNative.SystemSetup
+{
+    public class GenericComputerHostConfig : IHostSystemConfig, ICloneable
+    {
+
+        public object Clone()
+        {
+            var clone = (GenericComputerHostConfig)this.MemberwiseClone();
+            return clone;
+        }
+    }
+}

--- a/src/apps/Highbyte.DotNet6502.App.SilkNetNative/SystemSetup/GenericComputerSetup.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SilkNetNative/SystemSetup/GenericComputerSetup.cs
@@ -15,13 +15,15 @@ public class GenericComputerSetup : SystemConfigurer<SilkNetRenderContextContain
     public string SystemName => GenericComputer.SystemName;
 
     private readonly ILoggerFactory _loggerFactory;
+    private readonly GenericComputerHostConfig _genericComputerHostConfig;
 
-    public GenericComputerSetup(ILoggerFactory loggerFactory)
+    public GenericComputerSetup(ILoggerFactory loggerFactory, GenericComputerHostConfig genericComputerHostConfig)
     {
         _loggerFactory = loggerFactory;
+        _genericComputerHostConfig = genericComputerHostConfig;
     }
 
-    public async Task<ISystemConfig> GetNewConfig(string configurationVariant)
+    public Task<ISystemConfig> GetNewConfig(string configurationVariant)
     {
         var genericComputerConfig = new GenericComputerConfig
         {
@@ -52,13 +54,14 @@ public class GenericComputerSetup : SystemConfigurer<SilkNetRenderContextContain
 
         genericComputerConfig.Validate();
 
-        return genericComputerConfig;
+        return Task.FromResult<ISystemConfig>(genericComputerConfig);
     }
 
-    public async Task PersistConfig(ISystemConfig systemConfig)
+    public Task PersistConfig(ISystemConfig systemConfig)
     {
         var genericComputerConfig = (GenericComputerConfig)systemConfig;
         // TODO: Save config settings to file
+        return Task.CompletedTask;
     }
 
     public ISystem BuildSystem(ISystemConfig systemConfig)
@@ -67,10 +70,9 @@ public class GenericComputerSetup : SystemConfigurer<SilkNetRenderContextContain
         return GenericComputerBuilder.SetupGenericComputerFromConfig(genericComputerConfig, _loggerFactory);
     }
 
-
     public Task<IHostSystemConfig> GetHostSystemConfig()
     {
-        return Task.FromResult((IHostSystemConfig)null);
+        return Task.FromResult((IHostSystemConfig)_genericComputerHostConfig);
     }
 
     public SystemRunner BuildSystemRunner(

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Commodore64/C64ConfigUI.razor
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Commodore64/C64ConfigUI.razor
@@ -159,9 +159,9 @@
 
     [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; } = default!;
 
-    [Parameter] public ISystemConfig SystemConfig { get; set; }
+    [Parameter] public ISystemConfig SystemConfig { get; set; } = default!;
 
-    [Parameter] public IHostSystemConfig HostSystemConfig { get; set; }
+    [Parameter] public IHostSystemConfig HostSystemConfig { get; set; } = default!;
 
     public C64Config C64Config
     {
@@ -182,7 +182,7 @@
     protected override void OnInitialized() => BlazoredModal.SetTitle("C64 config");
 
 
-    private async Task UnloadROMs() => C64Config.ROMs = new List<ROM>();
+    private void UnloadROMs() => C64Config.ROMs = new List<ROM>();
 
 
     private async Task Ok() => await BlazoredModal.CloseAsync(ModalResult.Ok((SystemConfig, HostSystemConfig)));
@@ -246,9 +246,9 @@
                 else if (isChargen)
                     SetROM(C64Config.CHARGEN_ROM_NAME, fileBuffer);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                //Logger.LogError("File: {Filename} Error: {Error}",
+                // Logger.LogError("File: {Filename} Error: {Error}",
                 //    file.Name, ex.Message);
             }
         }
@@ -274,10 +274,10 @@
         rom.Data = data;
     }
 
-    private async Task OnSelectJoystickChanged(ChangeEventArgs e) 
-        => C64HostConfig.InputConfig.CurrentJoystick = int.Parse(e.Value.ToString());
+    private void OnSelectJoystickChanged(ChangeEventArgs e) 
+        => C64HostConfig.InputConfig.CurrentJoystick = int.Parse(e.Value!.ToString()!);
 
-    private async Task OnSelectKeyboardJoystickChanged(ChangeEventArgs e)
-        => C64Config.KeyboardJoystick = int.Parse(e.Value.ToString());
+    private void OnSelectKeyboardJoystickChanged(ChangeEventArgs e)
+        => C64Config.KeyboardJoystick = int.Parse(e.Value!.ToString()!);
     
 }

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Commodore64/C64Menu.razor
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Commodore64/C64Menu.razor
@@ -66,33 +66,37 @@
 
 <style>
     .systemCommandsStyle {
-        display: @Parent.GetSystemVisibilityDisplayStyle("Commands", SYSTEM_NAME);
+        display: @Parent.GetSystemVisibilityDisplayStyle("Commands", SYSTEM_NAME)
     }
     .systemHelpStyle {
-        display: @Parent.GetSystemVisibilityDisplayStyle("Help", SYSTEM_NAME);
+        display: @Parent.GetSystemVisibilityDisplayStyle("Help", SYSTEM_NAME)
     }
     .systemConfigStyle {
-        display: @Parent.GetSystemVisibilityDisplayStyle("Config", SYSTEM_NAME);
+        display: @Parent.GetSystemVisibilityDisplayStyle("Config", SYSTEM_NAME)
     }
 </style>
 
 <InputFile id="filePicker" OnChange="@OnFilePickerChange" hidden />
 <InputFile id="filePickerBasic" OnChange="@OnBasicFilePickerChange" hidden />
 
+@* Fix for compiler warning CS8669 https://github.com/dotnet/razor/issues/8720 *@
+@{
+#pragma warning disable CS8669
+} 
 @code {
-    @inject IJSRuntime Js
-    @inject HttpClient? HttpClient
+@inject IJSRuntime Js
+    @inject HttpClient HttpClient
     @inject ILoggerFactory LoggerFactory
 
-    private ILogger _logger;
+    private ILogger _logger = default!;
     private string _latestFileError = "";
     private string SYSTEM_NAME = C64.SystemName;
 
     // Note: The current config object (reference) is stored in this variable so that the UI can bind it's properties (not possible to use async call to _systemList.GetSystemConfig() in property )
-    private C64Config? _c64Config => Parent.SystemConfig as C64Config;
-    private C64HostConfig? _c64HostConfig => Parent.HostSystemConfig as C64HostConfig;
+    private C64Config _c64Config => (Parent.SystemConfig as C64Config)!;
+    private C64HostConfig _c64HostConfig => (Parent.HostSystemConfig as C64HostConfig)!;
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
         _logger = LoggerFactory.CreateLogger<C64Menu>();
         _logger.LogDebug("OnInitializedAsync() was called");
@@ -119,11 +123,11 @@
         }
     }
 
-    private async Task OnSelectJoystickChanged(ChangeEventArgs e)
-    => _c64HostConfig.InputConfig.CurrentJoystick = int.Parse(e.Value.ToString());
+    private void OnSelectJoystickChanged(ChangeEventArgs e)
+    => _c64HostConfig.InputConfig.CurrentJoystick = int.Parse(e.Value!.ToString()!);
 
-    private async Task OnSelectKeyboardJoystickChanged(ChangeEventArgs e)
-        => KeyboardJoystick = int.Parse(e.Value.ToString());
+    private void OnSelectKeyboardJoystickChanged(ChangeEventArgs e)
+        => KeyboardJoystick = int.Parse(e.Value!.ToString()!);
 
     private bool SelectKeyboardJoystickDisabled => !JoystickKeyboardEnabled;
 
@@ -162,9 +166,9 @@
         {"PlaySound", "6502binaries/C64/Basic/PlaySoundVoice1TriangleScale.prg" }
     };
 
-    public string SelectedAssemblyExample { get; set; }
+    public string SelectedAssemblyExample { get; set; } = default!;
 
-    public string SelectedBasicExample { get; set; }
+    public string SelectedBasicExample { get; set; } = default!;
 
     private bool _wasRunningBeforeFileDialog = false;
 
@@ -345,7 +349,7 @@
     }
 
 
-    private async Task OnAssemblyExampleChanged(ChangeEventArgs e)
+    private void OnAssemblyExampleChanged(ChangeEventArgs e)
     {
         SelectedAssemblyExample = e.Value?.ToString() ?? "";
     }
@@ -356,7 +360,7 @@
         if (string.IsNullOrEmpty(url))
             return;
 
-        await Parent.OnPause(new());
+        Parent.OnPause(new());
 
         try
         {
@@ -383,7 +387,7 @@
         await Parent.OnStart(new());
     }
 
-    private async Task OnBasicExampleChanged(ChangeEventArgs e)
+    private void OnBasicExampleChanged(ChangeEventArgs e)
     {
         SelectedBasicExample = e.Value?.ToString() ?? "";
     }
@@ -394,7 +398,7 @@
         if (string.IsNullOrEmpty(url))
             return;
 
-        await Parent.OnPause(new());
+        Parent.OnPause(new());
 
         try
         {

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Commodore64/C64MenuHelp.razor
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Commodore64/C64MenuHelp.razor
@@ -61,9 +61,13 @@
     }
 </style>
 
+@* Fix for compiler warning CS8669 https://github.com/dotnet/razor/issues/8720 *@
+@{
+#pragma warning disable CS8669
+}
 @code {
     @inject IJSRuntime Js
-    @inject HttpClient? HttpClient
+    @inject HttpClient HttpClient
 
     private string SYSTEM_NAME = C64.SystemName;
 

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Pages/DebugSound.razor.cs
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Pages/DebugSound.razor.cs
@@ -1,9 +1,7 @@
-using System;
 using Highbyte.DotNet6502.Impl.AspNet.JSInterop;
 using Highbyte.DotNet6502.Impl.AspNet.JSInterop.BlazorWebAudioSync;
 using Highbyte.DotNet6502.Impl.AspNet.JSInterop.BlazorWebAudioSync.Options;
 using Highbyte.DotNet6502.Impl.AspNet.JSInterop.BlazorWebAudioSync.WaveTables;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Highbyte.DotNet6502.App.WASM.Pages;
 
@@ -99,7 +97,7 @@ public partial class DebugSound
         {
             Type = OscillatorType.Custom, // Not working currently 
             Frequency = _oscFrequency,
-            PeriodicWave = wave 
+            PeriodicWave = wave
         };
         _oscillator = OscillatorNodeSync.Create(Js, _audioContext, oscillatorOptions);
 

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Pages/DebugSound.razor.cs
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Pages/DebugSound.razor.cs
@@ -7,14 +7,14 @@ namespace Highbyte.DotNet6502.App.WASM.Pages;
 
 public partial class DebugSound
 {
-    private AudioContextSync _audioContext;
-    private OscillatorNodeSync? _oscillator;
-    private CustomPulseOscillatorNodeSync? _customPulseOscillator;
-    private GainNodeSync? _ampGainNode;
-    private GainNodeSync? _widthDepthGainNode;
+    private AudioContextSync _audioContext = default!;
+    private OscillatorNodeSync _oscillator = default!;
+    private CustomPulseOscillatorNodeSync _customPulseOscillator = default!;
+    private GainNodeSync _ampGainNode = default!;
+    private GainNodeSync _widthDepthGainNode = default!;
 
-    private AudioBufferSync? _noiseBuffer;
-    private AudioBufferSourceNodeSync _noiseAudioBufferSourceNode;
+    private AudioBufferSync _noiseBuffer = default!;
+    private AudioBufferSourceNodeSync _noiseAudioBufferSourceNode = default!;
 
     // Input
     private int _oscFrequency = 110;
@@ -33,7 +33,7 @@ public partial class DebugSound
 
     private float _noiseSpeed = 1.0f;
 
-    private readonly SemaphoreSlim _semaphoreSlim = new(1);
+    //private readonly SemaphoreSlim _semaphoreSlim = new(1);
 
     protected override async Task OnInitializedAsync()
     {
@@ -330,7 +330,7 @@ public partial class DebugSound
         //);
         var oscWidthDepth = 0.5f;   // LFO depth
         var oscWidthAttack = 0.05f;
-        var oscWidthDecay = 0.4f;
+        //var oscWidthDecay = 0.4f;
         var oscWidthSustain = 0.4f;
         var oscWidthRelease = 0.4f;
         var widthDepthSustainTime = currentTime + oscWidthAttack + oscWidthRelease;
@@ -455,13 +455,13 @@ public partial class DebugSound
         audioParam.LinearRampToValueAtTime(0, currentTime + 0.05);
     }
 
-    private double Frequency(int octave, int pitch)
-    {
-        var noteIndex = octave * 12 + pitch;
-        var a = Math.Pow(2, 1.0 / 12);
-        var A4 = 440;
-        var A4Index = 4 * 12 + 10;
-        var halfStepDifference = noteIndex - A4Index;
-        return A4 * Math.Pow(a, halfStepDifference);
-    }
+    //private double Frequency(int octave, int pitch)
+    //{
+    //    var noteIndex = octave * 12 + pitch;
+    //    var a = Math.Pow(2, 1.0 / 12);
+    //    var A4 = 440;
+    //    var A4Index = 4 * 12 + 10;
+    //    var halfStepDifference = noteIndex - A4Index;
+    //    return A4 * Math.Pow(a, halfStepDifference);
+    //}
 }

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Pages/DebugSound.razor.cs
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Pages/DebugSound.razor.cs
@@ -7,31 +7,31 @@ namespace Highbyte.DotNet6502.App.WASM.Pages;
 
 public partial class DebugSound
 {
-    AudioContextSync _audioContext;
-    OscillatorNodeSync? _oscillator;
-    CustomPulseOscillatorNodeSync? _customPulseOscillator;
-    GainNodeSync? _ampGainNode;
-    GainNodeSync? _widthDepthGainNode;
+    private AudioContextSync _audioContext;
+    private OscillatorNodeSync? _oscillator;
+    private CustomPulseOscillatorNodeSync? _customPulseOscillator;
+    private GainNodeSync? _ampGainNode;
+    private GainNodeSync? _widthDepthGainNode;
 
-    AudioBufferSync? _noiseBuffer;
-    AudioBufferSourceNodeSync _noiseAudioBufferSourceNode;
+    private AudioBufferSync? _noiseBuffer;
+    private AudioBufferSourceNodeSync _noiseAudioBufferSourceNode;
 
     // Input
-    int _oscFrequency = 110;
+    private int _oscFrequency = 110;
 
     //float _ampScale = 1.0f;
 
-    float _ampGain = 0.22f;
-    double _ampAttack = 0.05f;
-    double _ampDecay = 0.4f;
-    float _ampSustain = 0.4f;
-    double _ampRelease = 0.4f;
+    private float _ampGain = 0.22f;
+    private double _ampAttack = 0.05f;
+    private double _ampDecay = 0.4f;
+    private float _ampSustain = 0.4f;
+    private double _ampRelease = 0.4f;
 
-    bool _automaticRelease = true;  // Set to false to not start Release phase after decay/sustain phase is finished. Sound will play until manually stopped.
+    private bool _automaticRelease = true;  // Set to false to not start Release phase after decay/sustain phase is finished. Sound will play until manually stopped.
 
-    float _pulseWidth = 0;
+    private float _pulseWidth = 0;
 
-    float _noiseSpeed = 1.0f;
+    private float _noiseSpeed = 1.0f;
 
     private readonly SemaphoreSlim _semaphoreSlim = new(1);
 
@@ -196,7 +196,6 @@ public partial class DebugSound
         var data = Float32ArraySync.Create(_audioContext.WebAudioHelper, _audioContext.JSRuntime, values);
         _noiseBuffer.CopyToChannel(data, 0);
     }
-
 
     protected void StartSoundPulse(MouseEventArgs mouseEventArgs)
     {
@@ -380,7 +379,6 @@ public partial class DebugSound
         //if (_gainNode2 != null)
         //    StopAudio(_gainNode2 , currentTime);
     }
-
 
     /// <summary>
     /// Set Attack (duration), Decay (duration), Sustain (level), and Release (duration)

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Pages/EnterFileName.razor
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Pages/EnterFileName.razor
@@ -11,10 +11,10 @@
 
 @code {
     private FormModel _formModel = new();
-    private InputText _fileNameRef;
+    private InputText _fileNameRef = default!;
     [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; } = default!;
 
-    protected override async void OnInitialized()
+    protected override void OnInitialized()
     {
         BlazoredModal.SetTitle("Enter Basic filename to save (.prg)");
     }

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Generic/GenericConfigUI.razor
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Generic/GenericConfigUI.razor
@@ -58,9 +58,9 @@ Memory addresses
 
     [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; } = default!;
 
-    [Parameter] public ISystemConfig SystemConfig { get; set; }
+    [Parameter] public ISystemConfig SystemConfig { get; set; } = default!;
 
-    [Parameter] public IHostSystemConfig HostSystemConfig { get; set; }
+    [Parameter] public IHostSystemConfig HostSystemConfig { get; set; } = default!;
 
     public GenericComputerConfig GenericComputerConfig => (GenericComputerConfig)SystemConfig;
 

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Generic/GenericMenu.razor
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Generic/GenericMenu.razor
@@ -26,9 +26,13 @@
 
 <InputFile id="filePicker" OnChange="@OnFilePickerChange" hidden />
 
+@* Fix for compiler warning CS8669 https://github.com/dotnet/razor/issues/8720 *@
+@{
+#pragma warning disable CS8669
+}
 @code {
     @inject IJSRuntime Js
-    @inject HttpClient? HttpClient
+    @inject HttpClient HttpClient
 
     private string SYSTEM_NAME = GenericComputer.SystemName;
 
@@ -36,9 +40,9 @@
     {
     };
 
-    public string SelectedAssemblyExample { get; set; }
+    public string SelectedAssemblyExample { get; set; } = default!;
 
-    private bool _wasRunningBeforeFileDialog = false;
+    //private bool _wasRunningBeforeFileDialog = false;
 
     private async Task ShowConfigUI() => await Parent.ShowConfigUI<GenericConfigUI>();
 
@@ -98,7 +102,7 @@
         await Parent.OnStart(new());
     }
 
-    private async Task OnAssemblyExampleChanged(ChangeEventArgs e)
+    private void OnAssemblyExampleChanged(ChangeEventArgs e)
     {
         SelectedAssemblyExample = e.Value?.ToString() ?? "";
     }
@@ -109,7 +113,7 @@
         if (string.IsNullOrEmpty(url))
             return;
 
-        await Parent.OnPause(new());
+        Parent.OnPause(new());
 
         var prgBytes = await HttpClient!.GetByteArrayAsync(url);
         // Load file into memory, assume starting at address specified in two first bytes of .prg file

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Generic/GenericMenuHelp.razor
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Generic/GenericMenuHelp.razor
@@ -31,9 +31,13 @@
     }
 </style>
 
+@* Fix for compiler warning CS8669 https://github.com/dotnet/razor/issues/8720 *@
+@{
+#pragma warning disable CS8669
+}
 @code {
     @inject IJSRuntime Js
-    @inject HttpClient? HttpClient
+    @inject HttpClient HttpClient
 
     private string SYSTEM_NAME = GenericComputer.SystemName;
 

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Index.razor.cs
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Index.razor.cs
@@ -44,7 +44,6 @@ public partial class Index
     private IHostSystemConfig _currentHostSystemConfig = default!;
     public IHostSystemConfig HostSystemConfig => _currentHostSystemConfig;
 
-
     private bool AudioEnabledToggleDisabled => (
             (!(_currentSystemConfig?.AudioSupported ?? true)) ||
             (CurrentEmulatorState == EmulatorState.Running || CurrentEmulatorState == EmulatorState.Paused)
@@ -147,10 +146,10 @@ public partial class Index
 
         var c64HostConfig = new C64HostConfig();
         var c64Setup = new C64Setup(_browserContext, LoggerFactory, c64HostConfig);
-        await _systemList.AddSystem(c64Setup);
+        _systemList.AddSystem(c64Setup);
 
         var genericComputerSetup = new GenericComputerSetup(_browserContext, LoggerFactory);
-        await _systemList.AddSystem(genericComputerSetup);
+        _systemList.AddSystem(genericComputerSetup);
 
         // Add emulator config + system-specific host configs
         _emulatorConfig = new EmulatorConfig
@@ -227,7 +226,6 @@ public partial class Index
     //    }
     //}
 
-
     private async Task OnSelectedEmulatorChanged(ChangeEventArgs e)
     {
         _selectedSystemName = e.Value?.ToString() ?? "";
@@ -246,8 +244,6 @@ public partial class Index
 
         _logger.LogInformation($"System selected: {_selectedSystemName}");
     }
-
-
 
     private async void UpdateCanvasSize()
     {
@@ -678,7 +674,7 @@ public partial class Index
     private async Task FocusMonitor()
     {
         await Task.Run(async () => await _monitorInputRef.FocusAsync());    // Task.Run fix for focusing on a element that is not yet visible (but about to be)
-                                                                                   //await _monitorInputRef.FocusAsync();
+        //await _monitorInputRef.FocusAsync();
     }
 
     /// <summary>

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Index.razor.cs
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Index.razor.cs
@@ -402,7 +402,6 @@ public partial class Index
         }
     }
 
-
     private void UpdateStats(string stats)
     {
         _statsString = stats;

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Skia/BrowserContext.cs
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Skia/BrowserContext.cs
@@ -4,7 +4,7 @@ namespace Highbyte.DotNet6502.App.WASM.Skia;
 
 public class BrowserContext
 {
-    public Uri Uri { get; set; }
-    public HttpClient HttpClient { get; set; }
-    public ILocalStorageService LocalStorage { get; set; }
+    public required Uri Uri { get; set; }
+    public required HttpClient HttpClient { get; set; }
+    public required ILocalStorageService LocalStorage { get; set; }
 }

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Skia/C64Setup.cs
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Skia/C64Setup.cs
@@ -13,7 +13,6 @@ public class C64Setup : SystemConfigurer<SkiaRenderContext, AspNetInputHandlerCo
 {
     public string SystemName => C64.SystemName;
 
-
     private const string LOCAL_STORAGE_ROM_PREFIX = "rom_";
     private readonly BrowserContext _browserContext;
     private readonly ILoggerFactory _loggerFactory;

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Skia/C64Setup.cs
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Skia/C64Setup.cs
@@ -16,13 +16,13 @@ public class C64Setup : SystemConfigurer<SkiaRenderContext, AspNetInputHandlerCo
     private const string LOCAL_STORAGE_ROM_PREFIX = "rom_";
     private readonly BrowserContext _browserContext;
     private readonly ILoggerFactory _loggerFactory;
-    private readonly C64HostConfig _c64HostConfig;
+    private readonly C64HostConfig _hostConfig;
 
     public C64Setup(BrowserContext browserContext, ILoggerFactory loggerFactory, C64HostConfig c64HostConfig)
     {
         _browserContext = browserContext;
         _loggerFactory = loggerFactory;
-        _c64HostConfig = c64HostConfig;
+        _hostConfig = c64HostConfig;
     }
 
     public async Task<ISystemConfig> GetNewConfig(string configurationVariant)
@@ -62,7 +62,7 @@ public class C64Setup : SystemConfigurer<SkiaRenderContext, AspNetInputHandlerCo
 
     public Task<IHostSystemConfig> GetHostSystemConfig()
     {
-        return Task.FromResult((IHostSystemConfig)_c64HostConfig);
+        return Task.FromResult((IHostSystemConfig)_hostConfig);
     }
 
     public SystemRunner BuildSystemRunner(
@@ -75,7 +75,7 @@ public class C64Setup : SystemConfigurer<SkiaRenderContext, AspNetInputHandlerCo
         )
     {
         var renderer = new C64SkiaRenderer();
-        var inputHandler = new C64AspNetInputHandler(_loggerFactory, _c64HostConfig.InputConfig);
+        var inputHandler = new C64AspNetInputHandler(_loggerFactory, _hostConfig.InputConfig);
         var audioHandler = new C64WASMAudioHandler(_loggerFactory);
 
         var c64 = (C64)system;

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Skia/EmulatorConfig.cs
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Skia/EmulatorConfig.cs
@@ -10,10 +10,10 @@ public class EmulatorConfig
     public const int DEFAULT_CANVAS_WINDOW_WIDTH = 640;
     public const int DEFAULT_CANVAS_WINDOW_HEIGHT = 400;
 
-    public string DefaultEmulator { get; set; }
+    public required string DefaultEmulator { get; set; }
     public double DefaultDrawScale { get; set; }
     public double CurrentDrawScale { get; set; }
-    public MonitorConfig? Monitor { get; set; }
+    public required MonitorConfig Monitor { get; set; }
 
     public Dictionary<string, IHostSystemConfig> HostSystemConfigs = new();
 

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Skia/EmulatorConfig.cs
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Skia/EmulatorConfig.cs
@@ -26,7 +26,7 @@ public class EmulatorConfig
     public void Validate(SystemList<SkiaRenderContext, AspNetInputHandlerContext, WASMAudioHandlerContext> systemList)
     {
         if (!systemList.Systems.Contains(DefaultEmulator))
-            throw new Exception($"Setting {nameof(DefaultEmulator)} value {DefaultEmulator} is not supported. Valid values are: {string.Join(',', systemList.Systems)}");
+            throw new DotNet6502Exception($"Setting {nameof(DefaultEmulator)} value {DefaultEmulator} is not supported. Valid values are: {string.Join(',', systemList.Systems)}");
         Monitor.Validate();
     }
 }

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Skia/GenericComputerHostConfig.cs
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Skia/GenericComputerHostConfig.cs
@@ -1,0 +1,13 @@
+using Highbyte.DotNet6502.Systems;
+
+namespace Highbyte.DotNet6502.App.WASM.Skia
+{
+    public class GenericComputerHostConfig : IHostSystemConfig, ICloneable
+    {
+        public object Clone()
+        {
+            var clone = (GenericComputerHostConfig)MemberwiseClone();
+            return clone;
+        }
+    }
+}

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Skia/GenericComputerSetup.cs
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Skia/GenericComputerSetup.cs
@@ -19,10 +19,13 @@ public class GenericComputerSetup : SystemConfigurer<SkiaRenderContext, AspNetIn
     private readonly BrowserContext _browserContext;
     private readonly ILoggerFactory _loggerFactory;
 
-    public GenericComputerSetup(BrowserContext browserContext, ILoggerFactory loggerFactory)
+    private readonly GenericComputerHostConfig _hostConfig;
+
+    public GenericComputerSetup(BrowserContext browserContext, ILoggerFactory loggerFactory, GenericComputerHostConfig genericComputerHostConfig)
     {
         _browserContext = browserContext;
         _loggerFactory = loggerFactory;
+        _hostConfig = genericComputerHostConfig;
     }
 
     public async Task<ISystemConfig> GetNewConfig(string configurationVariant)
@@ -76,10 +79,11 @@ public class GenericComputerSetup : SystemConfigurer<SkiaRenderContext, AspNetIn
         return genericComputerConfig;
     }
 
-    public async Task PersistConfig(ISystemConfig systemConfig)
+    public Task PersistConfig(ISystemConfig systemConfig)
     {
         var genericComputerConfig = (GenericComputerConfig)systemConfig;
         // TODO: Save config settings to browser local storage
+        return Task.CompletedTask;
     }
 
     public ISystem BuildSystem(ISystemConfig systemConfig)
@@ -90,7 +94,7 @@ public class GenericComputerSetup : SystemConfigurer<SkiaRenderContext, AspNetIn
 
     public Task<IHostSystemConfig> GetHostSystemConfig()
     {
-        return Task.FromResult((IHostSystemConfig)null);
+        return Task.FromResult<IHostSystemConfig>(_hostConfig);
     }
 
     public SystemRunner BuildSystemRunner(

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Skia/WasmHost.cs
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Skia/WasmHost.cs
@@ -117,6 +117,8 @@ public class WasmHost : IDisposable
         _updateTimer?.Stop();
 
         _systemRunner.AudioHandler.PausePlaying();
+
+        _logger.LogInformation($"System stopped: {_systemName}");
     }
 
     public void Start()
@@ -137,6 +139,8 @@ public class WasmHost : IDisposable
             _updateTimer.Elapsed += UpdateTimerElapsed;
         }
         _updateTimer!.Start();
+
+        _logger.LogInformation($"System started: {_systemName}");
     }
 
     public void Cleanup()

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Skia/WasmHost.cs
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Skia/WasmHost.cs
@@ -16,15 +16,15 @@ public class WasmHost : IDisposable
 
     private PeriodicAsyncTimer? _updateTimer;
 
-    private SystemRunner _systemRunner;
+    private SystemRunner _systemRunner = default!;
     public SystemRunner SystemRunner => _systemRunner;
 
-    private SKCanvas _skCanvas;
-    private GRContext _grContext;
+    private SKCanvas _skCanvas = default!;
+    private GRContext _grContext = default!;
 
-    private SkiaRenderContext _skiaRenderContext;
-    public WASMAudioHandlerContext AudioHandlerContext { get; private set; }
-    public AspNetInputHandlerContext InputHandlerContext { get; private set; }
+    private SkiaRenderContext _skiaRenderContext = default!;
+    public WASMAudioHandlerContext AudioHandlerContext { get; private set; } = default!;
+    public AspNetInputHandlerContext InputHandlerContext { get; private set; } = default!;
 
     private readonly string _systemName;
     private readonly SystemList<SkiaRenderContext, AspNetInputHandlerContext, WASMAudioHandlerContext> _systemList;
@@ -38,7 +38,7 @@ public class WasmHost : IDisposable
     private readonly float _initialMasterVolume;
     private readonly ILogger _logger;
 
-    public WasmMonitor Monitor { get; private set; }
+    public WasmMonitor Monitor { get; private set; } = default!;
 
     private const string HostStatRootName = "WASM";
     private const string SystemTimeStatName = "Emulator-SystemTime";
@@ -309,30 +309,30 @@ public class WasmHost : IDisposable
     /// Enable / Disable emulator functions such as monitor and stats/debug
     /// </summary>
     /// <param name="e"></param>
-    public async Task OnKeyDown(KeyboardEventArgs e)
+    public void OnKeyDown(KeyboardEventArgs e)
     {
         var key = e.Key;
 
         if (key == "F11")
         {
-            await _toggleDebugStatsState();
+            _toggleDebugStatsState();
 
         }
         else if (key == "F12")
         {
-            await ToggleMonitor();
+            ToggleMonitor();
         }
     }
 
-    public async Task ToggleMonitor()
+    public void ToggleMonitor()
     {
         if (Monitor.Visible)
         {
-            await Monitor.Disable();
+            Monitor.Disable();
         }
         else
         {
-            await Monitor.Enable();
+            Monitor.Enable();
         }
     }
 

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Skia/WasmMonitor.cs
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Skia/WasmMonitor.cs
@@ -32,7 +32,7 @@ public class WasmMonitor : MonitorBase
         _setMonitorState = setMonitorState;
     }
 
-    public async Task Enable(ExecEvaluatorTriggerResult? execEvaluatorTriggerResult = null)
+    public void Enable(ExecEvaluatorTriggerResult? execEvaluatorTriggerResult = null)
     {
         if (!_hasBeenInitializedOnce)
         {
@@ -52,13 +52,13 @@ public class WasmMonitor : MonitorBase
         DisplayStatus();
 
         Visible = true;
-        await _setMonitorState(true);
+        _setMonitorState(true);
     }
 
-    public async Task Disable()
+    public void Disable()
     {
         Visible = false;
-        await _setMonitorState(false);
+        _setMonitorState(false);
     }
 
     public void OnKeyDown(KeyboardEventArgs e)
@@ -178,7 +178,7 @@ public class WasmMonitor : MonitorBase
     /// Called after Blazor InputFile component callback has uploaded the user selected local file.
     /// </summary>
     /// <param name="fileData"></param>
-    public async Task LoadBinaryFromUser(byte[] fileData)
+    public void LoadBinaryFromUser(byte[] fileData)
     {
         try
         {

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet/AspNetInputHandlerContext.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet/AspNetInputHandlerContext.cs
@@ -32,7 +32,7 @@ public class AspNetInputHandlerContext : IInputHandlerContext
         _gamepadConnectCheckTimer.Elapsed += GamepadConectCheckTimer_Elapsed;
     }
 
-    private async void GamepadConectCheckTimer_Elapsed(object sender, EventArgs args)
+    private async void GamepadConectCheckTimer_Elapsed(object? sender, EventArgs args)
     {
         await DetectConnectedGamepad();
     }
@@ -60,7 +60,7 @@ public class AspNetInputHandlerContext : IInputHandlerContext
         }
     }
 
-    private async void GamepadUpdateTimer_Elapsed(object sender, EventArgs args)
+    private void GamepadUpdateTimer_Elapsed(object? sender, EventArgs args)
     {
         try
         {

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Commodore64/Audio/C64WASMAudioHandler.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Commodore64/Audio/C64WASMAudioHandler.cs
@@ -25,7 +25,7 @@ public class C64WASMAudioHandler : IAudioHandler<C64, WASMAudioHandlerContext>
     internal WASMAudioHandlerContext AudioHandlerContext => _audioHandlerContext!;
     private AudioContextSync _audioContext => AudioHandlerContext!.AudioContext;
 
-    internal GainNodeSync? CommonSIDGainNode { get; private set; }
+    internal GainNodeSync CommonSIDGainNode { get; private set; } = default!;
 
     private readonly List<byte> _enabledVoices = new() { 1, 2, 3 }; // TODO: Set enabled voices via config.
     //private List<byte> _enabledVoices = new() { 1 }; // TODO: Set enabled voices via config.

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Commodore64/Audio/C64WASMNoiseOscillator.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Commodore64/Audio/C64WASMNoiseOscillator.cs
@@ -12,7 +12,7 @@ namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64.Audio
         private Action<string> _addDebugMessage => _c64WASMVoiceContext.AddDebugMessage;
 
         // SID noise oscillator
-        private AudioBufferSync _noiseBuffer;
+        private AudioBufferSync _noiseBuffer = default!;
         internal AudioBufferSourceNodeSync? NoiseGenerator;
 
         public C64WASMNoiseOscillator(C64WASMVoiceContext c64WASMVoiceContext)

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Commodore64/Audio/C64WASMNoiseOscillator.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Commodore64/Audio/C64WASMNoiseOscillator.cs
@@ -39,7 +39,7 @@ namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64.Audio
         internal void Start()
         {
             if (NoiseGenerator == null)
-                throw new Exception($"NoiseGenerator is null. Call Create() first.");
+                throw new DotNet6502Exception($"NoiseGenerator is null. Call Create() first.");
             _addDebugMessage($"Starting NoiseGenerator");
             NoiseGenerator!.Start();
             //voiceContext!.NoiseGenerator.Start(0, 0, currentTime + wasmVoiceParameter.AttackDurationSeconds + wasmVoiceParameter.ReleaseDurationSeconds);
@@ -57,7 +57,7 @@ namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64.Audio
         internal void StopLater(double when)
         {
             if (NoiseGenerator == null)
-                throw new Exception($"NoiseGenerator is null. Call Create() first.");
+                throw new DotNet6502Exception($"NoiseGenerator is null. Call Create() first.");
             _addDebugMessage($"Planning stopp of NoiseGenerator: {when}");
             NoiseGenerator!.Stop(when);
         }
@@ -65,7 +65,7 @@ namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64.Audio
         internal void Connect()
         {
             if (NoiseGenerator == null)
-                throw new Exception($"NoiseGenerator is null. Call Create() first.");
+                throw new DotNet6502Exception($"NoiseGenerator is null. Call Create() first.");
             NoiseGenerator!.Connect(_c64WASMVoiceContext.GainNode!);
         }
 

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Commodore64/Audio/C64WASMPulseOscillator.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Commodore64/Audio/C64WASMPulseOscillator.cs
@@ -67,7 +67,7 @@ namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64.Audio
         internal void Start()
         {
             if (PulseOscillator == null)
-                throw new Exception($"PulseOscillator is null. Call CreatePulseOscillator() first.");
+                throw new DotNet6502Exception($"PulseOscillator is null. Call CreatePulseOscillator() first.");
             _addDebugMessage($"Starting PulseOscillator and LFOOscillator");
             PulseOscillator!.Start();
             LFOOscillator!.Start();
@@ -89,7 +89,7 @@ namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64.Audio
         internal void StopLater(double when)
         {
             if (PulseOscillator == null)
-                throw new Exception($"PulseOscillator is null. Call Create() first.");
+                throw new DotNet6502Exception($"PulseOscillator is null. Call Create() first.");
             _addDebugMessage($"Planning stopp of PulseOscillator and LFOOscillator: {when}");
             PulseOscillator!.Stop(when);
             LFOOscillator!.Stop(when);
@@ -99,7 +99,7 @@ namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64.Audio
         internal void Connect()
         {
             if (PulseOscillator == null)
-                throw new Exception($"PulseOscillator is null. Call Create() first.");
+                throw new DotNet6502Exception($"PulseOscillator is null. Call Create() first.");
             PulseOscillator!.Connect(_c64WASMVoiceContext.GainNode!);
         }
 

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Commodore64/Audio/C64WASMSawToothOscillator.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Commodore64/Audio/C64WASMSawToothOscillator.cs
@@ -35,7 +35,7 @@ namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64.Audio
         internal void Start()
         {
             if (SawToothOscillator == null)
-                throw new Exception($"SawToothOscillator is null. Call Create() first.");
+                throw new DotNet6502Exception($"SawToothOscillator is null. Call Create() first.");
             _addDebugMessage($"Starting SawToothOscillator");
             SawToothOscillator!.Start();
         }
@@ -52,7 +52,7 @@ namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64.Audio
         internal void StopLater(double when)
         {
             if (SawToothOscillator == null)
-                throw new Exception($"SawToothOscillator is null. Call Create() first.");
+                throw new DotNet6502Exception($"SawToothOscillator is null. Call Create() first.");
             _addDebugMessage($"Planning stopp of SawToothOscillator: {when}");
             SawToothOscillator!.Stop(when);
         }
@@ -60,7 +60,7 @@ namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64.Audio
         internal void Connect()
         {
             if (SawToothOscillator == null)
-                throw new Exception($"SawToothOscillator is null. Call Create() first.");
+                throw new DotNet6502Exception($"SawToothOscillator is null. Call Create() first.");
             SawToothOscillator!.Connect(_c64WASMVoiceContext.GainNode!);
         }
 

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Commodore64/Audio/C64WASMTriangleOscillator.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Commodore64/Audio/C64WASMTriangleOscillator.cs
@@ -43,7 +43,7 @@ namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64.Audio
         internal void StopLater(double when)
         {
             if (TriangleOscillator == null)
-                throw new Exception($"TriangleOscillator is null. Call Create() first.");
+                throw new DotNet6502Exception($"TriangleOscillator is null. Call Create() first.");
             _addDebugMessage($"Planning stopp of TriangleOscillator: {when}");
             TriangleOscillator!.Stop(when);
         }
@@ -51,7 +51,7 @@ namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64.Audio
         internal void Start()
         {
             if (TriangleOscillator == null)
-                throw new Exception($"TriangleOscillator is null. Call Create() first.");
+                throw new DotNet6502Exception($"TriangleOscillator is null. Call Create() first.");
             _addDebugMessage($"Starting TriangleOscillator");
             TriangleOscillator!.Start();
         }
@@ -59,7 +59,7 @@ namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64.Audio
         internal void Connect()
         {
             if (TriangleOscillator == null)
-                throw new Exception($"TriangleOscillator is null. Call Create() first.");
+                throw new DotNet6502Exception($"TriangleOscillator is null. Call Create() first.");
             TriangleOscillator!.Connect(_c64WASMVoiceContext.GainNode!);
         }
 

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Commodore64/Audio/C64WASMVoiceContext.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Commodore64/Audio/C64WASMVoiceContext.cs
@@ -7,13 +7,13 @@ namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64.Audio
     public class C64WASMVoiceContext
     {
 
-        private C64WASMAudioHandler _audioHandler;
+        private C64WASMAudioHandler _audioHandler = default!;
         internal GainNodeSync? GainNode { get; private set; }
 
         internal WASMAudioHandlerContext AudioHandlerContext => _audioHandler.AudioHandlerContext!;
         private AudioContextSync _audioContext => AudioHandlerContext.AudioContext;
 
-        private Action<string, int?, SidVoiceWaveForm?, AudioVoiceStatus?> _addDebugMessage;
+        private Action<string, int?, SidVoiceWaveForm?, AudioVoiceStatus?> _addDebugMessage = default!;
 
         internal void AddDebugMessage(string msg)
         {
@@ -26,21 +26,23 @@ namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64.Audio
         public SidVoiceWaveForm CurrentSidVoiceWaveForm = SidVoiceWaveForm.None;
 
         // SID Triangle Oscillator
-        public C64WASMTriangleOscillator C64WASMTriangleOscillator { get; private set; }
+        public C64WASMTriangleOscillator C64WASMTriangleOscillator { get; private set; } = default!;
 
         // SID Sawtooth Oscillator
-        public C64WASMSawToothOscillator C64WASMSawToothOscillator { get; private set; }
+        public C64WASMSawToothOscillator C64WASMSawToothOscillator { get; private set; } = default!;
 
         // SID pulse oscillator
-        public C64WASMPulseOscillator C64WASMPulseOscillator { get; private set; }
+        public C64WASMPulseOscillator C64WASMPulseOscillator { get; private set; } = default!;
 
         // SID noise oscillator
-        public C64WASMNoiseOscillator C64WASMNoiseOscillator { get; private set; }
+        public C64WASMNoiseOscillator C64WASMNoiseOscillator { get; private set; } = default!;
 
-        private EventListener<EventSync> _audioStoppedCallback;
+        private EventListener<EventSync> _audioStoppedCallback = default!;
 
-        private Timer _adsCycleCompleteTimer;
-        private Timer _releaseCycleCompleteTimer;
+#pragma warning disable IDE0052 // Remove unread private members
+        private Timer _adsCycleCompleteTimer = default!;
+        private Timer _releaseCycleCompleteTimer = default!;
+#pragma warning restore IDE0052 // Remove unread private members
 
         //private readonly SemaphoreSlim _semaphoreSlim = new(1);
         //public SemaphoreSlim SemaphoreSlim => _semaphoreSlim;
@@ -444,8 +446,10 @@ namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64.Audio
             SetGainRelease(audioVoiceParameter, currentTime);
 
             if (_audioHandler.StopAndRecreateOscillator)
+            {
                 // Plan oscillator built-in delayed stop with callback
                 StopOscillatorLater(CurrentSidVoiceWaveForm, currentTime + audioVoiceParameter.ReleaseDurationSeconds);
+            }
             else
             {
                 // Plan manual callback after release duration (as we don't stop the oscillator in this scenario, as it cannot be started again)

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Commodore64/Input/C64AspNetInputHandler.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet/Commodore64/Input/C64AspNetInputHandler.cs
@@ -10,8 +10,8 @@ namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64.Input;
 public class C64AspNetInputHandler : IInputHandler<C64, AspNetInputHandlerContext>
 {
     private AspNetInputHandlerContext? _inputHandlerContext = default!;
-    private ILogger<C64AspNetInputHandler> _logger;
-    private C64AspNetKeyboard _c64AspNetKeyboard;
+    private readonly ILogger<C64AspNetInputHandler> _logger;
+    private C64AspNetKeyboard _c64AspNetKeyboard = default!;
     private readonly C64AspNetConfig _c64AspNetConfig;
 
     // Instrumentations
@@ -154,7 +154,6 @@ public class C64AspNetInputHandler : IInputHandler<C64, AspNetInputHandlerContex
         }
         return c64JoystickActions;
     }
-
 
     public List<string> GetDebugInfo()
     {

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet/JSInterop/BlazorDOMSync/EventListener.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet/JSInterop/BlazorDOMSync/EventListener.cs
@@ -23,7 +23,6 @@ public class EventListener<TEvent> : BaseJSWrapperSync where TEvent : EventSync,
         return eventListener;
     }
 
-
     protected EventListener(IJSInProcessObjectReference helper, IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference)
         : base(helper, jSRuntime, jSReference)
     {

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet/JSInterop/BlazorDOMSync/EventSync.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet/JSInterop/BlazorDOMSync/EventSync.cs
@@ -22,7 +22,7 @@ public class EventSync : BaseJSWrapperSync, IJSWrapperSync<EventSync>, IJSWrappe
             jSRuntime,
             helper.Invoke<IJSInProcessObjectReference>(
                 "constructEvent",
-                new object[2] { type, eventInitDict }));
+                new object[2] { type, eventInitDict! }));
     }
 
     protected EventSync(IJSInProcessObjectReference helper, IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference)

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet/JSInterop/BlazorWebAudioSync/AudioBufferSourceNodeSync.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet/JSInterop/BlazorWebAudioSync/AudioBufferSourceNodeSync.cs
@@ -5,7 +5,7 @@ namespace Highbyte.DotNet6502.Impl.AspNet.JSInterop.BlazorWebAudioSync;
 
 public class AudioBufferSourceNodeSync : AudioScheduledSourceNodeSync
 {
-    public static AudioBufferSourceNodeSync Create(IJSRuntime jSRuntime, BaseAudioContextSync context, AudioBufferSourceNodeOptions options = null)
+    public static AudioBufferSourceNodeSync Create(IJSRuntime jSRuntime, BaseAudioContextSync context, AudioBufferSourceNodeOptions options)
     {
         var helper = context.WebAudioHelper;
 

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet/JSInterop/BlazorWebAudioSync/AudioDestinationNodeSync.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet/JSInterop/BlazorWebAudioSync/AudioDestinationNodeSync.cs
@@ -9,7 +9,7 @@ namespace Highbyte.DotNet6502.Impl.AspNet.JSInterop.BlazorWebAudioSync;
 
 public class AudioDestinationNodeSync : AudioNodeSync
 {
-    public static AudioDestinationNodeSync Create(IJSInProcessObjectReference helper, IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference)
+    public static new AudioDestinationNodeSync Create(IJSInProcessObjectReference helper, IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference)
     {
         return new AudioDestinationNodeSync(helper, jSRuntime, jSReference);
     }

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet/JSInterop/BlazorWebAudioSync/AudioNodeSync.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet/JSInterop/BlazorWebAudioSync/AudioNodeSync.cs
@@ -12,7 +12,7 @@ public class AudioNodeSync : EventTargetSync
 {
     protected IJSInProcessObjectReference WebAudioHelper => _helper;
 
-    public static AudioNodeSync Create(IJSInProcessObjectReference helper, IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference)
+    public static new AudioNodeSync Create(IJSInProcessObjectReference helper, IJSRuntime jSRuntime, IJSInProcessObjectReference jSReference)
     {
         return new AudioNodeSync(helper, jSRuntime, jSReference);
     }

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet/JSInterop/BlazorWebAudioSync/CustomPulseOscillatorNodeSync.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet/JSInterop/BlazorWebAudioSync/CustomPulseOscillatorNodeSync.cs
@@ -14,9 +14,9 @@ public class CustomPulseOscillatorNodeSync : AudioScheduledSourceNodeSync
     private static Float32ArraySync? s_pulseCurve;
     private static Float32ArraySync? s_constantOneCurve;
 
-    private WaveShaperNodeSync _pulseShaper;
+    private WaveShaperNodeSync _pulseShaper = default!;
 
-    public GainNodeSync WidthGainNode { get; private set; }
+    public GainNodeSync WidthGainNode { get; private set; } = default!;
 
     public static CustomPulseOscillatorNodeSync Create(
         IJSRuntime jSRuntime,

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet/WASMAudioHandlerContext.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet/WASMAudioHandlerContext.cs
@@ -14,7 +14,7 @@ namespace Highbyte.DotNet6502.Impl.AspNet
 
         public IJSRuntime JSRuntime => _jsRuntime;
 
-        private GainNodeSync _masterVolumeGainNode;
+        private GainNodeSync _masterVolumeGainNode = default!;
         internal GainNodeSync MasterVolumeGainNode => _masterVolumeGainNode;
 
         public WASMAudioHandlerContext(

--- a/src/libraries/Highbyte.DotNet6502.Impl.NAudio/Commodore64/Audio/C64NAudioVoiceContext.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.NAudio/Commodore64/Audio/C64NAudioVoiceContext.cs
@@ -48,8 +48,8 @@ namespace Highbyte.DotNet6502.Impl.NAudio.Commodore64.Audio
 
         //private EventListener<EventSync> _audioStoppedCallback;
 
-        private readonly Timer _adsCycleCompleteTimer = default!;
-        private readonly Timer _releaseCycleCompleteTimer = default!;
+        //private readonly Timer _adsCycleCompleteTimer = default!;
+        //private readonly Timer _releaseCycleCompleteTimer = default!;
 
         //private readonly SemaphoreSlim _semaphoreSlim = new(1);
         //public SemaphoreSlim SemaphoreSlim => _semaphoreSlim;

--- a/src/libraries/Highbyte.DotNet6502.Impl.NAudio/NAudioAudioHandlerContext.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.NAudio/NAudioAudioHandlerContext.cs
@@ -7,7 +7,7 @@ namespace Highbyte.DotNet6502.Impl.NAudio
     public class NAudioAudioHandlerContext : IAudioHandlerContext
     {
         private readonly IWavePlayer _wavePlayer;
-        private VolumeSampleProvider _masterVolumeControl;
+        private VolumeSampleProvider _masterVolumeControl = default!;
 
         private float _initialVolumePercent;
 
@@ -48,7 +48,7 @@ namespace Highbyte.DotNet6502.Impl.NAudio
 
         public void StopWavePlayer()
         {
-            if(_wavePlayer.PlaybackState != PlaybackState.Stopped)
+            if (_wavePlayer.PlaybackState != PlaybackState.Stopped)
                 _wavePlayer.Stop();
         }
 

--- a/src/libraries/Highbyte.DotNet6502.Impl.NAudio/NAudioOpenALProvider/SilkNetOpenALWavePlayer.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.NAudio/NAudioOpenALProvider/SilkNetOpenALWavePlayer.cs
@@ -348,46 +348,46 @@ public class SilkNetOpenALWavePlayer : IWavePlayer
         GC.SuppressFinalize(this);
     }
 
-    private BufferFormat TranslateFormat(WaveFormat format)
-    {
-        if (format.Channels == 2)
-        {
-            //if (format.BitsPerSample == 32)
-            //{
-            //    //return ALFormat.StereoFloat32Ext;
-            //}
-            if (format.BitsPerSample == 16)
-            {
-                //return ALFormat.Stereo16;
-                return BufferFormat.Stereo16;
-            }
-            else if (format.BitsPerSample == 8)
-            {
-                //return ALFormat.Stereo16;
-                return BufferFormat.Stereo8;
-            }
-        }
-        else if (format.Channels == 1)
-        {
-            //if (format.BitsPerSample == 32)
-            //{
-            //    //return ALFormat.MonoFloat32Ext;
-            //}
-            if (format.BitsPerSample == 16)
-            {
-                //return ALFormat.Mono16;
-                return BufferFormat.Mono16;
-            }
-            else if (format.BitsPerSample == 8)
-            {
-                //return ALFormat.Mono8;
-                return BufferFormat.Mono8;
+    //private BufferFormat TranslateFormat(WaveFormat format)
+    //{
+    //    if (format.Channels == 2)
+    //    {
+    //        //if (format.BitsPerSample == 32)
+    //        //{
+    //        //    //return ALFormat.StereoFloat32Ext;
+    //        //}
+    //        if (format.BitsPerSample == 16)
+    //        {
+    //            //return ALFormat.Stereo16;
+    //            return BufferFormat.Stereo16;
+    //        }
+    //        else if (format.BitsPerSample == 8)
+    //        {
+    //            //return ALFormat.Stereo16;
+    //            return BufferFormat.Stereo8;
+    //        }
+    //    }
+    //    else if (format.Channels == 1)
+    //    {
+    //        //if (format.BitsPerSample == 32)
+    //        //{
+    //        //    //return ALFormat.MonoFloat32Ext;
+    //        //}
+    //        if (format.BitsPerSample == 16)
+    //        {
+    //            //return ALFormat.Mono16;
+    //            return BufferFormat.Mono16;
+    //        }
+    //        else if (format.BitsPerSample == 8)
+    //        {
+    //            //return ALFormat.Mono8;
+    //            return BufferFormat.Mono8;
 
-            }
-        }
+    //        }
+    //    }
 
-        throw new FormatException("Cannot translate WaveFormat.");
-    }
+    //    throw new FormatException("Cannot translate WaveFormat.");
+    //}
 
     private FloatBufferFormat BufferFormatFloat32(WaveFormat format)
     {

--- a/src/libraries/Highbyte.DotNet6502.Impl.SadConsole/EmulatorHost.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SadConsole/EmulatorHost.cs
@@ -53,11 +53,11 @@ public class EmulatorHost
                 break;
 
             default:
-                throw new Exception($"Unknown emulator name: {_sadConsoleConfig.Emulator}");
+                throw new DotNet6502Exception($"Unknown emulator name: {_sadConsoleConfig.Emulator}");
         }
 
         if (systemRunner.System.Screen is not ITextMode)
-            throw new Exception("SadConsole host only supports running emulator systems that supports text mode.");
+            throw new DotNet6502Exception("SadConsole host only supports running emulator systems that supports text mode.");
 
         // Create the main SadConsole class that is responsible for configuring and starting up SadConsole and running the emulator code every frame with our preferred configuration.
         s_sadConsoleMain = new SadConsoleMain(

--- a/src/libraries/Highbyte.DotNet6502.Impl.SadConsole/EmulatorHost.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SadConsole/EmulatorHost.cs
@@ -7,7 +7,6 @@ using Highbyte.DotNet6502.Impl.SadConsole.Generic.Video;
 using Highbyte.DotNet6502.Impl.SadConsole.Generic.Input;
 using Highbyte.DotNet6502.Impl.SadConsole.Commodore64.Video;
 using Highbyte.DotNet6502.Impl.SadConsole.Commodore64.Input;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging;
 
 namespace Highbyte.DotNet6502.Impl.SadConsole;
@@ -19,7 +18,6 @@ public class EmulatorHost
     private readonly C64Config _c64Config;
     private static SadConsoleMain s_sadConsoleMain = default!;
     private readonly ILoggerFactory _loggerFactory;
-
 
     public EmulatorHost(
         SadConsoleConfig sadConsoleConfig,

--- a/src/libraries/Highbyte.DotNet6502.Impl.SadConsole/Generic/Video/GenericSadConsoleRenderer.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SadConsole/Generic/Video/GenericSadConsoleRenderer.cs
@@ -7,7 +7,7 @@ namespace Highbyte.DotNet6502.Impl.SadConsole.Generic.Video;
 
 public class GenericSadConsoleRenderer : IRenderer<GenericComputer, SadConsoleRenderContext>
 {
-    private SadConsoleRenderContext _sadConsoleRenderContext;
+    private SadConsoleRenderContext _sadConsoleRenderContext = default!;
 
     private readonly EmulatorScreenConfig _emulatorScreenConfig;
 
@@ -148,7 +148,9 @@ public class GenericSadConsoleRenderer : IRenderer<GenericComputer, SadConsoleRe
 
         byte sadConsoleCharacter;
         if (_emulatorScreenConfig.UseAscIICharacters)
+        {
             sadConsoleCharacter = emulatorCharacter;
+        }
         else
         {
             var dictKey = emulatorCharacter.ToString();

--- a/src/libraries/Highbyte.DotNet6502.Impl.SadConsole/Generic/Video/GenericSadConsoleRenderer.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SadConsole/Generic/Video/GenericSadConsoleRenderer.cs
@@ -142,9 +142,9 @@ public class GenericSadConsoleRenderer : IRenderer<GenericComputer, SadConsoleRe
         }
 
         if (!_emulatorScreenConfig.ColorMap.ContainsKey(emulatorFgColor))
-            throw new Exception($"Color value (foreground) {emulatorFgColor} is not mapped.");
+            throw new DotNet6502Exception($"Color value (foreground) {emulatorFgColor} is not mapped.");
         if (!_emulatorScreenConfig.ColorMap.ContainsKey(emulatorBgColor))
-            throw new Exception($"Color value (background) {emulatorBgColor} is not mapped.");
+            throw new DotNet6502Exception($"Color value (background) {emulatorBgColor} is not mapped.");
 
         byte sadConsoleCharacter;
         if (_emulatorScreenConfig.UseAscIICharacters)

--- a/src/libraries/Highbyte.DotNet6502.Impl.SadConsole/SadConsoleConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SadConsole/SadConsoleConfig.cs
@@ -12,7 +12,7 @@ public class SadConsoleConfig
     /// Example: Fonts/C64.font
     /// </summary>
     /// <value></value>
-    public string Font { get; set; }
+    public string? Font { get; set; }
     /// <summary>
     /// Font scale. 1 is default.
     /// </summary>

--- a/src/libraries/Highbyte.DotNet6502.Impl.SadConsole/SadConsoleMain.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SadConsole/SadConsoleMain.cs
@@ -5,7 +5,7 @@ namespace Highbyte.DotNet6502.Impl.SadConsole;
 public class SadConsoleMain
 {
     private readonly SadConsoleConfig _sadConsoleConfig;
-    private SadConsoleScreenObject _sadConsoleScreen;
+    private SadConsoleScreenObject _sadConsoleScreen = default!;
     public SadConsoleScreenObject SadConsoleScreen => _sadConsoleScreen;
 
     private readonly SystemRunner _systemRunner;
@@ -25,7 +25,8 @@ public class SadConsoleMain
         // Setup the SadConsole engine and create the main window. 
         // If font is null or empty, the default SadConsole font will be used.
         var screen = _systemRunner.System.Screen;
-        var textMode = screen as ITextMode;
+        if (screen is not ITextMode textMode)
+            throw new DotNet6502Exception("SadConsoleMain only supports system that implements ITextMode of Screen.");
 
         // int totalCols = (textMode.TextCols + (textMode.BorderCols * 2));
         // int totalRows = (textMode.TextRows + (textMode.BorderRows * 2));
@@ -65,7 +66,9 @@ public class SadConsoleMain
     {
         // Create a SadConsole screen
         var screen = _systemRunner.System.Screen;
-        var textMode = screen as ITextMode;
+        if (screen is not ITextMode textMode)
+            throw new DotNet6502Exception("SadConsoleMain only supports system that implements ITextMode of Screen.");
+
         _sadConsoleScreen = new SadConsoleScreenObject(textMode, screen, _sadConsoleConfig);
 
         global::SadConsole.Game.Instance.Screen = _sadConsoleScreen;
@@ -81,7 +84,7 @@ public class SadConsoleMain
     /// Responsible for letting the SadConsole engine interact with the emulator
     /// </summary>
     /// <param name="gameTime"></param>
-    private void UpdateSadConsole(object sender, GameHost e)
+    private void UpdateSadConsole(object? sender, GameHost e)
     {
         // Capture SadConsole input
         _systemRunner.ProcessInput();

--- a/src/libraries/Highbyte.DotNet6502.Impl.SilkNet/Commodore64/Video/C64SilkNetOpenGlRenderer.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SilkNet/Commodore64/Video/C64SilkNetOpenGlRenderer.cs
@@ -1,8 +1,6 @@
 using System.Numerics;
 using Highbyte.DotNet6502.Impl.SilkNet.OpenGLHelpers;
 using Highbyte.DotNet6502.Instrumentation;
-using Highbyte.DotNet6502.Instrumentation.Stats;
-using Highbyte.DotNet6502.Monitor;
 using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Commodore64;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
@@ -15,7 +13,7 @@ namespace Highbyte.DotNet6502.Impl.SilkNet.Commodore64.Video;
 public class C64SilkNetOpenGlRenderer : IRenderer<C64, SilkNetOpenGlRenderContext>, IDisposable
 {
 
-    private SilkNetOpenGlRenderContext _silkNetOpenGlRenderContext;
+    private SilkNetOpenGlRenderContext _silkNetOpenGlRenderContext = default!;
     private GL _gl => _silkNetOpenGlRenderContext.Gl;
 
     private bool _changedAllCharsetCodes = false;
@@ -111,18 +109,18 @@ public class C64SilkNetOpenGlRenderer : IRenderer<C64, SilkNetOpenGlRenderContex
         public uint ____;     // unused  
     }
 
-    private BufferObject<float> _vbo;
-    private VertexArrayObject<float, int> _vba;
+    private BufferObject<float> _vbo = default!;
+    private VertexArrayObject<float, int> _vba = default!;
 
-    private OpenGLHelpers.Shader _shader;
+    private OpenGLHelpers.Shader _shader = default!;
 
-    private BufferObject<TextData> _uboTextData;
-    private BufferObject<CharsetData> _uboCharsetData;
-    private BufferObject<BitmapData> _uboBitmapData;
-    private BufferObject<ColorMapData> _uboColorMapData;
-    private BufferObject<ScreenLineData> _uboScreenLineData;
-    private BufferObject<SpriteData> _uboSpriteData;
-    private BufferObject<SpriteContentData> _uboSpriteContentData;
+    private BufferObject<TextData> _uboTextData = default!;
+    private BufferObject<CharsetData> _uboCharsetData = default!;
+    private BufferObject<BitmapData> _uboBitmapData = default!;
+    private BufferObject<ColorMapData> _uboColorMapData = default!;
+    private BufferObject<ScreenLineData> _uboScreenLineData = default!;
+    private BufferObject<SpriteData> _uboSpriteData = default!;
+    private BufferObject<SpriteContentData> _uboSpriteContentData = default!;
     private readonly C64SilkNetOpenGlRendererConfig _config;
 
     public C64SilkNetOpenGlRenderer(C64SilkNetOpenGlRendererConfig config)
@@ -149,7 +147,6 @@ public class C64SilkNetOpenGlRenderer : IRenderer<C64, SilkNetOpenGlRenderContex
         _gl.GetInteger(GLEnum.MaxGeometryUniformComponents, out int maxGeometryUniformComponents); // 2048
         _gl.GetInteger(GLEnum.MaxFragmentUniformComponents, out int maxFragmentUniformComponents); // 4096
 #endif
-
 
         // Two triangles that covers entire screen
         float[] vertices =
@@ -182,7 +179,6 @@ public class C64SilkNetOpenGlRenderer : IRenderer<C64, SilkNetOpenGlRenderContex
         // Define bitmap & create Uniform Buffer Object for fragment shader
         var bitmapData = BuildBitmapData(c64);
         _uboBitmapData = new BufferObject<BitmapData>(_gl, bitmapData, BufferTargetARB.UniformBuffer, BufferUsageARB.StaticDraw);
-
 
         // Screen line data Uniform Buffer Object for fragment shader
         var screenLineData = new ScreenLineData[c64.Vic2.Vic2Screen.VisibleHeight];
@@ -248,7 +244,6 @@ public class C64SilkNetOpenGlRenderer : IRenderer<C64, SilkNetOpenGlRenderContex
         //_gl.Enable(EnableCap.DepthTest);
         //_gl.Clear((uint)(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit));
         _gl.Clear((uint)(ClearBufferMask.ColorBufferBit));
-
 
         // Update shader uniform buffers that needs to be updated
 
@@ -427,7 +422,9 @@ public class C64SilkNetOpenGlRenderer : IRenderer<C64, SilkNetOpenGlRenderContex
     private void CharsetChangedHandler(C64 c64, Vic2CharsetManager.CharsetAddressChangedEventArgs e)
     {
         if (e.ChangeType == Vic2CharsetManager.CharsetAddressChangedEventArgs.CharsetChangeType.CharacterSetBaseAddress)
+        {
             _changedAllCharsetCodes = true;
+        }
         else if (e.ChangeType == Vic2CharsetManager.CharsetAddressChangedEventArgs.CharsetChangeType.CharacterSetCharacter && e.CharCode.HasValue)
         {
             // Updating individual characters in the UBO array probably take longer time than just updating the entire array.

--- a/src/libraries/Highbyte.DotNet6502.Impl.SilkNet/OpenGLHelpers/Shader.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SilkNet/OpenGLHelpers/Shader.cs
@@ -39,7 +39,7 @@ namespace Highbyte.DotNet6502.Impl.SilkNet.OpenGLHelpers
             _gl.LinkProgram(_programHandle);
             _gl.GetProgram(_programHandle, GLEnum.LinkStatus, out var status);
             if (status == 0)
-                throw new Exception($"Program failed to link with error: {_gl.GetProgramInfoLog(_programHandle)}");
+                throw new DotNet6502Exception($"Program failed to link with error: {_gl.GetProgramInfoLog(_programHandle)}");
 
             if (vertexShaderHandle != null)
             {
@@ -67,7 +67,7 @@ namespace Highbyte.DotNet6502.Impl.SilkNet.OpenGLHelpers
         {
             var location = _gl.GetUniformLocation(_programHandle, name);
             if (!skipExistCheck && location == -1)
-                throw new Exception($"{name} uniform not found on shader.");
+                throw new DotNet6502Exception($"{name} uniform not found on shader.");
             _gl.Uniform1(location, value);
         }
 
@@ -75,7 +75,7 @@ namespace Highbyte.DotNet6502.Impl.SilkNet.OpenGLHelpers
         {
             var location = _gl.GetUniformLocation(_programHandle, name);
             if (!skipExistCheck && location == -1)
-                throw new Exception($"{name} uniform not found on shader.");
+                throw new DotNet6502Exception($"{name} uniform not found on shader.");
             _gl.Uniform1(location, value);
         }
 
@@ -83,7 +83,7 @@ namespace Highbyte.DotNet6502.Impl.SilkNet.OpenGLHelpers
         {
             var location = _gl.GetUniformLocation(_programHandle, name);
             if (!skipExistCheck && location == -1)
-                throw new Exception($"{name} uniform not found on shader.");
+                throw new DotNet6502Exception($"{name} uniform not found on shader.");
             _gl.Uniform1(location, value ? 1 : 0);
         }
 
@@ -92,7 +92,7 @@ namespace Highbyte.DotNet6502.Impl.SilkNet.OpenGLHelpers
             //A new overload has been created for setting a uniform so we can use the transform in our shader.
             var location = _gl.GetUniformLocation(_programHandle, name);
             if (!skipExistCheck && location == -1)
-                throw new Exception($"{name} uniform not found on shader.");
+                throw new DotNet6502Exception($"{name} uniform not found on shader.");
             _gl.UniformMatrix4(location, 1, false, (float*)&value);
         }
 
@@ -101,7 +101,7 @@ namespace Highbyte.DotNet6502.Impl.SilkNet.OpenGLHelpers
             //A new overload has been created for setting a uniform so we can use the transform in our shader.
             var location = _gl.GetUniformLocation(_programHandle, name);
             if (!skipExistCheck && location == -1)
-                throw new Exception($"{name} uniform not found on shader.");
+                throw new DotNet6502Exception($"{name} uniform not found on shader.");
             _gl.Uniform4(location, value.X, value.Y, value.Z, value.W);
         }
 
@@ -110,7 +110,7 @@ namespace Highbyte.DotNet6502.Impl.SilkNet.OpenGLHelpers
             //A new overload has been created for setting a uniform so we can use the transform in our shader.
             var location = _gl.GetUniformLocation(_programHandle, name);
             if (!skipExistCheck && location == -1)
-                throw new Exception($"{name} uniform not found on shader.");
+                throw new DotNet6502Exception($"{name} uniform not found on shader.");
             _gl.Uniform3(location, value.X, value.Y, value.Z);
         }
 
@@ -119,7 +119,7 @@ namespace Highbyte.DotNet6502.Impl.SilkNet.OpenGLHelpers
             //A new overload has been created for setting a uniform so we can use the transform in our shader.
             var location = _gl.GetUniformLocation(_programHandle, name);
             if (!skipExistCheck && location == -1)
-                throw new Exception($"{name} uniform not found on shader.");
+                throw new DotNet6502Exception($"{name} uniform not found on shader.");
             _gl.Uniform2(location, value.X, value.Y);
         }
 
@@ -127,7 +127,7 @@ namespace Highbyte.DotNet6502.Impl.SilkNet.OpenGLHelpers
         {
             var location = _gl.GetUniformLocation(_programHandle, name);
             if (location == -1)
-                throw new Exception($"{name} uniform not found on shader.");
+                throw new DotNet6502Exception($"{name} uniform not found on shader.");
             _gl.Uniform1(location, value);
         }
 
@@ -168,7 +168,7 @@ namespace Highbyte.DotNet6502.Impl.SilkNet.OpenGLHelpers
             _gl.CompileShader(handle);
             var infoLog = _gl.GetShaderInfoLog(handle);
             if (!string.IsNullOrWhiteSpace(infoLog))
-                throw new Exception($"Error compiling shader of type {type}, failed with error {infoLog}");
+                throw new DotNet6502Exception($"Error compiling shader of type {type}, failed with error {infoLog}");
 
             return handle;
         }

--- a/src/libraries/Highbyte.DotNet6502.Impl.SilkNet/SilkNetInputHandlerContext.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SilkNet/SilkNetInputHandlerContext.cs
@@ -1,8 +1,6 @@
-using System.Linq;
 using System.Runtime.InteropServices;
 using Highbyte.DotNet6502.Systems;
 using Microsoft.Extensions.Logging;
-using Silk.NET.Input;
 using Silk.NET.SDL;
 
 namespace Highbyte.DotNet6502.Impl.SilkNet;
@@ -11,11 +9,11 @@ public class SilkNetInputHandlerContext : IInputHandlerContext
 {
     private readonly IWindow _silkNetWindow;
     private readonly ILogger<SilkNetInputHandlerContext> _logger;
-    private static IInputContext s_inputcontext;
+    private static IInputContext s_inputcontext = default!;
     public IInputContext InputContext => s_inputcontext;
 
     // Keyboard
-    private IKeyboard _primaryKeyboard;
+    private IKeyboard _primaryKeyboard = default!;
     public IKeyboard PrimaryKeyboard => _primaryKeyboard;
     public HashSet<Key> KeysDown = new();
     private bool _capsLockKeyDownCaptured;
@@ -64,7 +62,6 @@ public class SilkNetInputHandlerContext : IInputHandlerContext
         {
             _logger.LogInformation("No gamepads found.");
         }
-
     }
 
     private void ConnectionChanged(IInputDevice device, bool isConnected)
@@ -121,15 +118,15 @@ public class SilkNetInputHandlerContext : IInputHandlerContext
         //_currentGamePad.TriggerMoved += GamepadTriggerMoved;
     }
 
-    private void GamepadTriggerMoved(IGamepad gamepad, Trigger trigger)
-    {
-        _logger.LogDebug($"GamepadTriggerMoved: {trigger.Index}");
-    }
+    //private void GamepadTriggerMoved(IGamepad gamepad, Trigger trigger)
+    //{
+    //    _logger.LogDebug($"GamepadTriggerMoved: {trigger.Index}");
+    //}
 
-    private void GamepadThumbstickMoved(IGamepad gamepad, Thumbstick thumbstick)
-    {
-        _logger.LogDebug($"GamepadThumbstickMoved: {thumbstick.Index} {thumbstick.X},{thumbstick.Y}");
-    }
+    //private void GamepadThumbstickMoved(IGamepad gamepad, Thumbstick thumbstick)
+    //{
+    //    _logger.LogDebug($"GamepadThumbstickMoved: {thumbstick.Index} {thumbstick.X},{thumbstick.Y}");
+    //}
 
     private void GamepadButtonUp(IGamepad gamepad, Button button)
     {

--- a/src/libraries/Highbyte.DotNet6502.Impl.SilkNet/SilkNetInputHandlerContext.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SilkNet/SilkNetInputHandlerContext.cs
@@ -43,7 +43,7 @@ public class SilkNetInputHandlerContext : IInputHandlerContext
         s_inputcontext = _silkNetWindow.CreateInput();
 
         if (s_inputcontext == null)
-            throw new Exception("Silk.NET Input Context not found.");
+            throw new DotNet6502Exception("Silk.NET Input Context not found.");
 
         s_inputcontext.ConnectionChanged += ConnectionChanged;
 
@@ -51,7 +51,7 @@ public class SilkNetInputHandlerContext : IInputHandlerContext
         if (s_inputcontext.Keyboards != null && s_inputcontext.Keyboards.Count != 0)
             _primaryKeyboard = s_inputcontext.Keyboards[0];
         if (_primaryKeyboard == null)
-            throw new Exception("Keyboard not found");
+            throw new DotNet6502Exception("Keyboard not found");
         ListenForKeyboardInput();
 
         // Silk.NET Input: Gamepad

--- a/src/libraries/Highbyte.DotNet6502.Impl.Skia/Commodore64/Video/C64SkiaRenderer.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Skia/Commodore64/Video/C64SkiaRenderer.cs
@@ -11,20 +11,20 @@ namespace Highbyte.DotNet6502.Impl.Skia.Commodore64.Video;
 
 public class C64SkiaRenderer : IRenderer<C64, SkiaRenderContext>
 {
-    private Func<SKCanvas> _getSkCanvas;
+    private Func<SKCanvas> _getSkCanvas = default!;
 
-    private C64SkiaPaint _c64SkiaPaint;
+    private C64SkiaPaint _c64SkiaPaint = default!;
 
-    private Dictionary<int, SKImage> _characterSetCurrent;
-    private Dictionary<int, SKImage> _characterSetMultiColorCurrent;
+    private Dictionary<int, SKImage> _characterSetCurrent = default!;
+    private Dictionary<int, SKImage> _characterSetMultiColorCurrent = default!;
 
-    private Dictionary<int, SKImage> _characterSetROMShiftedImage;
-    private Dictionary<int, SKImage> _characterSetROMShiftedMultiColorImage;
-    private Dictionary<int, SKImage> _characterSetROMUnshiftedImage;
-    private Dictionary<int, SKImage> _characterSetROMUnshiftedMultiColorImage;
+    private Dictionary<int, SKImage> _characterSetROMShiftedImage = default!;
+    private Dictionary<int, SKImage> _characterSetROMShiftedMultiColorImage = default!;
+    private Dictionary<int, SKImage> _characterSetROMUnshiftedImage = default!;
+    private Dictionary<int, SKImage> _characterSetROMUnshiftedMultiColorImage = default!;
 
     private bool _changedAllCharsetCodes = false;
-    private HashSet<byte> _changedCharsetCodes = new();
+    private readonly HashSet<byte> _changedCharsetCodes = new();
 
     private SKRect _drawImageSource = new SKRect();
     private SKRect _drawImageDest = new SKRect();
@@ -289,7 +289,6 @@ public class C64SkiaRenderer : IRenderer<C64, SkiaRenderContext>
         canvas.Restore();
     }
 
-
     // Draw border per line across screen. Assumes the screen in the middle is drawn afterwards and will overwrite.
     // Slower, but more accurate (though not completley, becasuse border color changes within a line is not accounted for).
     private void DrawRasterLinesBorder(C64 c64, SKCanvas canvas)
@@ -332,33 +331,33 @@ public class C64SkiaRenderer : IRenderer<C64, SkiaRenderContext>
         }
     }
 
-    // Simple approximation, draw 4 rectangles for border. Fast, but does not handle changes in border color per raster line.
-    private void DrawSimpleBorder(C64 c64, SKCanvas canvas)
-    {
-        var emulatorMem = c64.Mem;
-        var vic2Screen = c64.Vic2.Vic2Screen;
+    //// Simple approximation, draw 4 rectangles for border. Fast, but does not handle changes in border color per raster line.
+    //private void DrawSimpleBorder(C64 c64, SKCanvas canvas)
+    //{
+    //    var emulatorMem = c64.Mem;
+    //    var vic2Screen = c64.Vic2.Vic2Screen;
 
-        var borderColor = c64.ReadIOStorage(Vic2Addr.BORDER_COLOR);
-        var borderPaint = _c64SkiaPaint.GetFillPaint(borderColor);
+    //    var borderColor = c64.ReadIOStorage(Vic2Addr.BORDER_COLOR);
+    //    var borderPaint = _c64SkiaPaint.GetFillPaint(borderColor);
 
-        canvas.DrawRect(0, 0, vic2Screen.VisibleWidth, vic2Screen.VisibleTopBottomBorderHeight, borderPaint);
-        canvas.DrawRect(0, vic2Screen.VisibleTopBottomBorderHeight + vic2Screen.DrawableAreaHeight, vic2Screen.VisibleWidth, vic2Screen.VisibleTopBottomBorderHeight, borderPaint);
-        canvas.DrawRect(0, vic2Screen.VisibleTopBottomBorderHeight, vic2Screen.VisibleLeftRightBorderWidth, vic2Screen.DrawableAreaHeight, borderPaint);
-        canvas.DrawRect(vic2Screen.VisibleLeftRightBorderWidth + vic2Screen.DrawableAreaWidth, vic2Screen.VisibleTopBottomBorderHeight, vic2Screen.VisibleLeftRightBorderWidth, vic2Screen.DrawableAreaHeight, borderPaint);
-    }
+    //    canvas.DrawRect(0, 0, vic2Screen.VisibleWidth, vic2Screen.VisibleTopBottomBorderHeight, borderPaint);
+    //    canvas.DrawRect(0, vic2Screen.VisibleTopBottomBorderHeight + vic2Screen.DrawableAreaHeight, vic2Screen.VisibleWidth, vic2Screen.VisibleTopBottomBorderHeight, borderPaint);
+    //    canvas.DrawRect(0, vic2Screen.VisibleTopBottomBorderHeight, vic2Screen.VisibleLeftRightBorderWidth, vic2Screen.DrawableAreaHeight, borderPaint);
+    //    canvas.DrawRect(vic2Screen.VisibleLeftRightBorderWidth + vic2Screen.DrawableAreaWidth, vic2Screen.VisibleTopBottomBorderHeight, vic2Screen.VisibleLeftRightBorderWidth, vic2Screen.DrawableAreaHeight, borderPaint);
+    //}
 
-    // Simple approximation, draw 1 rectangle for border. Fast, but does not handle changes in background color per raster line.
-    private void DrawSimpleBackground(C64 c64, SKCanvas canvas)
-    {
-        var emulatorMem = c64.Mem;
-        var vic2Screen = c64.Vic2.Vic2Screen;
+    //// Simple approximation, draw 1 rectangle for border. Fast, but does not handle changes in background color per raster line.
+    //private void DrawSimpleBackground(C64 c64, SKCanvas canvas)
+    //{
+    //    var emulatorMem = c64.Mem;
+    //    var vic2Screen = c64.Vic2.Vic2Screen;
 
-        // Draw 1 rectangle for background
-        var backgroundColor = c64.ReadIOStorage(Vic2Addr.BACKGROUND_COLOR_0);
-        var bgPaint = _c64SkiaPaint.GetFillPaint(backgroundColor);
+    //    // Draw 1 rectangle for background
+    //    var backgroundColor = c64.ReadIOStorage(Vic2Addr.BACKGROUND_COLOR_0);
+    //    var bgPaint = _c64SkiaPaint.GetFillPaint(backgroundColor);
 
-        canvas.DrawRect(vic2Screen.VisibleLeftRightBorderWidth, vic2Screen.VisibleTopBottomBorderHeight, vic2Screen.DrawableAreaWidth, vic2Screen.DrawableAreaHeight, bgPaint);
-    }
+    //    canvas.DrawRect(vic2Screen.VisibleLeftRightBorderWidth, vic2Screen.VisibleTopBottomBorderHeight, vic2Screen.DrawableAreaWidth, vic2Screen.DrawableAreaHeight, bgPaint);
+    //}
 
     /// <summary>
     /// Draw character to screen, with adjusted position for border.

--- a/src/libraries/Highbyte.DotNet6502.Impl.Skia/Commodore64/Video/Chargen.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Skia/Commodore64/Video/Chargen.cs
@@ -113,7 +113,7 @@ public class CharGen
         using (new SKAutoCanvasRestore(canvas))
         {
             if (dataRows.Length != 8)
-                throw new Exception("A character in chargen must consist of 8 bytes.");
+                throw new DotNet6502Exception("A character in chargen must consist of 8 bytes.");
             foreach (var row in dataRows)
             {
                 DrawCharacterLine(canvas, paint, paintMultiColorBG1, paintMultiColorBG2, row, multiColor);
@@ -139,7 +139,7 @@ public class CharGen
                             0b01 => paintMultiColorBG1,
                             0b10 => paintMultiColorBG2,
                             0b11 => paint,
-                            _ => throw new Exception("Invalid pixel pair value.")
+                            _ => throw new DotNet6502Exception("Invalid pixel pair value.")
                         };
                         canvas.DrawRect(0, 0, 2, 0, pixelPairPaint);
                     }

--- a/src/libraries/Highbyte.DotNet6502.Impl.Skia/SkiaRenderContext.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Skia/SkiaRenderContext.cs
@@ -22,7 +22,7 @@ public class SkiaRenderContext : IRenderContext
             return _canvas;
         if (_getSkCanvasExternal != null)
             return _getSkCanvasExternal();
-        throw new Exception("Internal error. SkCanvas not configured.");
+        throw new DotNet6502Exception("Internal error. SkCanvas not configured.");
     }
 
     private GRContext GetGRContextInternal()
@@ -31,7 +31,7 @@ public class SkiaRenderContext : IRenderContext
             return _grContext;
         if (_getGrContextExternal != null)
             return _getGrContextExternal();
-        throw new Exception("Internal error. GRContext not configured.");
+        throw new DotNet6502Exception("Internal error. GRContext not configured.");
     }
 
     public SkiaRenderContext(Func<SKCanvas> getSkCanvas, Func<GRContext> getGrContext)
@@ -49,7 +49,7 @@ public class SkiaRenderContext : IRenderContext
         var grContextOptions = new GRContextOptions { };
         _grContext = GRContext.CreateGl(glInterface, grContextOptions);
         if (_grContext == null)
-            throw new Exception("Cannot create OpenGL context.");
+            throw new DotNet6502Exception("Cannot create OpenGL context.");
 
         // Create main Skia surface from OpenGL context
         GRGlFramebufferInfo glFramebufferInfo = new(0, SKColorType.Rgba8888.ToGlSizedFormat());
@@ -64,7 +64,7 @@ public class SkiaRenderContext : IRenderContext
         // Create the SkiaSharp render target surface
         _renderSurface = SKSurface.Create(_grContext, _renderTarget, GRSurfaceOrigin.BottomLeft, SKColorType.Rgba8888);
         if (_renderSurface == null)
-            throw new Exception("Cannot create SkiaSharp SKSurface.");
+            throw new DotNet6502Exception("Cannot create SkiaSharp SKSurface.");
 
         _renderSurface.Canvas.Scale(scale);
 

--- a/src/libraries/Highbyte.DotNet6502.Monitor/MonitorConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Monitor/MonitorConfig.cs
@@ -25,6 +25,6 @@ public class MonitorConfig
             DefaultDirectory = Environment.CurrentDirectory;
         var defaultDir = PathHelper.ExpandOSEnvironmentVariables(DefaultDirectory);
         if (!Directory.Exists(defaultDir))
-            throw new Exception($"Setting {nameof(DefaultDirectory)} value {defaultDir} does not contain an existing directory.");
+            throw new DotNet6502Exception($"Setting {nameof(DefaultDirectory)} value {defaultDir} does not contain an existing directory.");
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/C64.cs
@@ -1,10 +1,8 @@
-using System.Diagnostics;
 using Highbyte.DotNet6502.Instrumentation.Stats;
 using Highbyte.DotNet6502.Instrumentation;
 using Highbyte.DotNet6502.Monitor.SystemSpecific;
 using Highbyte.DotNet6502.Systems.Commodore64.Audio;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
-using Highbyte.DotNet6502.Systems.Commodore64.Keyboard;
 using Highbyte.DotNet6502.Systems.Commodore64.Models;
 using Highbyte.DotNet6502.Systems.Commodore64.Monitor;
 using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
@@ -240,7 +238,7 @@ public class C64 : ISystem, ISystemMonitor
         mem.Write(1, 0x7);
     }
 
-    private static CPU CreateC64CPU( ILoggerFactory loggerFactory)
+    private static CPU CreateC64CPU(ILoggerFactory loggerFactory)
     {
         var cpu = new CPU(loggerFactory);
         // The CPU execute method uses will not raise any events (like after instruction executed). Therefore advance VIC2 raster line etc needs to be manually called instead (see ExecuteOneFrame)

--- a/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Config/C64Config.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Config/C64Config.cs
@@ -23,7 +23,7 @@ public class C64Config : ISystemConfig
     };
 
     public bool LoadROMs { get; set; } = true;
-    private List<ROM> _roms;
+    private List<ROM> _roms = default!;
     public List<ROM> ROMs
     {
         get
@@ -98,6 +98,7 @@ public class C64Config : ISystemConfig
     }
 
     private string _colorMapName;
+
     public string ColorMapName
     {
         get
@@ -111,15 +112,40 @@ public class C64Config : ISystemConfig
         }
     }
 
-    public bool KeyboardJoystickEnabled { get; set; }
-    public int KeyboardJoystick { get; set; } = 2;
+    private bool _keyboardJoystickEnabled;
+    public bool KeyboardJoystickEnabled
+    {
+        get
+        {
+            return _keyboardJoystickEnabled;
+        }
+        set
+        {
+            _keyboardJoystickEnabled = value;
+            _isDirty = true;
+        }
+    }
+
+    private int _keyboardJoystick;
+    public int KeyboardJoystick
+    {
+        get
+        {
+            return _keyboardJoystick;
+        }
+        set
+        {
+            _keyboardJoystick = value;
+            _isDirty = true;
+        }
+    }
 
     public C64KeyboardJoystickMap KeyboardJoystickMap { get; private set; }
 
     public C64Config()
     {
         // Defaults
-        ROMs = new List<ROM>
+        _roms = new List<ROM>
         {
             new ROM
             {
@@ -143,20 +169,21 @@ public class C64Config : ISystemConfig
                 Checksum = "1d503e56df85a62fee696e7618dc5b4e781df1bb",
             },
         };
-        ROMDirectory = "%USERPROFILE%/Documents/C64/VICE/C64";
+        _romDirectory = "%USERPROFILE%/Documents/C64/VICE/C64";
 
-        C64Model = "C64NTSC";
-        Vic2Model = "NTSC";
+        _c64Model = "C64NTSC";
+        _vic2Model = "NTSC";
 
+        _colorMapName = ColorMaps.DEFAULT_COLOR_MAP_NAME;
+
+        _audioEnabled = false;
+        _keyboardJoystickEnabled = false;
+        _keyboardJoystick = 2;
+
+        // Settings not currently changeable by user
         TimerMode = TimerMode.UpdateEachRasterLine;
         //TimerMode = TimerMode.UpdateEachInstruction;
-
         AudioSupported = false; // Set to true after creating if the audio system is implemented for the host platform
-        AudioEnabled = false;
-
-        ColorMapName = ColorMaps.DEFAULT_COLOR_MAP_NAME;
-
-        KeyboardJoystickEnabled = false;
         KeyboardJoystickMap = new C64KeyboardJoystickMap();
     }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Config/C64Config.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Config/C64Config.cs
@@ -195,7 +195,7 @@ public class C64Config : ISystemConfig
     public void Validate()
     {
         if (!IsValid(out List<string> validationErrors))
-            throw new Exception($"Config errors: {string.Join(',', validationErrors)}");
+            throw new DotNet6502Exception($"Config errors: {string.Join(',', validationErrors)}");
     }
 
     public bool IsValid(out List<string> validationErrors)

--- a/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Video/Vic2.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Video/Vic2.cs
@@ -636,7 +636,7 @@ public class Vic2
 
 #if DEBUG
         if (Vic2IRQ.ConfiguredIRQRasterLine > Vic2Model.TotalHeight)
-            throw new Exception($"Internal error. Setting unreachable scan line for IRQ: {Vic2IRQ.ConfiguredIRQRasterLine}. Incorrect ROM for Vic2 model: {Vic2Model.Name} ?");
+            throw new DotNet6502Exception($"Internal error. Setting unreachable scan line for IRQ: {Vic2IRQ.ConfiguredIRQRasterLine}. Incorrect ROM for Vic2 model: {Vic2Model.Name} ?");
 #endif
 
     }
@@ -767,7 +767,7 @@ public class Vic2
         {
 #if DEBUG
             if (newLine > Vic2Model.TotalHeight)
-                throw new Exception($"Internal error. Unreachable scan line: {newLine}. The CPU probably executed more cycles current frame than allowed.");
+                throw new DotNet6502Exception($"Internal error. Unreachable scan line: {newLine}. The CPU probably executed more cycles current frame than allowed.");
 #endif
 
             _currentRasterLineInternal = newLine;

--- a/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Video/Vic2.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Video/Vic2.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
 using Highbyte.DotNet6502.Systems.Commodore64.Models;
 using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
@@ -17,15 +16,15 @@ namespace Highbyte.DotNet6502.Systems.Commodore64.Video;
 /// </summary>
 public class Vic2
 {
-    public C64? C64 { get; private set; }
-    public Vic2ModelBase? Vic2Model { get; private set; }
-    public Vic2Screen? Vic2Screen { get; private set; }
+    public C64 C64 { get; private set; } = default!;
+    public Vic2ModelBase Vic2Model { get; private set; } = default!;
+    public Vic2Screen Vic2Screen { get; private set; } = default!;
     /// <summary>
     /// Vic2 screem memory for text, graphics and sprites.
     /// </summary>
-    public Memory? Vic2Mem { get; private set; }
+    public Memory Vic2Mem { get; private set; } = default!;
 
-    public Vic2IRQ? Vic2IRQ { get; private set; }
+    public Vic2IRQ Vic2IRQ { get; private set; } = default!;
 
     public ulong CyclesConsumedCurrentVblank { get; private set; } = 0;
 
@@ -33,7 +32,7 @@ public class Vic2
 
     public ushort VideoMatrixBaseAddress { get; private set; }
 
-     public DispMode DisplayMode
+    public DispMode DisplayMode
     {
         get
         {
@@ -122,12 +121,12 @@ public class Vic2
         }
     }
 
-    public Dictionary<int, ScreenLineData> ScreenLineIORegisterValues { get; private set; }
+    public Dictionary<int, ScreenLineData> ScreenLineIORegisterValues { get; private set; } = default!;
 
-    public Vic2ScreenLayouts? ScreenLayouts { get; private set; }
-    public Vic2SpriteManager? SpriteManager { get; private set; }
-    public Vic2CharsetManager? CharsetManager { get; private set; }
-    public Vic2BitmapManager? BitmapManager { get; private set; }
+    public Vic2ScreenLayouts ScreenLayouts { get; private set; } = default!;
+    public Vic2SpriteManager SpriteManager { get; private set; } = default!;
+    public Vic2CharsetManager CharsetManager { get; private set; } = default!;
+    public Vic2BitmapManager BitmapManager { get; private set; } = default!;
 
     private Vic2() { }
 
@@ -164,28 +163,6 @@ public class Vic2
         vic2.BitmapManager = bitmapManager;
 
         return vic2;
-    }
-
-    private static Dictionary<int, byte> InitializeScreenLineBorderColorLookup(Vic2ModelBase vic2Model)
-    {
-        var screenLineBorderColor = new Dictionary<int, byte>();
-        for (ushort i = 0; i < vic2Model.TotalHeight; i++)
-        {
-            screenLineBorderColor.Add(i, 0);
-        }
-        return screenLineBorderColor;
-    }
-
-    private static Dictionary<int, byte> InitializeScreenLineBackgroundColorLookup(Vic2ModelBase vic2Model)
-    {
-        var screenLineBackgroundColor = new Dictionary<int, byte>();
-        for (ushort i = 0; i < vic2Model.TotalHeight; i++)
-        {
-            if (!vic2Model.IsRasterLineInMainScreen(i))
-                continue;
-            screenLineBackgroundColor.Add(i, 0);
-        }
-        return screenLineBackgroundColor;
     }
 
     public void MapIOLocations(Memory c64Mem)
@@ -390,7 +367,6 @@ public class Vic2
 
         return vic2Mem;
     }
-
 
     public void SpriteEnableStore(ushort address, byte value)
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Video/Vic2BitmapManager.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Video/Vic2BitmapManager.cs
@@ -9,19 +9,16 @@ public class Vic2BitmapManager
 {
     public const int BITMAP_SIZE = (320 * 200) / 8; // 8000 bytes, 1 byte contains 8 pixels.
 
-    public Vic2 Vic2 { get; private set; }
-    private Memory _vic2Mem => Vic2.Vic2Mem;
+    private readonly Vic2 _vic2;
+    private Memory _vic2Mem => _vic2.Vic2Mem;
 
     // Offset into the currently selected VIC2 bank (Mem.SetMemoryConfiguration(bank))
-    private ushort _bitmapAddressInVIC2Bank;
+    private ushort _bitmapAddressInVIC2Bank = default;
     public ushort BitmapAddressInVIC2Bank => _bitmapAddressInVIC2Bank;
-
-
-    private Vic2BitmapManager() { }
 
     public Vic2BitmapManager(Vic2 vic2)
     {
-        Vic2 = vic2;
+        _vic2 = vic2;
     }
 
     public void NotifyBitmapAddressChanged()
@@ -37,7 +34,6 @@ public class Vic2BitmapManager
         // The parameter characterBaseAddressSetting contains that 3-bit value.
         // 
         // Only the highest bit is significant, the other bits are ignored.
-
 
         // By default, this value is 2 (%010), which after ignoring the lowest bits means %000, which corresponds to
         // addresses 0x0000-0x1F40 offset from Bank below. 
@@ -78,7 +74,7 @@ public class Vic2BitmapManager
         }
     }
 
-    public event EventHandler<BitmapAddressChangedEventArgs> BitmapAddressChanged;
+    public event EventHandler<BitmapAddressChangedEventArgs>? BitmapAddressChanged;
     protected virtual void OnBitmapAddressChanged(BitmapAddressChangedEventArgs e)
     {
         var handler = BitmapAddressChanged;
@@ -95,13 +91,12 @@ public class Vic2BitmapManager
     public byte GetBitmapCharacterLine(int characterCol, int characterRow, int line)
     {
         var characterSetLineAddress = (ushort)(BitmapAddressInVIC2Bank
-            + (characterRow * Vic2.Vic2Screen.CharacterHeight * Vic2.Vic2Screen.TextCols)
-            + (characterCol * Vic2.Vic2Screen.CharacterHeight)
+            + (characterRow * _vic2.Vic2Screen.CharacterHeight * _vic2.Vic2Screen.TextCols)
+            + (characterCol * _vic2.Vic2Screen.CharacterHeight)
             + line
             );
         return _vic2Mem[characterSetLineAddress];
     }
-
 
     public class BitmapAddressChangedEventArgs : EventArgs
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Video/Vic2CharsetManager.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Video/Vic2CharsetManager.cs
@@ -11,8 +11,8 @@ public class Vic2CharsetManager
     public const int CHARACTERSET_ONE_CHARACTER_BYTES = 8;      // 8 bytes (one line per byte) for each character.
     public const int CHARACTERSET_SIZE = CHARACTERSET_NUMBER_OF_CHARCTERS * CHARACTERSET_ONE_CHARACTER_BYTES;    // = 2KB -> 2048 (0x0800) bytes. 256 characters, where each character takes up 8 bytes (1 byte per character line)
 
-    public Vic2 Vic2 { get; private set; }
-    private Memory _vic2Mem => Vic2.Vic2Mem;
+    private readonly Vic2 _vic2;
+    private Memory _vic2Mem => _vic2.Vic2Mem;
 
     // Offset into the currently selected VIC2 bank (Mem.SetMemoryConfiguration(bank))
     private ushort _characterSetAddressInVIC2Bank;
@@ -21,12 +21,9 @@ public class Vic2CharsetManager
     public bool CharacterSetAddressInVIC2BankIsChargenROMShifted => _characterSetAddressInVIC2Bank == 0x1000;
     public bool CharacterSetAddressInVIC2BankIsChargenROMUnshifted => _characterSetAddressInVIC2Bank == 0x1800;
 
-
-    private Vic2CharsetManager() { }
-
     public Vic2CharsetManager(Vic2 vic2)
     {
-        Vic2 = vic2;
+        _vic2 = vic2;
     }
 
     public void NotifyCharsetAddressChanged()
@@ -94,7 +91,7 @@ public class Vic2CharsetManager
         }
     }
 
-    public event EventHandler<CharsetAddressChangedEventArgs> CharsetAddressChanged;
+    public event EventHandler<CharsetAddressChangedEventArgs>? CharsetAddressChanged;
     protected virtual void OnCharsetAddressChanged(CharsetAddressChangedEventArgs e)
     {
         var handler = CharsetAddressChanged;
@@ -110,9 +107,9 @@ public class Vic2CharsetManager
     /// <returns></returns>
     public byte GetTextModeCharacterLine(int characterCol, int characterRow, int line)
     {
-        var characterAddress = (ushort)(Vic2.VideoMatrixBaseAddress + (characterRow * Vic2.Vic2Screen.TextCols) + characterCol);
+        var characterAddress = (ushort)(_vic2.VideoMatrixBaseAddress + (characterRow * _vic2.Vic2Screen.TextCols) + characterCol);
         var characterCode = _vic2Mem[characterAddress];
-        var characterSetLineAddress = (ushort)(CharacterSetAddressInVIC2Bank + (characterCode * Vic2.Vic2Screen.CharacterHeight) + line);
+        var characterSetLineAddress = (ushort)(CharacterSetAddressInVIC2Bank + (characterCode * _vic2.Vic2Screen.CharacterHeight) + line);
         return _vic2Mem[characterSetLineAddress];
     }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Video/Vic2Screen.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Video/Vic2Screen.cs
@@ -255,17 +255,17 @@ public class Vic2ScreenLayouts
 
 public class Vic2ScreenLayout
 {
-    public Vic2Area? TopBorder { get; set; }
-    public Vic2Area? LeftBorder { get; set; }
-    public Vic2Area? Screen { get; set; }
-    public Vic2Area? BottomBorder { get; set; }
-    public Vic2Area? RightBorder { get; set; }
+    public required Vic2Area TopBorder { get; set; }
+    public required Vic2Area LeftBorder { get; set; }
+    public required Vic2Area Screen { get; set; }
+    public required Vic2Area BottomBorder { get; set; }
+    public required Vic2Area RightBorder { get; set; }
 }
 
 public class Vic2Area
 {
-    public IntVector2? Start { get; set; }
-    public IntVector2? End { get; set; }
+    public required IntVector2 Start { get; set; }
+    public required IntVector2 End { get; set; }
 }
 
 public class IntVector2

--- a/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Video/Vic2Sprite.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Video/Vic2Sprite.cs
@@ -27,7 +27,7 @@ public class Vic2Sprite
     public int WidthBytes => WidthPixels / 8;
     public int HeightPixels => DoubleHeight ? DEFAULT_HEIGTH * 2 : DEFAULT_HEIGTH;
 
-    private Vic2SpriteData _data = new Vic2SpriteData();
+    private readonly Vic2SpriteData _data = new Vic2SpriteData();
     public Vic2SpriteData Data => BuildSpriteData();
 
     public bool IsDirty => _isDirty;
@@ -96,66 +96,66 @@ public class Vic2Sprite
         _isDirty = false;
     }
 
-    private void CreateTestSpriteImage()
-    {
-        // Fake sprite data
-        _data.Rows[00].Bytes = new byte[] { 0b11111111, 0b11111111, 0b11111111 };
-        _data.Rows[01].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
-        _data.Rows[02].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
-        _data.Rows[03].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
-        _data.Rows[04].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
-        _data.Rows[05].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
-        _data.Rows[06].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
-        _data.Rows[07].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
-        _data.Rows[08].Bytes = new byte[] { 0b11111111, 0b11111111, 0b11111111 };
-        _data.Rows[09].Bytes = new byte[] { 0b11111111, 0b11111111, 0b11111111 };
+    //private void CreateTestSpriteImage()
+    //{
+    //    // Fake sprite data
+    //    _data.Rows[00].Bytes = new byte[] { 0b11111111, 0b11111111, 0b11111111 };
+    //    _data.Rows[01].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
+    //    _data.Rows[02].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
+    //    _data.Rows[03].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
+    //    _data.Rows[04].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
+    //    _data.Rows[05].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
+    //    _data.Rows[06].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
+    //    _data.Rows[07].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
+    //    _data.Rows[08].Bytes = new byte[] { 0b11111111, 0b11111111, 0b11111111 };
+    //    _data.Rows[09].Bytes = new byte[] { 0b11111111, 0b11111111, 0b11111111 };
 
-        _data.Rows[10].Bytes = new byte[] { 0b11111111, 0b11111111, 0b11111111 };
-        _data.Rows[11].Bytes = new byte[] { 0b11111111, 0b11111111, 0b11111111 };
-        _data.Rows[12].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
-        _data.Rows[13].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
-        _data.Rows[14].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
-        _data.Rows[15].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
-        _data.Rows[16].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
-        _data.Rows[17].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
-        _data.Rows[18].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
-        _data.Rows[19].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
+    //    _data.Rows[10].Bytes = new byte[] { 0b11111111, 0b11111111, 0b11111111 };
+    //    _data.Rows[11].Bytes = new byte[] { 0b11111111, 0b11111111, 0b11111111 };
+    //    _data.Rows[12].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
+    //    _data.Rows[13].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
+    //    _data.Rows[14].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
+    //    _data.Rows[15].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
+    //    _data.Rows[16].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
+    //    _data.Rows[17].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
+    //    _data.Rows[18].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
+    //    _data.Rows[19].Bytes = new byte[] { 0b10000000, 0b00111100, 0b00000001 };
 
-        _data.Rows[20].Bytes = new byte[] { 0b11111111, 0b11111111, 0b11111111 };
-    }
+    //    _data.Rows[20].Bytes = new byte[] { 0b11111111, 0b11111111, 0b11111111 };
+    //}
 
-    private void CreateTestMultiColorSpriteImage()
-    {
-        // Fake multi-color sprite data
-        // Each multi-color pixel is 2 pixels wide.
-        // 00 = Background color (transparent)
-        // 01 = Sprite multicolor register 0 (53285, $D025) shared by all sprites
-        // 10 = Sprite Color Registers (53287-94, $D027-E), color per sprite
-        // 11 = Sprite multicolor register 1 (53286, $D026) shared by all sprites
-        _data.Rows[00].Bytes = new byte[] { 0b01_01_01_01, 0b01_01_01_01, 0b01_01_01_01 };
-        _data.Rows[01].Bytes = new byte[] { 0b01_00_00_00, 0b00_10_10_00, 0b00_00_00_01 };
-        _data.Rows[01].Bytes = new byte[] { 0b01_00_00_00, 0b00_10_10_00, 0b00_00_00_01 };
-        _data.Rows[01].Bytes = new byte[] { 0b01_00_00_00, 0b00_10_10_00, 0b00_00_00_01 };
-        _data.Rows[01].Bytes = new byte[] { 0b01_00_00_00, 0b00_10_10_00, 0b00_00_00_01 };
-        _data.Rows[01].Bytes = new byte[] { 0b01_00_00_00, 0b00_10_10_00, 0b00_00_00_01 };
-        _data.Rows[01].Bytes = new byte[] { 0b01_00_00_00, 0b00_10_10_00, 0b00_00_00_01 };
-        _data.Rows[01].Bytes = new byte[] { 0b01_00_00_00, 0b00_10_10_00, 0b00_00_00_01 };
-        _data.Rows[00].Bytes = new byte[] { 0b01_01_01_01, 0b01_01_01_01, 0b01_01_01_01 };
-        _data.Rows[00].Bytes = new byte[] { 0b01_01_01_01, 0b01_01_01_01, 0b01_01_01_01 };
+    //private void CreateTestMultiColorSpriteImage()
+    //{
+    //    // Fake multi-color sprite data
+    //    // Each multi-color pixel is 2 pixels wide.
+    //    // 00 = Background color (transparent)
+    //    // 01 = Sprite multicolor register 0 (53285, $D025) shared by all sprites
+    //    // 10 = Sprite Color Registers (53287-94, $D027-E), color per sprite
+    //    // 11 = Sprite multicolor register 1 (53286, $D026) shared by all sprites
+    //    _data.Rows[00].Bytes = new byte[] { 0b01_01_01_01, 0b01_01_01_01, 0b01_01_01_01 };
+    //    _data.Rows[01].Bytes = new byte[] { 0b01_00_00_00, 0b00_10_10_00, 0b00_00_00_01 };
+    //    _data.Rows[01].Bytes = new byte[] { 0b01_00_00_00, 0b00_10_10_00, 0b00_00_00_01 };
+    //    _data.Rows[01].Bytes = new byte[] { 0b01_00_00_00, 0b00_10_10_00, 0b00_00_00_01 };
+    //    _data.Rows[01].Bytes = new byte[] { 0b01_00_00_00, 0b00_10_10_00, 0b00_00_00_01 };
+    //    _data.Rows[01].Bytes = new byte[] { 0b01_00_00_00, 0b00_10_10_00, 0b00_00_00_01 };
+    //    _data.Rows[01].Bytes = new byte[] { 0b01_00_00_00, 0b00_10_10_00, 0b00_00_00_01 };
+    //    _data.Rows[01].Bytes = new byte[] { 0b01_00_00_00, 0b00_10_10_00, 0b00_00_00_01 };
+    //    _data.Rows[00].Bytes = new byte[] { 0b01_01_01_01, 0b01_01_01_01, 0b01_01_01_01 };
+    //    _data.Rows[00].Bytes = new byte[] { 0b01_01_01_01, 0b01_01_01_01, 0b01_01_01_01 };
 
-        _data.Rows[00].Bytes = new byte[] { 0b01_01_01_01, 0b01_01_01_01, 0b01_01_01_01 };
-        _data.Rows[00].Bytes = new byte[] { 0b01_01_01_01, 0b01_01_01_01, 0b01_01_01_01 };
-        _data.Rows[01].Bytes = new byte[] { 0b11_00_00_00, 0b00_11_11_00, 0b00_00_00_11 };
-        _data.Rows[01].Bytes = new byte[] { 0b11_00_00_00, 0b00_11_11_00, 0b00_00_00_11 };
-        _data.Rows[01].Bytes = new byte[] { 0b11_00_00_00, 0b00_11_11_00, 0b00_00_00_11 };
-        _data.Rows[01].Bytes = new byte[] { 0b11_00_00_00, 0b00_11_11_00, 0b00_00_00_11 };
-        _data.Rows[01].Bytes = new byte[] { 0b11_00_00_00, 0b00_11_11_00, 0b00_00_00_11 };
-        _data.Rows[01].Bytes = new byte[] { 0b11_00_00_00, 0b00_11_11_00, 0b00_00_00_11 };
-        _data.Rows[01].Bytes = new byte[] { 0b11_00_00_00, 0b00_11_11_00, 0b00_00_00_11 };
-        _data.Rows[01].Bytes = new byte[] { 0b11_00_00_00, 0b00_11_11_00, 0b00_00_00_11 };
+    //    _data.Rows[00].Bytes = new byte[] { 0b01_01_01_01, 0b01_01_01_01, 0b01_01_01_01 };
+    //    _data.Rows[00].Bytes = new byte[] { 0b01_01_01_01, 0b01_01_01_01, 0b01_01_01_01 };
+    //    _data.Rows[01].Bytes = new byte[] { 0b11_00_00_00, 0b00_11_11_00, 0b00_00_00_11 };
+    //    _data.Rows[01].Bytes = new byte[] { 0b11_00_00_00, 0b00_11_11_00, 0b00_00_00_11 };
+    //    _data.Rows[01].Bytes = new byte[] { 0b11_00_00_00, 0b00_11_11_00, 0b00_00_00_11 };
+    //    _data.Rows[01].Bytes = new byte[] { 0b11_00_00_00, 0b00_11_11_00, 0b00_00_00_11 };
+    //    _data.Rows[01].Bytes = new byte[] { 0b11_00_00_00, 0b00_11_11_00, 0b00_00_00_11 };
+    //    _data.Rows[01].Bytes = new byte[] { 0b11_00_00_00, 0b00_11_11_00, 0b00_00_00_11 };
+    //    _data.Rows[01].Bytes = new byte[] { 0b11_00_00_00, 0b00_11_11_00, 0b00_00_00_11 };
+    //    _data.Rows[01].Bytes = new byte[] { 0b11_00_00_00, 0b00_11_11_00, 0b00_00_00_11 };
 
-        _data.Rows[20].Bytes = new byte[] { 0b11_11_11_11, 0b11_11_11_11, 0b11_11_11_11 };
-    }
+    //    _data.Rows[20].Bytes = new byte[] { 0b11_11_11_11, 0b11_11_11_11, 0b11_11_11_11 };
+    //}
 
     public class Vic2SpriteData
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Video/Vic2SpriteManager.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Commodore64/Video/Vic2SpriteManager.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Highbyte.DotNet6502.Systems.Utils;
 using static Highbyte.DotNet6502.Systems.Commodore64.Video.Vic2;
 using static Highbyte.DotNet6502.Systems.Commodore64.Video.Vic2Sprite;
@@ -10,7 +9,7 @@ namespace Highbyte.DotNet6502.Systems.Commodore64.Video;
 /// </summary>
 public class Vic2SpriteManager
 {
-    public Vic2 Vic2 { get; private set; }
+    public readonly Vic2 Vic2;
     private Memory _vic2Mem => Vic2.Vic2Mem;
 
     public int SpritePointerStartAddress => Vic2.VideoMatrixBaseAddress + 0x03f8; // Default value is 0x07f8 (because Vic2.VideoMatrixBaseAddress is 0x0400 by default). 8 sprites, last is 0x07ff.
@@ -27,8 +26,6 @@ public class Vic2SpriteManager
 
     public byte SpriteToBackgroundCollisionStore { get; internal set; }
     public bool SpriteToBackgroundCollisionIRQBlock { get; internal set; }
-
-    private Vic2SpriteManager() { }
 
     public Vic2SpriteManager(Vic2 vic2)
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems/Generic/Config/EmulatorMemoryConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Generic/Config/EmulatorMemoryConfig.cs
@@ -36,8 +36,8 @@ public class EmulatorMemoryConfig
 
     public EmulatorMemoryConfig()
     {
-        Screen = new();
-        Input = new();
+        _screen = new();
+        _input = new();
     }
 
     public EmulatorMemoryConfig Clone()
@@ -95,7 +95,6 @@ public class EmulatorMemoryConfig
         if (Within(Input.KeyReleasedAddress, colorMemoryStart, colorMemoryEnd))
             validationErrors.Add("KeyReleasedAddress cannot be in color memory.");
 
-
         // --------------------------------
         // Character and color maps
         // --------------------------------
@@ -127,6 +126,7 @@ public class EmulatorScreenConfig
     private ushort _screenColorStartAddress;
     private ushort _screenRefreshStatusAddress;
     private ushort _screenBorderColorAddress;
+    private ushort _screenBackgroundColorAddress;
     private byte _defaultFgColor;
     private byte _defaultBgColor;
     private byte _defaultBorderColor;
@@ -139,7 +139,6 @@ public class EmulatorScreenConfig
     {
         _isDirty = false;
     }
-
 
     public int Cols
     {
@@ -216,7 +215,16 @@ public class EmulatorScreenConfig
             _isDirty = true;
         }
     }
-    public ushort ScreenBackgroundColorAddress { get; set; }
+
+    public ushort ScreenBackgroundColorAddress
+    {
+        get { return _screenBackgroundColorAddress; }
+        set
+        {
+            _screenBackgroundColorAddress = value;
+            _isDirty = true;
+        }
+    }
 
     public byte DefaultFgColor
     {
@@ -282,29 +290,29 @@ public class EmulatorScreenConfig
 
     public EmulatorScreenConfig()
     {
-        Cols = 80;
-        Rows = 25;
-        BorderCols = 0;
-        BorderRows = 0;
+        _cols = 80;
+        _rows = 25;
+        _borderCols = 0;
+        _borderRows = 0;
 
         // Mimic C64 for some memory addresses (though we have 80 cols here instead of 40)
-        ScreenStartAddress = 0x0400;   //80*25 = 2000(0x07d0) -> range 0x0400 - 0x0bcf
-        ScreenColorStartAddress = 0xd800;   //80*25 = 2000(0x07d0) -> range 0xd800 - 0xdfcf
+        _screenStartAddress = 0x0400;   //80*25 = 2000(0x07d0) -> range 0x0400 - 0x0bcf
+        _screenColorStartAddress = 0xd800;   //80*25 = 2000(0x07d0) -> range 0xd800 - 0xdfcf
 
-        ScreenRefreshStatusAddress = 0xd000;   // To sync 6502 code with host frame: The 6502 code should wait for bit 0 to become set, and then wait for it to become cleared.
+        _screenRefreshStatusAddress = 0xd000;   // To sync 6502 code with host frame: The 6502 code should wait for bit 0 to become set, and then wait for it to become cleared.
 
-        ScreenBorderColorAddress = 0xd020;
-        ScreenBackgroundColorAddress = 0xd021;
+        _screenBorderColorAddress = 0xd020;
+        _screenBackgroundColorAddress = 0xd021;
 
-        DefaultFgColor = 0x0e;  // 0x0e = Light blue
-        DefaultBgColor = 0x06;  // 0x06 = Blue
-        DefaultBorderColor = 0x0e;  // 0x0e = Blue
+        _defaultFgColor = 0x0e;  // 0x0e = Light blue
+        _defaultBgColor = 0x06;  // 0x06 = Blue
+        _defaultBorderColor = 0x0e;  // 0x0e = Blue
 
-        ColorMap = ColorMaps.GenericColorMap;        // Default to C64 color map. TODO: Make it configurable from config file (via enum?)
+        _colorMap = ColorMaps.GenericColorMap;        // Default to C64 color map. TODO: Make it configurable from config file (via enum?)
 
-        UseAscIICharacters = true;
+        _useAscIICharacters = true;
 
-        //CharacterMap = CharacterMaps.PETSCIIMap; // TODO
+        _characterMap = default!; // TODO CharacterMaps.PETSCIIMap
     }
 
     public EmulatorScreenConfig Clone()

--- a/src/libraries/Highbyte.DotNet6502.Systems/Generic/Config/GenericComputerConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Generic/Config/GenericComputerConfig.cs
@@ -123,7 +123,7 @@ public class GenericComputerConfig : ISystemConfig
     public void Validate()
     {
         if (!IsValid(out List<string> validationErrors))
-            throw new Exception($"Config errors: {string.Join(',', validationErrors)}");
+            throw new DotNet6502Exception($"Config errors: {string.Join(',', validationErrors)}");
     }
 
     public bool IsValid(out List<string> validationErrors)

--- a/src/libraries/Highbyte.DotNet6502.Systems/ROM.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/ROM.cs
@@ -43,7 +43,7 @@ public class ROM
     public void Validate(string romDirectory)
     {
         if (!Validate(out List<string> validationErrors, romDirectory))
-            throw new Exception($"Invalid ROM. Errors: {string.Join(',', validationErrors)}");
+            throw new DotNet6502Exception($"Invalid ROM. Errors: {string.Join(',', validationErrors)}");
     }
 
     public bool Validate(out List<string> validationErrors, string romDirectory)
@@ -90,7 +90,7 @@ public class ROM
     public string GetROMFilePath(string romDirectory)
     {
         if (File == null)
-            throw new Exception($"Cannot get ROM file path if rom File is empty.");
+            throw new DotNet6502Exception($"Cannot get ROM file path if rom File is empty.");
         string romFilePath;
         if (!string.IsNullOrEmpty(romDirectory))
             romFilePath = Path.Combine(romDirectory, File);

--- a/src/libraries/Highbyte.DotNet6502.Systems/ROM.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/ROM.cs
@@ -5,7 +5,7 @@ public class ROM
     /// <summary>
     /// Name of ROM
     /// </summary>
-    public string Name { get; set; }
+    public required string Name { get; set; }
     /// <summary>
     /// Optional. File name of the ROM. If this is set, the ROM contents is read from the file instead of used from the Data property.
     /// </summary>

--- a/src/libraries/Highbyte.DotNet6502.Systems/SystemList.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/SystemList.cs
@@ -44,7 +44,7 @@ public class SystemList<TRenderContext, TInputHandlerContext, TAudioHandlerConte
     {
         var systemName = systemConfigurer.SystemName;
         if (Systems.Contains(systemName))
-            throw new Exception($"System already added: {systemName}");
+            throw new DotNet6502Exception($"System already added: {systemName}");
         Systems.Add(systemName);
 
         _systemConfigurers[systemName] = systemConfigurer;
@@ -62,7 +62,7 @@ public class SystemList<TRenderContext, TInputHandlerContext, TAudioHandlerConte
     public async Task<ISystem> GetSystem(string systemName, string configurationVariant = DEFAULT_CONFIGURATION_VARIANT)
     {
         if (!Systems.Contains(systemName))
-            throw new Exception($"System does not exist: {systemName}");
+            throw new DotNet6502Exception($"System does not exist: {systemName}");
         var cacheKey = BuildSystemCacheKey(systemName, configurationVariant);
         if (!_systemsCache.ContainsKey(cacheKey))
             await BuildAndCacheSystem(systemName, configurationVariant);
@@ -79,12 +79,12 @@ public class SystemList<TRenderContext, TInputHandlerContext, TAudioHandlerConte
     private async Task BuildAndCacheSystem(string systemName, string configurationVariant)
     {
         if (!Systems.Contains(systemName))
-            throw new Exception($"System does not exist: {systemName}");
+            throw new DotNet6502Exception($"System does not exist: {systemName}");
 
         var cacheKey = BuildSystemCacheKey(systemName, configurationVariant);
 
         if (!await IsValidConfig(systemName, configurationVariant))
-            throw new Exception($"Internal error. Configuration for system {cacheKey} is invalid.");
+            throw new DotNet6502Exception($"Internal error. Configuration for system {cacheKey} is invalid.");
 
         if (_systemsCache.ContainsKey(cacheKey))
             _systemsCache.Remove(cacheKey);
@@ -97,7 +97,7 @@ public class SystemList<TRenderContext, TInputHandlerContext, TAudioHandlerConte
     private void CacheSystemConfig(string systemName, string configurationVariant, ISystemConfig systemConfig)
     {
         if (!Systems.Contains(systemName))
-            throw new Exception($"System does not exist: {systemName}");
+            throw new DotNet6502Exception($"System does not exist: {systemName}");
 
         var cacheKey = BuildSystemCacheKey(systemName, configurationVariant);
 
@@ -114,11 +114,11 @@ public class SystemList<TRenderContext, TInputHandlerContext, TAudioHandlerConte
         string configurationVariant = DEFAULT_CONFIGURATION_VARIANT)
     {
         if (_getRenderContext == null)
-            throw new Exception("RenderContext has not been initialized. Call InitContext to initialize.");
+            throw new DotNet6502Exception("RenderContext has not been initialized. Call InitContext to initialize.");
         if (_getInputHandlerContext == null)
-            throw new Exception("InputHandlerContext has not been initialized. Call InitContext to initialize.");
+            throw new DotNet6502Exception("InputHandlerContext has not been initialized. Call InitContext to initialize.");
         if (_getAudioHandlerContext == null)
-            throw new Exception("AudioHandlerContext has not been initialized. Call InitContext to initialize.");
+            throw new DotNet6502Exception("AudioHandlerContext has not been initialized. Call InitContext to initialize.");
 
         await BuildAndCacheSystem(systemName, configurationVariant);
 
@@ -132,7 +132,7 @@ public class SystemList<TRenderContext, TInputHandlerContext, TAudioHandlerConte
     public async Task<ISystemConfig> GetCurrentSystemConfig(string systemName, string configurationVariant = DEFAULT_CONFIGURATION_VARIANT)
     {
         if (!Systems.Contains(systemName))
-            throw new Exception($"System does not exist: {systemName}");
+            throw new DotNet6502Exception($"System does not exist: {systemName}");
 
         var cacheKey = BuildSystemCacheKey(systemName, configurationVariant);
         if (!_systemConfigsCache.ContainsKey(cacheKey))

--- a/src/libraries/Highbyte.DotNet6502.Systems/SystemList.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/SystemList.cs
@@ -39,7 +39,7 @@ public class SystemList<TRenderContext, TInputHandlerContext, TAudioHandlerConte
     /// <param name="persistSystemConfig">A callback method to persist a configuration object for the system</param>
     /// <returns></returns>
     /// <exception cref="Exception"></exception>
-    public async Task AddSystem(
+    public void AddSystem(
         SystemConfigurer<TRenderContext, TInputHandlerContext, TAudioHandlerContext> systemConfigurer)
     {
         var systemName = systemConfigurer.SystemName;

--- a/src/libraries/Highbyte.DotNet6502/AddrModeCalcResult.cs
+++ b/src/libraries/Highbyte.DotNet6502/AddrModeCalcResult.cs
@@ -2,13 +2,9 @@ namespace Highbyte.DotNet6502;
 
 public struct AddrModeCalcResult
 {
-    public OpCode OpCode { get; set; }
+
+    public required OpCode OpCode { get; set; }
     public byte? InsValue { get; set; }
     public ushort? InsAddress { get; set; }
     public bool AddressCalculationCrossedPageBoundary { get; set; }
-
-    //public AddrModeCalcResult(OpCode opCode)
-    //{
-    //    OpCode = opCode;            
-    //}
 }

--- a/src/libraries/Highbyte.DotNet6502/BinaryLoader.cs
+++ b/src/libraries/Highbyte.DotNet6502/BinaryLoader.cs
@@ -65,7 +65,7 @@ public static class BinaryLoader
         if (fileHeaderLoadAddress.HasValue)
             loadedAtAddress = fileHeaderLoadAddress.Value;
         else
-            loadedAtAddress = forceLoadAddress.Value;
+            loadedAtAddress = forceLoadAddress ?? throw new ArgumentNullException(nameof(forceLoadAddress), "No load address specified and file does not contain a load address in the header.");
 
         mem.StoreData(loadedAtAddress, fileData);
     }
@@ -86,11 +86,10 @@ public static class BinaryLoader
         if (fileHeaderLoadAddress.HasValue)
             loadedAtAddress = fileHeaderLoadAddress.Value;
         else
-            loadedAtAddress = forceLoadAddress.Value;
+            loadedAtAddress = forceLoadAddress ?? throw new ArgumentNullException(nameof(forceLoadAddress), "No load address specified and file does not contain a load address in the header.");
 
         mem.StoreData(loadedAtAddress, data);
     }
-
 
     public static byte[] ReadFile(
         string binaryFilePath,

--- a/src/libraries/Highbyte.DotNet6502/CPU.cs
+++ b/src/libraries/Highbyte.DotNet6502/CPU.cs
@@ -505,37 +505,12 @@ public class CPU
 
     /// <summary>
     /// Gets the full 16-bit address at current PC, with X offset.
-    /// Takes extra cycle if final address cross page boundary.
+    /// If the page boundary was crossed, the out parameter didCrossPageBoundary is set to true.
     /// </summary>
     /// <param name="fullAddress"></param>
+    /// <param name="didCrossPageBoundary"></param>
     /// <returns></returns>
-    private ushort CalcFullAddressX(ushort fullAddress)
-    {
-        return CalcFullAddressX(fullAddress, out _, alwaysExtraCycleWhenCrossBoundary: false);
-    }
-
-    /// <summary>
-    /// Gets the full 16-bit address at current PC, with X offset.
-    /// Takes extra cycle if final address cross page boundary.
-    /// If alwaysExtraCycleWhenCrossBoundary is set to true, the extra cycle is always added.
-    /// </summary>
-    /// <param name="fullAddress"></param>
-    /// <returns></returns>
-    public ushort CalcFullAddressX(ushort fullAddress, bool alwaysExtraCycleWhenCrossBoundary)
-    {
-        return CalcFullAddressX(fullAddress, out _, alwaysExtraCycleWhenCrossBoundary);
-    }
-
-    /// <summary>
-    /// Gets the full 16-bit address at current PC, with X offset.
-    /// Takes extra cycle if final address cross page boundary.
-    /// If alwaysExtraCycleWhenCrossBoundary is set to true, the extra cycle is always added.
-    /// If the page boundary was crossed, the out paraamter didCrossPageBoundary is set to true.
-    /// </summary>
-    /// <param name="fullAddress"></param>
-    /// <param name="alwaysExtraCycleWhenCrossBoundary"></param>
-    /// <returns></returns>
-    public ushort CalcFullAddressX(ushort fullAddress, out bool didCrossPageBoundary, bool alwaysExtraCycleWhenCrossBoundary)
+    public ushort CalcFullAddressX(ushort fullAddress, out bool didCrossPageBoundary)
     {
         didCrossPageBoundary = (fullAddress & 0x00ff) + X > 0xff;
         var fullAddressX = (ushort)(fullAddress + X);
@@ -544,25 +519,12 @@ public class CPU
 
     /// <summary>
     /// Gets the full 16-bit address at current PC, with Y offset.
-    /// Takes extra cycle if final address cross page boundary.
-    /// </summary>
-    /// <param name="fullAddress"></param>
-    /// <param name="alwaysExtraCycleWhenCrossBoundary"></param>
-    /// <returns></returns>
-    public ushort CalcFullAddressY(ushort fullAddress, bool alwaysExtraCycleWhenCrossBoundary = false)
-    {
-        return CalcFullAddressY(fullAddress, out bool _, alwaysExtraCycleWhenCrossBoundary);
-    }
-
-    /// <summary>
-    /// Gets the full 16-bit address at current PC, with Y offset.
-    /// Takes extra cycle if final address cross page boundary.
+    /// If the page boundary was crossed, the out parameter didCrossPageBoundary is set to true.
     /// </summary>
     /// <param name="fullAddress"></param>
     /// <param name="didCrossPageBoundary"></param>
-    /// <param name="alwaysExtraCycleWhenCrossBoundary"></param>
     /// <returns></returns>
-    public ushort CalcFullAddressY(ushort fullAddress, out bool didCrossPageBoundary, bool alwaysExtraCycleWhenCrossBoundary)
+    public ushort CalcFullAddressY(ushort fullAddress, out bool didCrossPageBoundary)
     {
         didCrossPageBoundary = (fullAddress & 0x00ff) + Y > 0xff;
         var fullAddressY = (ushort)(fullAddress + Y);

--- a/src/libraries/Highbyte.DotNet6502/DotNet6502Exception.cs
+++ b/src/libraries/Highbyte.DotNet6502/DotNet6502Exception.cs
@@ -1,20 +1,8 @@
-using System.Runtime.Serialization;
-
 namespace Highbyte.DotNet6502;
 
-[Serializable]
-public class DotNet6502Exception: Exception
+public class DotNet6502Exception : Exception
 {
-    public DotNet6502Exception(string message): base(message)
+    public DotNet6502Exception(string message) : base(message)
     {
-    }
-    protected DotNet6502Exception(SerializationInfo info,
-        StreamingContext context): base(info, context)
-    {
-    }
-    public override void GetObjectData(SerializationInfo info,
-        StreamingContext context)
-    {
-        base.GetObjectData(info, context);
     }
 }

--- a/src/libraries/Highbyte.DotNet6502/InstructionExecutor.cs
+++ b/src/libraries/Highbyte.DotNet6502/InstructionExecutor.cs
@@ -7,7 +7,7 @@ namespace Highbyte.DotNet6502;
 /// </summary>
 public class InstructionExecutor
 {
-    private ILogger _logger;
+    private readonly ILogger _logger;
 
     public InstructionExecutor(ILoggerFactory loggerFactory)
     {
@@ -47,10 +47,6 @@ public class InstructionExecutor
         // on how to get to the actual value used with the instruction.
 
         AddrModeCalcResult addrModeCalcResult = new AddrModeCalcResult() { OpCode = opCodeObject };
-        addrModeCalcResult.OpCode = opCodeObject;
-        addrModeCalcResult.AddressCalculationCrossedPageBoundary = false;
-        addrModeCalcResult.InsAddress = null;
-        addrModeCalcResult.InsValue = null;
 
         switch (opCodeObject.AddressingMode)
         {
@@ -82,14 +78,14 @@ public class InstructionExecutor
             case AddrMode.ABS_X:
             {
                 // Note: CalcFullAddressX will check if adding X to address will cross page boundary. If so, one more cycle is consumed.
-                addrModeCalcResult.InsAddress = cpu.CalcFullAddressX(cpu.FetchOperandWord(mem), out bool didCrossPageBoundary, false);
+                addrModeCalcResult.InsAddress = cpu.CalcFullAddressX(cpu.FetchOperandWord(mem), out bool didCrossPageBoundary);
                 addrModeCalcResult.AddressCalculationCrossedPageBoundary = didCrossPageBoundary;
                 break;
             }
             case AddrMode.ABS_Y:
             {
                 // Note: CalcFullAddressY will check if adding Y to address will cross page boundary. If so, one more cycle is consumed.
-                addrModeCalcResult.InsAddress = cpu.CalcFullAddressY(cpu.FetchOperandWord(mem), out bool didCrossPageBoundary, false);
+                addrModeCalcResult.InsAddress = cpu.CalcFullAddressY(cpu.FetchOperandWord(mem), out bool didCrossPageBoundary);
                 addrModeCalcResult.AddressCalculationCrossedPageBoundary = didCrossPageBoundary;
                 break;
             }
@@ -100,7 +96,7 @@ public class InstructionExecutor
             }
             case AddrMode.IND_IX:
             {
-                addrModeCalcResult.InsAddress = cpu.CalcFullAddressY(cpu.FetchWord(mem, cpu.FetchOperand(mem)), out bool didCrossPageBoundary, false);
+                addrModeCalcResult.InsAddress = cpu.CalcFullAddressY(cpu.FetchWord(mem, cpu.FetchOperand(mem)), out bool didCrossPageBoundary);
                 addrModeCalcResult.AddressCalculationCrossedPageBoundary = didCrossPageBoundary;
                 break;
             }

--- a/src/libraries/Highbyte.DotNet6502/InstructionList.cs
+++ b/src/libraries/Highbyte.DotNet6502/InstructionList.cs
@@ -6,20 +6,22 @@ namespace Highbyte.DotNet6502;
 /// </summary>
 public class InstructionList
 {
-    public Dictionary<byte, OpCode> OpCodeDictionary {get; private set;}
-    public Dictionary<byte, Instruction> InstructionDictionary {get; private set;}
+    public Dictionary<byte, OpCode> OpCodeDictionary { get; private set; }
+    public Dictionary<byte, Instruction> InstructionDictionary { get; private set; }
 
-    public InstructionList()
+    public InstructionList(Dictionary<byte, OpCode> opCodeDictionary, Dictionary<byte, Instruction> instructionDictionary)
     {
+        OpCodeDictionary = opCodeDictionary;
+        InstructionDictionary = instructionDictionary;
     }
 
     public InstructionList(List<Instruction> insList)
     {
         InstructionDictionary = new Dictionary<byte, Instruction>();
         OpCodeDictionary = new Dictionary<byte, OpCode>();
-        foreach(var instruction in insList)
+        foreach (var instruction in insList)
         {
-            foreach(var opCode in instruction.OpCodes)
+            foreach (var opCode in instruction.OpCodes)
             {
                 OpCodeDictionary.Add(opCode.Code.ToByte(), opCode);
                 InstructionDictionary.Add(opCode.CodeRaw, instruction);
@@ -39,11 +41,7 @@ public class InstructionList
 
     public InstructionList Clone()
     {
-        return new InstructionList()
-        {
-            OpCodeDictionary = this.OpCodeDictionary,
-            InstructionDictionary = this.InstructionDictionary,
-        };
+        return new InstructionList(this.OpCodeDictionary, this.InstructionDictionary);
     }
 
     public static InstructionList GetAllInstructions()
@@ -60,16 +58,19 @@ public class InstructionList
 
         var typesToSearch = typeof(InstructionList).Assembly.GetTypes();
 
-        var instructionTypes = typesToSearch.Where(p => 
+        var instructionTypes = typesToSearch.Where(p =>
             p.GetTypeInfo().IsSubclassOf(typeof(Instruction))
             && !p.GetTypeInfo().IsAbstract
         );
 
         var instructions = new List<Instruction>();
-        foreach(var instructionType in instructionTypes)
+        foreach (var instructionType in instructionTypes)
         {
-            Instruction instruction = (Instruction)Activator.CreateInstance(instructionType);
-            instructions.Add(instruction);
+            Instruction? instruction = (Instruction?)Activator.CreateInstance(instructionType);
+            if (instruction != null)
+            {
+                instructions.Add(instruction);
+            }
         }
         return new InstructionList(instructions);
     }

--- a/src/libraries/Highbyte.DotNet6502/Instructions/DEC.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/DEC.cs
@@ -12,7 +12,7 @@ public class DEC : Instruction, IInstructionUsesByte
     public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
     {
         value--;
-        cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress.Value);
+        cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
         BinaryArithmeticHelpers.SetFlagsAfterRegisterLoadIncDec(value, cpu.ProcessorStatus);
 
         return 0;

--- a/src/libraries/Highbyte.DotNet6502/Instructions/INC.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/INC.cs
@@ -12,12 +12,12 @@ public class INC : Instruction, IInstructionUsesByte
     public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
     {
         value++;
-        cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress.Value);
+        cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
         BinaryArithmeticHelpers.SetFlagsAfterRegisterLoadIncDec(value, cpu.ProcessorStatus);
 
         return 0;
     }
-   
+
     public INC()
     {
         _opCodes = new List<OpCode>

--- a/src/libraries/Highbyte.DotNet6502/Logging/Console/DotNet6502ConsoleLogger.cs
+++ b/src/libraries/Highbyte.DotNet6502/Logging/Console/DotNet6502ConsoleLogger.cs
@@ -16,7 +16,6 @@ public class DotNet6502ConsoleLogger : DotNet6502LoggerBase
         _getCurrentConfig = getCurrentConfig;
     }
 
-    public override IDisposable BeginScope<TState>(TState state) => default!;
     public override bool IsEnabled(LogLevel logLevel) => logLevel >= _getCurrentConfig().LogLevel;
     public override void WriteLog(string message) => System.Console.WriteLine(message);
 }

--- a/src/libraries/Highbyte.DotNet6502/Logging/DotNet6502LoggerBase.cs
+++ b/src/libraries/Highbyte.DotNet6502/Logging/DotNet6502LoggerBase.cs
@@ -7,7 +7,7 @@ namespace Highbyte.DotNet6502.Logging
     public abstract class DotNet6502LoggerBase : ILogger
     {
         private readonly ObjectPool<StringBuilder> _stringBuilderPool;
-        protected readonly string _categoryName;
+        private readonly string _categoryName;
 
         public DotNet6502LoggerBase(
             ObjectPool<StringBuilder> stringBuilderPool,
@@ -17,10 +17,11 @@ namespace Highbyte.DotNet6502.Logging
             _categoryName = categoryName;
         }
 
-        public virtual IDisposable BeginScope<TState>(TState state) => default!;
+        IDisposable ILogger.BeginScope<TState>(TState state) => default!;
+
         public abstract bool IsEnabled(LogLevel logLevel);
 
-        public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
             if (!IsEnabled(logLevel))
                 return;
@@ -36,7 +37,7 @@ namespace Highbyte.DotNet6502.Logging
             WriteMessage(logLevel, eventId.Id, message, exception);
         }
 
-        protected virtual void WriteMessage(LogLevel logLevel, int eventId, string message, Exception ex)
+        protected virtual void WriteMessage(LogLevel logLevel, int eventId, string message, Exception? ex)
         {
             var builder = _stringBuilderPool.Get();
             try

--- a/src/libraries/Highbyte.DotNet6502/Logging/InMem/DotNet6502InMemLogger.cs
+++ b/src/libraries/Highbyte.DotNet6502/Logging/InMem/DotNet6502InMemLogger.cs
@@ -16,7 +16,6 @@ public class DotNet6502InMemLogger : DotNet6502LoggerBase
         _getCurrentConfig = getCurrentConfig;
     }
 
-    public override IDisposable BeginScope<TState>(TState state) => default!;
     public override bool IsEnabled(LogLevel logLevel) => logLevel >= _getCurrentConfig().LogLevel;
     public override void WriteLog(string message) => _getCurrentConfig().WriteLog(message);
 }

--- a/src/libraries/Highbyte.DotNet6502/Memory.cs
+++ b/src/libraries/Highbyte.DotNet6502/Memory.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics;
-
 namespace Highbyte.DotNet6502;
 
 public class Memory
@@ -13,27 +11,27 @@ public class Memory
         public byte Value { get; set; }
     }
 
-    public const int MAX_MEMORY_SIZE = 1024*64;
+    public const int MAX_MEMORY_SIZE = 1024 * 64;
 
     public int Size { get; private set; }
     public int NumberOfConfigurations { get; private set; }
     public int CurrentConfiguration { get; private set; }
 
-    private LoadByte[] _readers;
-    private StoreByte[] _writers;
-    private StoreByte[] _originalWriters;
+    private LoadByte[] _readers = null!;
+    private StoreByte[] _writers = null!;
+    private StoreByte[] _originalWriters = null!;
 
-    private LoadByte[][] _readersPerConfiguration;
-    private StoreByte[][] _writersPerConfiguration;
-    private StoreByte[][] _originalWritersPerConfiguration;
+    private readonly LoadByte[][] _readersPerConfiguration;
+    private readonly StoreByte[][] _writersPerConfiguration;
+    private readonly StoreByte[][] _originalWritersPerConfiguration;
 
-    public Memory(int memorySize = MAX_MEMORY_SIZE, int numberOfConfigurations=1, bool mapToDefaultRAM = true) 
+    public Memory(int memorySize = MAX_MEMORY_SIZE, int numberOfConfigurations = 1, bool mapToDefaultRAM = true)
     {
-        if(memorySize<=0)
+        if (memorySize <= 0)
             throw new ArgumentException("Must be greater than 0", nameof(memorySize));
-        if(memorySize > MAX_MEMORY_SIZE)
+        if (memorySize > MAX_MEMORY_SIZE)
             throw new ArgumentException($"Must be less than or equal to {MAX_MEMORY_SIZE}", nameof(memorySize));
-        if(numberOfConfigurations<=0)
+        if (numberOfConfigurations <= 0)
             throw new ArgumentException("Must be equal to or greater than 1", nameof(numberOfConfigurations));
 
         Size = memorySize;
@@ -58,8 +56,8 @@ public class Memory
 
     public void SetMemoryConfiguration(int configuration)
     {
-        if(configuration>=NumberOfConfigurations)
-            throw new ArgumentException($"Memory configuration doesn't exist. Max value is {NumberOfConfigurations-1} ", nameof(configuration));
+        if (configuration >= NumberOfConfigurations)
+            throw new ArgumentException($"Memory configuration doesn't exist. Max value is {NumberOfConfigurations - 1} ", nameof(configuration));
         CurrentConfiguration = configuration;
         _readers = _readersPerConfiguration[CurrentConfiguration];
         _writers = _writersPerConfiguration[CurrentConfiguration];
@@ -80,7 +78,7 @@ public class Memory
 
     public void MapRAM(ushort baseAddress, byte[] data, ushort dataOffset = 0, ushort? length = null, PreWriteIntercept? preWriteIntercept = null)
     {
-        LoadByte reader = delegate(ushort address)
+        LoadByte reader = delegate (ushort address)
         {
             return data[(address + dataOffset) - baseAddress];
         };
@@ -136,7 +134,7 @@ public class Memory
 
     public void MapROM(ushort baseAddress, byte[] data)
     {
-        LoadByte reader = delegate(ushort address)
+        LoadByte reader = delegate (ushort address)
         {
             return data[address - baseAddress];
         };
@@ -151,16 +149,15 @@ public class Memory
         }
     }
 
-
     public void MapRO(ushort address, MemValue memValue)
     {
-        LoadByte reader = _ => { return memValue.Value;};
+        LoadByte reader = _ => { return memValue.Value; };
         _readers[address] = reader;
     }
 
     public void MapWO(ushort address, MemValue memValue)
     {
-        StoreByte writer = (_, newVal) => { memValue.Value = newVal;};
+        StoreByte writer = (_, newVal) => { memValue.Value = newVal; };
         _writers[address] = writer;
     }
 
@@ -169,7 +166,6 @@ public class Memory
         MapRO(address, memValue);
         MapWO(address, memValue);
     }
-
 
     /// <summary>
     /// Maps an individual address to a delegate for reading 

--- a/src/libraries/Highbyte.DotNet6502/OutputGen.cs
+++ b/src/libraries/Highbyte.DotNet6502/OutputGen.cs
@@ -5,7 +5,7 @@ namespace Highbyte.DotNet6502;
 /// </summary>
 public static class OutputGen
 {
-    const string HexPrefix = "";
+    private const string HexPrefix = "";
     /// <summary>
     /// Returns a string with the following information
     /// [last instruction PC]  [byte1 [byte2 [byte3]]]  [instruction] [addressingmode/value] 
@@ -15,8 +15,11 @@ public static class OutputGen
     /// <returns></returns>
     public static string GetLastInstructionDisassembly(CPU cpu, Memory mem)
     {
-        ushort programAddress = cpu.ExecState.PCBeforeLastOpCodeExecuted.Value;
-        return GetInstructionDisassembly(cpu, mem, programAddress);
+        ushort? programAddress = cpu.ExecState.PCBeforeLastOpCodeExecuted;
+        if (programAddress.HasValue)
+            return GetInstructionDisassembly(cpu, mem, programAddress.Value);
+        else
+            throw new Exception("programAddress is null");
     }
 
     /// <summary>
@@ -53,19 +56,19 @@ public static class OutputGen
     public static string BuildMemoryString(CPU cpu, Memory mem, ushort address)
     {
         byte opCodeByte = mem[address];
-        if(!cpu.InstructionList.OpCodeDictionary.ContainsKey(opCodeByte))
+        if (!cpu.InstructionList.OpCodeDictionary.ContainsKey(opCodeByte))
             return $"{opCodeByte.ToHex(HexPrefix, lowerCase: true)}";
 
         var opCode = cpu.InstructionList.GetOpCode(opCodeByte);
         var operand = mem.ReadData((ushort)(address + 1), (ushort)(opCode.Size - 1)); // -1 for the opcode itself
 
-        return $"{opCodeByte.ToHex(HexPrefix, lowerCase: true)} {string.Join(" ", operand.Select(x=>x.ToHex(HexPrefix, lowerCase: true)))}";
+        return $"{opCodeByte.ToHex(HexPrefix, lowerCase: true)} {string.Join(" ", operand.Select(x => x.ToHex(HexPrefix, lowerCase: true)))}";
     }
 
     public static string BuildInstructionString(CPU cpu, Memory mem, ushort address)
     {
         byte opCodeByte = mem[address];
-        if(!cpu.InstructionList.OpCodeDictionary.ContainsKey(opCodeByte))
+        if (!cpu.InstructionList.OpCodeDictionary.ContainsKey(opCodeByte))
             return "???";
 
         var opCode = cpu.InstructionList.GetOpCode(opCodeByte);
@@ -192,5 +195,4 @@ public static class OutputGen
     {
         return $"SP={cpu.SP.ToHex(HexPrefix)} PC={cpu.PC.ToHex(HexPrefix)}";
     }
-
 }

--- a/src/libraries/Highbyte.DotNet6502/OutputGen.cs
+++ b/src/libraries/Highbyte.DotNet6502/OutputGen.cs
@@ -154,13 +154,15 @@ public static class OutputGen
 
     public static Dictionary<string, string> GetProcessorStateDictionary(CPU cpu, bool includeCycles = false)
     {
-        var state = new Dictionary<string, string>();
-        state.Add("A", cpu.A.ToHex(HexPrefix));
-        state.Add("X", cpu.X.ToHex(HexPrefix));
-        state.Add("Y", cpu.Y.ToHex(HexPrefix));
-        state.Add("PS", GetStatusValueString(cpu));
-        state.Add("PC", cpu.PC.ToHex(HexPrefix));
-        state.Add("SP", cpu.SP.ToHex(HexPrefix));
+        var state = new Dictionary<string, string>
+        {
+            { "A", cpu.A.ToHex(HexPrefix) },
+            { "X", cpu.X.ToHex(HexPrefix) },
+            { "Y", cpu.Y.ToHex(HexPrefix) },
+            { "PS", GetStatusValueString(cpu) },
+            { "PC", cpu.PC.ToHex(HexPrefix) },
+            { "SP", cpu.SP.ToHex(HexPrefix) }
+        };
         if (includeCycles)
             state.Add("CY", cpu.ExecState.CyclesConsumed.ToString());
         return state;

--- a/src/libraries/Highbyte.DotNet6502/OutputGen.cs
+++ b/src/libraries/Highbyte.DotNet6502/OutputGen.cs
@@ -19,7 +19,7 @@ public static class OutputGen
         if (programAddress.HasValue)
             return GetInstructionDisassembly(cpu, mem, programAddress.Value);
         else
-            throw new Exception("programAddress is null");
+            throw new DotNet6502Exception("programAddress is null");
     }
 
     /// <summary>

--- a/src/libraries/Highbyte.DotNet6502/Systems/SystemRunner.cs
+++ b/src/libraries/Highbyte.DotNet6502/Systems/SystemRunner.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics;
-
 namespace Highbyte.DotNet6502.Systems;
 
 public class SystemRunner
@@ -16,9 +14,6 @@ public class SystemRunner
 
     private IExecEvaluator? _customExecEvaluator;
     public IExecEvaluator? CustomExecEvaluator => _customExecEvaluator;
-
-    // Detailed perf stat to audio generation that occurs after each instruction
-    private readonly Stopwatch _audioSw = new();
 
     public SystemRunner(ISystem system)
     {
@@ -55,7 +50,7 @@ public class SystemRunner
     /// </summary>
     public ExecEvaluatorTriggerResult RunEmulatorOneFrame()
     {
-        var execEvaluatorTriggerResult = _system.ExecuteOneFrame(this,  _customExecEvaluator);
+        var execEvaluatorTriggerResult = _system.ExecuteOneFrame(this, _customExecEvaluator);
         return execEvaluatorTriggerResult;
     }
 

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Video/Sprite_collitions_debug.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Video/Sprite_collitions_debug.cs
@@ -13,7 +13,7 @@ public class Sprite_collitions_debug
     private readonly C64 _c64;
     private readonly Vic2 _vic2;
     private readonly Memory _vic2Mem;
-    private readonly Vic2SpriteManager? _vic2SpriteManager;
+    private readonly Vic2SpriteManager _vic2SpriteManager;
 
     public Sprite_collitions_debug(ITestOutputHelper testOutputHelper)
     {
@@ -170,13 +170,11 @@ public class Sprite_collitions_debug
             _output.WriteLine($"{string.Join(" ", spriteLine.Select(b => Convert.ToString(b, 2).PadLeft(8, '0')))}");
     }
 
-
     private void WriteToTextScreen(byte characterCode, int col, int row)
     {
         var characterAddress = (ushort)(_vic2.VideoMatrixBaseAddress + (row * _vic2.Vic2Screen.TextCols) + col);
         _vic2Mem[characterAddress] = characterCode;
     }
-
 
     private Vic2Sprite CreateSprite(int spriteNumber, byte x, byte y, bool doubleWidth, bool doubleHeight, bool multiColor, byte[] spriteShape, byte spritePointer = 192)
     {

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Video/Sprite_collitions_debug.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Video/Sprite_collitions_debug.cs
@@ -12,7 +12,7 @@ public class Sprite_collitions_debug
     private readonly ITestOutputHelper _output;
     private readonly C64 _c64;
     private readonly Vic2 _vic2;
-    private readonly Memory? _vic2Mem;
+    private readonly Memory _vic2Mem;
     private readonly Vic2SpriteManager? _vic2SpriteManager;
 
     public Sprite_collitions_debug(ITestOutputHelper testOutputHelper)
@@ -88,7 +88,7 @@ public class Sprite_collitions_debug
                 collisionFoundSpriteScreenLine = spriteScreenLine;
         }
 
-        if(collisionFoundSpriteScreenLine.HasValue)
+        if (collisionFoundSpriteScreenLine.HasValue)
             _output.WriteLine($"Collision found at line: {collisionFoundSpriteScreenLine}");
         else
             _output.WriteLine("No collision");

--- a/tests/Highbyte.DotNet6502.Tests/BinaryLoaderTest.cs
+++ b/tests/Highbyte.DotNet6502.Tests/BinaryLoaderTest.cs
@@ -36,6 +36,82 @@ public class BinaryLoaderTest
     }
 
     [Fact]
+    public void Load_Can_Load_A_Binary_File_To_Emulator_Memory_At_Specific_Address()
+    {
+        // Arrange
+        byte[] bytes = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+        var filePath = "test.bin";
+        File.WriteAllBytes(filePath, bytes);
+        ushort loadAddress = 0x0100;
+
+        var bytesString = string.Join(" ", bytes.Select(b => Convert.ToString(b, 2).PadLeft(8, '0')));
+        _output.WriteLine("Bytes saved:");
+        _output.WriteLine(bytesString);
+
+        var mem = new Memory();
+
+        // Act
+        BinaryLoader.Load(mem, filePath, out ushort loadedAtAddress, out ushort fileLength, forceLoadAddress: loadAddress);
+
+        // Assert
+        Assert.Equal(loadAddress, loadedAtAddress);
+        Assert.Equal(bytes.Length, fileLength);
+
+        byte[] memBytes = mem.ReadData(loadedAtAddress, (ushort)(bytes.Length));
+        Assert.Equivalent(bytes, memBytes);
+    }
+
+    [Fact]
+    public void Load_Can_Load_A_Binary_Array_To_Emulator_Memory()
+    {
+        // Arrange
+        byte[] header = { 0x00, 0x01 };
+        byte[] data = { 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+        byte[] bytes = header.Concat(data).ToArray();
+
+        var bytesString = string.Join(" ", bytes.Select(b => Convert.ToString(b, 2).PadLeft(8, '0')));
+        _output.WriteLine("Bytes:");
+        _output.WriteLine(bytesString);
+
+        var mem = new Memory();
+
+        // Act
+        BinaryLoader.Load(mem, bytes, out ushort loadedAtAddress, out ushort fileLength, forceLoadAddress: null);
+
+        // Assert
+        Assert.Equal(header.ToLittleEndianWord(), loadedAtAddress);
+        Assert.Equal(data.Length, fileLength);
+
+        byte[] memBytes = mem.ReadData(loadedAtAddress, (ushort)(data.Length));
+        Assert.Equivalent(data, memBytes);
+    }
+
+    [Fact]
+    public void Load_Can_Load_A_Binary_Array_To_Emulator_Memory_At_Specific_Address()
+    {
+        // Arrange
+        byte[] bytes = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+
+        ushort loadAddress = 0x0100;
+
+        var bytesString = string.Join(" ", bytes.Select(b => Convert.ToString(b, 2).PadLeft(8, '0')));
+        _output.WriteLine("Bytes:");
+        _output.WriteLine(bytesString);
+
+        var mem = new Memory();
+
+        // Act
+        BinaryLoader.Load(mem, bytes, out ushort loadedAtAddress, out ushort fileLength, forceLoadAddress: loadAddress);
+
+        // Assert
+        Assert.Equal(loadAddress, loadedAtAddress);
+        Assert.Equal(bytes.Length, fileLength);
+
+        byte[] memBytes = mem.ReadData(loadedAtAddress, (ushort)(bytes.Length));
+        Assert.Equivalent(bytes, memBytes);
+    }
+
+    [Fact]
     public void Load_Can_Load_A_Binary_File_And_Return_A_Emulator_Memory_Object()
     {
         // Arrange

--- a/tests/Highbyte.DotNet6502.Tests/BinaryLoaderTest.cs
+++ b/tests/Highbyte.DotNet6502.Tests/BinaryLoaderTest.cs
@@ -1,0 +1,59 @@
+namespace Highbyte.DotNet6502.Tests;
+
+public class BinaryLoaderTest
+{
+    private readonly ITestOutputHelper _output;
+    public BinaryLoaderTest(ITestOutputHelper testOutputHelper)
+    {
+        _output = testOutputHelper;
+    }
+
+    [Fact]
+    public void ReadFile_Can_Read_A_Binary_File()
+    {
+        // Arrange
+        byte[] bytes = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+        var filePath = "test.bin";
+        File.WriteAllBytes(filePath, bytes);
+
+        var bytesString = string.Join(" ", bytes.Select(b => Convert.ToString(b, 2).PadLeft(8, '0')));
+        _output.WriteLine("Bytes saved:");
+        _output.WriteLine(bytesString);
+
+
+        // Act
+        var loadedBytes = BinaryLoader.ReadFile(filePath, fileHeaderContainsLoadAddress: false, out _, out ushort codeAndDataFileSize);
+
+        // Assert
+        Assert.Equal(bytes.Length, loadedBytes.Length);
+        Assert.Equal(bytes.Length, codeAndDataFileSize);
+
+        Assert.Equivalent(bytes, loadedBytes);
+    }
+
+    [Fact]
+    public void ReadFile_Can_Read_A_Binary_File_With_Address_Header()
+    {
+        // Arrange
+        byte[] header = { 0x00, 0x01 };
+        byte[] data = { 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+        byte[] bytes = header.Concat(data).ToArray();
+        var filePath = "test.bin";
+        File.WriteAllBytes(filePath, bytes);
+
+        var bytesString = string.Join(" ", bytes.Select(b => Convert.ToString(b, 2).PadLeft(8, '0')));
+        _output.WriteLine("Bytes saved:");
+        _output.WriteLine(bytesString);
+
+        // Act
+        var loadedBytes = BinaryLoader.ReadFile(filePath, fileHeaderContainsLoadAddress: true, out ushort? fileHeaderLoadAddress, out ushort codeAndDataFileSize);
+
+        // Assert
+        Assert.Equal(data.Length , loadedBytes.Length);
+        Assert.Equal(data.Length, codeAndDataFileSize);
+        Assert.Equal((ushort)0x0100, fileHeaderLoadAddress);
+
+        Assert.Equivalent(data, loadedBytes);
+    }
+
+}

--- a/tests/Highbyte.DotNet6502.Tests/BinaryLoaderTest.cs
+++ b/tests/Highbyte.DotNet6502.Tests/BinaryLoaderTest.cs
@@ -9,6 +9,58 @@ public class BinaryLoaderTest
     }
 
     [Fact]
+    public void Load_Can_Load_A_Binary_File_To_Emulator_Memory()
+    {
+        // Arrange
+        byte[] header = { 0x00, 0x01 };
+        byte[] data = { 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+        byte[] bytes = header.Concat(data).ToArray();
+        var filePath = "test.bin";
+        File.WriteAllBytes(filePath, bytes);
+
+        var bytesString = string.Join(" ", bytes.Select(b => Convert.ToString(b, 2).PadLeft(8, '0')));
+        _output.WriteLine("Bytes saved:");
+        _output.WriteLine(bytesString);
+
+        var mem = new Memory();
+
+        // Act
+        BinaryLoader.Load(mem, filePath, out ushort loadedAtAddress, out ushort fileLength, forceLoadAddress: null);
+
+        // Assert
+        Assert.Equal(header.ToLittleEndianWord(), loadedAtAddress);
+        Assert.Equal(data.Length, fileLength);
+
+        byte[] memBytes = mem.ReadData(loadedAtAddress, (ushort)(data.Length));
+        Assert.Equivalent(data, memBytes);
+    }
+
+    [Fact]
+    public void Load_Can_Load_A_Binary_File_And_Return_A_Emulator_Memory_Object()
+    {
+        // Arrange
+        byte[] header = { 0x00, 0x01 };
+        byte[] data = { 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+        byte[] bytes = header.Concat(data).ToArray();
+        var filePath = "test.bin";
+        File.WriteAllBytes(filePath, bytes);
+
+        var bytesString = string.Join(" ", bytes.Select(b => Convert.ToString(b, 2).PadLeft(8, '0')));
+        _output.WriteLine("Bytes saved:");
+        _output.WriteLine(bytesString);
+
+        // Act
+        var mem = BinaryLoader.Load(filePath, out ushort loadedAtAddress, out ushort fileLength, forceLoadAddress: null);
+
+        // Assert
+        Assert.Equal(header.ToLittleEndianWord(), loadedAtAddress);
+        Assert.Equal(data.Length, fileLength);
+
+        byte[] memBytes = mem.ReadData(loadedAtAddress, (ushort)(data.Length));
+        Assert.Equivalent(data, memBytes);
+    }
+
+    [Fact]
     public void ReadFile_Can_Read_A_Binary_File()
     {
         // Arrange
@@ -19,7 +71,6 @@ public class BinaryLoaderTest
         var bytesString = string.Join(" ", bytes.Select(b => Convert.ToString(b, 2).PadLeft(8, '0')));
         _output.WriteLine("Bytes saved:");
         _output.WriteLine(bytesString);
-
 
         // Act
         var loadedBytes = BinaryLoader.ReadFile(filePath, fileHeaderContainsLoadAddress: false, out _, out ushort codeAndDataFileSize);
@@ -55,5 +106,4 @@ public class BinaryLoaderTest
 
         Assert.Equivalent(data, loadedBytes);
     }
-
 }

--- a/tests/Highbyte.DotNet6502.Tests/CPUTest.cs
+++ b/tests/Highbyte.DotNet6502.Tests/CPUTest.cs
@@ -82,7 +82,6 @@ public class CPUTest
         Assert.Equal(originalSP, cpu.SP);       // StackPointer should not have been changed (PC/PS not pushed to stack)
     }
 
-
     [Fact]
     public void CPU_Handles_Hardware_NMI_Even_When_InterruptDisable_Is_Set()
     {
@@ -142,7 +141,7 @@ public class CPUTest
         // Act
         var execState = cpu.Execute(
             mem,
-            new LegacyExecEvaluator(new ExecOptions{MaxNumberOfInstructions=1, UnknownInstructionThrowsException = false}));
+            new LegacyExecEvaluator(new ExecOptions { MaxNumberOfInstructions = 1, UnknownInstructionThrowsException = false }));
 
         // Assert
         Assert.False(execState.LastOpCodeWasHandled);

--- a/tests/Highbyte.DotNet6502.Tests/Functional_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Functional_test.cs
@@ -1,9 +1,8 @@
-using Highbyte.DotNet6502.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Highbyte.DotNet6502.Tests;
 
-[Trait("TestType", "Integration")] 
+[Trait("TestType", "Integration")]
 public class Functional_test
 {
     private readonly ITestOutputHelper _output;
@@ -21,18 +20,18 @@ public class Functional_test
 
         // There is no 2 byte header in the 6502_functional_test.bin file.
         // It's supposed to be loaded to memory at 0x0000, and started at 0x0400
-        ushort loadAddress  = 0x000A;
+        ushort loadAddress = 0x000A;
         ushort startAddress = 0x0400;
 
         var mem = BinaryLoader.Load(
-            functionalTestBinary, 
-            out ushort loadedAtAddress, 
+            functionalTestBinary,
+            out ushort loadedAtAddress,
             out ushort fileLength,
             forceLoadAddress: loadAddress);
 
-        _output.WriteLine($"Data & code load  address: {loadAddress.ToHex(), 10} ({loadAddress})");
-        _output.WriteLine($"Code+data length (bytes):  0x{fileLength, -8:X8} ({fileLength})");
-        _output.WriteLine($"Code start address:        {startAddress.ToHex(), 10} ({startAddress})");
+        _output.WriteLine($"Data & code load  address: {loadAddress.ToHex(),10} ({loadAddress})");
+        _output.WriteLine($"Code+data length (bytes):  0x{fileLength,-8:X8} ({fileLength})");
+        _output.WriteLine($"Code start address:        {startAddress.ToHex(),10} ({startAddress})");
 
         var cpu = new CPU();
         cpu.PC = startAddress;

--- a/tests/Highbyte.DotNet6502.Tests/Functional_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Functional_test.cs
@@ -16,7 +16,7 @@ public class Functional_test
     {
         // Arrange
         var functionalTestCompiler = new FunctionalTestCompiler(NullLogger<FunctionalTestCompiler>.Instance);
-        var functionalTestBinary = functionalTestCompiler.Get6502FunctionalTestBinary(disableDecimalTests: true);
+        var functionalTestBinary = functionalTestCompiler.Get6502FunctionalTestBinary(disableDecimalTests: false);
 
         // There is no 2 byte header in the 6502_functional_test.bin file.
         // It's supposed to be loaded to memory at 0x0000, and started at 0x0400

--- a/tests/Highbyte.DotNet6502.Tests/GlobalSuppressions.cs
+++ b/tests/Highbyte.DotNet6502.Tests/GlobalSuppressions.cs
@@ -1,0 +1,3 @@
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Style", "IDE0055:For formatting")]

--- a/tests/Highbyte.DotNet6502.Tests/Helpers/FunctionalTestCompiler.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Helpers/FunctionalTestCompiler.cs
@@ -50,7 +50,7 @@ public class FunctionalTestCompiler
     {
         _logger = logger;
     }
-    public string Get6502FunctionalTestBinary(bool disableDecimalTests = true, string? downloadDir = null)
+    public string Get6502FunctionalTestBinary(bool disableDecimalTests = false, string? downloadDir = null)
     {
         // Get source code file path (with modified contents to suit our test purpose)
         var sourceCodeFilePath = Get6502FunctionalTestSourceCode(disableDecimalTests, downloadDir);
@@ -119,7 +119,7 @@ public class FunctionalTestCompiler
         // Modify test source code to disable decimal tests
         var modifiedFileName = "6502_functional_test_decimal_disabled.a65";
         var modifiedFunctionalTestSourceCodeFileFilePath = Path.Join(downloadDir, modifiedFileName);
-        ModifyAsmSourceCodeSettings(functionalTestSourceCodeFileFilePath, modifiedFunctionalTestSourceCodeFileFilePath);
+        ModifyAsmSourceCodeSettings(functionalTestSourceCodeFileFilePath, modifiedFunctionalTestSourceCodeFileFilePath, disableDecimal: true);
 
         return modifiedFunctionalTestSourceCodeFileFilePath;
     }
@@ -130,7 +130,7 @@ public class FunctionalTestCompiler
         File.WriteAllBytes(outputPath, fileBytes);
     }
 
-    private void ModifyAsmSourceCodeSettings(string originalFile, string newFile)
+    private void ModifyAsmSourceCodeSettings(string originalFile, string newFile, bool disableDecimal)
     {
         // Change settings by modifying assembler source code
         var fileContentsLineArray = File.ReadAllLines(originalFile);
@@ -138,8 +138,11 @@ public class FunctionalTestCompiler
         for (int i = 0; i < fileContentsLineArray.Length; i++)
         {
             var line = fileContentsLineArray[i];
-            if (line.StartsWith("disable_decimal") && line.Contains("="))
-                line = "disable_decimal = 1";
+            if(disableDecimal)
+            {
+                if (line.StartsWith("disable_decimal") && line.Contains("="))
+                    line = "disable_decimal = 1";
+            }
             modifiedFileContentsLineArray.Add(line);
         }
         // Write modified 6502 assembler code to new file

--- a/tests/Highbyte.DotNet6502.Tests/Helpers/FunctionalTestCompiler.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Helpers/FunctionalTestCompiler.cs
@@ -46,11 +46,11 @@ public class FunctionalTestCompiler
 
     private static readonly HttpClient s_httpClient = new HttpClient();
 
-    public FunctionalTestCompiler(ILogger<FunctionalTestCompiler> logger)        
+    public FunctionalTestCompiler(ILogger<FunctionalTestCompiler> logger)
     {
         _logger = logger;
     }
-    public string Get6502FunctionalTestBinary(bool disableDecimalTests = true, string downloadDir = null)
+    public string Get6502FunctionalTestBinary(bool disableDecimalTests = true, string? downloadDir = null)
     {
         // Get source code file path (with modified contents to suit our test purpose)
         var sourceCodeFilePath = Get6502FunctionalTestSourceCode(disableDecimalTests, downloadDir);
@@ -66,10 +66,10 @@ public class FunctionalTestCompiler
         // Assume output files of the compilation (.bin and .lst file) are placed 
         // in same directory as the source code that was compiled.
         string compiledBinFile = Path.Join(Path.GetDirectoryName(sourceCodeFilePath), Path.GetFileNameWithoutExtension(sourceCodeFilePath)) + ".bin";
-        if(File.Exists(compiledBinFile))
+        if (File.Exists(compiledBinFile))
             File.Delete(compiledBinFile);
         string compiledLstFile = Path.Join(Path.GetDirectoryName(sourceCodeFilePath), Path.GetFileNameWithoutExtension(sourceCodeFilePath)) + ".lst";
-        if(File.Exists(compiledLstFile))
+        if (File.Exists(compiledLstFile))
             File.Delete(compiledLstFile);
 
         string arguments = $"-l -m -w -h0 {sourceCodeFilePath}";
@@ -87,7 +87,7 @@ public class FunctionalTestCompiler
             process.OutputDataReceived += (sender, data) => _logger.LogTrace(data.Data);
             //Seems every row written to stderr by the as65.exe does not mean it's an error.
             //Hack: Don't send logs to _logger.LogError(data.Data), insted as trace
-            process.ErrorDataReceived += (sender, data) => _logger.LogTrace(data.Data); 
+            process.ErrorDataReceived += (sender, data) => _logger.LogTrace(data.Data);
             _logger.LogInformation($"Executing {as65exeFilePath}");
             process.Start();
             process.BeginOutputReadLine();
@@ -96,16 +96,16 @@ public class FunctionalTestCompiler
             _logger.LogInformation($"Exited: {exited}");
         }
 
-        if(!File.Exists(compiledBinFile))
+        if (!File.Exists(compiledBinFile))
             throw new DotNet6502Exception($"Executing {as65exeFilePath} with arguments {arguments} did not generate expected binary file at {compiledBinFile}");
         return compiledBinFile;
     }
 
-    private string Get6502FunctionalTestSourceCode(bool disableDecimalTests, string downloadDir)
+    private string Get6502FunctionalTestSourceCode(bool disableDecimalTests, string? downloadDir = null)
     {
-        if(string.IsNullOrEmpty(downloadDir))
-            Directory.GetCurrentDirectory();
-        
+        if (string.IsNullOrEmpty(downloadDir))
+            downloadDir = Directory.GetCurrentDirectory();
+
         // Download 6502 functional test source code (.as64 assembler)
         var functionalTestSourceCodeUrl = "https://raw.githubusercontent.com/Klaus2m5/6502_65C02_functional_tests/master/6502_functional_test.a65";
         var functionalTestSourceCodeFileName = "6502_functional_test.a65";
@@ -113,7 +113,7 @@ public class FunctionalTestCompiler
 
         DownloadFile(functionalTestSourceCodeUrl, functionalTestSourceCodeFileFilePath);
 
-        if(!disableDecimalTests)
+        if (!disableDecimalTests)
             return functionalTestSourceCodeFileFilePath;
 
         // Modify test source code to disable decimal tests
@@ -138,26 +138,25 @@ public class FunctionalTestCompiler
         for (int i = 0; i < fileContentsLineArray.Length; i++)
         {
             var line = fileContentsLineArray[i];
-            if(line.StartsWith("disable_decimal") && line.Contains("="))
+            if (line.StartsWith("disable_decimal") && line.Contains("="))
                 line = "disable_decimal = 1";
             modifiedFileContentsLineArray.Add(line);
         }
         // Write modified 6502 assembler code to new file
         File.WriteAllLines(newFile, modifiedFileContentsLineArray);
-    }        
+    }
 
-    private string GetAS65AssemblerFilePath(string downloadDir = null)
+    private string GetAS65AssemblerFilePath(string? downloadDir = null)
     {
         // Download 6502 functional test program assembler source code
-        var wc = new System.Net.WebClient();
         var url = "https://github.com/Klaus2m5/6502_65C02_functional_tests/blob/master/as65_142.zip?raw=true";
 
-        if(string.IsNullOrEmpty(downloadDir))
+        if (string.IsNullOrEmpty(downloadDir))
             downloadDir = Directory.GetCurrentDirectory();
-            
+
         var downloadFileName = "as65_142.zip";
         var downloadFullFilePath = Path.Join(downloadDir, downloadFileName);
-        wc.DownloadFile(url, downloadFullFilePath);
+        DownloadFile(url, downloadFullFilePath);
 
         // Unzip as65.exe from .zip and get full file path to it
         var as65ExeFilePath = GetAS65AssemblerExeFilePath(downloadFullFilePath);
@@ -170,7 +169,7 @@ public class FunctionalTestCompiler
     {
         // Unzip to folder in same directory as .zip file
         string zipExtractPath = Path.Join(Path.GetDirectoryName(as65ZipFilePath), Path.GetFileNameWithoutExtension(as65ZipFilePath));
-        if(Directory.Exists(zipExtractPath))
+        if (Directory.Exists(zipExtractPath))
             Directory.Delete(zipExtractPath, recursive: true);
         Directory.CreateDirectory(zipExtractPath);
 
@@ -210,5 +209,4 @@ public class FunctionalTestCompiler
         // Return the full file path to the unzipped as65.exe
         return Path.Join(zipExtractPath, as65ExeFileName);
     }
-
 }

--- a/tests/Highbyte.DotNet6502.Tests/Helpers/TestContext.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Helpers/TestContext.cs
@@ -2,8 +2,8 @@ namespace Highbyte.DotNet6502.Tests.Helpers;
 
 public class TestContext
 {
-    public CPU CPU { get; private set; }
-    public Memory Mem { get; private set; }
+    public CPU CPU { get; private set; } = default!;
+    public Memory Mem { get; private set; } = default!;
     private TestContext() {}
     public static TestContext NewTestContext(ushort startPos = 0x1000, int memorySize = 1024*64)
     {

--- a/tests/Highbyte.DotNet6502.Tests/Helpers/TestSpec.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Helpers/TestSpec.cs
@@ -79,7 +79,6 @@ public class TestSpec
     /// <value></value>
     public byte? FinalValue { get; set; }
 
-
     /// <summary>
     /// Optional.
     /// Only used by Indirect addressing mode (JMP is the only instruction that uses it.)
@@ -141,7 +140,6 @@ public class TestSpec
             ExpectedV = value.HasValue && value.Value.IsBitSet(StatusFlagBits.Overflow);
             ExpectedN = value.HasValue && value.Value.IsBitSet(StatusFlagBits.Negative);
         }
-
     }
     public bool? ExpectedC { get; set; }
     public bool? ExpectedZ { get; set; }
@@ -169,9 +167,9 @@ public class TestSpec
 
     public void Execute_And_Verify(
         AddrMode addrMode
-        , bool ZP_X_Should_Wrap_Over_Byte = false
-        , bool ZP_Y_Should_Wrap_Over_Byte = false
-        , bool FullAddress_Should_Cross_Page_Boundary = false
+        , bool zp_X_Should_Wrap_Over_Byte = false
+        , bool zp_Y_Should_Wrap_Over_Byte = false
+        , bool fullAddress_Should_Cross_Page_Boundary = false
         )
     {
         if (!InsEffect.HasValue)
@@ -237,7 +235,7 @@ public class TestSpec
         if (ExpectedI.HasValue && !I.HasValue)
             I = !ExpectedI.Value;
         if (ExpectedD.HasValue && !D.HasValue)
-            D = !ExpectedZ.Value;
+            D = !ExpectedD.Value;
         if (ExpectedB.HasValue && !B.HasValue)
             B = !ExpectedB.Value;
         if (ExpectedU.HasValue && !U.HasValue)
@@ -341,7 +339,7 @@ public class TestSpec
                 // Use a default value for X index if not specified in test
                 if (!X.HasValue)
                 {
-                    if (!ZP_X_Should_Wrap_Over_Byte)
+                    if (!zp_X_Should_Wrap_Over_Byte)
                         X = 0x05;
                     else
                         X = 0xf5;   // Force final ZP+X address bigger than one byte (0x0010 + 0xf5 = 0x0105)
@@ -349,7 +347,7 @@ public class TestSpec
                 // Calculate ZeroPage + X address
                 ZPAddressX = (ushort)(ZeroPageAddress + X);
                 // Adjust that we expect the final address to wrap when getting larger than a byte
-                if (ZP_X_Should_Wrap_Over_Byte)
+                if (zp_X_Should_Wrap_Over_Byte)
                     ZPAddressX = (ushort)(ZPAddressX & 0xff);
 
                 finalAddressUsed = ZPAddressX;
@@ -370,7 +368,7 @@ public class TestSpec
                 // Use a default value for Y index if not specified in test
                 if (!Y.HasValue)
                 {
-                    if (!ZP_Y_Should_Wrap_Over_Byte)
+                    if (!zp_Y_Should_Wrap_Over_Byte)
                         Y = 0x05;
                     else
                         Y = 0xf5;   // Force final ZP+Y address bigger than one byte (0x0010 + 0xf5 = 0x0105)
@@ -378,7 +376,7 @@ public class TestSpec
                 // Calculate ZeroPage + Y address
                 ZPAddressY = (ushort)(ZeroPageAddress + Y);
                 // Adjust that we expect the final address to wrap when getting larger than a byte
-                if (ZP_Y_Should_Wrap_Over_Byte)
+                if (zp_Y_Should_Wrap_Over_Byte)
                     ZPAddressY = (ushort)(ZPAddressY & 0xff);
 
                 finalAddressUsed = ZPAddressY;
@@ -423,7 +421,7 @@ public class TestSpec
                 // Use a default value for X index if not specified in test
                 if (!X.HasValue)
                 {
-                    if (!FullAddress_Should_Cross_Page_Boundary)
+                    if (!fullAddress_Should_Cross_Page_Boundary)
                         X = 0x05;
                     else
                         X = 0xf0;   // Force final FullAddress+X address crosses page boundary (0xab12 + 0xf0 = 0xac02)
@@ -451,7 +449,7 @@ public class TestSpec
                 // Use a default value for X index if not specified in test
                 if (!Y.HasValue)
                 {
-                    if (!FullAddress_Should_Cross_Page_Boundary)
+                    if (!fullAddress_Should_Cross_Page_Boundary)
                         Y = 0x05;
                     else
                         Y = 0xf0;   // Force final FullAddress+X address crosses page boundary (0xab12 + 0xf0 = 0xac02)
@@ -478,7 +476,7 @@ public class TestSpec
                 // Use a default value for X index if not specified in test
                 if (!X.HasValue)
                 {
-                    if (!ZP_X_Should_Wrap_Over_Byte)
+                    if (!zp_X_Should_Wrap_Over_Byte)
                         X = 0x05;
                     else
                         X = 0xf0;   // Force final ZeroPage address +X to wrap around a byte (0x20 + 0xf0 = 0x10)
@@ -509,7 +507,7 @@ public class TestSpec
                 // Initialize memory we will read from
                 // We calculate a full address to store in a zero page address, adjusted by -Y (because the instruction will add Y when it retrieves it)
                 // If we want to force crossing page boundary FullAddress + Y, we will hard code FullAddress and Y values
-                if (FullAddress_Should_Cross_Page_Boundary)
+                if (fullAddress_Should_Cross_Page_Boundary)
                 {
                     // The address to be found in zero page address
                     FullAddress = 0xab12;
@@ -600,7 +598,9 @@ public class TestSpec
 
         // Verify Program Counter
         if (ExpectedPC.HasValue)
+        {
             Assert.Equal(ExpectedPC.Value, cpu.PC);
+        }
         else
         {
             // If no PC check has been defined, by default verify PC has been moved forward as many bytes we used up for the instruction.
@@ -618,7 +618,9 @@ public class TestSpec
                 && OpCode != OpCodeId.JMP_ABS // Absolute addressing mode
                 && OpCode != OpCodeId.JSR     // Absolute addressing mode
             )
+            {
                 Assert.Equal(codeMemPos, cpu.PC);
+            }
         }
 
         // Verify expected # of cycles

--- a/tests/Highbyte.DotNet6502.Tests/Helpers/TestSpec.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Helpers/TestSpec.cs
@@ -15,7 +15,7 @@ public class TestSpec
 
     // Initial flag values
     // The entire processor status byte
-    public byte? PS
+    public byte PS
     {
         get
         {
@@ -32,14 +32,14 @@ public class TestSpec
         }
         set
         {
-            C = value.HasValue && value.Value.IsBitSet(StatusFlagBits.Carry);
-            Z = value.HasValue && value.Value.IsBitSet(StatusFlagBits.Zero);
-            I = value.HasValue && value.Value.IsBitSet(StatusFlagBits.InterruptDisable);
-            D = value.HasValue && value.Value.IsBitSet(StatusFlagBits.Decimal);
-            B = value.HasValue && value.Value.IsBitSet(StatusFlagBits.Break);
-            U = value.HasValue && value.Value.IsBitSet(StatusFlagBits.Unused);
-            V = value.HasValue && value.Value.IsBitSet(StatusFlagBits.Overflow);
-            N = value.HasValue && value.Value.IsBitSet(StatusFlagBits.Negative);
+            C = value.IsBitSet(StatusFlagBits.Carry);
+            Z = value.IsBitSet(StatusFlagBits.Zero);
+            I = value.IsBitSet(StatusFlagBits.InterruptDisable);
+            D = value.IsBitSet(StatusFlagBits.Decimal);
+            B = value.IsBitSet(StatusFlagBits.Break);
+            U = value.IsBitSet(StatusFlagBits.Unused);
+            V = value.IsBitSet(StatusFlagBits.Overflow);
+            N = value.IsBitSet(StatusFlagBits.Negative);
         }
     }
     public bool? C { get; set; }

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/ADC_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/ADC_test.cs
@@ -334,7 +334,7 @@ public class ADC_test
             ExpectedA      = 0x02,
             ExpectedCycles = 4,
         };
-        test.Execute_And_Verify(AddrMode.ZP_X, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.ZP_X, zp_X_Should_Wrap_Over_Byte: true);
     }
 
     /// <summary>
@@ -386,7 +386,7 @@ public class ADC_test
             ExpectedA      = 0x02,
             ExpectedCycles = 5,
         };
-        test.Execute_And_Verify(AddrMode.ABS_X, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_X, fullAddress_Should_Cross_Page_Boundary: true);
     }
 
     [Fact]
@@ -419,7 +419,7 @@ public class ADC_test
             ExpectedA      = 0x02,
             ExpectedCycles = 5,
         };
-        test.Execute_And_Verify(AddrMode.ABS_Y, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_Y, fullAddress_Should_Cross_Page_Boundary: true);
     }
 
     /// <summary>
@@ -466,7 +466,7 @@ public class ADC_test
             ExpectedA      = 0x02,
             ExpectedCycles = 6,
         };
-        test.Execute_And_Verify(AddrMode.IX_IND, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.IX_IND, zp_X_Should_Wrap_Over_Byte: true);
     }
 
     /// <summary>
@@ -518,7 +518,7 @@ public class ADC_test
             ExpectedA      = 0x02,
             ExpectedCycles = 6,
         };
-        test.Execute_And_Verify(AddrMode.IND_IX, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.IND_IX, fullAddress_Should_Cross_Page_Boundary: true);
     }
 
     [Fact]

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/AND_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/AND_test.cs
@@ -157,7 +157,7 @@ public class AND_test
             ExpectedA      = 0b00000010,
             ExpectedCycles = 4
         };
-        test.Execute_And_Verify(AddrMode.ZP_X, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.ZP_X, zp_X_Should_Wrap_Over_Byte: true);
     }
 
     [Fact]
@@ -199,7 +199,7 @@ public class AND_test
             ExpectedA      = 0b00000010,
             ExpectedCycles = 5
         };
-        test.Execute_And_Verify(AddrMode.ABS_X, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_X, fullAddress_Should_Cross_Page_Boundary: true);
     }
 
     [Fact]
@@ -227,7 +227,7 @@ public class AND_test
             ExpectedA      = 0b00000010,
             ExpectedCycles = 5
         };
-        test.Execute_And_Verify(AddrMode.ABS_Y, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_Y, fullAddress_Should_Cross_Page_Boundary: true);
     }
 
     /// <summary>
@@ -255,7 +255,7 @@ public class AND_test
             ExpectedA      = 0b00000010,
             ExpectedCycles = 6  // Should take 6 cycles, even though we are not 
         };
-        test.Execute_And_Verify(AddrMode.IX_IND, FullAddress_Should_Cross_Page_Boundary: false);
+        test.Execute_And_Verify(AddrMode.IX_IND, fullAddress_Should_Cross_Page_Boundary: false);
     }
     
     /// <summary>
@@ -272,7 +272,7 @@ public class AND_test
             ExpectedA      = 0b00000010,
             ExpectedCycles = 6
         };
-        test.Execute_And_Verify(AddrMode.IX_IND, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.IX_IND, zp_X_Should_Wrap_Over_Byte: true);
     }
 
 
@@ -323,6 +323,6 @@ public class AND_test
             ExpectedA      = 0b00000010,
             ExpectedCycles = 6
         };
-        test.Execute_And_Verify(AddrMode.IND_IX, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.IND_IX, fullAddress_Should_Cross_Page_Boundary: true);
     }
 }

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/ASL_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/ASL_test.cs
@@ -143,7 +143,7 @@ public class ASL_test
             ExpectedMemVal = 0b00110010,
             ExpectedCycles = 6
         };
-        test.Execute_And_Verify(AddrMode.ZP_X, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.ZP_X, zp_X_Should_Wrap_Over_Byte: true);
     }
 
     [Fact]
@@ -185,6 +185,6 @@ public class ASL_test
             ExpectedMemVal = 0b00110010,
             ExpectedCycles = 7
         };
-        test.Execute_And_Verify(AddrMode.ABS_X, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_X, fullAddress_Should_Cross_Page_Boundary: true);
     }
 }

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/BRK_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/BRK_test.cs
@@ -94,7 +94,7 @@ public class BRK_test
 
         // Verify that the processor status was the second value pushed to stack.
         // Assume BRK take a copy of the process or status and set Break and Unused flag before storing the copy on stack.
-        byte expectedProcessorStatusOnStack = test.PS.Value;
+        byte expectedProcessorStatusOnStack = test.PS;
         expectedProcessorStatusOnStack.SetBit(StatusFlagBits.Break);
         expectedProcessorStatusOnStack.SetBit(StatusFlagBits.Unused);
         Assert.Equal(expectedProcessorStatusOnStack,  mem[(ushort)(CPU.StackBaseAddress + originalSP - 2)]);

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/CMP_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/CMP_test.cs
@@ -176,7 +176,7 @@ public class CMP_test
             ExpectedN      = false,
             ExpectedCycles = 4
         };
-        test.Execute_And_Verify(AddrMode.ZP_X, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.ZP_X, zp_X_Should_Wrap_Over_Byte: true);
     }
 
     [Fact]
@@ -224,7 +224,7 @@ public class CMP_test
             ExpectedN      = false,
             ExpectedCycles = 5
         };
-        test.Execute_And_Verify(AddrMode.ABS_X, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_X, fullAddress_Should_Cross_Page_Boundary: true);
     }
 
     [Fact]
@@ -256,7 +256,7 @@ public class CMP_test
             ExpectedN      = false,
             ExpectedCycles = 5
         };
-        test.Execute_And_Verify(AddrMode.ABS_Y, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_Y, fullAddress_Should_Cross_Page_Boundary: true);
     }
 
     /// <summary>
@@ -286,7 +286,7 @@ public class CMP_test
             ExpectedN      = false,
             ExpectedCycles = 6  // Should take 6 cycles, even though we are not 
         };
-        test.Execute_And_Verify(AddrMode.IX_IND, FullAddress_Should_Cross_Page_Boundary: false);
+        test.Execute_And_Verify(AddrMode.IX_IND, fullAddress_Should_Cross_Page_Boundary: false);
     }
     
     /// <summary>
@@ -305,7 +305,7 @@ public class CMP_test
             ExpectedN      = false,
             ExpectedCycles = 6
         };
-        test.Execute_And_Verify(AddrMode.IX_IND, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.IX_IND, zp_X_Should_Wrap_Over_Byte: true);
     }
 
 
@@ -360,6 +360,6 @@ public class CMP_test
             ExpectedN      = false,
             ExpectedCycles = 6
         };
-        test.Execute_And_Verify(AddrMode.IND_IX, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.IND_IX, fullAddress_Should_Cross_Page_Boundary: true);
     }
 }

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/DEC_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/DEC_test.cs
@@ -123,7 +123,7 @@ public class DEC_test
             ExpectedMemVal = 0x01,
             ExpectedCycles = 6,
         };
-        test.Execute_And_Verify(AddrMode.ZP_X, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.ZP_X, zp_X_Should_Wrap_Over_Byte: true);
     }
 
     [Fact]

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/EOR_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/EOR_test.cs
@@ -157,7 +157,7 @@ public class EOR_test
             ExpectedA      = 0b01100000,
             ExpectedCycles = 4
         };
-        test.Execute_And_Verify(AddrMode.ZP_X, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.ZP_X, zp_X_Should_Wrap_Over_Byte: true);
     }
 
     [Fact]
@@ -199,7 +199,7 @@ public class EOR_test
             ExpectedA      = 0b01100000,
             ExpectedCycles = 5
         };
-        test.Execute_And_Verify(AddrMode.ABS_X, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_X, fullAddress_Should_Cross_Page_Boundary: true);
     }
 
     [Fact]
@@ -227,7 +227,7 @@ public class EOR_test
             ExpectedA      = 0b01100000,
             ExpectedCycles = 5
         };
-        test.Execute_And_Verify(AddrMode.ABS_Y, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_Y, fullAddress_Should_Cross_Page_Boundary: true);
     }
 
     /// <summary>
@@ -255,7 +255,7 @@ public class EOR_test
             ExpectedA      = 0b01100000,
             ExpectedCycles = 6  // Should take 6 cycles, even though we are not 
         };
-        test.Execute_And_Verify(AddrMode.IX_IND, FullAddress_Should_Cross_Page_Boundary: false);
+        test.Execute_And_Verify(AddrMode.IX_IND, fullAddress_Should_Cross_Page_Boundary: false);
     }
     
     /// <summary>
@@ -272,7 +272,7 @@ public class EOR_test
             ExpectedA      = 0b01100000,
             ExpectedCycles = 6
         };
-        test.Execute_And_Verify(AddrMode.IX_IND, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.IX_IND, zp_X_Should_Wrap_Over_Byte: true);
     }
 
 
@@ -323,6 +323,6 @@ public class EOR_test
             ExpectedA      = 0b01100000,
             ExpectedCycles = 6
         };
-        test.Execute_And_Verify(AddrMode.IND_IX, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.IND_IX, fullAddress_Should_Cross_Page_Boundary: true);
     }
 }

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/INC_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/INC_test.cs
@@ -123,7 +123,7 @@ public class INC_test
             ExpectedMemVal = 0x02,
             ExpectedCycles = 6,
         };
-        test.Execute_And_Verify(AddrMode.ZP_X, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.ZP_X, zp_X_Should_Wrap_Over_Byte: true);
     }
 
     [Fact]

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/LDA_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/LDA_test.cs
@@ -152,7 +152,7 @@ public class LDA_test
             ExpectedA      = 0x12,
             ExpectedCycles = 4
         };
-        test.Execute_And_Verify(AddrMode.ZP_X, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.ZP_X, zp_X_Should_Wrap_Over_Byte: true);
     }
 
     [Fact]
@@ -194,7 +194,7 @@ public class LDA_test
             ExpectedA      = 0x12,
             ExpectedCycles = 5
         };
-        test.Execute_And_Verify(AddrMode.ABS_X, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_X, fullAddress_Should_Cross_Page_Boundary: true);
     }
 
     [Fact]
@@ -222,7 +222,7 @@ public class LDA_test
             ExpectedA      = 0x12,
             ExpectedCycles = 5
         };
-        test.Execute_And_Verify(AddrMode.ABS_Y, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_Y, fullAddress_Should_Cross_Page_Boundary: true);
     }
 
     /// <summary>
@@ -250,7 +250,7 @@ public class LDA_test
             ExpectedA      = 0x12,
             ExpectedCycles = 6  // Should take 6 cycles, even though we are not 
         };
-        test.Execute_And_Verify(AddrMode.IX_IND, FullAddress_Should_Cross_Page_Boundary: false);
+        test.Execute_And_Verify(AddrMode.IX_IND, fullAddress_Should_Cross_Page_Boundary: false);
     }
     
     /// <summary>
@@ -267,7 +267,7 @@ public class LDA_test
             ExpectedA      = 0x12,
             ExpectedCycles = 6
         };
-        test.Execute_And_Verify(AddrMode.IX_IND, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.IX_IND, zp_X_Should_Wrap_Over_Byte: true);
     }
 
 
@@ -318,6 +318,6 @@ public class LDA_test
             ExpectedA      = 0x12,
             ExpectedCycles = 6
         };
-        test.Execute_And_Verify(AddrMode.IND_IX, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.IND_IX, fullAddress_Should_Cross_Page_Boundary: true);
     }
 }

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/LDX_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/LDX_test.cs
@@ -152,7 +152,7 @@ public class LDX_test
             ExpectedX      = 0x12,
             ExpectedCycles = 4
         };
-        test.Execute_And_Verify(AddrMode.ZP_Y, ZP_Y_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.ZP_Y, zp_Y_Should_Wrap_Over_Byte: true);
     }
 
     [Fact]
@@ -194,6 +194,6 @@ public class LDX_test
             ExpectedX      = 0x12,
             ExpectedCycles = 5
         };
-        test.Execute_And_Verify(AddrMode.ABS_Y, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_Y, fullAddress_Should_Cross_Page_Boundary: true);
     }
 }

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/LDY_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/LDY_test.cs
@@ -152,7 +152,7 @@ public class LDY_test
             ExpectedY      = 0x12,
             ExpectedCycles = 4
         };
-        test.Execute_And_Verify(AddrMode.ZP_X, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.ZP_X, zp_X_Should_Wrap_Over_Byte: true);
     }
 
     [Fact]
@@ -194,6 +194,6 @@ public class LDY_test
             ExpectedY      = 0x12,
             ExpectedCycles = 5
         };
-        test.Execute_And_Verify(AddrMode.ABS_X, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_X, fullAddress_Should_Cross_Page_Boundary: true);
     }
 }

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/LSR_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/LSR_test.cs
@@ -143,7 +143,7 @@ public class LSR_test
             ExpectedMemVal = 0b00011001,
             ExpectedCycles = 6
         };
-        test.Execute_And_Verify(AddrMode.ZP_X, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.ZP_X, zp_X_Should_Wrap_Over_Byte: true);
     }
 
     [Fact]
@@ -185,6 +185,6 @@ public class LSR_test
             ExpectedMemVal = 0b00011001,
             ExpectedCycles = 7
         };
-        test.Execute_And_Verify(AddrMode.ABS_X, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_X, fullAddress_Should_Cross_Page_Boundary: true);
     }
 }

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/ORA_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/ORA_test.cs
@@ -157,7 +157,7 @@ public class ORA_test
             ExpectedA      = 0b00000111,
             ExpectedCycles = 4
         };
-        test.Execute_And_Verify(AddrMode.ZP_X, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.ZP_X, zp_X_Should_Wrap_Over_Byte: true);
     }
 
     [Fact]
@@ -199,7 +199,7 @@ public class ORA_test
             ExpectedA      = 0b00000111,
             ExpectedCycles = 5
         };
-        test.Execute_And_Verify(AddrMode.ABS_X, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_X, fullAddress_Should_Cross_Page_Boundary: true);
     }
 
     [Fact]
@@ -227,7 +227,7 @@ public class ORA_test
             ExpectedA      = 0b00000111,
             ExpectedCycles = 5
         };
-        test.Execute_And_Verify(AddrMode.ABS_Y, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_Y, fullAddress_Should_Cross_Page_Boundary: true);
     }
 
     /// <summary>
@@ -255,7 +255,7 @@ public class ORA_test
             ExpectedA      = 0b00000111,
             ExpectedCycles = 6  // Should take 6 cycles, even though we are not 
         };
-        test.Execute_And_Verify(AddrMode.IX_IND, FullAddress_Should_Cross_Page_Boundary: false);
+        test.Execute_And_Verify(AddrMode.IX_IND, fullAddress_Should_Cross_Page_Boundary: false);
     }
     
     /// <summary>
@@ -272,7 +272,7 @@ public class ORA_test
             ExpectedA      = 0b00000111,
             ExpectedCycles = 6
         };
-        test.Execute_And_Verify(AddrMode.IX_IND, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.IX_IND, zp_X_Should_Wrap_Over_Byte: true);
     }
 
 
@@ -323,6 +323,6 @@ public class ORA_test
             ExpectedA      = 0b00000111,
             ExpectedCycles = 6
         };
-        test.Execute_And_Verify(AddrMode.IND_IX, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.IND_IX, fullAddress_Should_Cross_Page_Boundary: true);
     }
 }

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/PHA_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/PHA_test.cs
@@ -46,5 +46,4 @@ public class PHA_test
         ushort stackPointerFullAddress = CPU.StackBaseAddress + 0xfe + 1;
         Assert.Equal(test.A, test.TestContext.Mem[stackPointerFullAddress]);
     }
-
 }

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/PHP_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/PHP_test.cs
@@ -34,7 +34,7 @@ public class PHP_test
         // Verify that stack (the previous position) contains value of Status register.
         // Remember that stack works downwards (0xff-0x00), points to the next free location, and is located at address 0x0100 + SP
         ushort stackPointerFullAddress = CPU.StackBaseAddress + 0xfe + 1;
-        byte expectedPSOnStack = test.PS.Value;
+        byte expectedPSOnStack = test.PS;
         expectedPSOnStack.SetBit(StatusFlagBits.Break); 
         expectedPSOnStack.SetBit(StatusFlagBits.Unused); 
         Assert.Equal(expectedPSOnStack, test.TestContext.Mem[stackPointerFullAddress]);

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/ROL_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/ROL_test.cs
@@ -150,7 +150,7 @@ public class ROL_test
             ExpectedMemVal = 0b00110010,
             ExpectedCycles = 6
         };
-        test.Execute_And_Verify(AddrMode.ZP_X, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.ZP_X, zp_X_Should_Wrap_Over_Byte: true);
     }
 
     [Fact]
@@ -195,6 +195,6 @@ public class ROL_test
             ExpectedMemVal = 0b00110010,
             ExpectedCycles = 7
         };
-        test.Execute_And_Verify(AddrMode.ABS_X, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_X, fullAddress_Should_Cross_Page_Boundary: true);
     }
 }

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/ROR_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/ROR_test.cs
@@ -150,7 +150,7 @@ public class ROR_test
             ExpectedMemVal = 0b00011001,
             ExpectedCycles = 6
         };
-        test.Execute_And_Verify(AddrMode.ZP_X, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.ZP_X, zp_X_Should_Wrap_Over_Byte: true);
     }
 
     [Fact]
@@ -195,6 +195,6 @@ public class ROR_test
             ExpectedMemVal = 0b00011001,
             ExpectedCycles = 7
         };
-        test.Execute_And_Verify(AddrMode.ABS_X, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_X, fullAddress_Should_Cross_Page_Boundary: true);
     }
 }

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/SBC_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/SBC_test.cs
@@ -420,7 +420,7 @@ public class SBC_test
             ExpectedA      = 0x01,
             ExpectedCycles = 4,
         };
-        test.Execute_And_Verify(AddrMode.ZP_X, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.ZP_X, zp_X_Should_Wrap_Over_Byte: true);
     }
 
     /// <summary>
@@ -472,7 +472,7 @@ public class SBC_test
             ExpectedA      = 0x01,
             ExpectedCycles = 5,
         };
-        test.Execute_And_Verify(AddrMode.ABS_X, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_X, fullAddress_Should_Cross_Page_Boundary: true);
     }
 
     [Fact]
@@ -505,7 +505,7 @@ public class SBC_test
             ExpectedA      = 0x01,
             ExpectedCycles = 5,
         };
-        test.Execute_And_Verify(AddrMode.ABS_Y, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_Y, fullAddress_Should_Cross_Page_Boundary: true);
     }
 
     /// <summary>
@@ -552,7 +552,7 @@ public class SBC_test
             ExpectedA      = 0x01,
             ExpectedCycles = 6,
         };
-        test.Execute_And_Verify(AddrMode.IX_IND, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.IX_IND, zp_X_Should_Wrap_Over_Byte: true);
     }
 
     /// <summary>
@@ -604,7 +604,7 @@ public class SBC_test
             ExpectedA      = 0x01,
             ExpectedCycles = 6,
         };
-        test.Execute_And_Verify(AddrMode.IND_IX, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.IND_IX, fullAddress_Should_Cross_Page_Boundary: true);
     }
 
     [Fact]

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/STA_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/STA_test.cs
@@ -69,7 +69,7 @@ public class STA_test
             ExpectedMemVal = 0x42,
             ExpectedCycles = 4,
         };
-        test.Execute_And_Verify(AddrMode.ZP_X, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.ZP_X, zp_X_Should_Wrap_Over_Byte: true);
     }
 
     [Fact]
@@ -114,7 +114,7 @@ public class STA_test
             ExpectedMemVal = 0x42,
             ExpectedCycles = 5,
         };
-        test.Execute_And_Verify(AddrMode.ABS_X, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_X, fullAddress_Should_Cross_Page_Boundary: true);
     }
 
     [Fact]
@@ -144,7 +144,7 @@ public class STA_test
             ExpectedMemVal = 0x42,
             ExpectedCycles = 5,
         };
-        test.Execute_And_Verify(AddrMode.ABS_Y, FullAddress_Should_Cross_Page_Boundary: true);
+        test.Execute_And_Verify(AddrMode.ABS_Y, fullAddress_Should_Cross_Page_Boundary: true);
     }
     
     
@@ -192,7 +192,7 @@ public class STA_test
             ExpectedMemVal = 0x42,
             ExpectedCycles = 6,
         };
-        test.Execute_And_Verify(AddrMode.IX_IND, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.IX_IND, zp_X_Should_Wrap_Over_Byte: true);
     }
 
 
@@ -245,6 +245,6 @@ public class STA_test
             ExpectedMemVal = 0x42,
             ExpectedCycles = 6,
         };
-        test.Execute_And_Verify(AddrMode.IND_IX, FullAddress_Should_Cross_Page_Boundary: true); 
+        test.Execute_And_Verify(AddrMode.IND_IX, fullAddress_Should_Cross_Page_Boundary: true); 
     }
 }

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/STX_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/STX_test.cs
@@ -69,7 +69,7 @@ public class STX_test
             ExpectedMemVal = 0x42,
             ExpectedCycles = 4,
         };
-        test.Execute_And_Verify(AddrMode.ZP_Y, ZP_Y_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.ZP_Y, zp_Y_Should_Wrap_Over_Byte: true);
     }
 
     [Fact]

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/STY_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/STY_test.cs
@@ -69,7 +69,7 @@ public class STY_test
             ExpectedMemVal = 0x42,
             ExpectedCycles = 4,
         };
-        test.Execute_And_Verify(AddrMode.ZP_X, ZP_X_Should_Wrap_Over_Byte: true);
+        test.Execute_And_Verify(AddrMode.ZP_X, zp_X_Should_Wrap_Over_Byte: true);
     }
 
     [Fact]

--- a/tests/Highbyte.DotNet6502.Tests/Instrumentation/ElapsedMillisecondsTimedStatTest.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instrumentation/ElapsedMillisecondsTimedStatTest.cs
@@ -95,6 +95,7 @@ namespace Highbyte.DotNet6502.Tests.Instrumentation
             }
             // Assert
             var ms = stat.GetStatMilliseconds();
+            Assert.NotNull(ms);
             Assert.Equal($"{Math.Round(ms.Value, 2).ToString("0.00")}ms", stat.GetDescription());
         }
     }

--- a/tests/Highbyte.DotNet6502.Tests/Logging/DotNet6502InMemLogStoreTest.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Logging/DotNet6502InMemLogStoreTest.cs
@@ -104,5 +104,4 @@ public class DotNet6502InMemLogStoreTest
         Assert.Equal(7, actualMessages.Count);
         Assert.Equal("Old message 9", actualMessages[0]);
     }
-
 }

--- a/tests/Highbyte.DotNet6502.Tests/Logging/DotNet6502LoggerBaseTest.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Logging/DotNet6502LoggerBaseTest.cs
@@ -49,7 +49,6 @@ public class DotNet6502LoggerBaseTest
         Assert.Equal(category, categoryPart);
     }
 
-
     [Fact]
     public void Writing_To_Log_Will_Create_Correctly_Formatted_MessagePart()
     {
@@ -68,17 +67,17 @@ public class DotNet6502LoggerBaseTest
         Assert.Equal(message, messagePart);
     }
 
-    private string GetTimePart(string formattedMessage)
-    {
-        var messagePartArray = formattedMessage.Split(' ');
+    //private string GetTimePart(string formattedMessage)
+    //{
+    //    var messagePartArray = formattedMessage.Split(' ');
 
-        var time = messagePartArray switch
-        {
-            [var tim, ..] => tim,
-            _ => throw new Exception($"Log has incorrect format: {formattedMessage}"),
-        };
-        return time;
-    }
+    //    var time = messagePartArray switch
+    //    {
+    //        [var tim, ..] => tim,
+    //        _ => throw new Exception($"Log has incorrect format: {formattedMessage}"),
+    //    };
+    //    return time;
+    //}
 
     private string GetLogLevelPart(string formattedMessage)
     {
@@ -130,8 +129,6 @@ public class FakeLogger : DotNet6502LoggerBase
     public FakeLogger(ObjectPool<StringBuilder> stringBuilderPool, string categoryName) : base(stringBuilderPool, categoryName)
     {
     }
-
-    public override IDisposable BeginScope<TState>(TState state) => default!;
 
     public override bool IsEnabled(LogLevel logLevel) => true;
 

--- a/tests/Highbyte.DotNet6502.Tests/MemoryTest.cs
+++ b/tests/Highbyte.DotNet6502.Tests/MemoryTest.cs
@@ -1,5 +1,3 @@
-using System.Net;
-using System.Reflection.Metadata.Ecma335;
 using static Highbyte.DotNet6502.Memory;
 
 namespace Highbyte.DotNet6502.Tests;
@@ -40,7 +38,7 @@ public class MemoryTest
         mem.MapRAM(baseAddress, data);
 
         // Act
-        ushort address = (ushort)(baseAddress+0x10);
+        ushort address = (ushort)(baseAddress + 0x10);
         byte expectedMemValue = 0x42;
         mem.Write(address, 0x00);   // Make sure memory doesn't
         mem.Write(address, expectedMemValue);
@@ -117,7 +115,7 @@ public class MemoryTest
         mem.MapRAM(baseAddress, ramData);
 
         byte storedValue = 0x41;
-        LoadByte reader = _ => { return storedValue;};
+        LoadByte reader = _ => { return storedValue; };
         mem.MapReader(0x0010, reader);
 
         // Act/Assert
@@ -135,14 +133,13 @@ public class MemoryTest
         mem.MapRAM(baseAddress, ramData1);
 
         byte storedValue = 0;
-        StoreByte writer = (address, newVal) => { storedValue = newVal;};
+        StoreByte writer = (address, newVal) => { storedValue = newVal; };
         mem.MapWriter(0x0010, writer);
 
         // Act/Assert
         mem.Write(0x010, 0x42);
         Assert.Equal(0x42, storedValue);
     }
-
 
     [Fact]
     public void Can_Map_Individual_Memory_Location_To_A_Single_Value_For_Reading()
@@ -153,7 +150,7 @@ public class MemoryTest
         ushort baseAddress = 0x0000;
         mem.MapRAM(baseAddress, ramData);
 
-        var memValue = new MemValue{Value = 0x41};
+        var memValue = new MemValue { Value = 0x41 };
         mem.MapRO(0x0010, memValue);
 
         // Act/Assert
@@ -170,7 +167,7 @@ public class MemoryTest
         ushort baseAddress = 0x0000;
         mem.MapRAM(baseAddress, ramData);
 
-        var memValue = new MemValue{Value = 0x00};
+        var memValue = new MemValue { Value = 0x00 };
         mem.MapWO(0x0010, memValue);
 
         // Act/Assert
@@ -187,7 +184,7 @@ public class MemoryTest
         ushort baseAddress = 0x0000;
         mem.MapRAM(baseAddress, ramData);
 
-        var memValue = new  MemValue{Value = 0x00};
+        var memValue = new MemValue { Value = 0x00 };
         mem.MapRW(0x0010, memValue);
 
         // Act/Assert
@@ -200,7 +197,7 @@ public class MemoryTest
     public void Can_Create_Multiple_Memory_Configurations()
     {
         // Arrange
-        var mem = new Memory(numberOfConfigurations:2, mapToDefaultRAM: false);
+        var mem = new Memory(numberOfConfigurations: 2, mapToDefaultRAM: false);
 
         // Act/Assert
         Assert.Equal(2, mem.NumberOfConfigurations);
@@ -210,7 +207,7 @@ public class MemoryTest
     public void Default_Configuration_Is_The_First_After_Creating_Multiple_Configurations()
     {
         // Arrange
-        var mem = new Memory(numberOfConfigurations:2, mapToDefaultRAM: false);
+        var mem = new Memory(numberOfConfigurations: 2, mapToDefaultRAM: false);
 
         // Act/Assert
         Assert.Equal(0, mem.CurrentConfiguration);
@@ -220,7 +217,7 @@ public class MemoryTest
     public void Can_Change_Memory_Configurations()
     {
         // Arrange
-        var mem = new Memory(numberOfConfigurations:2, mapToDefaultRAM: false);
+        var mem = new Memory(numberOfConfigurations: 2, mapToDefaultRAM: false);
         ushort baseAddress = 0x0000;
 
         // First configuration
@@ -265,6 +262,7 @@ public class MemoryTest
         mem.Write((ushort)(baseAddress + dataAddress), 0x42);
 
         // Assert
+        Assert.True(interceptCalled);
         Assert.Equal(dataAddress, interceptedAddress);
     }
 

--- a/tests/Highbyte.DotNet6502.Tests/OutputGenTest.cs
+++ b/tests/Highbyte.DotNet6502.Tests/OutputGenTest.cs
@@ -134,5 +134,4 @@ public class OutputGenTest
         Assert.Equal("--------", outputDictionary["PS"]);
         Assert.Equal("FF", outputDictionary["SP"]);
     }
-
 }

--- a/tests/Highbyte.DotNet6502.Tests/OutputGenTest.cs
+++ b/tests/Highbyte.DotNet6502.Tests/OutputGenTest.cs
@@ -50,6 +50,23 @@ public class OutputGenTest
         Assert.Equal("c0a0  a2 ee     LDX #$EE   ", outputString);
     }
 
+    [Fact]
+    public void OutputGen_Returns_Correctly_Formatted_Disassembly_For_Next_Instruction()
+    {
+        // Arrange
+        var cpu = new CPU();
+        cpu.PC = 0xc0a0;
+        var mem = new Memory();
+        mem[0xc0a0] = OpCodeId.LDX_I.ToByte();
+        mem[0xc0a1] = 0xee;
+
+        // Act
+        var outputString = OutputGen.GetNextInstructionDisassembly(cpu, mem);
+
+        // Assert
+        Assert.Equal("c0a0  a2 ee     LDX #$EE   ", outputString);
+    }
+
     [Theory]
     [InlineData(AddrMode.Accumulator,   new byte[]{},           "A")]
     [InlineData(AddrMode.I,             new byte[]{0xee},       "#$EE")]

--- a/tests/Highbyte.DotNet6502.Tests/OutputGenTest.cs
+++ b/tests/Highbyte.DotNet6502.Tests/OutputGenTest.cs
@@ -109,7 +109,30 @@ public class OutputGenTest
 
         // Assert
         Assert.Equal("A=01 X=FF Y=7F PS=[NVUBDIZC] SP=80 PC=2000", outputString);
-    }           
+    }
 
+    [Fact]
+    public void OutputGen_Returns_Correctl_ProcessorStateDictionary()
+    {
+        // Arrange
+        var cpu = new CPU();
+        cpu.PC = 0x1000;
+        cpu.A = 0x00;
+        cpu.X = 0x00;
+        cpu.Y = 0x00;
+        cpu.ProcessorStatus.Value = 0x00;
+        cpu.SP = 0xff;
+
+        // Act
+        var outputDictionary = OutputGen.GetProcessorStateDictionary(cpu, true);
+
+        // Assert
+        Assert.Equal("1000", outputDictionary["PC"]);
+        Assert.Equal("00", outputDictionary["A"]);
+        Assert.Equal("00", outputDictionary["X"]);
+        Assert.Equal("00", outputDictionary["Y"]);
+        Assert.Equal("--------", outputDictionary["PS"]);
+        Assert.Equal("FF", outputDictionary["SP"]);
+    }
 
 }

--- a/tests/Highbyte.DotNet6502.Tests/WordHelpersTest.cs
+++ b/tests/Highbyte.DotNet6502.Tests/WordHelpersTest.cs
@@ -22,7 +22,7 @@ public class WordHelpersTest
 
         // Assert
         Assert.Equal("8514 (0x2142)", output);
-    }        
+    }
 
     // TODO: More unit tests for WordHelpers class
 }


### PR DESCRIPTION
Use DotNet6502Exception type consistently.

Fixes a bunch of compiler warnings.

Enables BCD (Binary Coded Decimal) tests in 6502 functional test program.