### PR TITLE
Upgrade Avalonia projects to v12

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,16 +6,18 @@
   <ItemGroup>
     <!-- Avalonia packages -->
     <!-- Important: keep version in sync! -->
-    <PackageVersion Include="Avalonia" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.iOS" Version="11.3.6" />
-    <PackageVersion Include="Avalonia.Browser" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Android" Version="11.3.6" />
-    <PackageVersion Include="Avalonia.ReactiveUI" Version="11.3.8" />
-    <PackageVersion Include="Avalonia.Skia" Version="11.3.10" />
+    <PackageVersion Include="Avalonia" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.iOS" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Browser" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Android" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Skia" Version="12.0.1" />
+    <!-- ReactiveUI core: Avalonia.ReactiveUI was deprecated by the Avalonia team;
+         we keep ReactiveUI itself (.NET Foundation, actively maintained) and provide
+         our own AvaloniaDispatcherScheduler in place of AvaloniaScheduler. -->
+    <PackageVersion Include="ReactiveUI" Version="23.2.1" />
     <!-- Azure packages -->
     <PackageVersion Include="Azure.AI.OpenAI" Version="1.0.0-beta.11" />
     <!-- Benchmarking -->
@@ -23,8 +25,6 @@
     <!-- Blazor packages -->
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageVersion Include="Blazored.Modal" Version="7.3.1" />
-    <!-- CommunityToolkit -->
-    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <!-- Testing packages -->
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <!-- Microsoft Extensions packages -->
@@ -71,12 +71,13 @@
     <!-- SixLabors ImageSharp -->
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <!-- SkiaSharp -->
-    <PackageVersion Include="SkiaSharp" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.Views.Blazor" Version="3.119.1" />
+    <!-- SkiaSharp 3.119.3-preview.1.1 is required by Avalonia.Skia 12.0.1 (native assets). -->
+    <PackageVersion Include="SkiaSharp" Version="3.119.3-preview.1.1" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.3-preview.1.1" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="3.119.3-preview.1.1" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="3.119.3-preview.1.1" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.3-preview.1.1" />
+    <PackageVersion Include="SkiaSharp.Views.Blazor" Version="3.119.3-preview.1.1" />
     <!-- SourceLink -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <!-- StreamJsonRpc for Debug Adapter Protocol -->

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Android/Highbyte.DotNet6502.App.Avalonia.Android.csproj
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Android/Highbyte.DotNet6502.App.Avalonia.Android.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0-android</TargetFramework>
+    <TargetFramework>net10.0-android</TargetFramework>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ApplicationId>com.CompanyName.Avalonia</ApplicationId>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Android/MainActivity.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Android/MainActivity.cs
@@ -1,5 +1,6 @@
-﻿using Android.App;
+using Android.App;
 using Android.Content.PM;
+using Android.Runtime;
 using Avalonia;
 using Avalonia.Android;
 using Highbyte.DotNet6502.App.Avalonia.Core;
@@ -12,11 +13,18 @@ namespace Highbyte.DotNet6502.App.Avalonia.Android;
     Icon = "@drawable/icon",
     MainLauncher = true,
     ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode)]
-public class MainActivity : AvaloniaMainActivity<Highbyte.DotNet6502.App.Avalonia.Core.App>
+public class MainActivity : AvaloniaMainActivity
 {
-    protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
+}
+
+[Application]
+public class AndroidApp : AvaloniaAndroidApplication<App>
+{
+    protected AndroidApp(IntPtr javaReference, JniHandleOwnership transfer)
+        : base(javaReference, transfer)
     {
-        return base.CustomizeAppBuilder(builder)
-            .WithInterFont();
     }
+
+    protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
+        => base.CustomizeAppBuilder(builder).WithInterFont();
 }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/Highbyte.DotNet6502.App.Avalonia.Browser.csproj
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/Highbyte.DotNet6502.App.Avalonia.Browser.csproj
@@ -46,6 +46,16 @@
     <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" /> -->
   </ItemGroup>
 
+  <!--
+    Preserve the entire ReactiveUI assembly from IL trimming. The WASM trimmer otherwise
+    strips types like RxSchedulers and RxAppBuilder that our code references (the Core
+    project uses RxSchedulers.MainThreadScheduler across many ViewModels), producing
+    TypeLoadException at AOT load time.
+  -->
+  <ItemGroup>
+    <TrimmerRootAssembly Include="ReactiveUI" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Highbyte.DotNet6502.App.Avalonia.Core\Highbyte.DotNet6502.App.Avalonia.Core.csproj" />
     <ProjectReference Include="..\..\..\libraries\Highbyte.DotNet6502.Impl.Browser\Highbyte.DotNet6502.Impl.Browser.csproj" />

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/App.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/App.axaml.cs
@@ -5,9 +5,6 @@ using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Data.Core.Plugins;
-using Avalonia.Diagnostics;
-using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
 using Highbyte.DotNet6502.App.Avalonia.Core.SystemSetup;
@@ -23,6 +20,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ReactiveUI;
+using ReactiveUI.Builder;
 
 namespace Highbyte.DotNet6502.App.Avalonia.Core;
 
@@ -173,17 +171,28 @@ public partial class App : Application
     {
         WriteBootstrapLog("AppOnFrameworkInitializationCompleted called");
 
-#if DEBUG
-        // Rebind Avalonia built-in DevTools away from F12 because it's used by the emulator Monitor
-        // Instead use Ctrl+F12, and only attach DevTools when running as a desktop application.
-        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime)
-        {
-            this.AttachDevTools(new DevToolsOptions
-            {
-                Gesture = new KeyGesture(Key.F12, KeyModifiers.Control)
-            });
-        }
-#endif
+        // Initialize ReactiveUI 23.x (required — without this, the first use of
+        // ReactiveObject/WhenAnyValue throws TypeInitializationException with
+        // "ReactiveUI has not been initialized"). Formerly done by Avalonia.ReactiveUI's
+        // UseReactiveUI(), which was deprecated in v12; we replace it with the stock
+        // ReactiveUI builder and point the UI scheduler at our Avalonia dispatcher shim.
+        //
+        // Order matters: WithCoreServices() returns an IAppBuilder (terminal interface),
+        // so it must come after the IReactiveUIBuilder-returning methods.
+        var rxBuilder = RxAppBuilder.CreateReactiveUIBuilder()
+            .WithPlatformServices()
+            .WithMainThreadScheduler(AvaloniaDispatcherScheduler.Instance, setRxApp: true);
+
+        // Reactive exception handler (desktop only — in WASM ReactiveUI's handler uses
+        // threading APIs that throw PlatformNotSupportedException; exceptions there fall
+        // through to Avalonia's UI thread handler instead).
+        if (_emulatorConfig.UseGlobalExceptionHandler && !PlatformDetection.IsRunningInWebAssembly())
+            rxBuilder = rxBuilder.WithExceptionHandler(Observer.Create<Exception>(OnReactiveUIException));
+
+        rxBuilder.WithCoreServices().BuildApp();
+
+        // TODO: when Avalonia.Diagnostics 12.x ships, re-add the AttachDevTools call
+        // (DEBUG-only, rebound to Ctrl+F12 because F12 is used by the emulator Monitor).
 
         // Initialize the emulator host app
         WriteBootstrapLog("Calling InitializeHostApp");
@@ -196,8 +205,6 @@ public partial class App : Application
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             WriteBootstrapLog("ApplicationLifetime is IClassicDesktopStyleApplicationLifetime");
-
-            DisableAvaloniaDataAnnotationValidation();
 
             // Get MainViewModel from DI and set as DataContext
             // MainWindow.Content (MainView) is created by XAML and inherits DataContext
@@ -280,19 +287,6 @@ public partial class App : Application
         _serviceProvider = services.BuildServiceProvider();
     }
 
-    private void DisableAvaloniaDataAnnotationValidation()
-    {
-        // Get an array of plugins to remove
-        var dataValidationPluginsToRemove =
-            BindingPlugins.DataValidators.OfType<DataAnnotationsValidationPlugin>().ToArray();
-
-        // remove each entry found
-        foreach (var plugin in dataValidationPluginsToRemove)
-        {
-            BindingPlugins.DataValidators.Remove(plugin);
-        }
-    }
-
     /// <summary>
     /// Get the service provider for dependency injection.
     /// </summary>
@@ -367,25 +361,9 @@ public partial class App : Application
         // Set up handler for unhandled exceptions in tasks
         TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
 
-        // Set up ReactiveUI exception handler ONLY on desktop platforms
-        // In WebAssembly, ReactiveUI's exception handling uses threading which causes PlatformNotSupportedException
-        // Instead, let exceptions bubble up to Avalonia's UI thread handler which works correctly in WASM
-        if (!PlatformDetection.IsRunningInWebAssembly())
-        {
-            try
-            {
-                RxApp.DefaultExceptionHandler = Observer.Create<Exception>(OnReactiveUIException);
-                _logger.LogInformation("ReactiveUI exception handler configured successfully");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to configure ReactiveUI exception handler");
-            }
-        }
-        else
-        {
-            _logger.LogInformation("Skipping ReactiveUI exception handler in WebAssembly - exceptions will be caught by ReactiveCommandHelper");
-        }
+        // NOTE: The ReactiveUI-specific exception handler is registered later, via the
+        // RxAppBuilder chain in OnFrameworkInitializationCompleted (builder must be the one
+        // to set it because RxState.DefaultExceptionHandler is read-only in 23.x).
 
         _logger.LogInformation("Global exception handlers configured successfully for error dialog mode");
     }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/AvaloniaDispatcherScheduler.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/AvaloniaDispatcherScheduler.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using Avalonia.Threading;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Core;
+
+// Replacement for Avalonia.ReactiveUI's AvaloniaScheduler.
+//
+// Avalonia.ReactiveUI was deprecated by the Avalonia team when Avalonia 12 shipped
+// ("legacy and no longer maintained", per the NuGet listing) and no 12.x version was
+// released. That package's only role in this codebase was the .UseReactiveUI() AppBuilder
+// extension, which set RxApp.MainThreadScheduler = AvaloniaScheduler.Instance so that
+// ReactiveCommand / WhenAny / ObservableAsPropertyHelper callbacks run on the UI thread.
+//
+// We keep the ReactiveUI core package (separate, .NET Foundation, actively maintained) and
+// register this scheduler instead. See App.OnFrameworkInitializationCompleted.
+internal sealed class AvaloniaDispatcherScheduler : LocalScheduler
+{
+    public static readonly AvaloniaDispatcherScheduler Instance = new();
+
+    private AvaloniaDispatcherScheduler() { }
+
+    public override IDisposable Schedule<TState>(TState state, TimeSpan dueTime, Func<IScheduler, TState, IDisposable> action)
+    {
+        var disposable = new SingleAssignmentDisposable();
+        var delay = Scheduler.Normalize(dueTime);
+
+        if (delay == TimeSpan.Zero)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (!disposable.IsDisposed)
+                    disposable.Disposable = action(this, state);
+            });
+            return disposable;
+        }
+
+        var timer = new DispatcherTimer(delay, DispatcherPriority.Background, (_, _) => { });
+        timer.Tick += OnTick;
+        timer.Start();
+        disposable.Disposable = Disposable.Create(() =>
+        {
+            timer.Tick -= OnTick;
+            timer.Stop();
+        });
+        return disposable;
+
+        void OnTick(object? sender, EventArgs e)
+        {
+            timer.Tick -= OnTick;
+            timer.Stop();
+            if (!disposable.IsDisposed)
+                disposable.Disposable = action(this, state);
+        }
+    }
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Highbyte.DotNet6502.App.Avalonia.Core.csproj
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Highbyte.DotNet6502.App.Avalonia.Core.csproj
@@ -43,15 +43,10 @@
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
-    <PackageReference Include="Avalonia.ReactiveUI" />
     <PackageReference Include="Avalonia.Skia" />
-   
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Include="Avalonia.Diagnostics">
-      <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
-      <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="CommunityToolkit.Mvvm" />
+    <!-- TODO: re-add Avalonia.Diagnostics (DEBUG-only DevTools) once a 12.x release is published. -->
+    <!-- Avalonia.ReactiveUI was deprecated for v12; we use ReactiveUI core + our own AvaloniaDispatcherScheduler. -->
+    <PackageReference Include="ReactiveUI" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
   </ItemGroup>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/OverlayDialogHelper.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/OverlayDialogHelper.cs
@@ -4,7 +4,6 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Embedding;
 using Avalonia.Layout;
 using Avalonia.Media;
-using Avalonia.VisualTree;
 using Highbyte.DotNet6502.App.Avalonia.Core.Views;
 
 namespace Highbyte.DotNet6502.App.Avalonia.Core;
@@ -95,7 +94,7 @@ internal class OverlayDialogHelper
     /// </summary>
     private Grid? GetGrid(UserControl currentControl)
     {
-        var root = currentControl.GetVisualRoot();
+        var root = TopLevel.GetTopLevel(currentControl);
 
         // When running in desktop, and currentControl is displayed on MainWindow, root is MainWindow (which contains MainView which contains Grid)
         if (root is Window window && window.Content is MainView mainView && mainView.Content is Grid grid)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/C64ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/C64ConfigDialogViewModel.cs
@@ -103,11 +103,11 @@ public class C64ConfigDialogViewModel : ViewModelBase
         // Initialize ReactiveUI Commands with MainThreadScheduler for Browser compatibility
         DownloadRomsToByteArrayCommand = ReactiveCommandHelper.CreateSafeCommand(
             AutoDownloadRomsToByteArrayAsync,
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         DownloadRomsToFilesCommand = ReactiveCommandHelper.CreateSafeCommand(
             AutoDownloadROMsToFilesAsync,
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         ClearRomsCommand = ReactiveCommandHelper.CreateSafeCommand(
             () =>
@@ -115,11 +115,11 @@ public class C64ConfigDialogViewModel : ViewModelBase
                 UnloadRoms();
                 return Task.CompletedTask;
             },
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         TestAIBackendCommand = ReactiveCommandHelper.CreateSafeCommand(
             TestAIBackendAsync,
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         ResetCorsProxyOverrideURLCommand = ReactiveCommandHelper.CreateSafeCommand(
             () =>
@@ -127,7 +127,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
                 CorsProxyOverrideURL = string.Empty;
                 return Task.CompletedTask;
             },
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         SaveCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () =>
@@ -137,7 +137,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
                     ConfigurationChanged?.Invoke(this, true);
                 }
             },
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         CancelCommand = ReactiveCommandHelper.CreateSafeCommand(
             () =>
@@ -145,7 +145,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
                 ConfigurationChanged?.Invoke(this, false);
                 return Task.CompletedTask;
             },
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
     }
 
     public event EventHandler<bool>? ConfigurationChanged;

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/C64MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/C64MenuViewModel.cs
@@ -92,47 +92,47 @@ public class C64MenuViewModel : ViewModelBase
         CopyBasicSourceCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () => await CopyBasicSourceCode(),
             this.WhenAnyValue(x => x.IsCopyPasteEnabled),
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         PasteTextCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () => await PasteTextInternal(),
             this.WhenAnyValue(x => x.IsCopyPasteEnabled),
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         ToggleDiskImageCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () => await ToggleDiskImageInternal(),
             this.WhenAnyValue(x => x.CanToggleDisk),
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         LoadPreloadedDiskCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () => await LoadPreloadedDiskImage(),
             Observable.Return(true),
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         LoadAssemblyExampleCommand = ReactiveCommandHelper.CreateSafeCommand(
              async () => await LoadAssemblyExample(),
             this.WhenAnyValue(x => x.IsFileOperationEnabled),
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         LoadBasicExampleCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () => await LoadBasicExample(),
             this.WhenAnyValue(x => x.IsFileOperationEnabled),
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         LoadBasicFileCommand = ReactiveCommandHelper.CreateSafeCommand<byte[]>(
             async (fileBuffer) => await LoadBasicFile(fileBuffer),
             this.WhenAnyValue(x => x.IsFileOperationEnabled),
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         SaveBasicFileCommand = ReactiveCommandHelper.CreateSafeCommandWithResult<byte[]>(
             async () => await GetBasicProgramAsPrgFileBytes(),
             this.WhenAnyValue(x => x.IsFileOperationEnabled),
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         LoadBinaryFileCommand = ReactiveCommandHelper.CreateSafeCommand<byte[]>(
             async (fileBuffer) => await LoadBinaryFile(fileBuffer),
             this.WhenAnyValue(x => x.IsFileOperationEnabled),
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
     }
 
     private EmulatorState EmulatorState => _avaloniaHostApp.EmulatorState;

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/DebugGamepadViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/DebugGamepadViewModel.cs
@@ -28,7 +28,7 @@ public class DebugGamepadViewModel : ViewModelBase
                 StopPolling();
                 CloseRequested?.Invoke(this, true);
             },
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         // Set up a timer to poll gamepad state
         _updateTimer = new DispatcherTimer

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/DebugSoundViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/DebugSoundViewModel.cs
@@ -72,12 +72,12 @@ public class DebugSoundViewModel : ViewModelBase
             {
                 CloseRequested?.Invoke(this, true);
             },
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         InitAudioCommand = ReactiveCommandHelper.CreateSafeCommand(
             InitAudio,
             canExecute: this.WhenAnyValue(x => x.IsAudioNotInitialized),
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         PlayAudioCommand = ReactiveCommandHelper.CreateSafeCommand(
             PlayAudio,
@@ -86,7 +86,7 @@ public class DebugSoundViewModel : ViewModelBase
                 x => x.IsWavePlayerPaused,
                 x => x.IsWavePlayerStopped,
                 (initialized, paused, stopped) => initialized && (paused || stopped)),
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         PauseAudioCommand = ReactiveCommandHelper.CreateSafeCommand(
             PauseAudio,
@@ -94,7 +94,7 @@ public class DebugSoundViewModel : ViewModelBase
                 x => x.IsAudioInitialized,
                 x => x.IsWavePlayerPlaying,
                 (initialized, playing) => initialized && playing),
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         StopAudioCommand = ReactiveCommandHelper.CreateSafeCommand(
             StopAudio,
@@ -103,7 +103,7 @@ public class DebugSoundViewModel : ViewModelBase
                 x => x.IsWavePlayerPlaying,
                 x => x.IsWavePlayerPaused,
                 (initialized, playing, paused) => initialized && (playing || paused)),
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         PlayCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () =>
@@ -114,7 +114,7 @@ public class DebugSoundViewModel : ViewModelBase
                 x => x.IsAudioInitialized,
                 x => x.IsWavePlayerPlaying,
                 (initialized, playing) => initialized && playing),
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         StopCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () =>
@@ -125,7 +125,7 @@ public class DebugSoundViewModel : ViewModelBase
                 x => x.IsAudioInitialized,
                 x => x.IsWavePlayerPlaying,
                 (initialized, playing) => initialized && playing),
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
 
         PlaySynthCommand = ReactiveCommandHelper.CreateSafeCommand(
@@ -137,7 +137,7 @@ public class DebugSoundViewModel : ViewModelBase
                 x => x.IsAudioInitialized,
                 x => x.IsWavePlayerPlaying,
                 (initialized, playing) => initialized && playing),
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         StartSynthReleaseCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () =>
@@ -148,7 +148,7 @@ public class DebugSoundViewModel : ViewModelBase
                 x => x.IsAudioInitialized,
                 x => x.IsWavePlayerPlaying,
                 (initialized, playing) => initialized && playing),
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         StopSynthCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () =>
@@ -159,7 +159,7 @@ public class DebugSoundViewModel : ViewModelBase
                 x => x.IsAudioInitialized,
                 x => x.IsWavePlayerPlaying,
                 (initialized, playing) => initialized && playing),
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
     }
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/EmulatorConfigViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/EmulatorConfigViewModel.cs
@@ -60,7 +60,7 @@ public class EmulatorConfigViewModel : ViewModelBase
                     ConfigurationChanged?.Invoke(this, true);
                 }
             },
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         CancelCommand = ReactiveCommandHelper.CreateSafeCommand(
             () =>
@@ -68,7 +68,7 @@ public class EmulatorConfigViewModel : ViewModelBase
                 ConfigurationChanged?.Invoke(this, false);
                 return Task.CompletedTask;
             },
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         // Show info message on desktop about permanent settings
         if (!IsRunningInWebAssembly)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/ErrorViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/ErrorViewModel.cs
@@ -78,21 +78,21 @@ public class ErrorViewModel : ViewModelBase
             {
                 ShowDetails = !ShowDetails;
             },
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         ContinueCommand = ReactiveCommandHelper.CreateSafeCommand(
             () =>
             {
                 CloseRequested?.Invoke(this, false);
             },
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
         ExitCommand = ReactiveCommandHelper.CreateSafeCommand(
             () =>
             {
                 CloseRequested?.Invoke(this, true);
             },
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
 
     }
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
@@ -537,7 +537,7 @@ public class MainViewModel : ViewModelBase, IDisposable
             this.WhenAnyValue(
                 x => x.IsExternalDebugClientConnected,
                 connected => !connected),
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         // Initialize ReactiveCommands for ComboBox selections
         SelectSystemCommand = ReactiveCommandHelper.CreateSafeCommand<string>(
@@ -551,7 +551,7 @@ public class MainViewModel : ViewModelBase, IDisposable
             this.WhenAnyValue(
                 x => x.EmulatorState,
                 state => state == EmulatorState.Uninitialized),
-            RxApp.MainThreadScheduler); // RxApp.MainThreadScheduler required for it working in Browser app
+            RxSchedulers.MainThreadScheduler); // RxSchedulers.MainThreadScheduler required for it working in Browser app
 
         SelectSystemVariantCommand = ReactiveCommandHelper.CreateSafeCommand<string>(
             async (selectedVariant) =>
@@ -564,7 +564,7 @@ public class MainViewModel : ViewModelBase, IDisposable
             this.WhenAnyValue(
                 x => x.EmulatorState,
                 state => state == EmulatorState.Uninitialized),
-            RxApp.MainThreadScheduler); // RxApp.MainThreadScheduler required for it working in Browser app
+            RxSchedulers.MainThreadScheduler); // RxSchedulers.MainThreadScheduler required for it working in Browser app
 
         // Initialize ReactiveCommands for buttons
         StartCommand = ReactiveCommandHelper.CreateSafeCommand(
@@ -573,28 +573,28 @@ public class MainViewModel : ViewModelBase, IDisposable
                 x => x.EmulatorState,
                 x => x.HasValidationErrors,
                 (state, hasErrors) => !hasErrors && state != EmulatorState.Running),
-            RxApp.MainThreadScheduler); // RxApp.MainThreadScheduler required for it working in Browser app
+            RxSchedulers.MainThreadScheduler); // RxSchedulers.MainThreadScheduler required for it working in Browser app
 
         PauseCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () => _hostApp.Pause(),
             this.WhenAnyValue(
                 x => x.EmulatorState,
                 state => state == EmulatorState.Running),
-            RxApp.MainThreadScheduler); // RxApp.MainThreadScheduler required for it working in Browser app
+            RxSchedulers.MainThreadScheduler); // RxSchedulers.MainThreadScheduler required for it working in Browser app
 
         StopCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () => _hostApp.Stop(),
             this.WhenAnyValue(
                 x => x.EmulatorState,
                 state => state != EmulatorState.Uninitialized),
-            RxApp.MainThreadScheduler); // RxApp.MainThreadScheduler required for it working in Browser app
+            RxSchedulers.MainThreadScheduler); // RxSchedulers.MainThreadScheduler required for it working in Browser app
 
         ResetCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () => await _hostApp.Reset(),
             this.WhenAnyValue(
                 x => x.EmulatorState,
                 state => state != EmulatorState.Uninitialized),
-            RxApp.MainThreadScheduler); // RxApp.MainThreadScheduler required for it working in Browser app
+            RxSchedulers.MainThreadScheduler); // RxSchedulers.MainThreadScheduler required for it working in Browser app
 
         MonitorCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () => _hostApp.Monitor?.Toggle(),
@@ -602,14 +602,14 @@ public class MainViewModel : ViewModelBase, IDisposable
                 x => x.EmulatorState,
                 x => x.IsExternalDebuggerAttached,
                 (state, isExternalDebuggerAttached) => state == EmulatorState.Running && !isExternalDebuggerAttached),
-            RxApp.MainThreadScheduler); // RxApp.MainThreadScheduler required for it working in Browser app
+            RxSchedulers.MainThreadScheduler); // RxSchedulers.MainThreadScheduler required for it working in Browser app
 
         StatsCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () => _hostApp.ToggleStatisticsPanel(),
             this.WhenAnyValue(
                 x => x.EmulatorState,
                 state => state != EmulatorState.Uninitialized),
-            RxApp.MainThreadScheduler); // RxApp.MainThreadScheduler required for it working in Browser app
+            RxSchedulers.MainThreadScheduler); // RxSchedulers.MainThreadScheduler required for it working in Browser app
 
         ClearLogCommand = ReactiveCommandHelper.CreateSafeCommand(
             () =>
@@ -630,7 +630,7 @@ public class MainViewModel : ViewModelBase, IDisposable
             this.WhenAnyValue(
                 x => x.LogMessages.Count,
                 count => count > 0),
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         ToggleScriptEnabledCommand = ReactiveCommandHelper.CreateSafeCommand<string>(
             (fileName) =>
@@ -641,7 +641,7 @@ public class MainViewModel : ViewModelBase, IDisposable
                 _hostApp.ScriptingEngine.SetScriptEnabled(fileName, newEnabled);
             },
             null,
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         ReloadScriptCommand = ReactiveCommandHelper.CreateSafeCommand<string>(
             (fileName) =>
@@ -649,7 +649,7 @@ public class MainViewModel : ViewModelBase, IDisposable
                 _hostApp.ScriptingEngine.ReloadScript(fileName);
             },
             null,
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         AddScriptCommand = ReactiveCommandHelper.CreateSafeCommand(
             () =>
@@ -657,7 +657,7 @@ public class MainViewModel : ViewModelBase, IDisposable
                 RequestAddScript?.Invoke(this, EventArgs.Empty);
             },
             null,
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         EditScriptCommand = ReactiveCommandHelper.CreateSafeCommand<string>(
             (fileName) =>
@@ -665,7 +665,7 @@ public class MainViewModel : ViewModelBase, IDisposable
                 RequestEditScript?.Invoke(this, fileName);
             },
             null,
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         DeleteScriptCommand = ReactiveCommandHelper.CreateSafeCommand<string>(
             async (fileName) =>
@@ -677,17 +677,17 @@ public class MainViewModel : ViewModelBase, IDisposable
                     _hostApp.DeleteScript(fileName);
             },
             null,
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         RefreshScriptsCommand = ReactiveCommandHelper.CreateSafeCommand(
             () => _hostApp.RefreshScripts(),
             null,
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         OpenScriptFolderCommand = ReactiveCommandHelper.CreateSafeCommand(
             () => RequestOpenScriptFolder?.Invoke(this, EventArgs.Empty),
             null,
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         SortByColumnCommand = ReactiveCommandHelper.CreateSafeCommand<ScriptSortColumn>(
             col =>
@@ -706,7 +706,7 @@ public class MainViewModel : ViewModelBase, IDisposable
                 this.RaisePropertyChanged(nameof(HooksSortIndicator));
             },
             null,
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         // Emulator Options command - only enabled when emulator is uninitialized
         EmulatorOptionsCommand = ReactiveCommandHelper.CreateSafeCommand(
@@ -717,7 +717,7 @@ public class MainViewModel : ViewModelBase, IDisposable
             this.WhenAnyValue(
                 x => x.EmulatorState,
                 state => state == EmulatorState.Uninitialized),
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
 
         // Initialize timer for batched log UI updates
         InitializeLogUpdateTimer();
@@ -745,7 +745,7 @@ public class MainViewModel : ViewModelBase, IDisposable
         LoadExamplesCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () => await _hostApp.LoadExamplesAsync(),
             null,
-            RxApp.MainThreadScheduler);
+            RxSchedulers.MainThreadScheduler);
         RefreshScriptStatuses();
         _hostApp.ScriptingEngine.ScriptStatusChanged += OnScriptStatusChanged;
     }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MonitorViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MonitorViewModel.cs
@@ -36,11 +36,11 @@ public class MonitorViewModel : ViewModelBase
         SendCommand = ReactiveCommandHelper.CreateSafeCommand(
             ExecuteSend,
             canExecute: Observable.Return(true),
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
         CloseCommand = ReactiveCommandHelper.CreateSafeCommand(
             ExecuteClose,
             canExecute: Observable.Return(true),
-            outputScheduler: RxApp.MainThreadScheduler);
+            outputScheduler: RxSchedulers.MainThreadScheduler);
     }
 
     public ReactiveCommand<Unit, Unit> SendCommand { get; }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/C64MenuView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/C64MenuView.axaml.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Platform.Storage;
@@ -58,19 +59,24 @@ public partial class C64MenuView : UserControl
     private void OnClipboardCopyRequested(object? sender, string text)
         => SafeAsyncHelper.Execute(async () =>
         {
-            if (TopLevel.GetTopLevel(this) is { } topLevel)
+            if (TopLevel.GetTopLevel(this) is { } topLevel && topLevel.Clipboard is { } clipboard)
             {
-                await topLevel.Clipboard?.SetTextAsync(text)!;
+                using var data = new DataTransfer();
+                data.Add(DataTransferItem.CreateText(text));
+                await clipboard.SetDataAsync(data);
             }
         });
 
     private void OnClipboardPasteRequested(object? sender, EventArgs e)
         => SafeAsyncHelper.Execute(async () =>
         {
-            if (ViewModel != null && TopLevel.GetTopLevel(this) is { } topLevel)
+            if (ViewModel != null
+                && TopLevel.GetTopLevel(this) is { } topLevel
+                && topLevel.Clipboard is { } clipboard)
             {
-                var text = await topLevel.Clipboard?.GetTextAsync()!;
-                ViewModel.ClipboardPasteResult = text;
+                using var data = await clipboard.TryGetDataAsync();
+                if (data is not null)
+                    ViewModel.ClipboardPasteResult = await data.TryGetTextAsync();
             }
         });
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainWindow.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainWindow.axaml.cs
@@ -6,12 +6,7 @@ public partial class MainWindow : Window
 {
     public MainWindow()
     {
-#if DEBUG
-        // Temporarily disable the automatic opening of dev tools via F12 as it conflicts with emulator key input. Is enabled via another key in App.axaml.cs
-        InitializeComponent(attachDevTools: false);
-#else
         InitializeComponent();
-#endif
 
         // Remove fixed Width since SizeToContent="Width" will handle it
         Height = 800;

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Highbyte.DotNet6502.App.Avalonia.Desktop.csproj
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Highbyte.DotNet6502.App.Avalonia.Desktop.csproj
@@ -17,11 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Include="Avalonia.Diagnostics">
-      <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
-      <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
-    </PackageReference>
+    <!-- TODO: re-add Avalonia.Diagnostics (DEBUG-only DevTools) once a 12.x release is published. -->
 
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Program.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Program.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia;
-using Avalonia.ReactiveUI;
 using Avalonia.Threading;
 using Highbyte.DotNet6502.App.Avalonia.Core;
 using Highbyte.DotNet6502.Impl.SilkNet.SDL.Input;
@@ -393,7 +392,6 @@ internal sealed partial class Program
             .UsePlatformDetect()
             .WithInterFont()
             .LogToTrace()
-            .UseReactiveUI()
             .AfterSetup(_ =>
             {
                 // Set up the Avalonia logger bridge to route logs via Avalonia Logger through ILogger

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.iOS/Highbyte.DotNet6502.App.Avalonia.iOS.csproj
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.iOS/Highbyte.DotNet6502.App.Avalonia.iOS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0-ios</TargetFramework>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

Upgrades Avalonia from 11.3.x to **12.0.1** across all six Avalonia projects (Core library + Desktop/Browser/iOS/Android apps).

Priority per the upgrade plan: **Desktop and Browser must run**; iOS and Android only need to compile.

## Package changes

- All 8 `Avalonia.*` packages → `12.0.1` (including `Avalonia.Skia`, `Avalonia.Android`, `Avalonia.iOS`, `Avalonia.Browser`).
- SkiaSharp native-asset packages bumped to the `3.119.3-preview.1.1` line (Avalonia 12 Skia requires it).
- Dropped `Avalonia.Diagnostics` (no 12.x release yet — temporarily removes Ctrl+F12 DevTools in Debug desktop builds).
- Dropped `Avalonia.ReactiveUI` (deprecated for v12) and replaced it with the **`ReactiveUI` core** package (not deprecated, actively maintained).
- Removed the unused `CommunityToolkit.Mvvm` reference.

## ReactiveUI migration

`Avalonia.ReactiveUI`'s only real contribution in this codebase was registering `AvaloniaScheduler` as `RxApp.MainThreadScheduler` via `.UseReactiveUI()`. It's replaced with:

- A custom `AvaloniaDispatcherScheduler` shim (~30 lines, posts to `Dispatcher.UIThread`).
- Explicit ReactiveUI 23.x bootstrap via `RxAppBuilder.CreateReactiveUIBuilder()...BuildApp()` in `App.OnFrameworkInitializationCompleted`. (ReactiveUI 23 no longer auto-initializes — first use of `ReactiveObject` throws `TypeInitializationException` without this.)
- Find/replace across 8 ViewModels: `RxApp.MainThreadScheduler` → `RxSchedulers.MainThreadScheduler` (the `RxApp` class was split into `RxSchedulers` / `RxState` in ReactiveUI 23).
- Browser `.csproj` adds `<TrimmerRootAssembly Include="ReactiveUI" />` — the WASM AOT trimmer otherwise strips `RxSchedulers` / `RxAppBuilder` and the app throws `TypeLoadException` at load time.

All existing `ReactiveObject` / `RaiseAndSetIfChanged` / `ReactiveCommand` / `ObservableAsPropertyHelper` usage is unchanged.

## v12 breaking-change fixes

- `App.axaml.cs`: removed the `DisableAvaloniaDataAnnotationValidation` method and its call — the data-annotations binding plugin was removed in v12 (compiled bindings are now the default).
- `C64MenuView.axaml.cs`: migrated clipboard from `GetTextAsync` / `SetTextAsync` to the new `IAsyncDataTransfer` / `DataTransferItem` API.
- `OverlayDialogHelper.cs`: `GetVisualRoot()` → `TopLevel.GetTopLevel(...)` (the visual-tree helper extension is gone).
- `MainWindow.axaml.cs`: removed `InitializeComponent(attachDevTools: false)` — the parameter was removed in v12.
- Android `MainActivity.cs`: rewritten for the v12 model — non-generic `AvaloniaMainActivity` + a new `AvaloniaAndroidApplication<App>` subclass hosting `CustomizeAppBuilder`.
- iOS/Android `.csproj` target frameworks: `net9.0-ios` / `net9.0-android` → `net10.0-ios` / `net10.0-android` (Avalonia 12 mobile requires .NET 10).

## Test plan

- [x] Full solution build succeeds (0 errors, Debug & Release).
- [x] Desktop app launches, menu opens, clipboard copy+paste works, a C64 system loads & runs.
- [x] Browser app boots in a browser, main view renders, Lua script panel works.
- [ ] iOS/Android only verified to compile — no runtime test required this cycle (not actively used).

## Known follow-ups

- Re-add `Avalonia.Diagnostics` (DevTools) once a 12.x release is published — marker comment left in `Core.csproj`.
- `SkiaSharp.NativeAssets.*` are pinned to a prerelease; bump to stable when one compatible with Avalonia 12 ships.
- The `TrimmerRootAssembly Include="ReactiveUI"` in the Browser project preserves ~150KB of ReactiveUI IL from trimming. If WASM payload size becomes a concern, this is the first thing to revisit.