### PR TITLE
C64 Basic token parser

### DIFF
--- a/src/apps/Highbyte.DotNet6502.App.SadConsole/ConfigUI/C64MenuConsole.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SadConsole/ConfigUI/C64MenuConsole.cs
@@ -6,6 +6,8 @@ using SadRogue.Primitives;
 using Microsoft.Extensions.Logging;
 using Highbyte.DotNet6502.Utils;
 using TextCopy;
+using Highbyte.DotNet6502.Systems.Commodore64.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Highbyte.DotNet6502.App.SadConsole.ConfigUI;
 public class C64MenuConsole : ControlsConsole
@@ -60,16 +62,23 @@ public class C64MenuConsole : ControlsConsole
         c64SaveBasicButton.Click += C64SaveBasicButton_Click;
         Controls.Add(c64SaveBasicButton);
 
+        // Copy Basic Source Code
+        var c64CopyBasicSourceCodeButton = new Button("Copy")
+        {
+            Name = "c64CopyBasicSourceCodeButton",
+            Position = (1, c64SaveBasicButton.Bounds.MaxExtentY + 2),
+        };
+        c64CopyBasicSourceCodeButton.Click += C64CopyBasicSourceCodeButton_Click;
+        Controls.Add(c64CopyBasicSourceCodeButton);
 
-        // Save Basic
+        // Paste
         var c64PasteTextButton = new Button("Paste")
         {
             Name = "c64PasteTextButton",
-            Position = (1, c64SaveBasicButton.Bounds.MaxExtentY + 2),
+            Position = (c64CopyBasicSourceCodeButton.Bounds.MaxExtentX + 9, c64CopyBasicSourceCodeButton.Position.Y),
         };
         c64PasteTextButton.Click += C64PasteTextButton_Click;
         Controls.Add(c64PasteTextButton);
-
 
         // Config
         var c64ConfigButton = new Button("C64 Config")
@@ -213,6 +222,13 @@ public class C64MenuConsole : ControlsConsole
         window.Show(true);
     }
 
+    private void C64CopyBasicSourceCodeButton_Click(object sender, EventArgs e)
+    {
+        var c64 = (C64)_sadConsoleHostApp.CurrentRunningSystem!;
+        var basicSourceCode = c64.BasicTokenParser.GetBasicTextLines();
+        ClipboardService.SetText(basicSourceCode.ToLower());
+    }
+
     private void C64PasteTextButton_Click(object sender, EventArgs e)
     {
         var c64 = (C64)_sadConsoleHostApp.CurrentRunningSystem!;
@@ -238,6 +254,9 @@ public class C64MenuConsole : ControlsConsole
 
         var c64ConfigButton = Controls["c64ConfigButton"];
         c64ConfigButton.IsEnabled = _sadConsoleHostApp.EmulatorState == Systems.EmulatorState.Uninitialized;
+
+        var c64CopyBasicSourceCodeButton = Controls["c64CopyBasicSourceCodeButton"];
+        c64CopyBasicSourceCodeButton.IsEnabled = _sadConsoleHostApp.EmulatorState == Systems.EmulatorState.Running;
 
         var c64PasteTextButton = Controls["c64PasteTextButton"];
         c64PasteTextButton.IsEnabled = _sadConsoleHostApp.EmulatorState == Systems.EmulatorState.Running;

--- a/src/apps/Highbyte.DotNet6502.App.SilkNetNative/SilkNetImGuiMenu.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SilkNetNative/SilkNetImGuiMenu.cs
@@ -444,7 +444,18 @@ public class SilkNetImGuiMenu : ISilkNetImGuiWindow
         }
         ImGui.EndDisabled();
 
+        // C64 copy basic source code
+        ImGui.BeginDisabled(disabled: EmulatorState == EmulatorState.Uninitialized);
+        if (ImGui.Button("Copy"))
+        {
+            var c64 = (C64)_silkNetHostApp.CurrentRunningSystem!;
+            var sourceCode = c64.BasicTokenParser.GetBasicTextLines();
+            ClipboardService.SetText(sourceCode.ToLower());
+        }
+        ImGui.EndDisabled();
+
         // C64 paste text
+        ImGui.SameLine();
         ImGui.BeginDisabled(disabled: EmulatorState == EmulatorState.Uninitialized);
         if (ImGui.Button("Paste"))
         {
@@ -453,7 +464,6 @@ public class SilkNetImGuiMenu : ISilkNetImGuiWindow
             if (string.IsNullOrEmpty(text))
                 return;
             c64.TextPaste.Paste(text);
-
         }
         ImGui.EndDisabled();
 

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Commodore64/C64Menu.razor
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Commodore64/C64Menu.razor
@@ -57,6 +57,7 @@
         </div>
 
         <p>Misc.</p>
+        <button @onclick="CopyBasicSourceCode" disabled=@OnCopySourceCodeDisabled>Copy</button>
         <button @onclick="PasteText" disabled=@OnPasteTextDisabled>Paste</button>
 
     </div>
@@ -214,7 +215,10 @@
 
     protected bool OnBasicFilePickerDisabled => Parent.CurrentEmulatorState == EmulatorState.Uninitialized;
 
+    protected bool OnCopySourceCodeDisabled=> Parent.CurrentEmulatorState == EmulatorState.Uninitialized;
+    
     protected bool OnPasteTextDisabled => Parent.CurrentEmulatorState == EmulatorState.Uninitialized;
+
 
     /// <summary>
     /// Open Load binary file dialog
@@ -469,6 +473,13 @@
         await Parent.OnStart(new());
     }
 
+    private async Task CopyBasicSourceCode()
+    {
+        var c64 = (C64)Parent.WasmHost.CurrentRunningSystem!;
+        var sourceCode = c64.BasicTokenParser.GetBasicTextLines();
+        await Clipboard.SetTextAsync(sourceCode.ToLower());
+        await Parent.FocusEmulator();
+    }
 
     private async Task PasteText()
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -56,6 +56,7 @@ public class C64 : ISystem, ISystemMonitor
 
     public bool RememberVic2RegistersPerRasterLine { get; set; } = true;
 
+    public C64BasicTokenParser BasicTokenParser { get; private set; }
     public C64TextPaste TextPaste { get; private set; }
 
     //public static ROM[] ROMS = new ROM[]
@@ -224,6 +225,7 @@ public class C64 : ISystem, ISystemMonitor
         var mem = c64.CreateC64Memory(ram, io, romData);
         c64.Mem = mem;
 
+        c64.BasicTokenParser = new C64BasicTokenParser(c64, loggerFactory);
         c64.TextPaste = new C64TextPaste(c64, loggerFactory);
 
         // Configure the current memory configuration on startup

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Utils/C64BasicTokenParser.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Utils/C64BasicTokenParser.cs
@@ -1,0 +1,116 @@
+using System.Text;
+using Highbyte.DotNet6502.Utils;
+using Microsoft.Extensions.Logging;
+
+namespace Highbyte.DotNet6502.Systems.Commodore64.Utils;
+
+/// <summary>
+/// Parser for C64 Basic program in binary (token) format.
+/// 
+/// Based on: https://github.com/abbrev/prg-tools/blob/master/src/prg2bas.c
+/// </summary>
+public class C64BasicTokenParser
+{
+    private readonly ILogger<C64BasicTokenParser> _logger;
+    private readonly C64 _c64;
+
+    public C64BasicTokenParser(C64 c64, ILoggerFactory loggerFactory)
+    {
+        _logger = loggerFactory.CreateLogger<C64BasicTokenParser>();
+        _c64 = c64;
+    }
+
+    public string GetBasicTextLines(bool spaceAfterLineNumber = true, bool addNewLineAfterLastCharacter = true)
+    {
+        ushort startAddressValue = C64.BASIC_LOAD_ADDRESS;
+        var endAddressValue = _c64.GetBasicProgramEndAddress();
+        var prgBytes = BinarySaver.BuildSaveData(_c64.Mem, startAddressValue, endAddressValue, addFileHeaderWithLoadAddress: true);
+
+        return GetBasicTextLines(prgBytes, spaceAfterLineNumber, addNewLineAfterLastCharacter);
+    }
+
+    public string GetBasicTextLines(byte[] basicPrg, bool spaceAfterLineNumber = true, bool addNewLineAfterLastCharacter = true)
+    {
+        if (basicPrg.Length < 2)
+            throw new ArgumentException("Basic program is too short to contain a load address.");
+
+        using MemoryStream stream = new MemoryStream(basicPrg);
+
+        // First to bytes is the load address
+        byte[] prgHeader = new byte[2];
+        stream.ReadExactly(prgHeader, 0, 2);
+        var loadAddress = ByteHelpers.ToLittleEndianWord(prgHeader[0], prgHeader[1]);
+
+        _logger.LogInformation($"Basic load address: {loadAddress}");
+        if (loadAddress != C64.BASIC_LOAD_ADDRESS)
+        {
+            _logger.LogWarning($"Basic load address is not the expected {C64.BASIC_LOAD_ADDRESS}, probably not a Basic file. Skipping parsing.");
+            return string.Empty;
+        }
+
+        StringBuilder sb = new StringBuilder();
+
+        // Loop each basic line
+        while (true)
+        {
+
+            // Get next line address
+            var addr = stream.ReadWord();
+            if (addr < 0 || addr == 0)   // Negative -> end of stream, 0 -> end of basic program
+                break;
+
+            // Get next line number
+            var lineNumber = stream.ReadWord();
+            if (lineNumber < 0)    // Negative -> end of stream,
+                break;
+
+            // Add new line if not first line
+            if (sb.Length > 0)
+                sb.AppendLine();
+
+            sb.Append(lineNumber);
+            if (spaceAfterLineNumber)
+                sb.Append(' ');
+
+
+            // Loop each token in the basic line
+            bool quoted = false;
+            bool endOfProgram = false;
+            bool nextLine = false;
+            while (!endOfProgram || !nextLine)
+            {
+                var token = stream.ReadByte();
+                if (token < 0) // Negative -> end of stream
+                {
+                    endOfProgram = true;
+                    break;
+                }
+                if (token == 0) // Next line
+                {
+                    nextLine = true;
+                    break;
+                }
+
+                if (token == '"')
+                    quoted = !quoted;
+
+                if (!quoted && token >= 0x80)
+                {
+                    sb.Append(C64BasicTokens.Tokens[(byte)token]);
+                }
+                else
+                {
+                    sb.Append((char)token);
+                }
+            }
+
+            if (endOfProgram)
+                break;
+        }
+
+        if (addNewLineAfterLastCharacter)
+            sb.AppendLine();
+
+        return sb.ToString();
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Utils/C64BasicTokens.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Utils/C64BasicTokens.cs
@@ -1,0 +1,159 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Utils;
+
+/// <summary>
+/// Tokens used by C64 Basic program in binary (token) format.
+/// 
+/// Based on: https://github.com/abbrev/prg-tools/blob/master/src/tokens.c
+/// </summary>
+public static class C64BasicTokens
+{
+    /// <summary>
+    /// Dictionary that maps C64 token byte values to their string representation.
+    /// </summary>
+    public static Dictionary<byte, string> Tokens = new Dictionary<byte, string>
+    {
+        { 0x80, "END" },
+        { 0x81, "FOR" },
+        { 0x82, "NEXT" },
+        { 0x83, "DATA" },
+        { 0x84, "INPUT#" },
+        { 0x85, "INPUT" },
+        { 0x86, "DIM" },
+        { 0x87, "READ" },
+
+        { 0x88, "LET" },
+        { 0x89, "GOTO" },
+        { 0x8A, "RUN" },
+        { 0x8B, "IF" },
+        { 0x8C, "RESTORE" },
+        { 0x8D, "GOSUB" },
+        { 0x8E, "RETURN" },
+        { 0x8F, "REM" },
+
+        { 0x90, "STOP" },
+        { 0x91, "ON" },
+        { 0x92, "WAIT" },
+        { 0x93, "LOAD" },
+        { 0x94, "SAVE" },
+        { 0x95, "VERIFY" },
+        { 0x96, "DEF" },
+        { 0x97, "POKE" },
+
+        { 0x98, "PRINT#" },
+        { 0x99, "PRINT" },
+        { 0x9A, "CONT" },
+        { 0x9B, "LIST" },
+        { 0x9C, "CLR" },
+        { 0x9D, "CMD" },
+        { 0x9E, "SYS" },
+        { 0x9F, "OPEN" },
+
+        { 0xA0, "CLOSE" },
+        { 0xA1, "GET" },
+        { 0xA2, "NEW" },
+        { 0xA3, "TAB(" },
+        { 0xA4, "TO" },
+        { 0xA5, "FN" },
+        { 0xA6, "SPC(" },
+        { 0xA7, "THEN" },
+
+        { 0xA8, "NOT" },
+        { 0xA9, "STEP" },
+        { 0xAA, "+" },
+        { 0xAB, "-" },
+        { 0xAC, "*" },
+        { 0xAD, "/" },
+        { 0xAE, "^" },
+        { 0xAF, "AND" },
+
+        { 0xB0, "OR" },
+        { 0xB1, ">" },
+        { 0xB2, "=" },
+        { 0xB3, "<" },
+        { 0xB4, "SGN" },
+        { 0xB5, "INT" },
+        { 0xB6, "ABS" },
+        { 0xB7, "USR" },
+
+        { 0xB8, "FRE" },
+        { 0xB9, "POS" },
+        { 0xBA, "SQR" },
+        { 0xBB, "RND" },
+        { 0xBC, "LOG" },
+        { 0xBD, "EXP" },
+        { 0xBE, "COS" },
+        { 0xBF, "SIN" },
+
+        { 0xC0, "TAN" },
+        { 0xC1, "ATN" },
+        { 0xC2, "PEEK" },
+        { 0xC3, "LEN" },
+        { 0xC4, "STR$" },
+        { 0xC5, "VAL" },
+        { 0xC6, "ASC" },
+        { 0xC7, "CHR$" },
+
+        { 0xC8, "LEFT$" },
+        { 0xC9, "RIGHT$" },
+        { 0xCA, "MID$" },
+        { 0xCB, "GO" },
+        { 0xCC, "{cc}" },
+        { 0xCD, "{cd}" },
+        { 0xCE, "{ce}" },
+        { 0xCF, "{cf}" },
+
+        { 0xD0, "{d0}" },
+        { 0xD1, "{d1}" },
+        { 0xD2, "{d2}" },
+        { 0xD3, "{d3}" },
+        { 0xD4, "{d4}" },
+        { 0xD5, "{d5}" },
+        { 0xD6, "{d6}" },
+        { 0xD7, "{d7}" },
+
+        { 0xD8, "{d8}" },
+        { 0xD9, "{d9}" },
+        { 0xDA, "{da}" },
+        { 0xDB, "{db}" },
+        { 0xDC, "{dc}" },
+        { 0xDD, "{dd}" },
+        { 0xDE, "{de}" },
+        { 0xDF, "{df}" },
+
+        { 0xE0, "{e0}" },
+        { 0xE1, "{e1}" },
+        { 0xE2, "{e2}" },
+        { 0xE3, "{e3}" },
+        { 0xE4, "{e4}" },
+        { 0xE5, "{e5}" },
+        { 0xE6, "{e6}" },
+        { 0xE7, "{e7}" },
+
+        { 0xE8, "{e8}" },
+        { 0xE9, "{e9}" },
+        { 0xEA, "{ea}" },
+        { 0xEB, "{eb}" },
+        { 0xEC, "{ec}" },
+        { 0xED, "{ed}" },
+        { 0xEE, "{ee}" },
+        { 0xEF, "{ef}" },
+
+        { 0xF0, "{f0}" },
+        { 0xF1, "{f1}" },
+        { 0xF2, "{f2}" },
+        { 0xF3, "{f3}" },
+        { 0xF4, "{f4}" },
+        { 0xF5, "{f5}" },
+        { 0xF6, "{f6}" },
+        { 0xF7, "{f7}" },
+
+        { 0xF8, "{f8}" },
+        { 0xF9, "{f9}" },
+        { 0xFA, "{fa}" },
+        { 0xFB, "{fb}" },
+        { 0xFC, "{fc}" },
+        { 0xFD, "{fd}" },
+        { 0xFE, "{fe}" },
+        { 0xFF, "{pi}" }
+    };
+}

--- a/src/libraries/Highbyte.DotNet6502/Utils/WordHelpers.cs
+++ b/src/libraries/Highbyte.DotNet6502/Utils/WordHelpers.cs
@@ -86,4 +86,21 @@ public static class WordHelpers
         return $"{value} ({value.ToHex(hexPrefix, lowerCase)})";
     }
 
+    /// <summary>
+    /// Read a little endian word from stream.
+    /// Return -1 if end of stream.
+    /// </summary>
+    /// <param name="stream"></param>
+    /// <returns></returns>
+    public static int ReadWord(this MemoryStream stream)
+    {
+        byte[] wordBytes = new byte[2];
+        var byte1 = stream.ReadByte();
+        if (byte1 < 0)
+            return -1;
+        var byte2 = stream.ReadByte();
+        if (byte2 < 0)
+            return -1;
+        return ByteHelpers.ToLittleEndianWord((byte)byte1, (byte)byte2);
+    }
 }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Utils/C64BasicTokenParserTest.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Utils/C64BasicTokenParserTest.cs
@@ -1,0 +1,116 @@
+using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Systems.Commodore64.Utils;
+using Highbyte.DotNet6502.Utils;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64.Utils;
+public class C64BasicTokenParserTest
+{
+    private readonly ITestOutputHelper _output;
+    private readonly ILoggerFactory _loggerFactory = new NullLoggerFactory();
+    private const string HelloWorldBasicPrgFile = "../../../../../samples/Basic/C64/Text/Build/HelloWorld.prg";
+
+    private const string HelloWorldBasicSourceCode =
+@"10 c1=7:c2=14
+20 c=c1
+30 if c=c1 then c=c2 : goto 50
+40 if c=c2 then c=c1
+50 poke 53280,c
+60 print ""hello world!""
+70 for i=1 to 150:next
+80 goto 30";
+
+    public C64BasicTokenParserTest(ITestOutputHelper testOutputHelper)
+    {
+        _output = testOutputHelper;
+    }
+
+    [Fact]
+    public void GetBasicTextLines_WhenBasicProgramIsTooShort_ThrowsException()
+    {
+        // Arrange
+        var c64 = BuildC64();
+        var basicTokenParser = new C64BasicTokenParser(c64, _loggerFactory);
+
+        // Act / Assert
+        Assert.Throws<ArgumentException>(() => basicTokenParser.GetBasicTextLines(new byte[] { 0x00 }));
+    }
+
+    [Fact]
+    public void GetBasicTextLines_WhenBasicProgramHasNoLines_ReturnsEmptyList()
+    {
+        // Arrange
+        var c64 = BuildC64();
+        var basicTokenParser = new C64BasicTokenParser(c64, _loggerFactory);
+
+        // Act
+        var sourceCode = basicTokenParser.GetBasicTextLines(new byte[] { 0x00, 0x00 });
+
+        // Assert
+        Assert.Empty(sourceCode);
+    }
+
+    [Fact]
+    public void GetBasicTextLines_Returns_All_Lines_In_Program_ByteArray()
+    {
+        // Arrange
+        var c64 = BuildC64();
+        var basicTokenParser = new C64BasicTokenParser(c64, _loggerFactory);
+
+        // Act
+        var prg = File.ReadAllBytes(HelloWorldBasicPrgFile);
+        var sourceCode = basicTokenParser.GetBasicTextLines(prg, addNewLineAfterLastCharacter: false);
+
+        // Assert
+        _output.WriteLine(sourceCode);
+
+        var lines = sourceCode.Split(Environment.NewLine).ToList();
+        Assert.Equal(8, lines.Count);
+
+        Assert.Equal(HelloWorldBasicSourceCode, sourceCode.ToLower());
+    }
+
+    [Fact]
+    public void GetBasicTextLines_Returns_All_Lines_In_Basic_Program_Loaded_Into_C64()
+    {
+        // Arrange
+        var c64 = BuildC64();
+        var basicTokenParser = new C64BasicTokenParser(c64, _loggerFactory);
+
+        BinaryLoader.Load(
+            c64.Mem,
+            HelloWorldBasicPrgFile,
+            out ushort loadedAtAddress,
+            out ushort fileLength);
+
+        c64.InitBasicMemoryVariables(loadedAtAddress, fileLength);
+
+        // Act
+        var sourceCode = basicTokenParser.GetBasicTextLines(addNewLineAfterLastCharacter: false);
+
+        // Assert
+        _output.WriteLine(sourceCode);
+
+        var lines = sourceCode.Split(Environment.NewLine).ToList();
+        Assert.Equal(8, lines.Count);
+
+        Assert.Equal(HelloWorldBasicSourceCode, sourceCode.ToLower());
+    }
+
+
+    private C64 BuildC64()
+    {
+        var c64Config = new C64Config
+        {
+            C64Model = "C64NTSC",   // C64NTSC, C64PAL
+            Vic2Model = "NTSC",     // NTSC, NTSC_old, PAL
+            LoadROMs = false
+        };
+
+        var c64 = C64.BuildC64(c64Config, _loggerFactory);
+        return c64;
+    }
+}


### PR DESCRIPTION
#### PR Classification
New feature to parse and copy C64 Basic programs.

#### PR Summary
Introduced functionality to parse C64 Basic programs and copy them to the clipboard.
- Added `C64BasicTokenParser` and `C64BasicTokens` classes for parsing and mapping tokens.
- Integrated `C64BasicTokenParser` into the `C64` class.
- Updated `C64MenuConsole` and `C64Menu.razor` to include a new copy button and its event handlers.
- Added `ReadWord` extension method in `WordHelpers`.
- Created unit tests in `C64BasicTokenParserTest`.
