### PR TITLE
Feature/fix cors proxy

### DIFF
--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/SystemSetup/C64HostConfig.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/SystemSetup/C64HostConfig.cs
@@ -15,7 +15,8 @@ public class C64HostConfig : IHostSystemConfig, ICloneable
     //public const string DefaultCorsProxyURL = "https://api.allorigins.win/raw?url="; // Doesn't work reliably
     //public const string DefaultCorsProxyURL = "https://corsproxy.io/?url="; // Stopped being possible to download binary files on free tier
     //public const string DefaultCorsProxyURL = "https://proxy.corsfix.com/?url="; // Only free from localhost
-    public const string DefaultCorsProxyURL = "https://cors-anywhere.com/";
+    //public const string DefaultCorsProxyURL = "https://cors-anywhere.com/"; // Only works from localhost 
+    public const string DefaultCorsProxyURL = "https://api.codetabs.com/v1/proxy?quest=";
 
     private C64SystemConfig _systemConfig = new();
     ISystemConfig IHostSystemConfig.SystemConfig => _systemConfig;

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/SystemSetup/C64HostConfig.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/SystemSetup/C64HostConfig.cs
@@ -32,7 +32,32 @@ public class C64HostConfig : IHostSystemConfig, ICloneable
 
     public C64AvaloniaInputConfig InputConfig { get; set; } = new C64AvaloniaInputConfig();
 
-    public string CorsProxyURL { get; set; } = DefaultCorsProxyURL;
+    /// <summary>
+    /// Cors Proxy address override.
+    /// If set to null or empty, the default CORS proxy URL will be used when running in WebAssembly. When running on desktop, this setting is ignored and no CORS proxy will be used.
+    /// </summary>
+    /// <value></value>
+    public string? CorsProxyOverrideURL { get; set; } = null;
+
+    /// <summary>
+    /// Return the current CORS proxy URL to use.
+    /// If running in WebAssembly, this will return the CorsProxyOverrideURL if set, or the DefaultCorsProxyURL if CorsProxyOverrideURL is null or empty. 
+    /// If not running in WebAssembly, this will return null to indicate that no CORS proxy should be used.
+    /// </summary>
+    /// <returns></returns> <summary>
+    /// 
+    /// </summary>
+    /// <returns></returns>
+    public string GetCorsProxyURL()
+    {
+        if (!PlatformDetection.IsRunningInWebAssembly())
+        {
+            // CORS proxy is only needed when running in WebAssembly, so return null to not use any proxy when running on desktop
+            return null!;
+        }
+        // If running in WebAssembly, return the configured CORS proxy URL, or the default if not set
+        return string.IsNullOrEmpty(CorsProxyOverrideURL) ? DefaultCorsProxyURL : CorsProxyOverrideURL;
+    }
 
     private bool _basicAIAssistantDefaultEnabled;
     [JsonIgnore]

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/C64ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/C64ConfigDialogViewModel.cs
@@ -48,6 +48,8 @@ public class C64ConfigDialogViewModel : ViewModelBase
     private RenderTargetOption? _selectedRenderTarget;
     private bool _suppressRenderTargetUpdate;
 
+    private string _corsProxyOverrideURL = string.Empty;
+
     // AI Coding Assistant properties - now using config objects
     private CodeSuggestionBackendTypeEnum _selectedAIBackendType;
     private ApiConfig _openAIConfig = new();
@@ -61,6 +63,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
     public ReactiveCommand<Unit, Unit> DownloadRomsToFilesCommand { get; }
     public ReactiveCommand<Unit, Unit> ClearRomsCommand { get; }
     public ReactiveCommand<Unit, Unit> TestAIBackendCommand { get; }
+    public ReactiveCommand<Unit, Unit> ResetCorsProxyOverrideURLCommand { get; }
     public ReactiveCommand<Unit, Unit> SaveCommand { get; }
     public ReactiveCommand<Unit, Unit> CancelCommand { get; }
 
@@ -86,6 +89,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
         AudioEnabled = _workingConfig.SystemConfig.AudioEnabled;
 
         RomDirectory = _workingConfig.SystemConfig.ROMDirectory;
+        CorsProxyOverrideURL = _workingConfig.CorsProxyOverrideURL ?? string.Empty;
 
         // Initialize AI Coding Assistant properties
         SelectedAIBackendType = _workingConfig.CodeSuggestionBackendType;
@@ -115,6 +119,14 @@ public class C64ConfigDialogViewModel : ViewModelBase
 
         TestAIBackendCommand = ReactiveCommandHelper.CreateSafeCommand(
             TestAIBackendAsync,
+            outputScheduler: RxApp.MainThreadScheduler);
+
+        ResetCorsProxyOverrideURLCommand = ReactiveCommandHelper.CreateSafeCommand(
+            () =>
+            {
+                CorsProxyOverrideURL = string.Empty;
+                return Task.CompletedTask;
+            },
             outputScheduler: RxApp.MainThreadScheduler);
 
         SaveCommand = ReactiveCommandHelper.CreateSafeCommand(
@@ -269,6 +281,21 @@ public class C64ConfigDialogViewModel : ViewModelBase
         }
     }
 
+    public string CorsProxyOverrideURL
+    {
+        get => _corsProxyOverrideURL;
+        set
+        {
+            if (_corsProxyOverrideURL == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _corsProxyOverrideURL, value);
+            _workingConfig.CorsProxyOverrideURL = string.IsNullOrEmpty(value) ? null : value;
+        }
+    }
+
+    public static string CorsProxyOverrideURLWatermark => C64HostConfig.DefaultCorsProxyURL;
+
     public RenderProviderOption? SelectedRenderProvider
     {
         get => _selectedRenderProvider;
@@ -331,8 +358,9 @@ public class C64ConfigDialogViewModel : ViewModelBase
 
             foreach (var romDownload in _workingConfig.SystemConfig.ROMDownloadUrls)
             {
-                var fullROMUrl = !string.IsNullOrEmpty(_workingConfig.CorsProxyURL)
-                    ? $"{_workingConfig.CorsProxyURL}{Uri.EscapeDataString(romDownload.Value)}"
+                var proxyUrl = _workingConfig.GetCorsProxyURL();
+                var fullROMUrl = !string.IsNullOrEmpty(proxyUrl)
+                    ? $"{proxyUrl}{Uri.EscapeDataString(romDownload.Value)}"
                     : romDownload.Value;
 
                 var romBytes = await _httpClient.GetByteArrayAsync(fullROMUrl);
@@ -1034,6 +1062,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
     private void ApplyWorkingConfigToOriginal()
     {
         _originalConfig.SystemConfig.ROMDirectory = _workingConfig.SystemConfig.ROMDirectory;
+        _originalConfig.CorsProxyOverrideURL = _workingConfig.CorsProxyOverrideURL;
         _originalConfig.SystemConfig.AudioEnabled = _workingConfig.SystemConfig.AudioEnabled;
         _originalConfig.SystemConfig.KeyboardJoystickEnabled = _workingConfig.SystemConfig.KeyboardJoystickEnabled;
         _originalConfig.SystemConfig.KeyboardJoystick = _workingConfig.SystemConfig.KeyboardJoystick;

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/C64MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/C64MenuViewModel.cs
@@ -528,7 +528,7 @@ public class C64MenuViewModel : ViewModelBase
                    _loggerFactory,
                    _httpClient,
                    HostApp!,
-                    corsProxyUrl: PlatformDetection.IsRunningInWebAssembly() ? c64HostConfig.CorsProxyURL : null);
+                   corsProxyUrl: c64HostConfig.GetCorsProxyURL());
             }
 
             await _d64AutoDownloadAndRun.DownloadAndRunDiskImage(

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/C64ConfigUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/C64ConfigUserControl.axaml
@@ -229,6 +229,35 @@
         </Border>
         </StackPanel>
 
+        <!-- Network Section (browser only) -->
+        <StackPanel Width="460" Classes="wrap-item"
+                    IsVisible="{Binding IsRunningInWebAssembly}">
+            <Border Classes="content-section">
+                <StackPanel Classes="spacing-tight">
+                    <TextBlock Text="Network"/>
+
+                    <Grid ColumnDefinitions="90,*,Auto" Classes="spacing-tight">
+                        <TextBlock Grid.Column="0"
+                                   Text="CORS proxy:"
+                                   Classes="secondary-text"/>
+                        <TextBox Grid.Column="1"
+                                 Text="{Binding CorsProxyOverrideURL, Mode=TwoWay}"
+                                 Watermark="{Binding CorsProxyOverrideURLWatermark}"
+                                 Classes="field-aligned"
+                                 KeyDown="CorsProxyTextBox_KeyDown"/>
+                        <Button Grid.Column="2"
+                                Content="Reset"
+                                Command="{Binding ResetCorsProxyOverrideURLCommand}"
+                                Margin="4,0,0,0"
+                                Height="32"
+                                Padding="12,0"
+                                VerticalContentAlignment="Center"
+                                Classes=""/>
+                    </Grid>
+                </StackPanel>
+            </Border>
+        </StackPanel>
+
         <!-- AI Coding Assistant Section -->
         <StackPanel Width="460" Classes="wrap-item">
         <Border Classes="content-section">

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/C64ConfigUserControl.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/C64ConfigUserControl.axaml.cs
@@ -258,6 +258,35 @@ public partial class C64ConfigUserControl : UserControl
         }
     }
 
+    // In Avalonia WASM on macOS, TextBox default key bindings only include Ctrl+C/V, not Meta (CMD).
+    // This handler explicitly handles CMD+C/V/X/A so copy/paste works in the browser.
+    private void CorsProxyTextBox_KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (sender is not TextBox textBox) return;
+        if ((e.KeyModifiers & (KeyModifiers.Meta | KeyModifiers.Control)) == 0) return;
+
+        if (e.Key == Key.C)
+        {
+            textBox.Copy();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.V)
+        {
+            textBox.Paste();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.X)
+        {
+            textBox.Cut();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.A)
+        {
+            textBox.SelectAll();
+            e.Handled = true;
+        }
+    }
+
     private async void LoadRoms_Click(object? sender, RoutedEventArgs e)
     {
         if (TopLevel.GetTopLevel(this)?.StorageProvider == null)

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Emulator/SystemSetup/C64HostConfig.cs
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Emulator/SystemSetup/C64HostConfig.cs
@@ -14,7 +14,8 @@ public class C64HostConfig : IHostSystemConfig, ICloneable
     //public const string DefaultCorsProxyURL = "https://thingproxy.freeboard.io/fetch/"; // Doesn't seem to work with redirects
     //public const string DefaultCorsProxyURL = "https://corsproxy.io/?url="; // Stopped being possible to download binary files on free tier
     //public const string DefaultCorsProxyURL = "https://proxy.corsfix.com/?url="; // Only free from localhost
-    public const string DefaultCorsProxyURL = "https://cors-anywhere.com/";
+    //public const string DefaultCorsProxyURL = "https://cors-anywhere.com/"; // Only works from localhost 
+    public const string DefaultCorsProxyURL = "https://api.codetabs.com/v1/proxy?quest=";
 
     private C64SystemConfig _systemConfig;
     ISystemConfig IHostSystemConfig.SystemConfig => _systemConfig;


### PR DESCRIPTION
Change CORS Proxy handling in Avalonia Browser app. Now the cors proxy URL is a override. If nothing is set a default proxy is used.

Also change to a new default CORS proxy. 
