### PR TITLE
Fixes #123

### DIFF
--- a/src/libraries/Highbyte.DotNet6502/CPU.cs
+++ b/src/libraries/Highbyte.DotNet6502/CPU.cs
@@ -272,16 +272,18 @@ public class CPU
         if (CPUInterrupts.NMILineEnabled)
         {
             // TODO: Should all NMI sources be cleared here?
-            foreach (var source in CPUInterrupts.ActiveNMISources)
+            for (int i = CPUInterrupts.ActiveNMISources.Count - 1; i >= 0; i--)
             {
+                var source = CPUInterrupts.ActiveNMISources.ElementAt(i);
                 CPUInterrupts.SetNMISourceInactive(source);
             }
             ProcessHardwareNMI(mem);
         }
         else if (CPUInterrupts.IRQLineEnabled && !ProcessorStatus.InterruptDisable)
         {
-            foreach (var source in CPUInterrupts.ActiveIRQSources.Keys)
+            for (int i = CPUInterrupts.ActiveIRQSources.Count - 1; i >= 0; i--)
             {
+                var source = CPUInterrupts.ActiveIRQSources.ElementAt(i).Key;
                 // Automatically remove IRQ sources that should not manually be acknowledged.
                 if (CPUInterrupts.ActiveIRQSources[source])
                 {


### PR DESCRIPTION
Fixes #123

#### PR Classification
Code improvement to ensure safe removal of elements during iteration.

#### PR Summary
Replaced `foreach` loops with `for` loops iterating from the last to the first element to allow safe removal of elements during iteration.
- `ProcessInterrupts` method: Changed `foreach` loop for `CPUInterrupts.ActiveNMISources` to a `for` loop.
- `ProcessInterrupts` method: Changed `foreach` loop for `CPUInterrupts.ActiveIRQSources.Keys` to a `for` loop.
