### PR TITLE
Add C64 paste from clipboard functionality

### DIFF
--- a/src/apps/Highbyte.DotNet6502.App.SadConsole/ConfigUI/C64MenuConsole.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SadConsole/ConfigUI/C64MenuConsole.cs
@@ -5,6 +5,7 @@ using SadConsole.UI.Controls;
 using SadRogue.Primitives;
 using Microsoft.Extensions.Logging;
 using Highbyte.DotNet6502.Utils;
+using TextCopy;
 
 namespace Highbyte.DotNet6502.App.SadConsole.ConfigUI;
 public class C64MenuConsole : ControlsConsole
@@ -60,16 +61,27 @@ public class C64MenuConsole : ControlsConsole
         Controls.Add(c64SaveBasicButton);
 
 
+        // Save Basic
+        var c64PasteTextButton = new Button("Paste")
+        {
+            Name = "c64PasteTextButton",
+            Position = (1, c64SaveBasicButton.Bounds.MaxExtentY + 2),
+        };
+        c64PasteTextButton.Click += C64PasteTextButton_Click;
+        Controls.Add(c64PasteTextButton);
+
+
         // Config
         var c64ConfigButton = new Button("C64 Config")
         {
             Name = "c64ConfigButton",
-            Position = (1, c64SaveBasicButton.Bounds.MaxExtentY + 2),
+            Position = (1, c64PasteTextButton.Bounds.MaxExtentY + 2),
         };
         c64ConfigButton.Click += C64ConfigButton_Click;
         Controls.Add(c64ConfigButton);
 
-        var validationMessageValueLabel = CreateLabelValue(new string(' ', 20), 1, c64ConfigButton.Bounds.MaxExtentY + 2, "validationMessageValueLabel");
+
+        var validationMessageValueLabel = CreateLabelValue(new string(' ', 20), 1, c64PasteTextButton.Bounds.MaxExtentY + 2, "validationMessageValueLabel");
         validationMessageValueLabel.TextColor = Controls.GetThemeColors().Red;
 
         // Helper function to create a label and add it to the console
@@ -201,6 +213,15 @@ public class C64MenuConsole : ControlsConsole
         window.Show(true);
     }
 
+    private void C64PasteTextButton_Click(object sender, EventArgs e)
+    {
+        var c64 = (C64)_sadConsoleHostApp.CurrentRunningSystem!;
+        var text = ClipboardService.GetText();
+        if (string.IsNullOrEmpty(text))
+            return;
+        c64.TextPaste.Paste(text);
+    }
+
     protected override void OnIsDirtyChanged()
     {
         if (IsDirty)
@@ -215,8 +236,11 @@ public class C64MenuConsole : ControlsConsole
         var c64SaveBasicButton = Controls["c64SaveBasicButton"];
         c64SaveBasicButton.IsEnabled = _sadConsoleHostApp.EmulatorState != Systems.EmulatorState.Uninitialized;
 
-        var systemComboBox = Controls["c64ConfigButton"];
-        systemComboBox.IsEnabled = _sadConsoleHostApp.EmulatorState == Systems.EmulatorState.Uninitialized;
+        var c64ConfigButton = Controls["c64ConfigButton"];
+        c64ConfigButton.IsEnabled = _sadConsoleHostApp.EmulatorState == Systems.EmulatorState.Uninitialized;
+
+        var c64PasteTextButton = Controls["c64PasteTextButton"];
+        c64PasteTextButton.IsEnabled = _sadConsoleHostApp.EmulatorState == Systems.EmulatorState.Running;
 
         var validationMessageValueLabel = Controls["validationMessageValueLabel"] as Label;
         (var isOk, var validationErrors) = _sadConsoleHostApp.IsValidConfigWithDetails().Result;

--- a/src/apps/Highbyte.DotNet6502.App.SadConsole/Highbyte.DotNet6502.App.SadConsole.csproj
+++ b/src/apps/Highbyte.DotNet6502.App.SadConsole/Highbyte.DotNet6502.App.SadConsole.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
     <PackageReference Include="SadConsole.Extended" Version="10.4.0" />
+    <PackageReference Include="TextCopy" Version="6.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/apps/Highbyte.DotNet6502.App.SadConsole/SadConsoleHostApp.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SadConsole/SadConsoleHostApp.cs
@@ -279,7 +279,8 @@ public class SadConsoleHostApp : HostApp<SadConsoleRenderContext, SadConsoleInpu
         {
             _monitorConsole.Init();
         }
-        _sadConsoleEmulatorConsole.IsFocused = true;
+
+        SetEmulatorConsoleFocus();
 
         if (_infoConsole.IsVisible)
         {
@@ -555,6 +556,12 @@ public class SadConsoleHostApp : HostApp<SadConsoleRenderContext, SadConsoleInpu
     public void SetVolumePercent(float volumePercent)
     {
         _audioHandlerContext.SetMasterVolumePercent(masterVolumePercent: volumePercent);
+    }
+
+    public void SetEmulatorConsoleFocus()
+    {
+        if (_sadConsoleEmulatorConsole != null)
+            _sadConsoleEmulatorConsole.IsFocused = true;
     }
 
     private void HandleUIKeyboardInput()

--- a/src/apps/Highbyte.DotNet6502.App.SilkNetNative/Highbyte.DotNet6502.App.SilkNetNative.csproj
+++ b/src/apps/Highbyte.DotNet6502.App.SilkNetNative/Highbyte.DotNet6502.App.SilkNetNative.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Silk.NET.OpenGL" Version="2.21.0" />
     <PackageReference Include="Silk.NET.Windowing" Version="2.21.0" />
     <PackageReference Include="Silk.NET.OpenGL.Extensions.ImGui" Version="2.21.0" />
+    <PackageReference Include="TextCopy" Version="6.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/apps/Highbyte.DotNet6502.App.SilkNetNative/SilkNetImGuiMenu.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SilkNetNative/SilkNetImGuiMenu.cs
@@ -8,6 +8,7 @@ using Highbyte.DotNet6502.Systems.Generic.Config;
 using Highbyte.DotNet6502.Utils;
 using Microsoft.Extensions.Logging;
 using NativeFileDialogSharp;
+using TextCopy;
 
 namespace Highbyte.DotNet6502.App.SilkNetNative;
 
@@ -440,6 +441,19 @@ public class SilkNetImGuiMenu : ISilkNetImGuiWindow
 
             if (wasRunning)
                 _silkNetHostApp.Start();
+        }
+        ImGui.EndDisabled();
+
+        // C64 paste text
+        ImGui.BeginDisabled(disabled: EmulatorState == EmulatorState.Uninitialized);
+        if (ImGui.Button("Paste"))
+        {
+            var c64 = (C64)_silkNetHostApp.CurrentRunningSystem!;
+            var text = ClipboardService.GetText();
+            if (string.IsNullOrEmpty(text))
+                return;
+            c64.TextPaste.Paste(text);
+
         }
         ImGui.EndDisabled();
 

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Highbyte.DotNet6502.App.WASM.csproj
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Highbyte.DotNet6502.App.WASM.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="SkiaSharp.Views.Blazor" Version="3.0.0-preview.4.1" />
     <PackageReference Include="PublishSPAforGitHubPages.Build" Version="2.2.0" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
+    <PackageReference Include="TextCopy" Version="6.2.1" />
     <PackageReference Include="Toolbelt.Blazor.Gamepad" Version="9.0.0" />
   </ItemGroup>
 

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Commodore64/C64Menu.razor
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Commodore64/C64Menu.razor
@@ -5,6 +5,7 @@
 @using static Highbyte.DotNet6502.App.WASM.Pages.Index;
 @using Highbyte.DotNet6502.App.WASM.Emulator.SystemSetup;
 @using Highbyte.DotNet6502.Utils;
+@using TextCopy
 
 @if(Parent.Initialized && Parent.WasmHost.SelectedSystemName == SYSTEM_NAME)
 {
@@ -54,6 +55,10 @@
             </select>
             <button @onclick="OnLoadBasicExample" disabled=@OnFilePickerDisabled>Load</button>
         </div>
+
+        <p>Misc.</p>
+        <button @onclick="PasteText" disabled=@OnPasteTextDisabled>Paste</button>
+
     </div>
 
     <div class="validation-message">
@@ -93,6 +98,7 @@
     @inject IJSRuntime Js
     @inject HttpClient HttpClient
     @inject ILoggerFactory LoggerFactory
+    @inject IClipboard Clipboard
 
     [Parameter]
     public Highbyte.DotNet6502.App.WASM.Pages.Index Parent { get; set; } = default!;
@@ -207,6 +213,8 @@
     protected bool OnFilePickerDisabled => Parent.CurrentEmulatorState == EmulatorState.Uninitialized;
 
     protected bool OnBasicFilePickerDisabled => Parent.CurrentEmulatorState == EmulatorState.Uninitialized;
+
+    protected bool OnPasteTextDisabled => Parent.CurrentEmulatorState == EmulatorState.Uninitialized;
 
     /// <summary>
     /// Open Load binary file dialog
@@ -447,14 +455,9 @@
                 c64.InitBasicMemoryVariables(loadedAtAddress, fileLength);
             }
 
-            // Send "list" + Enter to the keyboard buffer to immediately list the loaded program
-            var c64Keyboard = c64.Cia.Keyboard;
-            // Bypass keyboard matrix scanning and send directly to keyboard buffer?
-            c64Keyboard.InsertPetsciiCharIntoBuffer(Petscii.CharToPetscii['l']);
-            c64Keyboard.InsertPetsciiCharIntoBuffer(Petscii.CharToPetscii['i']);
-            c64Keyboard.InsertPetsciiCharIntoBuffer(Petscii.CharToPetscii['s']);
-            c64Keyboard.InsertPetsciiCharIntoBuffer(Petscii.CharToPetscii['t']);
-            c64Keyboard.InsertPetsciiCharIntoBuffer(Petscii.CharToPetscii[(char)13]);
+            // Send "list" + NewLine (Return) to the keyboard buffer to immediately list the loaded program.
+            // Bypass keyboard matrix scanning and send directly to keyboard buffer.
+            c64.TextPaste.Paste("list\n");
 
         }
         catch (Exception ex)
@@ -464,5 +467,17 @@
         }
 
         await Parent.OnStart(new());
+    }
+
+
+    private async Task PasteText()
+    {
+        var c64 = (C64)Parent.WasmHost.CurrentRunningSystem!;
+        var text = await Clipboard.GetTextAsync();
+        if (string.IsNullOrEmpty(text))
+            return;
+        c64.TextPaste.Paste(text);
+
+        await Parent.FocusEmulator();
     }
 }

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Index.razor.cs
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Index.razor.cs
@@ -640,7 +640,7 @@ public partial class Index
         _wasmHost.Monitor.OnKeyUp(e);
     }
 
-    private async Task FocusEmulator()
+    public async Task FocusEmulator()
     {
         await Js!.InvokeVoidAsync("focusId", "emulatorSKGLView", 100);  // Hack: Delay of x ms for focus to work.
     }

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Program.cs
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Program.cs
@@ -4,6 +4,7 @@ using Highbyte.DotNet6502.App.WASM;
 using Blazored.LocalStorage;
 using Toolbelt.Blazor.Extensions.DependencyInjection;
 using Highbyte.DotNet6502.Systems.Logging.Console;
+using TextCopy;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
@@ -12,6 +13,7 @@ builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.
 builder.Services.AddBlazoredModal();
 builder.Services.AddBlazoredLocalStorage();
 builder.Services.AddGamepadList();
+builder.Services.InjectClipboard();
 
 builder.Logging.ClearProviders();
 builder.Logging.AddDotNet6502Console();

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/C64Keyboard.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/C64Keyboard.cs
@@ -148,17 +148,21 @@ public class C64Keyboard
     /// <summary>
     /// Inserts a PETSCII character directly into the keyboard buffer, bypassing keyboard matrix.
     /// Can be useful when wanting to type Basic commands on behalf of the user.
+    /// 
+    /// Returns true if the character was inserted into the buffer, false if the buffer is full (and character couldn't be inserted).
     /// </summary>
     /// <param name="petsciiChar"></param>
-    public void InsertPetsciiCharIntoBuffer(byte petsciiChar)
+    /// 
+    public bool InsertPetsciiCharIntoBuffer(byte petsciiChar)
     {
         // Address: 0x00c6: Keyboard buffer index
         // Address: 0x0277 - 0x0280: Keyboard buffer
         var bufferIndex = _c64.Mem[0x00c6];
         if (bufferIndex >= 10)
-            return;
+            return false;
         _c64.Mem[0x00c6]++;
         _c64.Mem[(ushort)(0x0277 + bufferIndex)] = petsciiChar;
+        return true;
     }
 
     /// <summary>

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Utils/C64TextPaste.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Utils/C64TextPaste.cs
@@ -1,0 +1,64 @@
+using Highbyte.DotNet6502.Systems.Commodore64.Video;
+using Microsoft.Extensions.Logging;
+
+namespace Highbyte.DotNet6502.Systems.Commodore64.Utils;
+public class C64TextPaste
+{
+    private readonly Queue<char> _charQueue = new();
+    private readonly ILogger<C64TextPaste> _logger;
+    private readonly C64 _c64;
+
+    internal bool HasCharactersPending => _charQueue.Count > 0;
+
+
+    public C64TextPaste(C64 c64, ILoggerFactory loggerFactory)
+    {
+        _logger = loggerFactory.CreateLogger<C64TextPaste>();
+        _c64 = c64;
+    }
+
+    public void Paste(string text)
+    {
+        foreach (char c in text)
+            _charQueue.Enqueue(c);
+    }
+
+    internal void InsertNextCharacterToKeyboardBuffer()
+    {
+        bool foundChar = _charQueue.TryPeek(out char ansiChar);
+        if (!foundChar)
+            return;
+
+        // In Windows, a new line is CRLF (Carrige Return 13 and Line Feed 10)
+        // In Linux and macOS, a new line is only LF (Line feed 10).
+        // C64 only uses LF (13) which is "Return" for new line.
+        //
+        // Ignore Windows LF (10), and map Line Feed for all systems (10) to C64 Return (13).
+        if (ansiChar == 13)
+        {
+            _charQueue.Dequeue();
+            return;
+        }
+
+        if (ansiChar == 10)
+            ansiChar = (char)13;
+
+        if (!Petscii.CharToPetscii.ContainsKey(ansiChar))
+        {
+            _charQueue.Dequeue();
+            _logger.LogWarning($"'{ansiChar}' has no mapped PetscII char.");
+            return;
+        }
+
+        var petsciiChar = Petscii.CharToPetscii[ansiChar];
+        var inserted = _c64.Cia.Keyboard.InsertPetsciiCharIntoBuffer(petsciiChar);
+        if (inserted)
+        {
+            _charQueue.Dequeue();
+        }
+        else
+        {
+            _logger.LogWarning($"'{ansiChar}' could not be inserted into keyboard buffer.");
+        }
+    }
+}


### PR DESCRIPTION
#### PR Classification
New feature to enable clipboard text pasting functionality in the C64 emulator.

#### PR Summary
Introduced clipboard text pasting across different UI components and updated relevant classes to support this feature.
- Use NuGet package`TextCopy` to read clipboard in native and Blazor WASM apps.
- `C64MenuConsole`: Added "Paste" button and implemented event handler for pasting text.
- `C64Menu.razor`: Included "Paste" button and implemented `PasteText` method.
- `C64`: Added `C64TextPaste` property and refactored constructor for text-pasting logic.
- `C64Keyboard`: Updated to return a boolean for character insertion.
- `Program.cs`: Registered `TextCopy` service for clipboard operations.
