### PR TITLE
Add UI accessibility properties, keyboard shortcuts, and macOS native menu; standardize emulator display name

### DIFF
--- a/.github/workflows/release-desktop-apps.yml
+++ b/.github/workflows/release-desktop-apps.yml
@@ -109,7 +109,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-      - name: Download checksum files from release
+      - name: Download checksum files and macOS zip from release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -118,6 +118,9 @@ jobs:
               --repo ${{ github.repository }} \
               --pattern "checksums-${runtime}.sha256"
           done
+          gh release download "${{ github.event.release.tag_name }}" \
+            --repo ${{ github.repository }} \
+            --pattern "DotNet6502-Avalonia-osx-arm64.zip"
 
       - name: Extract SHA256 hashes
         id: hashes
@@ -136,10 +139,17 @@ jobs:
           echo "headless_win_x64=$(extract_hash Headless win-x64)" >> "$GITHUB_OUTPUT"
           echo "headless_win_arm64=$(extract_hash Headless win-arm64)" >> "$GITHUB_OUTPUT"
 
+      - name: Extract macOS app bundle name from zip
+        id: app_bundle
+        run: |
+          APP_NAME=$(zipinfo -1 DotNet6502-Avalonia-osx-arm64.zip | grep -E '^[^/]+\.app/$' | sed 's|/$||' | head -1)
+          echo "app_name=$APP_NAME" >> "$GITHUB_OUTPUT"
+
       - name: Update Homebrew tap
         env:
           GH_TOKEN: ${{ secrets.PACKAGE_MANAGER_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
+          APP_NAME: ${{ steps.app_bundle.outputs.app_name }}
           OSX_ARM64_HASH: ${{ steps.hashes.outputs.osx_arm64 }}
           LINUX_X64_HASH: ${{ steps.hashes.outputs.linux_x64 }}
           LINUX_ARM64_HASH: ${{ steps.hashes.outputs.linux_arm64 }}
@@ -153,6 +163,9 @@ jobs:
           # Update Cask (macOS desktop app)
           sed -i "s/version \".*\"/version \"${VERSION}\"/" Casks/dotnet-6502.rb
           sed -i "s/sha256 \".*\"/sha256 \"${OSX_ARM64_HASH}\"/" Casks/dotnet-6502.rb
+          # Update .app bundle name (read from the actual release zip, not source)
+          sed -i "s|app \".*\.app\"|app \"${APP_NAME}\"|" Casks/dotnet-6502.rb
+          sed -i "s|binary \".*\.app/Contents/MacOS/|binary \"${APP_NAME}/Contents/MacOS/|" Casks/dotnet-6502.rb
 
           # Update Formulas - use Python for multi-hash replacement
           python3 <<'PYEOF'

--- a/doc/APPS_AVALONIA_AUTOMATION.md
+++ b/doc/APPS_AVALONIA_AUTOMATION.md
@@ -136,8 +136,8 @@ Some controls inside nested `UserControl`s do not traverse cleanly to the macOS 
 On macOS, the shortcuts are discoverable by walking the app's menu bar via peekaboo:
 
 ```sh
-peekaboo menu list --app "DotNet6502 Emulator"
-peekaboo menu click --app "DotNet6502 Emulator" --path "C64 > Toggle Configuration section"
+peekaboo menu list --app "DotNet 6502 Emulator"
+peekaboo menu click --app "DotNet 6502 Emulator" --path "C64 > Toggle Configuration section"
 ```
 
 On Windows / Linux, the same shortcuts are dispatched by the main window's key bindings; an automation harness simulates the key combo instead of clicking a menu.
@@ -185,16 +185,16 @@ peekaboo permissions
 dotnet run --project src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop
 
 # In another terminal, capture the current AX state
-peekaboo see --app "DotNet6502 Emulator"
+peekaboo see --app "DotNet 6502 Emulator"
 
 # With an annotated screenshot showing clickable element IDs (elem_NN)
-peekaboo see --app "DotNet6502 Emulator" --annotate /tmp/ax.png
+peekaboo see --app "DotNet 6502 Emulator" --annotate /tmp/ax.png
 
 # Full JSON dump for scripting
-peekaboo see --app "DotNet6502 Emulator" --json > /tmp/ax.json
+peekaboo see --app "DotNet 6502 Emulator" --json > /tmp/ax.json
 ```
 
-The app's process name under macOS is `DotNet6502 Emulator` (set via `Application.Name` in `App.axaml`, which Avalonia applies to `NSApplication` at startup). Confirm with:
+The app's process name under macOS is `DotNet 6502 Emulator` (set via `Application.Name` in `App.axaml`, which Avalonia applies to `NSApplication` at startup). Confirm with:
 
 ```sh
 peekaboo list
@@ -206,16 +206,16 @@ peekaboo's `click` command has several selection modes:
 
 ```sh
 # 1. By the short "elem_NN" id from the latest `see` snapshot:
-peekaboo click --on elem_24 --app "DotNet6502 Emulator" --window-index 0
+peekaboo click --on elem_24 --app "DotNet 6502 Emulator" --window-index 0
 
 # 2. By a specific snapshot id (useful if you captured earlier):
-peekaboo click --on elem_24 --snapshot <UUID-from-see> --app "DotNet6502 Emulator" --window-index 0
+peekaboo click --on elem_24 --snapshot <UUID-from-see> --app "DotNet 6502 Emulator" --window-index 0
 
 # 3. By text query (matches Name/title/label):
-peekaboo click "Start" --app "DotNet6502 Emulator" --window-index 0
+peekaboo click "Start" --app "DotNet 6502 Emulator" --window-index 0
 
 # 4. By absolute screen coordinates:
-peekaboo click --coords "440,595" --app "DotNet6502 Emulator" --window-index 0
+peekaboo click --coords "440,595" --app "DotNet 6502 Emulator" --window-index 0
 ```
 
 ## Gotchas (learned the hard way)
@@ -233,10 +233,10 @@ peekaboo click --coords "440,595" --app "DotNet6502 Emulator" --window-index 0
 - **Sidebar buttons (C64MenuView) are not reachable via peekaboo `click`.** Controls in the left-hand sidebar — `DownloadAndRunDiskButton`, `PreloadedDiskComboBox`, `LoadBasicButton`, etc. — do not appear in the AX tree that peekaboo enumerates, so neither text-query nor `elem_NN` clicks work. `peekaboo click --coords` also fails because it still attempts AX focus resolution internally when `--app` is given. The reliable fallback is **AppleScript coordinate-click**, which does a raw hit-test outside the AX tree:
 
   ```applescript
-  tell application "DotNet6502 Emulator" to activate
+  tell application "DotNet 6502 Emulator" to activate
   delay 0.5
   tell application "System Events"
-      tell process "DotNet6502 Emulator"
+      tell process "DotNet 6502 Emulator"
           set winPos to position of window 1
           -- Replace (dx, dy) with the button's offset from the window's top-left corner
           click at {(item 1 of winPos) + dx, (item 2 of winPos) + dy}
@@ -250,19 +250,19 @@ peekaboo click --coords "440,595" --app "DotNet6502 Emulator" --window-index 0
 
 ```sh
 # Snapshot and find Start button
-SNAP=$(peekaboo see --app "DotNet6502 Emulator" --json | jq -r '.snapshot_id')
-START=$(peekaboo see --app "DotNet6502 Emulator" --json \
+SNAP=$(peekaboo see --app "DotNet 6502 Emulator" --json | jq -r '.snapshot_id')
+START=$(peekaboo see --app "DotNet 6502 Emulator" --json \
         | jq -r '.. | objects | select(.identifier == "StartButton") | .id')
 
 # 1. Click Start — emulator boots into C64 BASIC
 peekaboo click --on "$START" --snapshot "$SNAP" \
-               --app "DotNet6502 Emulator" --window-index 0
+               --app "DotNet 6502 Emulator" --window-index 0
 
 # 2. Click Log tab by coordinates (tab row is ~y=595 at the given window size)
-peekaboo click --coords "440,595" --app "DotNet6502 Emulator" --window-index 0
+peekaboo click --coords "440,595" --app "DotNet 6502 Emulator" --window-index 0
 
 # Verify
-peekaboo see --app "DotNet6502 Emulator" --annotate /tmp/after.png
+peekaboo see --app "DotNet 6502 Emulator" --annotate /tmp/after.png
 ```
 
 The JSON path shapes above are illustrative — adjust with your peekaboo version's output schema. `peekaboo list` + `peekaboo see --json` are the two fundamental queries to script anything more involved.

--- a/doc/APPS_AVALONIA_AUTOMATION.md
+++ b/doc/APPS_AVALONIA_AUTOMATION.md
@@ -230,6 +230,22 @@ peekaboo click --coords "440,595" --app "DotNet6502 Emulator" --window-index 0
 
 - **AXIdentifier-based clicking isn't directly supported.** peekaboo's `--id` / `--on` flags take the `elem_NN` token from a `see` snapshot, not the `AutomationProperties.AutomationId` string. To select by AutomationId, parse the JSON from `peekaboo see --json` and look for `identifier == "StartButton"` to find the corresponding `elem_NN`, then pass that to `click --on`.
 
+- **Sidebar buttons (C64MenuView) are not reachable via peekaboo `click`.** Controls in the left-hand sidebar — `DownloadAndRunDiskButton`, `PreloadedDiskComboBox`, `LoadBasicButton`, etc. — do not appear in the AX tree that peekaboo enumerates, so neither text-query nor `elem_NN` clicks work. `peekaboo click --coords` also fails because it still attempts AX focus resolution internally when `--app` is given. The reliable fallback is **AppleScript coordinate-click**, which does a raw hit-test outside the AX tree:
+
+  ```applescript
+  tell application "DotNet6502 Emulator" to activate
+  delay 0.5
+  tell application "System Events"
+      tell process "DotNet6502 Emulator"
+          set winPos to position of window 1
+          -- Replace (dx, dy) with the button's offset from the window's top-left corner
+          click at {(item 1 of winPos) + dx, (item 2 of winPos) + dy}
+      end tell
+  end tell
+  ```
+
+  From a shell script, wrap this in `osascript -e '...'` or `osascript <<'EOF' ... EOF`. Verified working for `DownloadAndRunDiskButton` (offset approx. `x+90, y+585` at default window size). For sidebar actions that have a C64 menu shortcut (toggle sections, set joystick port), prefer `peekaboo menu click` over coordinate hacks — those are more robust to window size changes.
+
 ## Worked example: start the emulator, then open the Log tab
 
 ```sh

--- a/doc/APPS_AVALONIA_AUTOMATION.md
+++ b/doc/APPS_AVALONIA_AUTOMATION.md
@@ -1,0 +1,229 @@
+<h1 align="center">Avalonia app UI automation and accessibility</h1>
+
+# Overview
+
+The Avalonia desktop and browser apps expose accessibility metadata so that screen readers and UI-automation agents (including AI agents) can identify, describe, and operate every interactive control.
+
+This is implemented by setting attached properties from the `Avalonia.Automation` namespace on controls in `.axaml`:
+
+- `AutomationProperties.AutomationId` — a stable, programmatic selector (flat PascalCase, e.g. `StartButton`, `ScaleSlider`). Maps to the platform-specific identifier (AX `identifier` on macOS, `AutomationId` on Windows UIA).
+- `AutomationProperties.Name` — a short human-readable label (e.g. "Start", "Scale"). Maps to AX `title` on macOS / `Name` on UIA. Read aloud by screen readers.
+
+The `AutomationProperties` attached properties live in the default `https://github.com/avaloniaui` XML namespace, so no extra `xmlns` is required.
+
+Source: [`src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/`](../src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/).
+
+# What Avalonia auto-generates (no attributes needed)
+
+Even without any `AutomationProperties` attributes, Avalonia already surfaces some data via its automation peers:
+
+| Source in XAML                | Auto-mapped to                                |
+| ----------------------------- | --------------------------------------------- |
+| `Button.Content="Start"`      | AX label / UIA Name = "Start"                 |
+| `TabItem.Header="Log"`        | AX label / UIA Name = "Log"                   |
+| `Name="MyControl"` / `x:Name` | AX `identifier` / UIA `AutomationId`          |
+| `ToolTip.Tip="…"`             | AX `help` / UIA `HelpText`                    |
+| `Window.Title="…"`            | AX window title                               |
+
+Because of this, controls with `Name="…"` already get a stable identifier for free. The codebase keeps existing `Name=` attributes (they're also used by code-behind `FindControl` lookups) and adds explicit `AutomationProperties.AutomationId` alongside — decoupling the automation identity from the code-behind field name.
+
+# Conventions used in this codebase
+
+1. **Flat PascalCase ids** matching existing `Name=` style: `StartButton`, `SystemSelectionComboBox`, `ScaleSlider`, `LogTab`, `OkButton`.
+2. **Per-row dynamic ids** for `ItemsControl` templates — bound to an identifying field. Pattern:
+   ```xml
+   <Button AutomationProperties.AutomationId="{Binding FileName, StringFormat='ScriptRow.Reload.{0}'}"
+           AutomationProperties.Name="Reload script"
+           Content="↻" />
+   ```
+   Use `.` as separator (e.g. `ScriptRow.Reload.snake.lua`, `RomFileTextBox.Kernal`).
+   **Escape leading `{0}`** in a `StringFormat` with `{}` to prevent the XAML parser from interpreting it as a markup extension:
+   ```xml
+   StringFormat='{}{0} ROM file name'
+   ```
+3. **Icon-only buttons** (`↻`, `+`, `i`, pencil, trash) need *both* `AutomationId` and a descriptive `Name`, because the `Content` is a glyph that doesn't describe the action.
+4. **Text-only buttons** (`Content="Start"`) — `Content` already becomes the AX label, so only `AutomationId` is strictly needed. `Name` is added when `Content` is bound or ambiguous.
+5. **Decorative elements** (`TextBlock` labels, `Border`, `Image`, layout `Grid`) do not get AutomationProperties unless an agent needs to read their text (e.g. status strings).
+6. **Container-level AutomationId** on root `UserControl`/`Window` elements (`StatisticsView`, `C64InfoView`, `EmulatorPlaceholderView`, dialog windows) so agents can locate and scope to a view.
+
+# What is surfaced
+
+A non-exhaustive list of the most useful AutomationIds, grouped by view. All of these are present in the compiled app and queryable via the platform's accessibility API.
+
+## MainView (always visible)
+
+- **System selection**: `SystemSelectionComboBox`, `SystemVariantSelectionComboBox`
+- **Emulator control**: `StartButton`, `PauseButton`, `ResetButton`, `StopButton`, `MonitorButton`, `StatsButton`
+- **Display/audio**: `ScaleSlider`, `AudioCheckBox`, `AudioVolumeSlider`, `OptionsButton`
+- **Status**: `EmulatorStateText`
+- **Bottom tab control**: `InformationTabControl` with tabs `InformationTab`, `ConfigStatusTab`, `LogTab`, `ScriptsTab`, `GeneralInfoTab`, `DebugTab`
+- **Log tab**: `ClearLogButton`
+- **Scripts tab**: `ScriptsBannerRefreshButton`, `ScriptFolderLink`, `AddScriptButton`, `LoadExamplesButton`, `ScriptsRefreshButton`; sort headers `SortByFileNameButton`, `SortByStatusButton`, `SortByYieldButton`, `SortByHooksButton`
+- **Script rows (dynamic)**: `ScriptRow.ToggleEnabled.<FileName>`, `ScriptRow.Reload.<FileName>`, `ScriptRow.Edit.<FileName>`, `ScriptRow.Delete.<FileName>`
+- **Debug tab**: `ExternalDebugToggleButton`, `ExternalDebugPortInput`, `DebugSoundButton`, `DebugGamepadButton`
+
+## C64MenuView (sidebar)
+
+- **Basic clipboard**: `CopyBasicButton`, `PasteTextButton`, `AiBasicCheckBox`, `AiBasicInfoButton`
+- **Collapsible section headers**: `DiskSectionHeader`, `LoadSaveSectionHeader`, `ConfigSectionHeader`
+- **Disk section**: `DiskToggleButton`, `DiskInfoButton`, `PreloadedDiskComboBox`, `PreloadedDiskInfoButton`, `DownloadAndRunDiskButton`
+- **Load/Save section**: `LoadBasicButton`, `SaveBasicButton`, `LoadBinaryButton`, `AssemblyExampleComboBox`, `LoadAssemblyExampleButton`, `BasicExampleComboBox`, `LoadBasicExampleButton`
+- **Config section**: `ActiveJoystickComboBox`, `JoystickKeyboardCheckBox`, `KeyboardJoystickComboBox`, `C64ConfigButton`
+
+## C64ConfigDialog / C64ConfigUserControl
+
+- **Window**: `C64ConfigDialog`
+- **ROMs (dynamic per ROM)**: `RomFileTextBox.Kernal`, `RomFileTextBox.Basic`, `RomFileTextBox.Chargen`
+- **ROM actions**: `RomDirectoryTextBox`, `ClearRomsButton`, `LoadRomsButton`, `DownloadRomsButton`, `DownloadRomFilesButton`
+- **Video**: `RenderProviderComboBox`, `RenderTargetComboBox`
+- **Audio**: `SidAudioCheckBox`
+- **Input**: `HostJoystickComboBox`, `KeyboardJoystickEnableCheckBox`, `KeyboardJoystickPortComboBox`, `KeyboardMappingsExpander`
+- **Network**: `CorsProxyTextBox`, `CorsProxyResetButton`
+- **AI assistant**: `AiHelpButton`, `AiBackendComboBox`, `OpenAiApiKeyTextBox`, `OllamaEndpointTextBox`, `OllamaModelNameTextBox`, `OllamaApiKeyTextBox`, `CustomEndpointApiKeyTextBox`, `TestAiBackendButton`
+- **Footer**: `CancelButton`, `OkButton`
+
+## EmulatorConfigUserControl (general options)
+
+`DefaultEmulatorComboBox`, `DefaultScaleSlider`, `ShowErrorDialogCheckBox`, `ShowDebugTabCheckBox`, `AudioProfileComboBox`, `StopOnBrkCheckBox`, `StopOnUnknownInstructionCheckBox`, `LuaScriptDirectoryTextBox`, `LuaStorePrefixTextBox`, `CancelButton`, `OkButton`.
+
+## MonitorDialog / MonitorUserControl
+
+- **Window**: `MonitorDialog`
+- `OutputScrollViewer`, `CommandTextBox`, `SendCommandButton`, `CloseMonitorButton`, `MonitorStatusScroll`
+
+## ScriptEditorDialog
+
+- **Root**: `ScriptEditorDialog`
+- `FileNameBox`, `ContentBox`, `CancelButton`, `SaveButton`
+
+## Debug views
+
+- **DebugSoundUserControl**: `InitAudioButton`, `PlayAudioButton`, `PauseAudioButton`, `StopAudioButton`, `PlaySynthButton`, `StartSynthReleaseButton`, `StopSynthButton`, `SoundTestComboBox`, `PlaySoundButton`, `StopSoundButton`, `CloseButton`
+- **DebugGamepadUserControl**: `CloseButton` (remainder is read-only visual status)
+
+## ErrorUserControl
+
+`ErrorMessageTextBox`, `ExceptionDetailsTextBox`, `ShowDetailsButton`, `ContinueButton`, `ExitButton`.
+
+## Other containers
+
+- `EmulatorView` (root) with `EmulatorRenderSurface` on the render ContentPresenter
+- `EmulatorPlaceholderView` (root, pre-start logo)
+- `StatisticsView` (root)
+- `C64InfoView` (root, keyboard mapping reference)
+
+# What is NOT surfaced (known gaps)
+
+1. **Individual `TabItem` controls on macOS** — verified with `peekaboo see` after running the app. The `InformationTabControl` surfaces, but its `TabItem` children (`InformationTab`, `LogTab`, etc.) do not appear as distinct clickable elements in the AX tree, *despite* having explicit `AutomationProperties.AutomationId` + `Name`. The AX tree on macOS reports roles limited to `button`, `group`, `menu`, `other`, `slider` — no `AXTabGroup` / `AXTab`.
+
+   This is most likely an Avalonia `TabItemAutomationPeer` / macOS NSAccessibility bridge limitation, not a bug in this codebase. Worth filing an issue upstream in `avaloniaui/Avalonia`.
+
+   **Workaround**: click the tab by screen coordinates (see the peekaboo section below), or use keyboard navigation (`Ctrl+Tab` / arrow keys when the tab control is focused).
+
+2. **Collapsed/conditional content** only appears in the AX tree when its container is rendered. Examples:
+   - `C64MenuView` section contents (`DiskSectionContent`, `LoadSaveSectionContent`, `ConfigSectionContent`) — only visible when the section header is expanded.
+   - `Debug` tab contents — hidden until `ShowDebugTab` is enabled in `EmulatorConfig`.
+   - Dialog controls (`C64ConfigDialog`, `MonitorDialog`, `ScriptEditorDialog`) — only exist while the dialog is open.
+
+   To automate these, expand/open the container first, then re-query the AX tree.
+
+3. **Dynamic row ids change with data**. `ScriptRow.Reload.<FileName>` depends on the loaded script set. An agent must first query the Scripts tab to discover current rows.
+
+4. **Browser/WebAssembly target**. Automation there goes through the DOM, not Avalonia's AX bridge. Accessibility attributes in `.axaml` propagate only where the Avalonia runtime has a peer — the browser story is not covered in this document.
+
+# Automating on macOS via peekaboo
+
+[peekaboo](https://peekaboo.dev) is a CLI tool for macOS UI automation (screenshots + AX tree traversal + input). These notes are from hands-on verification with the desktop app.
+
+## One-time setup
+
+Grant peekaboo these permissions (System Settings → Privacy & Security):
+
+- **Screen Recording** (required for `see` / `capture`)
+- **Accessibility** (required for `click`, `type`, focus management)
+
+Verify with:
+
+```sh
+peekaboo permissions
+```
+
+## Discovering the AX tree
+
+```sh
+# Launch the app first (from the repo root)
+dotnet run --project src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop
+
+# In another terminal, capture the current AX state
+peekaboo see --app "DotNet6502 Emulator"
+
+# With an annotated screenshot showing clickable element IDs (elem_NN)
+peekaboo see --app "DotNet6502 Emulator" --annotate /tmp/ax.png
+
+# Full JSON dump for scripting
+peekaboo see --app "DotNet6502 Emulator" --json > /tmp/ax.json
+```
+
+The app's process name under macOS is `DotNet6502 Emulator` (set via `Application.Name` in `App.axaml`, which Avalonia applies to `NSApplication` at startup). Confirm with:
+
+```sh
+peekaboo list
+```
+
+## Clicking controls
+
+peekaboo's `click` command has several selection modes:
+
+```sh
+# 1. By the short "elem_NN" id from the latest `see` snapshot:
+peekaboo click --on elem_24 --app "DotNet6502 Emulator" --window-index 0
+
+# 2. By a specific snapshot id (useful if you captured earlier):
+peekaboo click --on elem_24 --snapshot <UUID-from-see> --app "DotNet6502 Emulator" --window-index 0
+
+# 3. By text query (matches Name/title/label):
+peekaboo click "Start" --app "DotNet6502 Emulator" --window-index 0
+
+# 4. By absolute screen coordinates:
+peekaboo click --coords "440,595" --app "DotNet6502 Emulator" --window-index 0
+```
+
+## Gotchas (learned the hard way)
+
+- **Always pass `--window-index 0`** when targeting this app. The Avalonia runtime creates a secondary hidden window, and without a window scope the focus step in `click` times out with `Error: Timeout while waiting for condition`.
+
+- **Don't use `--no-auto-focus` from a terminal.** The terminal emulator (e.g. Ghostty) reclaims focus between commands, so a `--no-auto-focus` click lands on the terminal window at the same screen coordinates — `click` still reports "✅ Click successful" but against the wrong app. Let peekaboo's auto-focus bring the Avalonia window forward.
+
+- **Text-query clicks can hit the wrong element.** `peekaboo click "Log"` may match a `TextBlock` labelled "Log" *inside* the tab content rather than the tab header, because the header is behind the Avalonia TabItem AX gap described above. When targeting tabs specifically, use coordinates.
+
+- **Screenshot coordinates vs. screen coordinates.** The annotated screenshot from `peekaboo see --annotate` is scaled to roughly 0.75× the window-point size. To convert a pixel position in the screenshot to a click coordinate, scale by ~1.33× and add the window's screen offset (`peekaboo list` shows the window Position).
+
+- **AXIdentifier-based clicking isn't directly supported.** peekaboo's `--id` / `--on` flags take the `elem_NN` token from a `see` snapshot, not the `AutomationProperties.AutomationId` string. To select by AutomationId, parse the JSON from `peekaboo see --json` and look for `identifier == "StartButton"` to find the corresponding `elem_NN`, then pass that to `click --on`.
+
+## Worked example: start the emulator, then open the Log tab
+
+```sh
+# Snapshot and find Start button
+SNAP=$(peekaboo see --app "DotNet6502 Emulator" --json | jq -r '.snapshot_id')
+START=$(peekaboo see --app "DotNet6502 Emulator" --json \
+        | jq -r '.. | objects | select(.identifier == "StartButton") | .id')
+
+# 1. Click Start — emulator boots into C64 BASIC
+peekaboo click --on "$START" --snapshot "$SNAP" \
+               --app "DotNet6502 Emulator" --window-index 0
+
+# 2. Click Log tab by coordinates (tab row is ~y=595 at the given window size)
+peekaboo click --coords "440,595" --app "DotNet6502 Emulator" --window-index 0
+
+# Verify
+peekaboo see --app "DotNet6502 Emulator" --annotate /tmp/after.png
+```
+
+The JSON path shapes above are illustrative — adjust with your peekaboo version's output schema. `peekaboo list` + `peekaboo see --json` are the two fundamental queries to script anything more involved.
+
+# See also
+
+- [`APPS_AVALONIA.md`](APPS_AVALONIA.md) — general app overview and features
+- [Avalonia Accessibility docs](https://docs.avaloniaui.net/docs/concepts/accessibility)
+- [NSAccessibility Programming Guide](https://developer.apple.com/documentation/appkit/accessibility_for_appkit)
+- [peekaboo](https://peekaboo.dev) — macOS UI automation CLI used for the verification in this doc

--- a/doc/APPS_AVALONIA_AUTOMATION.md
+++ b/doc/APPS_AVALONIA_AUTOMATION.md
@@ -112,6 +112,36 @@ A non-exhaustive list of the most useful AutomationIds, grouped by view. All of 
 - `StatisticsView` (root)
 - `C64InfoView` (root, keyboard mapping reference)
 
+# Keyboard shortcuts (system menu contributions)
+
+Some controls inside nested `UserControl`s do not traverse cleanly to the macOS AX tree (see "known gaps" below — the left-pane `C64MenuView` sections are the most visible example). To keep those operations reachable for agents and keyboard users, the active system's menu ViewModel implements `ISystemMenuContributor` ([`Core/SystemSetup/ISystemMenuContributor.cs`](../src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/SystemSetup/ISystemMenuContributor.cs)) and contributes:
+- A `NativeMenu` that Avalonia installs on the **macOS system menu bar** (shown under a top-level header for the active system, e.g. `C64`). On macOS, `NativeMenu` items appear in the OS-level menu bar *outside* the app window — which is the desired UX. The macOS Accessibility API also exposes these items with their `Gesture` string, making shortcuts self-describing: an AI agent can discover them at runtime via `peekaboo menu list` without needing any prior documentation.
+- A parallel list of `KeyBinding`s applied to the main window on **Windows / Linux**. `NativeMenu` on these platforms would render as in-window chrome, which is not desired, so `KeyBinding`s are used instead. The shortcuts fire regardless of which child control has focus, but they are invisible to accessibility tools — an automation agent needs to know them in advance (e.g. from this document).
+
+`MainViewModel.ActiveMenuContributor` swaps when `SelectedSystemName` changes; `MainView.axaml.cs` applies the new menu / keybindings, and clears the previous one on teardown.
+
+## C64 shortcuts (active when the C64 system is selected)
+
+| Action                           | macOS               | Windows / Linux       |
+| -------------------------------- | ------------------- | --------------------- |
+| Toggle Disk Drive section        | `⌘⌥⇧D`         | `Ctrl+Alt+Shift+D`    |
+| Toggle Load/Save section         | `⌘⌥L`            | `Ctrl+Alt+L`          |
+| Toggle Configuration section     | `⌘⌥C`            | `Ctrl+Alt+C`          |
+| Active joystick → Port 1         | `⌘⌥1`            | `Ctrl+Alt+1`          |
+| Active joystick → Port 2         | `⌘⌥2`            | `Ctrl+Alt+2`          |
+| Toggle Joystick KB               | `⌘⌥K`            | `Ctrl+Alt+K`          |
+| Keyboard joystick → Port 1       | `⌘⌥⇧1`         | `Ctrl+Alt+Shift+1`    |
+| Keyboard joystick → Port 2       | `⌘⌥⇧2`         | `Ctrl+Alt+Shift+2`    |
+
+On macOS, the shortcuts are discoverable by walking the app's menu bar via peekaboo:
+
+```sh
+peekaboo menu list --app "DotNet6502 Emulator"
+peekaboo menu click --app "DotNet6502 Emulator" --path "C64 > Toggle Configuration section"
+```
+
+On Windows / Linux, the same shortcuts are dispatched by the main window's key bindings; an automation harness simulates the key combo instead of clicking a menu.
+
 # What is NOT surfaced (known gaps)
 
 1. **Individual `TabItem` controls on macOS** — verified with `peekaboo see` after running the app. The `InformationTabControl` surfaces, but its `TabItem` children (`InformationTab`, `LogTab`, etc.) do not appear as distinct clickable elements in the AX tree, *despite* having explicit `AutomationProperties.AutomationId` + `Name`. The AX tree on macOS reports roles limited to `button`, `group`, `menu`, `other`, `slider` — no `AXTabGroup` / `AXTab`.

--- a/doc/APPS_AVALONIA_TROUBLESHOOT.md
+++ b/doc/APPS_AVALONIA_TROUBLESHOOT.md
@@ -107,7 +107,7 @@ The Avalonia desktop application supports optional console logging for debugging
 
 On Windows, the application opens a **separate console window** for log output. This is because Windows GUI applications (WinExe) don't have a console attached by default.
 
-- A new console window titled "DotNet6502 Emulator - Log Output" will appear
+- A new console window titled "DotNet 6502 Emulator - Log Output" will appear
 - Log messages are displayed in this dedicated window
 - The console window closes automatically when the application exits
 

--- a/doc/INSTALL_DESKTOP_APPS.md
+++ b/doc/INSTALL_DESKTOP_APPS.md
@@ -49,7 +49,7 @@ dotnet-6502
 
 On macOS, the app is also installed to `/Applications` and can be launched from Launchpad, Spotlight, or Finder like any other Mac app.
 
-On Windows (Scoop), a Start Menu shortcut **DotNet6502 Emulator** is also created.
+On Windows (Scoop), a Start Menu shortcut **DotNet 6502 Emulator** is also created.
 
 ### Updating
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/wwwroot/safari-notice.html
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/wwwroot/safari-notice.html
@@ -50,7 +50,7 @@
     </style>
 </head>
 <body>
-    <h1>DotNet-6502 Emulator</h1>
+    <h1>DotNet 6502 Emulator</h1>
     
     <div class="notice error">
         <h3>⚠️ Safari Desktop Compatibility Issue</h3>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/App.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/App.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="using:Highbyte.DotNet6502.App.Avalonia.Core"
              x:Class="Highbyte.DotNet6502.App.Avalonia.Core.App"
+             Name="DotNet6502 Emulator"
              RequestedThemeVariant="Dark">
     <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/App.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/App.axaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="using:Highbyte.DotNet6502.App.Avalonia.Core"
              x:Class="Highbyte.DotNet6502.App.Avalonia.Core.App"
-             Name="DotNet6502 Emulator"
+             Name="DotNet 6502 Emulator"
              RequestedThemeVariant="Dark">
     <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/App.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/App.axaml.cs
@@ -164,6 +164,16 @@ public partial class App : Application
 
         AvaloniaXamlLoader.Load(this);
 
+        // Pre-register an empty NativeMenu on macOS so Avalonia's backend subscribes to
+        // Items.CollectionChanged before any window is shown. ApplyMenuContributor then
+        // mutates the items of this same object at runtime instead of replacing the menu,
+        // which is required for the macOS menu bar and its keyboard shortcuts to work.
+        if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+                System.Runtime.InteropServices.OSPlatform.OSX))
+        {
+            NativeMenu.SetMenu(this, new NativeMenu());
+        }
+
         WriteBootstrapLog("App Initialize end");
     }
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/SystemSetup/ISystemMenuContributor.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/SystemSetup/ISystemMenuContributor.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Input;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Core.SystemSetup;
+
+/// <summary>
+/// Supplies native-menu items and key bindings for the currently selected emulator system.
+/// Implementations live on the system's menu ViewModel (e.g. C64MenuViewModel) so that the
+/// shortcuts dispatch directly to the ViewModel commands without code-behind glue.
+///
+/// Platform split:
+/// - macOS:         GetNativeMenuItems() is installed as a NativeMenu on the Application.
+///                  On macOS, NativeMenu items appear in the OS-level system menu bar (not
+///                  inside the app window), which is the desired UX. The menu bar is also
+///                  exposed via the macOS Accessibility API (AXMenuItem), making shortcuts
+///                  self-describing and discoverable by AI agents at runtime.
+/// - Windows/Linux: NativeMenu would render as in-window chrome on these platforms, which
+///                  is not desired. GetKeyBindings() is used instead — shortcuts are registered
+///                  directly on the main Window and fire regardless of which child has focus,
+///                  but they are invisible to accessibility tools and require prior knowledge.
+/// - WASM:          Neither applies; this interface is a no-op in the browser target.
+/// </summary>
+public interface ISystemMenuContributor
+{
+    string MenuLabel { get; }
+
+    IReadOnlyList<NativeMenuItemBase> GetNativeMenuItems();
+
+    IReadOnlyList<KeyBinding> GetKeyBindings();
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/C64MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/C64MenuViewModel.cs
@@ -7,6 +7,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Avalonia.Controls;
 using Avalonia.Input;
 using Highbyte.DotNet6502.App.Avalonia.Core.SystemSetup;
 using Highbyte.DotNet6502.Impl.Avalonia.Commodore64.Input;
@@ -20,7 +21,7 @@ using ReactiveUI;
 
 namespace Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
 
-public class C64MenuViewModel : ViewModelBase
+public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
 {
     private readonly AvaloniaHostApp _avaloniaHostApp;
     private readonly ILoggerFactory _loggerFactory;
@@ -57,6 +58,14 @@ public class C64MenuViewModel : ViewModelBase
     public ReactiveCommand<byte[], Unit> LoadBasicFileCommand { get; }
     public ReactiveCommand<Unit, byte[]> SaveBasicFileCommand { get; }
     public ReactiveCommand<byte[], Unit> LoadBinaryFileCommand { get; }
+
+    // Section toggle / joystick commands used by both the UI click handlers and the menu/shortcut bridge.
+    public ReactiveCommand<Unit, Unit> ToggleDiskSectionCommand { get; }
+    public ReactiveCommand<Unit, Unit> ToggleLoadSaveSectionCommand { get; }
+    public ReactiveCommand<Unit, Unit> ToggleConfigSectionCommand { get; }
+    public ReactiveCommand<int, Unit> SetActiveJoystickCommand { get; }
+    public ReactiveCommand<Unit, Unit> ToggleJoystickKeyboardCommand { get; }
+    public ReactiveCommand<int, Unit> SetKeyboardJoystickCommand { get; }
     // --- End ReactiveUI Commands ---
 
     public C64MenuViewModel(
@@ -132,6 +141,40 @@ public class C64MenuViewModel : ViewModelBase
         LoadBinaryFileCommand = ReactiveCommandHelper.CreateSafeCommand<byte[]>(
             async (fileBuffer) => await LoadBinaryFile(fileBuffer),
             this.WhenAnyValue(x => x.IsFileOperationEnabled),
+            RxSchedulers.MainThreadScheduler);
+
+        ToggleDiskSectionCommand = ReactiveCommandHelper.CreateSafeCommand(
+            () => ToggleSection(C64MenuSection.Disk),
+            null,
+            RxSchedulers.MainThreadScheduler);
+
+        ToggleLoadSaveSectionCommand = ReactiveCommandHelper.CreateSafeCommand(
+            () => ToggleSection(C64MenuSection.LoadSave),
+            null,
+            RxSchedulers.MainThreadScheduler);
+
+        ToggleConfigSectionCommand = ReactiveCommandHelper.CreateSafeCommand(
+            () => ToggleSection(C64MenuSection.Config),
+            null,
+            RxSchedulers.MainThreadScheduler);
+
+        SetActiveJoystickCommand = ReactiveCommandHelper.CreateSafeCommand<int>(
+            port => CurrentJoystick = port,
+            null,
+            RxSchedulers.MainThreadScheduler);
+
+        ToggleJoystickKeyboardCommand = ReactiveCommandHelper.CreateSafeCommand(
+            () => JoystickKeyboardEnabled = !JoystickKeyboardEnabled,
+            null,
+            RxSchedulers.MainThreadScheduler);
+
+        SetKeyboardJoystickCommand = ReactiveCommandHelper.CreateSafeCommand<int>(
+            port =>
+            {
+                if (IsKeyboardJoystickSelectionEnabled)
+                    KeyboardJoystick = port;
+            },
+            null,
             RxSchedulers.MainThreadScheduler);
     }
 
@@ -330,6 +373,186 @@ public class C64MenuViewModel : ViewModelBase
 
             return !C64HostConfig.IsValid(out _);
         }
+    }
+
+    // Section expansion state — bound from XAML so both UI clicks and keyboard shortcuts
+    // go through the same ViewModel state.
+    private bool _isDiskSectionExpanded = true;
+    public bool IsDiskSectionExpanded
+    {
+        get => _isDiskSectionExpanded;
+        private set
+        {
+            if (_isDiskSectionExpanded == value)
+                return;
+            _isDiskSectionExpanded = value;
+            this.RaisePropertyChanged(nameof(IsDiskSectionExpanded));
+            this.RaisePropertyChanged(nameof(DiskSectionHeaderText));
+        }
+    }
+
+    private bool _isLoadSaveSectionExpanded = false;
+    public bool IsLoadSaveSectionExpanded
+    {
+        get => _isLoadSaveSectionExpanded;
+        private set
+        {
+            if (_isLoadSaveSectionExpanded == value)
+                return;
+            _isLoadSaveSectionExpanded = value;
+            this.RaisePropertyChanged(nameof(IsLoadSaveSectionExpanded));
+            this.RaisePropertyChanged(nameof(LoadSaveSectionHeaderText));
+        }
+    }
+
+    private bool _isConfigSectionExpanded = false;
+    public bool IsConfigSectionExpanded
+    {
+        get => _isConfigSectionExpanded;
+        private set
+        {
+            if (_isConfigSectionExpanded == value)
+                return;
+            _isConfigSectionExpanded = value;
+            this.RaisePropertyChanged(nameof(IsConfigSectionExpanded));
+            this.RaisePropertyChanged(nameof(ConfigSectionHeaderText));
+        }
+    }
+
+    public string DiskSectionHeaderText => (IsDiskSectionExpanded ? "▼ " : "▶ ") + "Disk Drive & .D64 images";
+    public string LoadSaveSectionHeaderText => (IsLoadSaveSectionExpanded ? "▼ " : "▶ ") + "Load/Save";
+    public string ConfigSectionHeaderText => (IsConfigSectionExpanded ? "▼ " : "▶ ") + "Configuration";
+
+    private enum C64MenuSection { Disk, LoadSave, Config }
+
+    private void ToggleSection(C64MenuSection section)
+    {
+        bool newState = section switch
+        {
+            C64MenuSection.Disk => !IsDiskSectionExpanded,
+            C64MenuSection.LoadSave => !IsLoadSaveSectionExpanded,
+            C64MenuSection.Config => !IsConfigSectionExpanded,
+            _ => false,
+        };
+
+        SetSectionExpanded(section, newState, collapseOthers: newState);
+    }
+
+    private void SetSectionExpanded(C64MenuSection section, bool expanded, bool collapseOthers)
+    {
+        switch (section)
+        {
+            case C64MenuSection.Disk:
+                IsDiskSectionExpanded = expanded;
+                if (collapseOthers && expanded)
+                {
+                    IsLoadSaveSectionExpanded = false;
+                    IsConfigSectionExpanded = false;
+                }
+                break;
+            case C64MenuSection.LoadSave:
+                IsLoadSaveSectionExpanded = expanded;
+                if (collapseOthers && expanded)
+                {
+                    IsDiskSectionExpanded = false;
+                    IsConfigSectionExpanded = false;
+                }
+                break;
+            case C64MenuSection.Config:
+                IsConfigSectionExpanded = expanded;
+                if (collapseOthers && expanded)
+                {
+                    IsDiskSectionExpanded = false;
+                    IsLoadSaveSectionExpanded = false;
+                }
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Called by the View when validation errors are present: collapse Disk/LoadSave and expand Config.
+    /// </summary>
+    public void ExpandConfigSectionOnValidationError()
+    {
+        IsDiskSectionExpanded = false;
+        IsLoadSaveSectionExpanded = false;
+        IsConfigSectionExpanded = true;
+    }
+
+    // --- ISystemMenuContributor ---
+    public string MenuLabel => "C64";
+
+    public IReadOnlyList<NativeMenuItemBase> GetNativeMenuItems()
+    {
+        // On macOS, NativeMenu items appear in the OS-level system menu bar (not the app window),
+        // which is the desired UX. The menu bar is also exposed via the macOS Accessibility API,
+        // making shortcuts self-describing and discoverable by AI agents at runtime.
+        // Use Meta+Alt (⌘⌥) as the primary modifier so hints show as "⌘⌥L" etc.
+        const KeyModifiers macBase = KeyModifiers.Meta | KeyModifiers.Alt;
+        //const KeyModifiers macBase = KeyModifiers.Alt;
+        const KeyModifiers macShift = KeyModifiers.Meta | KeyModifiers.Alt | KeyModifiers.Shift;
+
+        return new NativeMenuItemBase[]
+        {
+            BuildMenuItem("Toggle Disk Drive section", new KeyGesture(Key.D, macShift), ToggleDiskSectionCommand),
+            BuildMenuItem("Toggle Load/Save section", new KeyGesture(Key.L, macBase), ToggleLoadSaveSectionCommand),
+            BuildMenuItem("Toggle Configuration section", new KeyGesture(Key.C, macBase), ToggleConfigSectionCommand),
+            new NativeMenuItemSeparator(),
+            BuildMenuItem("Active joystick: Port 1", new KeyGesture(Key.D1, macBase), SetActiveJoystickCommand, 1),
+            BuildMenuItem("Active joystick: Port 2", new KeyGesture(Key.D2, macBase), SetActiveJoystickCommand, 2),
+            new NativeMenuItemSeparator(),
+            BuildMenuItem("Toggle Joystick KB", new KeyGesture(Key.K, macBase), ToggleJoystickKeyboardCommand),
+            BuildMenuItem("Keyboard joystick: Port 1", new KeyGesture(Key.D1, macShift), SetKeyboardJoystickCommand, 1),
+            BuildMenuItem("Keyboard joystick: Port 2", new KeyGesture(Key.D2, macShift), SetKeyboardJoystickCommand, 2),
+        };
+    }
+
+    public IReadOnlyList<KeyBinding> GetKeyBindings()
+    {
+        // On Windows/Linux, NativeMenu would render as in-window chrome, which is not the desired
+        // UX (on macOS it goes to the OS system menu bar, which is fine there). KeyBindings are
+        // used instead: registered on the main Window, they fire regardless of which child has focus.
+        // Ctrl+Alt combos are safe alongside the C64 emulator's own Ctrl+key color combinations
+        // (those trigger on plain Ctrl, without Alt).
+        const KeyModifiers nonMacBase = KeyModifiers.Control | KeyModifiers.Alt;
+        const KeyModifiers nonMacShift = KeyModifiers.Control | KeyModifiers.Alt | KeyModifiers.Shift;
+
+        return new[]
+        {
+            BuildKeyBinding(new KeyGesture(Key.D, nonMacShift), ToggleDiskSectionCommand),
+            BuildKeyBinding(new KeyGesture(Key.L, nonMacBase), ToggleLoadSaveSectionCommand),
+            BuildKeyBinding(new KeyGesture(Key.C, nonMacBase), ToggleConfigSectionCommand),
+            BuildKeyBinding(new KeyGesture(Key.D1, nonMacBase), SetActiveJoystickCommand, 1),
+            BuildKeyBinding(new KeyGesture(Key.D2, nonMacBase), SetActiveJoystickCommand, 2),
+            BuildKeyBinding(new KeyGesture(Key.K, nonMacBase), ToggleJoystickKeyboardCommand),
+            BuildKeyBinding(new KeyGesture(Key.D1, nonMacShift), SetKeyboardJoystickCommand, 1),
+            BuildKeyBinding(new KeyGesture(Key.D2, nonMacShift), SetKeyboardJoystickCommand, 2),
+        };
+    }
+
+    private static NativeMenuItem BuildMenuItem(string header, KeyGesture gesture, System.Windows.Input.ICommand command, object? parameter = null)
+    {
+        var item = new NativeMenuItem
+        {
+            Header = header,
+            Gesture = gesture,
+            Command = command,
+        };
+        if (parameter != null)
+            item.CommandParameter = parameter;
+        return item;
+    }
+
+    private static KeyBinding BuildKeyBinding(KeyGesture gesture, System.Windows.Input.ICommand command, object? parameter = null)
+    {
+        var binding = new KeyBinding
+        {
+            Gesture = gesture,
+            Command = command,
+        };
+        if (parameter != null)
+            binding.CommandParameter = parameter;
+        return binding;
     }
 
     private void InitializeC64Data()

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Timers;
+using Highbyte.DotNet6502.App.Avalonia.Core.SystemSetup;
 using Highbyte.DotNet6502.DebugAdapter;
 using Highbyte.DotNet6502.Impl.Avalonia.Monitor;
 using Highbyte.DotNet6502.Systems;
@@ -69,6 +70,17 @@ public class MainViewModel : ViewModelBase, IDisposable
     }
 
     public bool IsC64SystemSelected => string.Equals(SelectedSystemName, C64.SystemName, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Currently-active system menu contributor (supplies macOS native menu + keyboard shortcuts).
+    /// Swaps when <see cref="SelectedSystemName"/> changes; null when no system is selected.
+    /// </summary>
+    private ISystemMenuContributor? _activeMenuContributor;
+    public ISystemMenuContributor? ActiveMenuContributor
+    {
+        get => _activeMenuContributor;
+        private set => this.RaiseAndSetIfChanged(ref _activeMenuContributor, value);
+    }
 
     // Computed properties for control enabled states based on EmulatorState
     public bool IsEmulatorRunning => EmulatorState == EmulatorState.Running;
@@ -737,7 +749,11 @@ public class MainViewModel : ViewModelBase, IDisposable
 
         // System-specific ViewModel initializations
         this.WhenAnyValue(x => x.SelectedSystemName)
-                 .Subscribe(_ => this.RaisePropertyChanged(nameof(IsC64SystemSelected)));
+                 .Subscribe(_ =>
+                 {
+                     this.RaisePropertyChanged(nameof(IsC64SystemSelected));
+                     ActiveMenuContributor = ResolveMenuContributor();
+                 });
 
         // Initialize scripts tab data and subscribe to status changes
         CanManageScripts = _hostApp.CanManageScripts;
@@ -772,6 +788,15 @@ public class MainViewModel : ViewModelBase, IDisposable
     public async Task InitializeAsync()
     {
         await SetDefaultSystemSelection();
+    }
+
+    private ISystemMenuContributor? ResolveMenuContributor()
+    {
+        // Each system's menu ViewModel implements ISystemMenuContributor when it contributes
+        // shortcuts. Add more `else if` branches here as new systems gain shortcuts.
+        if (IsC64SystemSelected && C64MenuViewModel is ISystemMenuContributor c64Contributor)
+            return c64Contributor;
+        return null;
     }
 
     private async Task SetDefaultSystemSelection()

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/C64ConfigDialog.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/C64ConfigDialog.axaml
@@ -4,6 +4,8 @@
         xmlns:views="using:Highbyte.DotNet6502.App.Avalonia.Core.Views"
         x:Class="Highbyte.DotNet6502.App.Avalonia.Core.Views.C64ConfigDialog"
         x:DataType="vm:C64ConfigDialogViewModel"
+        AutomationProperties.AutomationId="C64ConfigDialog"
+        AutomationProperties.Name="C64 configuration"
         Title="C64 Configuration"
         Width="1020"
         Height="650"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/C64ConfigUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/C64ConfigUserControl.axaml
@@ -48,7 +48,9 @@
                         <TextBlock Grid.Column="0" 
                                     Text="{Binding Name}:"
                                     Classes="secondary-text"/>
-                        <TextBox Grid.Column="1" 
+                        <TextBox Grid.Column="1"
+                                AutomationProperties.AutomationId="{Binding Name, StringFormat='RomFileTextBox.{0}'}"
+                                AutomationProperties.Name="{Binding Name, StringFormat='{}{0} ROM file name'}"
                                 Text="{Binding RomFile, Mode=TwoWay}"
                                 Watermark="File name"
                                 Classes="field-aligned"/>
@@ -66,6 +68,8 @@
                                 Text="ROM directory:"
                                 Classes="secondary-text"/>
                     <TextBox Grid.Column="1"
+                            AutomationProperties.AutomationId="RomDirectoryTextBox"
+                            AutomationProperties.Name="ROM directory"
                             Text="{Binding RomDirectory}"
                             Watermark="Directory path"
                             Classes="field-aligned"/>
@@ -76,6 +80,7 @@
             <StackPanel Orientation="Horizontal" Classes="spacing-normal">
                 <!-- Clear for WASM app to clear ROM byte arrays -->
                 <Button Content="Clear"
+                        AutomationProperties.AutomationId="ClearRomsButton"
                         Command="{Binding ClearRomsCommand}"
                         MinWidth="90"
                         Classes="danger"
@@ -83,6 +88,7 @@
                         IsEnabled="{Binding IsNotBusy}"/>
                 <!-- Load button for WASM app to files via file picker to in-memory byte array -->
                 <Button Content="Load ROMs from files"
+                        AutomationProperties.AutomationId="LoadRomsButton"
                         MinWidth="150"
                         Classes="extraWide"
                         IsVisible="{Binding IsRunningInWebAssembly}"
@@ -90,6 +96,7 @@
                         Click="LoadRoms_Click"/>
                 <!-- Download button for WASM app to in-memory byte array -->
                 <Button Content="Download ROMs"
+                        AutomationProperties.AutomationId="DownloadRomsButton"
                         Command="{Binding DownloadRomsToByteArrayCommand}"
                         MinWidth="130"
                         Classes="primary wide"
@@ -98,6 +105,7 @@
 
                 <!-- Download button for Desktop app to files -->
                 <Button Content="Download ROM Files"
+                        AutomationProperties.AutomationId="DownloadRomFilesButton"
                         Command="{Binding DownloadRomsToFilesCommand}"
                         MinWidth="130"
                         Classes="primary extraWide"
@@ -121,6 +129,8 @@
                                 Text="Render provider:" 
                                 Classes="secondary-text"/>
                     <ComboBox Grid.Row="0" Grid.Column="1"
+                            AutomationProperties.AutomationId="RenderProviderComboBox"
+                            AutomationProperties.Name="Render provider"
                             ItemsSource="{Binding RenderProviders}"
                             SelectedItem="{Binding SelectedRenderProvider}"
                             ToolTip.Tip="{Binding SelectedRenderProviderHelpText}"
@@ -133,10 +143,12 @@
                         </ComboBox.ItemTemplate>
                     </ComboBox>
 
-                    <TextBlock Grid.Row="1" Grid.Column="0" 
-                                Text="Render target:" 
+                    <TextBlock Grid.Row="1" Grid.Column="0"
+                                Text="Render target:"
                                 Classes="secondary-text"/>
                     <ComboBox Grid.Row="1" Grid.Column="1"
+                            AutomationProperties.AutomationId="RenderTargetComboBox"
+                            AutomationProperties.Name="Render target"
                             ItemsSource="{Binding RenderTargets}"
                             SelectedItem="{Binding SelectedRenderTarget}"
                             ToolTip.Tip="{Binding SelectedRenderTargetHelpText}"
@@ -163,6 +175,8 @@
 
                     <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto" Classes="spacing-tight">
                         <CheckBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
+                                AutomationProperties.AutomationId="SidAudioCheckBox"
+                                AutomationProperties.Name="Enable SID audio"
                                 Content="Enable SID audio (experimental)"
                                 IsChecked="{Binding AudioEnabled}"
                                 Classes=""/>
@@ -184,6 +198,8 @@
                             Classes="secondary-text"
                             IsEnabled="false" />
                 <ComboBox Grid.Row="0" Grid.Column="1"
+                        AutomationProperties.AutomationId="HostJoystickComboBox"
+                        AutomationProperties.Name="Active joystick port"
                         ItemsSource="{Binding AvailableJoysticks}"
                         SelectedItem="{Binding SelectedHostJoystick}"
                         Classes="small"
@@ -192,14 +208,18 @@
                         IsEnabled="false" />
 
                 <CheckBox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                        AutomationProperties.AutomationId="KeyboardJoystickEnableCheckBox"
+                        AutomationProperties.Name="Enable keyboard joystick controls"
                         Content="Enable keyboard joystick controls"
                         IsChecked="{Binding KeyboardJoystickEnabled}"
                         Classes=""/>
 
-                <TextBlock Grid.Row="2" Grid.Column="0" 
-                            Text="Keyboard joystick port:" 
+                <TextBlock Grid.Row="2" Grid.Column="0"
+                            Text="Keyboard joystick port:"
                             Classes="secondary-text"/>
                 <ComboBox Grid.Row="2" Grid.Column="1"
+                        AutomationProperties.AutomationId="KeyboardJoystickPortComboBox"
+                        AutomationProperties.Name="Keyboard joystick port"
                         ItemsSource="{Binding AvailableJoysticks}"
                         SelectedItem="{Binding SelectedKeyboardJoystick}"
                         Classes="small"
@@ -209,6 +229,8 @@
 
             <!-- Collapsible Keyboard Mappings Section -->
             <Expander Header="Keyboard mappings"
+                        AutomationProperties.AutomationId="KeyboardMappingsExpander"
+                        AutomationProperties.Name="Keyboard mappings"
                         Classes="small secondary-text"
                         IsExpanded="False">
                 <ItemsControl ItemsSource="{Binding KeyboardMappings}"
@@ -241,11 +263,15 @@
                                    Text="CORS proxy:"
                                    Classes="secondary-text"/>
                         <TextBox Grid.Column="1"
+                                 AutomationProperties.AutomationId="CorsProxyTextBox"
+                                 AutomationProperties.Name="CORS proxy URL"
                                  Text="{Binding CorsProxyOverrideURL, Mode=TwoWay}"
                                  Watermark="{Binding CorsProxyOverrideURLWatermark}"
                                  Classes="field-aligned"
                                  KeyDown="CorsProxyTextBox_KeyDown"/>
                         <Button Grid.Column="2"
+                                AutomationProperties.AutomationId="CorsProxyResetButton"
+                                AutomationProperties.Name="Reset CORS proxy"
                                 Content="Reset"
                                 Command="{Binding ResetCorsProxyOverrideURLCommand}"
                                 Margin="4,0,0,0"
@@ -266,6 +292,8 @@
                 <TextBlock Text="Basic AI Coding Assistant"
                             Classes=""/>
                 <Button Content="i"
+                        AutomationProperties.AutomationId="AiHelpButton"
+                        AutomationProperties.Name="AI coding assistant help"
                         Classes="info"
                         ToolTip.Tip="Click for more information about the AI coding assistant"
                         Click="OpenAIHelpUrl_Click"/>
@@ -276,6 +304,8 @@
                             Text="AI backend type:" 
                             Classes="secondary-text"/>
                 <ComboBox Grid.Row="0" Grid.Column="1"
+                        AutomationProperties.AutomationId="AiBackendComboBox"
+                        AutomationProperties.Name="AI backend type"
                         ItemsSource="{Binding AIBackendTypes}"
                         SelectedItem="{Binding SelectedAIBackendTypeOption}"
                         Classes="h-stretch">
@@ -292,6 +322,8 @@
                         Classes="secondary-text"
                         IsVisible="{Binding ShowOpenAISettings}"/>
                 <TextBox Grid.Row="1" Grid.Column="1"
+                        AutomationProperties.AutomationId="OpenAiApiKeyTextBox"
+                        AutomationProperties.Name="OpenAI API key"
                         Text="{Binding OpenAIApiKey}"
                         Watermark="Enter OpenAI API key"
                         Classes=""
@@ -303,6 +335,8 @@
                         Classes="secondary-text"
                         IsVisible="{Binding ShowSelfHostedSettings}"/>
                 <TextBox Grid.Row="2" Grid.Column="1"
+                        AutomationProperties.AutomationId="OllamaEndpointTextBox"
+                        AutomationProperties.Name="Ollama endpoint"
                         Text="{Binding OpenAISelfHostedEndpoint}"
                         Watermark="http://localhost:11434/api"
                         Classes=""
@@ -313,6 +347,8 @@
                         Classes="secondary-text"
                         IsVisible="{Binding ShowSelfHostedSettings}"/>
                 <TextBox Grid.Row="3" Grid.Column="1"
+                        AutomationProperties.AutomationId="OllamaModelNameTextBox"
+                        AutomationProperties.Name="Ollama model name"
                         Text="{Binding OpenAISelfHostedModelName}"
                         Watermark="codellama:13b-code"
                         Classes=""
@@ -323,6 +359,8 @@
                         Classes="secondary-text"
                         IsVisible="{Binding ShowSelfHostedSettings}"/>
                 <TextBox Grid.Row="4" Grid.Column="1"
+                        AutomationProperties.AutomationId="OllamaApiKeyTextBox"
+                        AutomationProperties.Name="Ollama API key"
                         Text="{Binding OpenAISelfHostedApiKey}"
                         Watermark="Optional API key"
                         Classes=""
@@ -333,6 +371,8 @@
                         Classes="secondary-text"
                         IsVisible="{Binding ShowCustomEndpointSettings}"/>
                 <TextBox Grid.Row="5" Grid.Column="1"
+                        AutomationProperties.AutomationId="CustomEndpointApiKeyTextBox"
+                        AutomationProperties.Name="Custom endpoint API key"
                         Text="{Binding CustomEndpointApiKey}"
                         Watermark="API key - leave blank for default"
                         Classes=""
@@ -342,6 +382,8 @@
             <!-- Test Button and Status -->
             <StackPanel Classes="spacing-tight" IsVisible="{Binding ShowAITestButton}">
                 <Button Content="Test Connection"
+                        AutomationProperties.AutomationId="TestAiBackendButton"
+                        AutomationProperties.Name="Test AI backend connection"
                         Command="{Binding TestAIBackendCommand}"
                         MinWidth="130"
                         Classes="primary"/>
@@ -396,10 +438,14 @@
                    IsVisible="{Binding IsBusy}"
                    IsIndeterminate="True"/>
       <Button Grid.Column="1"
+              AutomationProperties.AutomationId="CancelButton"
+              AutomationProperties.Name="Cancel"
               Content="Cancel"
               Classes="cancel"
               Command="{Binding CancelCommand}"/>
       <Button Grid.Column="2"
+              AutomationProperties.AutomationId="OkButton"
+              AutomationProperties.Name="Save configuration"
               Content="{Binding OkButtonText}"
               Classes="primary"
               IsDefault="True"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/C64InfoView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/C64InfoView.axaml
@@ -3,6 +3,8 @@
              xmlns:vm="using:Highbyte.DotNet6502.App.Avalonia.Core.ViewModels"
              x:Class="Highbyte.DotNet6502.App.Avalonia.Core.Views.C64InfoView"
              x:DataType="vm:C64InfoViewModel"
+             AutomationProperties.AutomationId="C64InfoView"
+             AutomationProperties.Name="C64 information panel"
              Focusable="False">
 
     <!-- DataContext will be set from constructor via DI -->

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/C64MenuView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/C64MenuView.axaml
@@ -63,13 +63,14 @@
             <Button Name="DiskSectionHeader"
                     AutomationProperties.AutomationId="DiskSectionHeader"
                     AutomationProperties.Name="Toggle disk drive section"
-                    Content="▼ Disk Drive &amp; .D64 images"
+                    Content="{Binding DiskSectionHeaderText}"
                     Classes="section-toggle"
-                    Click="ToggleDiskSection_Click"/>
+                    Command="{Binding ToggleDiskSectionCommand}"/>
 
             <Border Name="DiskSectionContent"
                     AutomationProperties.AutomationId="DiskSectionContent"
-                    Classes="collapsible-content">
+                    Classes="collapsible-content"
+                    IsVisible="{Binding IsDiskSectionExpanded}">
                 <StackPanel Classes="spacing-tight">
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -135,13 +136,14 @@
             <Button Name="LoadSaveSectionHeader"
                     AutomationProperties.AutomationId="LoadSaveSectionHeader"
                     AutomationProperties.Name="Toggle Load/Save section"
-                    Content="▼ Load/Save"
+                    Content="{Binding LoadSaveSectionHeaderText}"
                     Classes="section-toggle"
-                    Click="ToggleLoadSaveSection_Click"/>
+                    Command="{Binding ToggleLoadSaveSectionCommand}"/>
 
             <Border Name="LoadSaveSectionContent"
                     AutomationProperties.AutomationId="LoadSaveSectionContent"
-                    Classes="collapsible-content" IsVisible="False">
+                    Classes="collapsible-content"
+                    IsVisible="{Binding IsLoadSaveSectionExpanded}">
                 <StackPanel Classes="spacing-tight">
                     <TextBlock Text="Load/save .prg files"
                                Classes="small secondary-text"/>
@@ -231,13 +233,14 @@
             <Button Name="ConfigSectionHeader"
                     AutomationProperties.AutomationId="ConfigSectionHeader"
                     AutomationProperties.Name="Toggle Configuration section"
-                    Content="▼ Configuration"
+                    Content="{Binding ConfigSectionHeaderText}"
                     Classes="section-toggle"
-                    Click="ToggleConfigSection_Click"/>
+                    Command="{Binding ToggleConfigSectionCommand}"/>
 
             <Border Name="ConfigSectionContent"
                     AutomationProperties.AutomationId="ConfigSectionContent"
-                    Classes="collapsible-content" IsVisible="False">
+                    Classes="collapsible-content"
+                    IsVisible="{Binding IsConfigSectionExpanded}">
                 <StackPanel Classes="spacing-tight">
                     <Grid Classes="spacing-tight">
                         <Grid.ColumnDefinitions>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/C64MenuView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/C64MenuView.axaml
@@ -25,10 +25,14 @@
             </Grid.ColumnDefinitions>
             <Button Grid.Column="0"
                     Content="Copy"
+                    AutomationProperties.AutomationId="CopyBasicButton"
+                    AutomationProperties.Name="Copy BASIC source to clipboard"
                     Command="{Binding CopyBasicSourceCommand}"
                     Classes="small"/>
             <Button Grid.Column="1"
                     Content="Paste"
+                    AutomationProperties.AutomationId="PasteTextButton"
+                    AutomationProperties.Name="Paste text from clipboard"
                     Command="{Binding PasteTextCommand}"
                     Classes="small"/>
         </Grid>
@@ -42,11 +46,14 @@
             </Grid.ColumnDefinitions>
             <CheckBox Grid.Column="0"
                       Content="AI Basic (F9)"
+                      AutomationProperties.AutomationId="AiBasicCheckBox"
                       Classes=""
                       IsChecked="{Binding BasicCodingAssistantEnabled}"
                       IsEnabled="{Binding BasicCodingAssistantAvailable}"/>
             <Button Grid.Column="2"
                     Content="i"
+                    AutomationProperties.AutomationId="AiBasicInfoButton"
+                    AutomationProperties.Name="About AI BASIC coding assistant"
                     Classes="info"
                     Click="OpenBasicAssistantInfo_Click"/>
         </Grid>
@@ -54,11 +61,15 @@
         <!-- Disk Drive & D64 images -->
         <StackPanel>
             <Button Name="DiskSectionHeader"
+                    AutomationProperties.AutomationId="DiskSectionHeader"
+                    AutomationProperties.Name="Toggle disk drive section"
                     Content="▼ Disk Drive &amp; .D64 images"
                     Classes="section-toggle"
                     Click="ToggleDiskSection_Click"/>
 
-            <Border Name="DiskSectionContent" Classes="collapsible-content">
+            <Border Name="DiskSectionContent"
+                    AutomationProperties.AutomationId="DiskSectionContent"
+                    Classes="collapsible-content">
                 <StackPanel Classes="spacing-tight">
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -68,10 +79,14 @@
                         <Button Grid.Column="0"
                                 Content="{Binding DiskToggleButtonText}"
                                 Name="DiskToggleButton"
+                                AutomationProperties.AutomationId="DiskToggleButton"
+                                AutomationProperties.Name="Attach or detach disk image"
                                 Command="{Binding ToggleDiskImageCommand}"
                                 Classes="small"/>
                         <Button Grid.Column="1"
                                 Content="i"
+                                AutomationProperties.AutomationId="DiskInfoButton"
+                                AutomationProperties.Name="About disk drive and .D64 images"
                                 Classes="info"
                                 Click="OpenDiskInfo_Click"/>
                     </Grid>
@@ -84,6 +99,8 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <ComboBox Grid.Column="0"
+                                  AutomationProperties.AutomationId="PreloadedDiskComboBox"
+                                  AutomationProperties.Name="Preloaded D64 program"
                                   ItemsSource="{Binding PreloadedD64Programs}"
                                   SelectedValue="{Binding SelectedPreloadedDisk}"
                                   DisplayMemberBinding="{Binding Value}"
@@ -93,11 +110,14 @@
                                   MinWidth="60"/>
                         <Button Grid.Column="1"
                                 Content="i"
+                                AutomationProperties.AutomationId="PreloadedDiskInfoButton"
+                                AutomationProperties.Name="About preloaded D64 programs"
                                 Classes="info"
                                 Click="OpenDiskInfo_Click"/>
                     </Grid>
 
                     <Button Content="Download &amp; Run"
+                            AutomationProperties.AutomationId="DownloadAndRunDiskButton"
                             Classes="primary small"
                             Command="{Binding LoadPreloadedDiskCommand}"
                             IsVisible="{Binding SelectedPreloadedDisk, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
@@ -113,11 +133,15 @@
         <!-- Load/Save -->
         <StackPanel>
             <Button Name="LoadSaveSectionHeader"
+                    AutomationProperties.AutomationId="LoadSaveSectionHeader"
+                    AutomationProperties.Name="Toggle Load/Save section"
                     Content="▼ Load/Save"
                     Classes="section-toggle"
                     Click="ToggleLoadSaveSection_Click"/>
 
-            <Border Name="LoadSaveSectionContent" Classes="collapsible-content" IsVisible="False">
+            <Border Name="LoadSaveSectionContent"
+                    AutomationProperties.AutomationId="LoadSaveSectionContent"
+                    Classes="collapsible-content" IsVisible="False">
                 <StackPanel Classes="spacing-tight">
                     <TextBlock Text="Load/save .prg files"
                                Classes="small secondary-text"/>
@@ -129,17 +153,20 @@
                         </Grid.ColumnDefinitions>
                         <Button Grid.Column="0"
                                 Content="Load Basic"
+                                AutomationProperties.AutomationId="LoadBasicButton"
                                 IsEnabled="{Binding IsFileOperationEnabled}"
                                 Click="LoadBasicFile_Click"
                                 Classes="small"/>
                         <Button Grid.Column="1"
                                 Content="Save Basic"
+                                AutomationProperties.AutomationId="SaveBasicButton"
                                 IsEnabled="{Binding IsFileOperationEnabled}"
                                 Click="SaveBasicFile_Click"
                                 Classes="small"/>
                     </Grid>
 
                     <Button Content="Load &amp; start binary"
+                            AutomationProperties.AutomationId="LoadBinaryButton"
                             Classes="primary small"
                             IsEnabled="{Binding IsFileOperationEnabled}"
                             Click="LoadBinaryFile_Click"/>
@@ -152,6 +179,8 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <ComboBox Grid.Column="0"
+                                  AutomationProperties.AutomationId="AssemblyExampleComboBox"
+                                  AutomationProperties.Name="Assembly example file"
                                   ItemsSource="{Binding AssemblyExamples}"
                                   SelectedValue="{Binding SelectedAssemblyExample}"
                                   DisplayMemberBinding="{Binding Value}"
@@ -162,6 +191,7 @@
                                   MinWidth="60"/>
                         <Button Grid.Column="1"
                                 Content="Load &amp; start"
+                                AutomationProperties.AutomationId="LoadAssemblyExampleButton"
                                 VerticalAlignment="Stretch"
                                 Classes="primary small"
                                 Command="{Binding LoadAssemblyExampleCommand}"/>
@@ -175,6 +205,8 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <ComboBox Grid.Column="0"
+                                  AutomationProperties.AutomationId="BasicExampleComboBox"
+                                  AutomationProperties.Name="Basic example file"
                                   ItemsSource="{Binding BasicExamples}"
                                   SelectedValue="{Binding SelectedBasicExample}"
                                   DisplayMemberBinding="{Binding Value}"
@@ -185,6 +217,7 @@
                                   MinWidth="60"/>
                         <Button Grid.Column="1"
                                 Content="Load"
+                                AutomationProperties.AutomationId="LoadBasicExampleButton"
                                 VerticalAlignment="Stretch"
                                 Classes="primary small"
                                 Command="{Binding LoadBasicExampleCommand}"/>
@@ -196,11 +229,15 @@
         <!-- Configuration -->
         <StackPanel>
             <Button Name="ConfigSectionHeader"
+                    AutomationProperties.AutomationId="ConfigSectionHeader"
+                    AutomationProperties.Name="Toggle Configuration section"
                     Content="▼ Configuration"
                     Classes="section-toggle"
                     Click="ToggleConfigSection_Click"/>
 
-            <Border Name="ConfigSectionContent" Classes="collapsible-content" IsVisible="False">
+            <Border Name="ConfigSectionContent"
+                    AutomationProperties.AutomationId="ConfigSectionContent"
+                    Classes="collapsible-content" IsVisible="False">
                 <StackPanel Classes="spacing-tight">
                     <Grid Classes="spacing-tight">
                         <Grid.ColumnDefinitions>
@@ -211,6 +248,8 @@
                                    Text="Active joystick:"
                                    Classes="small secondary-text"/>
                         <ComboBox Grid.Column="1"
+                                  AutomationProperties.AutomationId="ActiveJoystickComboBox"
+                                  AutomationProperties.Name="Active joystick"
                                   ItemsSource="{Binding AvailableJoysticks}"
                                   SelectedItem="{Binding CurrentJoystick}"
                                   Classes="small"
@@ -224,9 +263,12 @@
                         </Grid.ColumnDefinitions>
                         <CheckBox Grid.Column="0"
                                   Content="Joystick KB:"
+                                  AutomationProperties.AutomationId="JoystickKeyboardCheckBox"
                                   Classes="small"
                                   IsChecked="{Binding JoystickKeyboardEnabled}"/>
                         <ComboBox Grid.Column="1"
+                                  AutomationProperties.AutomationId="KeyboardJoystickComboBox"
+                                  AutomationProperties.Name="Keyboard joystick port"
                                   ItemsSource="{Binding AvailableJoysticks}"
                                   SelectedItem="{Binding KeyboardJoystick}"
                                   IsEnabled="{Binding IsKeyboardJoystickSelectionEnabled}"
@@ -235,6 +277,8 @@
                     </Grid>
 
                     <Button Name ="C64Config"
+                            AutomationProperties.AutomationId="C64ConfigButton"
+                            AutomationProperties.Name="Open C64 configuration dialog"
                             Content="C64 Config"
                             Click="OpenC64Config_Click"
                             IsEnabled="{Binding IsC64ConfigEnabled}"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/C64MenuView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/C64MenuView.axaml.cs
@@ -120,34 +120,13 @@ public partial class C64MenuView : UserControl
 
     private void UpdateSectionStatesIfNeeded()
     {
-        // If there are validation errors, expand config section and collapse others
+        // If there are validation errors, expand config section and collapse others.
+        // Section state now lives on the ViewModel; XAML IsVisible is bound to it.
         try
         {
             if (ViewModel != null && ViewModel.HasConfigValidationErrors)
             {
-                // Collapse Disk Section
-                var diskHeaderButton = this.FindControl<Button>("DiskSectionHeader");
-                var diskContentBorder = this.FindControl<Border>("DiskSectionContent");
-                if (diskHeaderButton != null && diskContentBorder != null)
-                {
-                    SetSectionState(diskHeaderButton, diskContentBorder, expanded: false);
-                }
-
-                // Collapse Load/Save Section
-                var loadSaveHeaderButton = this.FindControl<Button>("LoadSaveSectionHeader");
-                var loadSaveContentBorder = this.FindControl<Border>("LoadSaveSectionContent");
-                if (loadSaveHeaderButton != null && loadSaveContentBorder != null)
-                {
-                    SetSectionState(loadSaveHeaderButton, loadSaveContentBorder, expanded: false);
-                }
-
-                // Expand Config Section
-                var configHeaderButton = this.FindControl<Button>("ConfigSectionHeader");
-                var configContentBorder = this.FindControl<Border>("ConfigSectionContent");
-                if (configHeaderButton != null && configContentBorder != null)
-                {
-                    SetSectionState(configHeaderButton, configContentBorder, expanded: true);
-                }
+                ViewModel.ExpandConfigSectionOnValidationError();
 
                 var c64ConfigButton = this.FindControl<Button>("C64Config");
                 if (c64ConfigButton != null)
@@ -455,85 +434,6 @@ public partial class C64MenuView : UserControl
                 }
             }
         });
-
-    // Section toggle handlers (pure UI functionality)
-    private void ToggleDiskSection_Click(object? sender, RoutedEventArgs e)
-    {
-        ToggleSection("DiskSectionHeader", "DiskSectionContent",
-            new[] { ("LoadSaveSectionHeader", "LoadSaveSectionContent"),
-                    ("ConfigSectionHeader", "ConfigSectionContent") });
-    }
-
-    private void ToggleLoadSaveSection_Click(object? sender, RoutedEventArgs e)
-    {
-        ToggleSection("LoadSaveSectionHeader", "LoadSaveSectionContent",
-            new[] { ("DiskSectionHeader", "DiskSectionContent"),
-                    ("ConfigSectionHeader", "ConfigSectionContent") });
-    }
-
-    private void ToggleConfigSection_Click(object? sender, RoutedEventArgs e)
-    {
-        ToggleSection("ConfigSectionHeader", "ConfigSectionContent",
-            new[] { ("DiskSectionHeader", "DiskSectionContent"),
-                    ("LoadSaveSectionHeader", "LoadSaveSectionContent") });
-    }
-
-    /// <summary>
-    /// Toggles a collapsible section and collapses other specified sections if this one is being expanded.
-    /// The arrow character (▼/▶) at the start of the button content is automatically toggled.
-    /// </summary>
-    private void ToggleSection(
-        string headerButtonName,
-        string contentBorderName,
-        (string headerName, string contentName)[] otherSectionsToCollapse)
-    {
-        var headerButton = this.FindControl<Button>(headerButtonName);
-        var contentBorder = this.FindControl<Border>(contentBorderName);
-
-        if (headerButton != null && contentBorder != null)
-        {
-            bool newExpandedState = !contentBorder.IsVisible;
-            SetSectionState(headerButton, contentBorder, newExpandedState);
-
-            // Collapse other sections if this section is being expanded
-            if (newExpandedState)
-            {
-                foreach (var (headerName, contentName) in otherSectionsToCollapse)
-                {
-                    var otherHeaderButton = this.FindControl<Button>(headerName);
-                    var otherContentBorder = this.FindControl<Border>(contentName);
-
-                    if (otherHeaderButton != null && otherContentBorder != null)
-                    {
-                        SetSectionState(otherHeaderButton, otherContentBorder, expanded: false);
-                    }
-                }
-            }
-        }
-    }
-
-    /// <summary>
-    /// Sets the state of a collapsible section (expanded or collapsed).
-    /// Updates both the visibility of the content and the arrow character in the header button.
-    /// </summary>
-    private void SetSectionState(Button headerButton, Border contentBorder, bool expanded)
-    {
-        contentBorder.IsVisible = expanded;
-
-        if (headerButton.Content is string content)
-        {
-            if (expanded)
-            {
-                // Expand: change ▶ to ▼
-                headerButton.Content = content.Replace("▶", "▼");
-            }
-            else
-            {
-                // Collapse: change ▼ to ▶
-                headerButton.Content = content.Replace("▼", "▶");
-            }
-        }
-    }
 
     private CancellationTokenSource _buttonFlashCancellation;
 }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/DebugGamepadUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/DebugGamepadUserControl.axaml
@@ -157,6 +157,8 @@
                      IsVisible="{Binding IsBusy}"
                      IsIndeterminate="True"/>
         <Button Grid.Column="1"
+                AutomationProperties.AutomationId="CloseButton"
+                AutomationProperties.Name="Close"
                 Content="Close"
                 Classes="primary"
                 IsDefault="True"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/DebugSoundUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/DebugSoundUserControl.axaml
@@ -27,21 +27,29 @@
 
                     <!-- Basic audio init and play --> 
                     <Button Grid.Row="0" Grid.Column="0"
+                            AutomationProperties.AutomationId="InitAudioButton"
+                            AutomationProperties.Name="Initialize audio"
                             Command="{Binding InitAudioCommand}"
                             Classes="small">
                         Init audio
                     </Button>
                     <Button Grid.Row="0" Grid.Column="1"
+                            AutomationProperties.AutomationId="PlayAudioButton"
+                            AutomationProperties.Name="Play audio"
                             Command="{Binding PlayAudioCommand}"
                             Classes="small">
                         Play audio
                     </Button>
                     <Button Grid.Row="0" Grid.Column="2"
+                            AutomationProperties.AutomationId="PauseAudioButton"
+                            AutomationProperties.Name="Pause audio"
                             Command="{Binding PauseAudioCommand}"
                             Classes="small">
                         Pause audio
                     </Button>
                     <Button Grid.Row="0" Grid.Column="3"
+                            AutomationProperties.AutomationId="StopAudioButton"
+                            AutomationProperties.Name="Stop all audio"
                             Command="{Binding StopAudioCommand}"
                             Classes="small">
                         Stop all audio
@@ -49,16 +57,22 @@
 
                     <!-- ADSR synth waveforms-->
                     <Button Grid.Row="1" Grid.Column="0"
+                            AutomationProperties.AutomationId="PlaySynthButton"
+                            AutomationProperties.Name="Play synth"
                             Command="{Binding PlaySynthCommand}"
                             Classes="small">
                         Play synth
                     </Button>
                     <Button Grid.Row="1" Grid.Column="1"
+                            AutomationProperties.AutomationId="StartSynthReleaseButton"
+                            AutomationProperties.Name="Initiate synth release phase"
                             Command="{Binding StartSynthReleaseCommand}"
                             Classes="small">
                         Initiate synth release phase
                     </Button>
                     <Button Grid.Row="1" Grid.Column="2"
+                            AutomationProperties.AutomationId="StopSynthButton"
+                            AutomationProperties.Name="Stop synth sound"
                             Command="{Binding StopSynthCommand}"
                             Classes="small">
                         Stop synth sound
@@ -66,17 +80,23 @@
 
                     <!-- Custom generated waveforms-->
                     <ComboBox Grid.Row="2" Grid.Column="0"
+                            AutomationProperties.AutomationId="SoundTestComboBox"
+                            AutomationProperties.Name="Sound test selection"
                             ItemsSource="{Binding SoundTestValues}"
                             SelectedItem="{Binding SelectedSoundTest}"
                             Classes="small h-stretch"
                             MaxDropDownHeight="200"/>
                     <Button Grid.Row="2" Grid.Column="1"
+                            AutomationProperties.AutomationId="PlaySoundButton"
+                            AutomationProperties.Name="Play sound"
                             Command="{Binding PlayCommand}"
                             Classes="small">
                             >
                         Play sound
                     </Button>
                     <Button Grid.Row="2" Grid.Column="2"
+                            AutomationProperties.AutomationId="StopSoundButton"
+                            AutomationProperties.Name="Stop sound"
                             Command="{Binding StopCommand}"
                             Classes="small">
                             >
@@ -124,6 +144,8 @@
                    IsVisible="{Binding IsBusy}"
                    IsIndeterminate="True"/>
       <Button Grid.Column="2"
+              AutomationProperties.AutomationId="CloseButton"
+              AutomationProperties.Name="Close"
               Content="Close"
               Classes="primary"
               IsDefault="True"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorConfigUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorConfigUserControl.axaml
@@ -29,6 +29,8 @@
                            Classes="secondary-text"
                            VerticalAlignment="Center"/>
                 <ComboBox Grid.Row="0" Grid.Column="1"
+                          AutomationProperties.AutomationId="DefaultEmulatorComboBox"
+                          AutomationProperties.Name="Default emulator"
                           ItemsSource="{Binding AvailableEmulators}"
                           SelectedItem="{Binding SelectedDefaultEmulator}"
                           Width="150"
@@ -58,6 +60,8 @@
                            VerticalAlignment="Center"/>
                 <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" Classes="spacing-tight">
                   <Slider Minimum="1" Maximum="4"
+                          AutomationProperties.AutomationId="DefaultScaleSlider"
+                          AutomationProperties.Name="Default scale"
                           Value="{Binding DefaultDrawScale}"
                           TickFrequency="0.5"
                           IsSnapToTickEnabled="True"
@@ -87,6 +91,8 @@
                          Classes=""/>
 
               <CheckBox Content="Show error dialogs"
+                        AutomationProperties.AutomationId="ShowErrorDialogCheckBox"
+                        AutomationProperties.Name="Show error dialogs"
                         IsChecked="{Binding ShowErrorDialog}"
                         Classes=""/>
               
@@ -105,6 +111,8 @@
                          Classes=""/>
 
               <CheckBox Content="Show Debug tab"
+                        AutomationProperties.AutomationId="ShowDebugTabCheckBox"
+                        AutomationProperties.Name="Show Debug tab"
                         IsChecked="{Binding ShowDebugTab}"
                         Classes=""/>
               
@@ -128,6 +136,8 @@
                            Classes="secondary-text"
                            VerticalAlignment="Center"/>
                 <ComboBox Grid.Row="0" Grid.Column="1"
+                          AutomationProperties.AutomationId="AudioProfileComboBox"
+                          AutomationProperties.Name="Audio profile"
                           ItemsSource="{Binding AudioSettingsProfiles}"
                           SelectedItem="{Binding SelectedAudioSettingsProfile}"
                           Width="150"
@@ -151,6 +161,8 @@
                          Classes=""/>
 
               <CheckBox Content="Stop on BRK instruction"
+                        AutomationProperties.AutomationId="StopOnBrkCheckBox"
+                        AutomationProperties.Name="Stop on BRK instruction"
                         IsChecked="{Binding StopAfterBRKInstruction}"
                         Classes=""/>
               
@@ -160,6 +172,8 @@
                          Margin="20,0,0,8"/>
 
               <CheckBox Content="Stop on unknown instruction"
+                        AutomationProperties.AutomationId="StopOnUnknownInstructionCheckBox"
+                        AutomationProperties.Name="Stop on unknown instruction"
                         IsChecked="{Binding StopAfterUnknownInstruction}"
                         Classes=""/>
               
@@ -185,6 +199,8 @@
                            Classes="secondary-text"
                            VerticalAlignment="Center"/>
                 <TextBox Grid.Row="0" Grid.Column="1"
+                         AutomationProperties.AutomationId="LuaScriptDirectoryTextBox"
+                         AutomationProperties.Name="Lua script directory"
                          Text="{Binding LuaScriptDirectory}"
                          IsReadOnly="True"
                          Background="#1A000000"
@@ -205,6 +221,8 @@
                            Classes="secondary-text"
                            VerticalAlignment="Center"/>
                 <TextBox Grid.Row="0" Grid.Column="1"
+                         AutomationProperties.AutomationId="LuaStorePrefixTextBox"
+                         AutomationProperties.Name="Lua store prefix"
                          Text="{Binding LuaStorePrefix}"
                          IsReadOnly="True"
                          Background="#1A000000"
@@ -255,10 +273,14 @@
                    IsVisible="{Binding IsBusy}"
                    IsIndeterminate="True"/>
       <Button Grid.Column="1"
+              AutomationProperties.AutomationId="CancelButton"
+              AutomationProperties.Name="Cancel"
               Content="Cancel"
               Classes="cancel"
               Command="{Binding CancelCommand}"/>
       <Button Grid.Column="2"
+              AutomationProperties.AutomationId="OkButton"
+              AutomationProperties.Name="Save emulator options"
               Content="{Binding OkButtonText}"
               Classes="primary"
               IsDefault="True"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorPlaceholderView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorPlaceholderView.axaml
@@ -3,6 +3,8 @@
              xmlns:vm="using:Highbyte.DotNet6502.App.Avalonia.Core.ViewModels"
              x:Class="Highbyte.DotNet6502.App.Avalonia.Core.Views.EmulatorPlaceholderView"
              x:DataType="vm:EmulatorPlaceholderViewModel"
+             AutomationProperties.AutomationId="EmulatorPlaceholderView"
+             AutomationProperties.Name="DotNet 6502 emulator placeholder"
              Focusable="False"
              IsTabStop="False">
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorPlaceholderView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorPlaceholderView.axaml
@@ -4,7 +4,7 @@
              x:Class="Highbyte.DotNet6502.App.Avalonia.Core.Views.EmulatorPlaceholderView"
              x:DataType="vm:EmulatorPlaceholderViewModel"
              AutomationProperties.AutomationId="EmulatorPlaceholderView"
-             AutomationProperties.Name="DotNet 6502 emulator placeholder"
+             AutomationProperties.Name="DotNet 6502 Emulator placeholder"
              Focusable="False"
              IsTabStop="False">
 
@@ -15,7 +15,7 @@
                Height="256"
                HorizontalAlignment="Center" />
         
-        <TextBlock Text="DotNet 6502 emulator"
+        <TextBlock Text="DotNet 6502 Emulator"
                    HorizontalAlignment="Center"
                    Classes="h1" />
     </StackPanel>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorView.axaml
@@ -7,6 +7,8 @@
              Focusable="True"
              IsTabStop="True">
 
-    <ContentPresenter x:Name="RenderingControlContainer" />
+    <ContentPresenter x:Name="RenderingControlContainer"
+                      AutomationProperties.AutomationId="EmulatorRenderSurface"
+                      AutomationProperties.Name="Emulator display" />
 
 </UserControl>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/ErrorUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/ErrorUserControl.axaml
@@ -29,6 +29,8 @@
             <!-- Main error message -->
             <TextBox Grid.Row="1"
                      x:Name="ErrorMessageTextBox"
+                     AutomationProperties.AutomationId="ErrorMessageTextBox"
+                     AutomationProperties.Name="Error message"
                      Text="{Binding ErrorMessage}"
                      TextWrapping="Wrap"
                      Classes="h2"
@@ -50,7 +52,9 @@
                     <TextBlock Text="Exception Details:"
                                Foreground="{DynamicResource WarningColor}"
                                Margin="0,0,0,4"/>
-                    <TextBox Text="{Binding ExceptionDetails}"
+                    <TextBox AutomationProperties.AutomationId="ExceptionDetailsTextBox"
+                             AutomationProperties.Name="Exception details"
+                             Text="{Binding ExceptionDetails}"
                              TextWrapping="Wrap"
                              Classes="monospace"
                              Background="#1A000000"
@@ -69,6 +73,8 @@
                         Margin="0,0,0,12"
                         IsVisible="{Binding HasException}">
                 <Button x:Name="ShowDetailsButton"
+                        AutomationProperties.AutomationId="ShowDetailsButton"
+                        AutomationProperties.Name="Toggle exception details"
                         Content="{Binding ShowDetailsButtonText}"
                         Width="120"
                         Height="30"
@@ -82,6 +88,8 @@
                         HorizontalAlignment="Center"
                         Spacing="10">
                 <Button x:Name="ContinueButton"
+                        AutomationProperties.AutomationId="ContinueButton"
+                        AutomationProperties.Name="Continue"
                         Content="Continue"
                         Width="100"
                         Height="35"
@@ -96,6 +104,8 @@
                         IsDefault="True"
                         Click="ContinueButton_Click"/>-->
                 <Button x:Name="ExitButton"
+                        AutomationProperties.AutomationId="ExitButton"
+                        AutomationProperties.Name="Exit application"
                         Content="Exit"
                         Width="100"
                         Height="35"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
@@ -65,6 +65,8 @@
                         VerticalAlignment="Center"/>
                     <ComboBox Grid.Row="0" Grid.Column="1"
                         Name="SystemSelectionComboBox"
+                        AutomationProperties.AutomationId="SystemSelectionComboBox"
+                        AutomationProperties.Name="System selection"
                         ItemsSource="{Binding AvailableSystems}"
                         SelectedItem="{Binding SelectedSystemName}"
                         SelectionChanged="OnSystemSelectionChanged"
@@ -79,6 +81,8 @@
                         VerticalAlignment="Center"/>
                     <ComboBox Grid.Row="2" Grid.Column="1"
                         Name="SystemVariantSelectionComboBox"
+                        AutomationProperties.AutomationId="SystemVariantSelectionComboBox"
+                        AutomationProperties.Name="System variant selection"
                         ItemsSource="{Binding AvailableSystemVariants}"
                         SelectedItem="{Binding SelectedSystemVariant}"
                         SelectionChanged="OnSystemVariantSelectionChanged"
@@ -92,6 +96,7 @@
                         Classes="accent bold"
                         VerticalAlignment="Center"/>
                     <TextBlock Grid.Row="4" Grid.Column="1"
+                        AutomationProperties.AutomationId="EmulatorStateText"
                         Text="{Binding EmulatorState}"/>
                 </Grid>
 
@@ -106,10 +111,12 @@
                         </Grid.ColumnDefinitions>
                         <Button Grid.Column="0"
                             Content="Start"
+                            AutomationProperties.AutomationId="StartButton"
                             Classes="primary grid"
                             Command="{Binding StartCommand}"/>
                         <Button Grid.Column="2"
                             Content="Pause"
+                            AutomationProperties.AutomationId="PauseButton"
                             Classes="warning grid"
                             Command="{Binding PauseCommand}"/>
                     </Grid>
@@ -123,10 +130,12 @@
                         </Grid.ColumnDefinitions>
                         <Button Grid.Column="0"
                             Content="Reset"
+                            AutomationProperties.AutomationId="ResetButton"
                             Classes="secondary grid"
                             Command="{Binding ResetCommand}"/>
                         <Button Grid.Column="2"
                             Content="Stop"
+                            AutomationProperties.AutomationId="StopButton"
                             Classes="danger grid"
                             Command="{Binding StopCommand}"/>
                     </Grid>
@@ -140,11 +149,13 @@
                         </Grid.ColumnDefinitions>
                         <Button Grid.Column="0"
                             Content="Monitor"
+                            AutomationProperties.AutomationId="MonitorButton"
                             Classes="grid"
                             Command="{Binding MonitorCommand}"
                             ToolTip.Tip="Toggle with F12"/>
                         <Button Grid.Column="2"
                             Content="Stats"
+                            AutomationProperties.AutomationId="StatsButton"
                             Classes="grid"
                             Command="{Binding StatsCommand}"
                             ToolTip.Tip="Toggle with F11"/>
@@ -163,6 +174,8 @@
                             Text="Scale:"
                             Classes="accent bold"/>
                         <Slider Grid.Column="1"
+                            AutomationProperties.AutomationId="ScaleSlider"
+                            AutomationProperties.Name="Scale"
                             Minimum="1" Maximum="4"
                             Value="{Binding Scale}"
                             TickFrequency="0.5"
@@ -179,11 +192,14 @@
                             </Grid.ColumnDefinitions>
                             <CheckBox Grid.Column="0"
                                 Content="Audio"
+                                AutomationProperties.AutomationId="AudioCheckBox"
                                 IsVisible="true"
                                 IsEnabled="{Binding AudioSettingsEnabled }"
                                 IsChecked="{Binding AudioEnabled}"
                                 ToolTip.Tip="{Binding AudioTooltip}"/>
                             <Slider Grid.Column="1"
+                                AutomationProperties.AutomationId="AudioVolumeSlider"
+                                AutomationProperties.Name="Audio volume"
                                 Width="100"
                                 Minimum="0" Maximum="100"
                                 Value="{Binding AudioVolumePercent}"
@@ -206,6 +222,7 @@
                             <!-- General Emulator Options Button -->
                             <Button Grid.Column="0"
                                     Content="Options"
+                                    AutomationProperties.AutomationId="OptionsButton"
                                     Command="{Binding EmulatorOptionsCommand}"
                                     Classes="grid small"
                                     ToolTip.Tip="Configure general emulator settings"/>
@@ -259,9 +276,12 @@
                     Height="230"
                     Width="{Binding #EmulatorDisplayGrid.Bounds.Width}">
                     
-                    <TabControl Name="InformationTabControl">
+                    <TabControl Name="InformationTabControl"
+                                AutomationProperties.AutomationId="InformationTabControl">
                         <!-- Information Tab -->
-                        <TabItem Name="InformationTabItem" Header="Information">
+                        <TabItem Name="InformationTabItem" Header="Information"
+                                 AutomationProperties.AutomationId="InformationTab"
+                                 AutomationProperties.Name="Information tab">
                             <Border Classes="tab-content">
                                 <ScrollViewer Classes="auto-scroll">
                                     <!-- C64 Info panel-->
@@ -271,7 +291,9 @@
                         </TabItem>
 
                         <!-- Config Status Tab -->
-                        <TabItem Name="ConfigStatusTabItem" Header="Config status">
+                        <TabItem Name="ConfigStatusTabItem" Header="Config status"
+                                 AutomationProperties.AutomationId="ConfigStatusTab"
+                                 AutomationProperties.Name="Config status tab">
                             <Border Classes="tab-content">
                                 <ScrollViewer Classes="auto-scroll">
                                     <StackPanel Classes="spacing-tight">
@@ -304,7 +326,10 @@
                         </TabItem>
 
                         <!-- Log Tab -->
-                        <TabItem Name="LogTabItem" Header="{Binding LogTabHeader}" Classes.error-log="{Binding HasLogErrors}">
+                        <TabItem Name="LogTabItem" Header="{Binding LogTabHeader}"
+                                 AutomationProperties.AutomationId="LogTab"
+                                 AutomationProperties.Name="Log tab"
+                                 Classes.error-log="{Binding HasLogErrors}">
                             <Border Classes="tab-content">
                                 <Grid>
                                     <Grid.ColumnDefinitions>
@@ -391,6 +416,7 @@
                                 <!-- Clear button column -->
                                 <Border Grid.Column="1" Classes="v-top" Margin="4,0,0,0">
                                     <Button Command="{Binding ClearLogCommand}"
+                                            AutomationProperties.AutomationId="ClearLogButton"
                                             Classes="small"
                                             Width="60"
                                             Height="20"
@@ -405,6 +431,8 @@
 
                         <!-- Scripts Tab -->
                         <TabItem Name="ScriptsTabItem"
+                                 AutomationProperties.AutomationId="ScriptsTab"
+                                 AutomationProperties.Name="Scripts tab"
                                  Header="{Binding ScriptsTabHeader}"
                                  Classes.disabled-scripts="{Binding HasDisabledScripts}">
                             <Border Classes="tab-content">
@@ -434,6 +462,8 @@
                                                 <StackPanel Spacing="2">
                                                     <StackPanel Orientation="Horizontal" Spacing="4">
                                                         <Button Content="↻"
+                                                                AutomationProperties.AutomationId="ScriptsBannerRefreshButton"
+                                                                AutomationProperties.Name="Reload scripts from folder"
                                                                 Command="{Binding RefreshScriptsCommand}"
                                                                 FontSize="12"
                                                                 Height="22" Padding="4,0"
@@ -445,6 +475,8 @@
                                                                    Classes="small bold"
                                                                    VerticalAlignment="Center"/>
                                                         <Button Content="{Binding ScriptDirectory}"
+                                                                AutomationProperties.AutomationId="ScriptFolderLink"
+                                                                AutomationProperties.Name="Open script folder in file browser"
                                                                 Command="{Binding OpenScriptFolderCommand}"
                                                                 Classes="link"
                                                                 FontSize="10"
@@ -467,12 +499,14 @@
                                                         Margin="0,0,0,4"
                                                         IsVisible="{Binding CanManageScripts}">
                                                 <Button Content="+ Add Script"
+                                                        AutomationProperties.AutomationId="AddScriptButton"
                                                         Command="{Binding AddScriptCommand}"
                                                         FontSize="10"
                                                         Padding="6,2"
                                                         MinWidth="0"
                                                         MinHeight="0"/>
                                                 <Button Content="Load Examples"
+                                                        AutomationProperties.AutomationId="LoadExamplesButton"
                                                         Command="{Binding LoadExamplesCommand}"
                                                         IsVisible="{Binding CanLoadExamples}"
                                                         FontSize="10"
@@ -480,6 +514,8 @@
                                                         MinWidth="0"
                                                         MinHeight="0"/>
                                                 <Button Content="↻"
+                                                        AutomationProperties.AutomationId="ScriptsRefreshButton"
+                                                        AutomationProperties.Name="Reload all scripts from localStorage"
                                                         Command="{Binding RefreshScriptsCommand}"
                                                         FontSize="12"
                                                         Height="22" Padding="4,0"
@@ -503,6 +539,8 @@
                                                     <ColumnDefinition Width="*"/>
                                                 </Grid.ColumnDefinitions>
                                                 <Button Grid.Column="5" Classes="sort-header"
+                                                        AutomationProperties.AutomationId="SortByFileNameButton"
+                                                        AutomationProperties.Name="Sort by script file name"
                                                         Command="{Binding SortByColumnCommand}"
                                                         CommandParameter="{x:Static vm:ScriptSortColumn.FileName}">
                                                     <StackPanel Orientation="Horizontal">
@@ -511,6 +549,8 @@
                                                     </StackPanel>
                                                 </Button>
                                                 <Button Grid.Column="6" Classes="sort-header"
+                                                        AutomationProperties.AutomationId="SortByStatusButton"
+                                                        AutomationProperties.Name="Sort by script status"
                                                         Command="{Binding SortByColumnCommand}"
                                                         CommandParameter="{x:Static vm:ScriptSortColumn.Status}">
                                                     <StackPanel Orientation="Horizontal">
@@ -519,6 +559,8 @@
                                                     </StackPanel>
                                                 </Button>
                                                 <Button Grid.Column="7" Classes="sort-header"
+                                                        AutomationProperties.AutomationId="SortByYieldButton"
+                                                        AutomationProperties.Name="Sort by yield type"
                                                         Command="{Binding SortByColumnCommand}"
                                                         CommandParameter="{x:Static vm:ScriptSortColumn.YieldType}">
                                                     <StackPanel Orientation="Horizontal">
@@ -527,6 +569,8 @@
                                                     </StackPanel>
                                                 </Button>
                                                 <Button Grid.Column="8" Classes="sort-header"
+                                                        AutomationProperties.AutomationId="SortByHooksButton"
+                                                        AutomationProperties.Name="Sort by hooks"
                                                         Command="{Binding SortByColumnCommand}"
                                                         CommandParameter="{x:Static vm:ScriptSortColumn.Hooks}">
                                                     <StackPanel Orientation="Horizontal">
@@ -590,6 +634,8 @@
                                                                      Margin="0,1,0,-1">
                                                                 <CheckBox IsChecked="{Binding IsScriptEnabled, Mode=OneWay}"
                                                                           IsEnabled="{Binding CanToggle}"
+                                                                          AutomationProperties.AutomationId="{Binding FileName, StringFormat='ScriptRow.ToggleEnabled.{0}'}"
+                                                                          AutomationProperties.Name="Enable or disable script"
                                                                           Command="{Binding $parent[ItemsControl].((vm:MainViewModel)DataContext).ToggleScriptEnabledCommand}"
                                                                           CommandParameter="{Binding FileName}"
                                                                           Padding="0"
@@ -600,6 +646,8 @@
                                                             <!-- Reload button -->
                                                             <Button Grid.Column="2"
                                                                     Content="↻"
+                                                                    AutomationProperties.AutomationId="{Binding FileName, StringFormat='ScriptRow.Reload.{0}'}"
+                                                                    AutomationProperties.Name="Reload script"
                                                                     Command="{Binding $parent[ItemsControl].((vm:MainViewModel)DataContext).ReloadScriptCommand}"
                                                                     CommandParameter="{Binding FileName}"
                                                                     IsEnabled="{Binding CanReload}"
@@ -615,6 +663,8 @@
 
                                                             <!-- Edit button (browser/manage mode only) -->
                                                             <Button Grid.Column="3"
+                                                                    AutomationProperties.AutomationId="{Binding FileName, StringFormat='ScriptRow.Edit.{0}'}"
+                                                                    AutomationProperties.Name="Edit script"
                                                                     Command="{Binding $parent[ItemsControl].((vm:MainViewModel)DataContext).EditScriptCommand}"
                                                                     CommandParameter="{Binding FileName}"
                                                                     IsVisible="{Binding $parent[ItemsControl].((vm:MainViewModel)DataContext).CanManageScripts}"
@@ -631,6 +681,8 @@
 
                                                             <!-- Delete button (browser/manage mode only) -->
                                                             <Button Grid.Column="4"
+                                                                    AutomationProperties.AutomationId="{Binding FileName, StringFormat='ScriptRow.Delete.{0}'}"
+                                                                    AutomationProperties.Name="Delete script"
                                                                     Command="{Binding $parent[ItemsControl].((vm:MainViewModel)DataContext).DeleteScriptCommand}"
                                                                     CommandParameter="{Binding FileName}"
                                                                     IsVisible="{Binding $parent[ItemsControl].((vm:MainViewModel)DataContext).CanManageScripts}"
@@ -697,7 +749,9 @@
                         </TabItem>
 
                         <!-- General info -->
-                        <TabItem Name="GeneralInfoTabItem" Header="General info">
+                        <TabItem Name="GeneralInfoTabItem" Header="General info"
+                                 AutomationProperties.AutomationId="GeneralInfoTab"
+                                 AutomationProperties.Name="General info tab">
                             <ScrollViewer Classes="auto-scroll">
                                 <StackPanel Classes="spacing-tight h-left">
 
@@ -781,7 +835,10 @@
 
 
                         <!-- Debug  -->
-                        <TabItem Name="DebugTabItem" Header="Debug" IsVisible="{Binding IsDebugTabVisible}">
+                        <TabItem Name="DebugTabItem" Header="Debug"
+                                 AutomationProperties.AutomationId="DebugTab"
+                                 AutomationProperties.Name="Debug tab"
+                                 IsVisible="{Binding IsDebugTabVisible}">
                             <Border Classes="tab-content">
                                 <ScrollViewer Classes="auto-scroll">
                                     <StackPanel Classes="spacing-tight">
@@ -795,6 +852,8 @@
                                             <StackPanel Orientation="Horizontal" Classes="spacing-normal">
                                                 <!-- Start/Stop toggle button -->
                                                 <Button Content="{Binding ExternalDebugToggleButtonText}"
+                                                        AutomationProperties.AutomationId="ExternalDebugToggleButton"
+                                                        AutomationProperties.Name="Start or stop the TCP debug adapter server"
                                                         Command="{Binding ToggleExternalDebugCommand}"
                                                         Classes="small"
                                                         MinWidth="46"
@@ -808,6 +867,8 @@
                                                                FontSize="10"
                                                                VerticalAlignment="Center"/>
                                                     <NumericUpDown Value="{Binding ExternalDebugPort}"
+                                                                  AutomationProperties.AutomationId="ExternalDebugPortInput"
+                                                                  AutomationProperties.Name="External debug server TCP port"
                                                                   IsEnabled="{Binding !IsExternalDebugListening}"
                                                                   Minimum="0" Maximum="65535"
                                                                   FormatString="0"
@@ -834,6 +895,7 @@
 
                                                 <StackPanel Orientation="Horizontal" Classes="spacing-tight">
                                                     <Button Click="OpenSoundDebug_Click"
+                                                            AutomationProperties.AutomationId="DebugSoundButton"
                                                             IsEnabled="{Binding IsEmulatorUninitialized}"
                                                             Classes="small"
                                                             MinWidth="60"
@@ -842,6 +904,7 @@
                                                         Debug sound
                                                     </Button>
                                                     <Button Click="OpenGamepadDebug_Click"
+                                                            AutomationProperties.AutomationId="DebugGamepadButton"
                                                             IsEnabled="{Binding IsEmulatorUninitialized}"
                                                             Classes="small"
                                                             MinWidth="60"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -8,6 +9,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.Threading;
+using Highbyte.DotNet6502.App.Avalonia.Core.SystemSetup;
 using Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
 using Highbyte.DotNet6502.Systems;
 using Microsoft.Extensions.Configuration;
@@ -32,6 +34,10 @@ public partial class MainView : UserControl
     // For log auto-scroll
     private ScrollViewer? _logScrollViewer;
     private bool _logAutoScrollEnabled = true;
+
+    // KeyBindings added to the MainWindow on behalf of the current system menu contributor.
+    // Tracked so we can remove them when the active contributor swaps or the view detaches.
+    private readonly System.Collections.Generic.List<KeyBinding> _contributorKeyBindings = new();
 
     // Parameterless constructor - child views created by XAML!
     public MainView()
@@ -61,6 +67,10 @@ public partial class MainView : UserControl
             if (DataContext is MainViewModel viewModel)
             {
                 await viewModel.InitializeAsync();
+                // Explicit apply after initialization completes: the reactive chain fires
+                // during InitializeAsync but NativeMenu.SetMenu may require the call to
+                // originate on the UI thread AFTER the window is fully shown.
+                ApplyMenuContributor(_subscribedViewModel?.ActiveMenuContributor);
             }
 
             // TODO: When not having the emulator started, need to set focus to the EmulatorView to capture keyboard input.
@@ -118,6 +128,8 @@ public partial class MainView : UserControl
             _subscribedViewModel.LogMessages.CollectionChanged += LogMessages_CollectionChanged;
             // Set up tab selection tracking
             SetupTabSelectionTracking();
+            // Apply menu + shortcuts for the initial contributor (may already be resolved)
+            ApplyMenuContributor(_subscribedViewModel.ActiveMenuContributor);
         }
     }
 
@@ -128,6 +140,11 @@ public partial class MainView : UserControl
         if (e.PropertyName == nameof(MainViewModel.ValidationErrors))
         {
             CheckAndSelectValidationErrorsTab();
+        }
+
+        if (e.PropertyName == nameof(MainViewModel.ActiveMenuContributor) && _subscribedViewModel != null)
+        {
+            ApplyMenuContributor(_subscribedViewModel.ActiveMenuContributor);
         }
 
         if (e.PropertyName == nameof(MainViewModel.IsMonitorVisible) && DataContext is MainViewModel viewModel)
@@ -345,6 +362,9 @@ public partial class MainView : UserControl
     {
         base.OnDetachedFromVisualTree(e);
 
+        // Tear down any menu + keybindings we contributed while attached.
+        ApplyMenuContributor(null);
+
         if (_subscribedViewModel != null)
         {
             _subscribedViewModel.PropertyChanged -= OnViewModelPropertyChanged;
@@ -357,11 +377,104 @@ public partial class MainView : UserControl
             _subscribedViewModel = null;
         }
     }
+
+    /// <summary>
+    /// Replaces any previously-applied menu/keybindings with those from <paramref name="contributor"/>.
+    /// Pass null to clear (e.g. on detach or when no system is selected).
+    ///
+    /// Platform split:
+    /// - macOS:         <see cref="NativeMenu"/> is installed on the Application. On macOS this
+    ///                  appears in the OS-level system menu bar (outside the app window), which is
+    ///                  the desired UX. The items are also exposed via the macOS Accessibility API
+    ///                  (AXMenuItem), making shortcuts self-describing for AI agents.
+    /// - Windows/Linux: <see cref="NativeMenu"/> would render as in-window chrome on these platforms,
+    ///                  which is not desired. <see cref="KeyBinding"/>s are added to the MainWindow
+    ///                  instead — shortcuts fire regardless of focus but are not visible in any menu.
+    /// - WASM:          No-op; neither applies in the browser target.
+    /// </summary>
+    private void ApplyMenuContributor(ISystemMenuContributor? contributor)
+    {
+        if (PlatformDetection.IsRunningInWebAssembly())
+            return;
+
+        // NativeMenu.SetMenu must be called on the UI thread on macOS.
+        // SelectedSystemName PropertyChanged can fire on a background thread after an async await.
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Post(() => ApplyMenuContributor(contributor));
+            return;
+        }
+
+        var topLevel = TopLevel.GetTopLevel(this);
+        var window = topLevel as Window;
+
+        // Remove any previously-added key bindings from the window.
+        if (window != null)
+        {
+            foreach (var kb in _contributorKeyBindings)
+                window.KeyBindings.Remove(kb);
+        }
+        _contributorKeyBindings.Clear();
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            // On macOS: mutate the items of the pre-registered NativeMenu object (set in
+            // App.Initialize) rather than replacing the menu. Replacing the object stops
+            // Avalonia's backend from tracking it, so shortcuts and the menu bar stop working.
+            var appMenu = Application.Current is { } a ? NativeMenu.GetMenu(a) : null;
+            if (appMenu == null)
+            {
+                // Fallback: pre-registration didn't happen (e.g. non-macOS path ran first).
+                appMenu = new NativeMenu();
+                if (Application.Current is { } currentApp2)
+                    NativeMenu.SetMenu(currentApp2, appMenu);
+            }
+
+            appMenu.Items.Clear();
+
+            if (contributor != null)
+            {
+                var systemRoot = new NativeMenuItem { Header = contributor.MenuLabel };
+                var submenu = new NativeMenu();
+                foreach (var item in contributor.GetNativeMenuItems())
+                    submenu.Items.Add(item);
+                systemRoot.Menu = submenu;
+                appMenu.Items.Add(systemRoot);
+
+                Logger.LogInformation("[NativeMenu] Updated existing NativeMenu for contributor '{Label}': {Count} top-level items",
+                    contributor.MenuLabel, appMenu.Items.Count);
+            }
+            else
+            {
+                Logger.LogInformation("[NativeMenu] Cleared NativeMenu (no contributor)");
+            }
+        }
+        else
+        {
+            // On Windows/Linux: NativeMenu would render as in-window chrome, which is not the
+            // desired UX (unlike macOS where it goes to the OS system menu bar). Use window-level
+            // KeyBindings instead — shortcuts fire regardless of which child has focus, but they
+            // are invisible to accessibility tools and require prior knowledge to discover.
+            if (window != null && contributor != null)
+            {
+                foreach (var kb in contributor.GetKeyBindings())
+                {
+                    window.KeyBindings.Add(kb);
+                    _contributorKeyBindings.Add(kb);
+                }
+            }
+        }
+    }
     private void MainView_AttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
     {
         // Directly find the LogScrollViewer by name
         _logScrollViewer = this.FindControl<ScrollViewer>("LogScrollViewer");
         _logScrollViewer?.ScrollChanged += LogScrollViewer_ScrollChanged;
+
+        // Now that the MainView has a TopLevel (Window), apply the contributor's native menu /
+        // keybindings — the earlier call during DataContextChanged could not find the window.
+        if (_subscribedViewModel != null)
+            ApplyMenuContributor(_subscribedViewModel.ActiveMenuContributor);
     }
 
     private void LogScrollViewer_ScrollChanged(object? sender, ScrollChangedEventArgs e)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MonitorDialog.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MonitorDialog.axaml
@@ -2,6 +2,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:views="using:Highbyte.DotNet6502.App.Avalonia.Core.Views"
         x:Class="Highbyte.DotNet6502.App.Avalonia.Core.Views.MonitorDialog"
+        AutomationProperties.AutomationId="MonitorDialog"
+        AutomationProperties.Name="Machine code monitor"
         Title="Machine Code Monitor"
         Width="860"
         Height="620"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MonitorUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MonitorUserControl.axaml
@@ -83,7 +83,10 @@
 
         <!-- Output Area -->
         <Border Grid.Row="1" Classes="monitor-container">
-            <ScrollViewer x:Name="OutputScrollViewer" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+            <ScrollViewer x:Name="OutputScrollViewer"
+                          AutomationProperties.AutomationId="OutputScrollViewer"
+                          AutomationProperties.Name="Monitor output"
+                          VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                 <ItemsControl ItemsSource="{Binding OutputLines}">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>
@@ -106,20 +109,30 @@
                 <TextBlock Grid.Column="0" Text=">&#160;" VerticalAlignment="Center" Foreground="#A0AEC0" Classes="monitor-font"/>
                 <TextBox Grid.Column="1"
                      x:Name="CommandTextBox"
+                     AutomationProperties.AutomationId="CommandTextBox"
+                     AutomationProperties.Name="Monitor command"
                      Text="{Binding InputText, Mode=TwoWay}"
                      KeyDown="CommandTextBox_KeyDown"
                      Watermark="Enter monitor command"
                      Classes="monitor-font command-input"/>
                 <StackPanel Grid.Column="2" Orientation="Horizontal" Classes="spacing-normal">
-                    <Button Content="Send" Command="{Binding SendCommand}" Classes="primary"/>
-                    <Button Content="Close" Command="{Binding CloseCommand}" Classes="cancel"/>
+                    <Button Content="Send"
+                            AutomationProperties.AutomationId="SendCommandButton"
+                            AutomationProperties.Name="Send monitor command"
+                            Command="{Binding SendCommand}" Classes="primary"/>
+                    <Button Content="Close"
+                            AutomationProperties.AutomationId="CloseMonitorButton"
+                            AutomationProperties.Name="Close monitor"
+                            Command="{Binding CloseCommand}" Classes="cancel"/>
                 </StackPanel>
             </Grid>
         </Border>
 
         <!-- Status information -->
         <Border Grid.Row="3" Classes="status-container">
-            <ScrollViewer VerticalScrollBarVisibility="Auto" MaxHeight="140">
+            <ScrollViewer AutomationProperties.AutomationId="MonitorStatusScroll"
+                          AutomationProperties.Name="Monitor status"
+                          VerticalScrollBarVisibility="Auto" MaxHeight="140">
                 <ItemsControl ItemsSource="{Binding StatusLines}">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/ScriptEditorDialog.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/ScriptEditorDialog.axaml
@@ -3,6 +3,8 @@
         xmlns:vm="using:Highbyte.DotNet6502.App.Avalonia.Core.ViewModels"
         x:Class="Highbyte.DotNet6502.App.Avalonia.Core.Views.ScriptEditorDialog"
         x:DataType="vm:ScriptEditorViewModel"
+        AutomationProperties.AutomationId="ScriptEditorDialog"
+        AutomationProperties.Name="Lua script editor"
         Width="640"
         MinWidth="400"
         MinHeight="320">
@@ -22,6 +24,8 @@
                        VerticalAlignment="Center"
                        Margin="0,0,8,0"/>
             <TextBox x:Name="FileNameBox"
+                     AutomationProperties.AutomationId="FileNameBox"
+                     AutomationProperties.Name="Script file name"
                      Grid.Column="1"
                      Text="{Binding FileName}"
                      IsReadOnly="{Binding !IsNew}"
@@ -31,6 +35,8 @@
 
         <!-- Code editor -->
         <TextBox x:Name="ContentBox"
+                 AutomationProperties.AutomationId="ContentBox"
+                 AutomationProperties.Name="Script content"
                  Grid.Row="2"
                  Text="{Binding Content}"
                  AcceptsReturn="True"
@@ -49,8 +55,12 @@
                     HorizontalAlignment="Right"
                     Spacing="8">
             <Button Content="Cancel"
+                    AutomationProperties.AutomationId="CancelButton"
+                    AutomationProperties.Name="Cancel"
                     Command="{Binding CancelCommand}"/>
             <Button Content="Save"
+                    AutomationProperties.AutomationId="SaveButton"
+                    AutomationProperties.Name="Save script"
                     Command="{Binding SaveCommand}"
                     Classes="accent"/>
         </StackPanel>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/StatisticsView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/StatisticsView.axaml
@@ -5,7 +5,9 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Highbyte.DotNet6502.App.Avalonia.Core.Views.StatisticsView"
-             x:DataType="vm:StatisticsViewModel">
+             x:DataType="vm:StatisticsViewModel"
+             AutomationProperties.AutomationId="StatisticsView"
+             AutomationProperties.Name="Statistics panel">
 
     <StackPanel Classes="spacing-large"
                 Grid.IsSharedSizeScope="True">

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Info.plist
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Info.plist
@@ -15,7 +15,7 @@
     <key>CFBundleName</key>
     <string>DotNet6502</string>
     <key>CFBundleDisplayName</key>
-    <string>DotNet6502 Emulator</string>
+    <string>DotNet 6502 Emulator</string>
     <key>CFBundleIdentifier</key>
     <string>com.highbyte.dotnet6502</string>
     <key>CFBundleVersion</key>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Program.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Program.cs
@@ -157,7 +157,7 @@ internal sealed partial class Program
         if (enableConsoleLogging && RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !noConsoleWindow)
         {
             AllocConsole();
-            Console.Title = "DotNet6502 Emulator - Log Output";
+            Console.Title = "DotNet 6502 Emulator - Log Output";
         }
 
         WriteBootstrapLog("Starting.");

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/publish.sh
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/publish.sh
@@ -82,7 +82,7 @@ echo "✅ Published successfully to: $OUTPUT_DIR/$RUNTIME"
 
 # Create .app bundle for macOS
 if [[ "$RUNTIME" == osx-* ]]; then
-    APP_NAME="DotNet6502 Emulator.app"
+    APP_NAME="DotNet 6502 Emulator.app"
     APP_DIR="$OUTPUT_DIR/$RUNTIME/$APP_NAME"
     MACOS_DIR="$APP_DIR/Contents/MacOS"
     RESOURCES_DIR="$APP_DIR/Contents/Resources"

--- a/src/apps/Highbyte.DotNet6502.App.SadConsole/Program.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SadConsole/Program.cs
@@ -21,7 +21,7 @@ LogLevel consoleLogLevel = ParseLogLevel(args, defaultLevel: LogLevel.Informatio
 if (enableConsoleLogging && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 {
     AllocConsole();
-    System.Console.Title = "DotNet6502 Emulator (SadConsole) - Log Output";
+    System.Console.Title = "DotNet 6502 Emulator (SadConsole) - Log Output";
 }
 
 // Note: Don't call Console.WriteLine before AllocConsole() is called (Windows). Otherwise no logs will show in console.

--- a/src/apps/Highbyte.DotNet6502.App.SadConsole/SadConsoleHostApp.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SadConsole/SadConsoleHostApp.cs
@@ -162,7 +162,7 @@ public class SadConsoleHostApp : HostApp<SadConsoleInputHandlerContext, NAudioAu
         // Start SadConsole window
         Game.Create(builder);
 
-        Settings.WindowTitle = "Highbyte.DotNet6502 emulator + SadConsole (with NAudio)";
+        Settings.WindowTitle = "DotNet 6502 Emulator + SadConsole (with NAudio)";
         Settings.ResizeMode = Settings.WindowResizeOptions.None;
 
         try

--- a/src/apps/Highbyte.DotNet6502.App.SilkNetNative/Program.cs
+++ b/src/apps/Highbyte.DotNet6502.App.SilkNetNative/Program.cs
@@ -21,7 +21,7 @@ LogLevel consoleLogLevel = ParseLogLevel(args, defaultLevel: LogLevel.Informatio
 if (enableConsoleLogging && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 {
     AllocConsole();
-    Console.Title = "DotNet6502 Emulator (SilkNetNative) - Log Output";
+    Console.Title = "DotNet 6502 Emulator (SilkNetNative) - Log Output";
 }
 
 // Note: Don't call Console.WriteLine before AllocConsole() is called (Windows). Otherwise no logs will show in console.
@@ -118,7 +118,7 @@ windowOptions.FramesPerSecond = 60.0f;  // TODO: With Vsync=false the FramesPerS
 
 windowOptions.VSync = false;  // TODO: With Vsync=true Silk.NET seem to use incorrect UpdatePerSecond. The actual FPS its called is 10 lower than it should be (measured in the OnUpdate method)
 windowOptions.WindowState = WindowState.Normal;
-windowOptions.Title = "Highbyte.DotNet6502 emulator + Silk.NET (with ImGui, SkiaSharp, OpenGL, NAudio)";
+windowOptions.Title = "DotNet 6502 Emulator + Silk.NET (with ImGui, SkiaSharp, OpenGL, NAudio)";
 windowOptions.Size = new Vector2D<int>(windowWidth, windowHeight);
 windowOptions.WindowBorder = WindowBorder.Fixed;
 windowOptions.API = GraphicsAPI.Default; // = Default = OpenGL 3.3 with forward compatibility

--- a/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Index.razor
+++ b/src/apps/Highbyte.DotNet6502.App.WASM/Pages/Index.razor
@@ -116,7 +116,7 @@
 
                 <h2>
                     <img src="images/logo.png" align="middle" style="width:128px;height:128px;" title="DotNet 6502 logo" />
-                    The <a href="https://github.com/highbyte/dotnet-6502" target="_blank">DotNet 6502</a> emulator!
+                    The <a href="https://github.com/highbyte/dotnet-6502" target="_blank">DotNet 6502 Emulator</a>!
                 </h2>
 
                 <p>


### PR DESCRIPTION
### Accessibility / automation properties
Added `AutomationProperties.AutomationId` and `AutomationProperties.Name` to all key Avalonia UI elements (buttons, combo boxes, text blocks, panels, user controls across main view, C64 menu, monitor, script editor, etc.). Makes the app fully addressable by accessibility tools and AI automation agents (e.g. `peekaboo`).

### Keyboard shortcuts & macOS native menu
- Added `ISystemMenuContributor` interface — each system's menu ViewModel can supply both macOS native menu items and keyboard bindings from a single place, without code-behind glue.
- `C64MenuViewModel` now implements `ISystemMenuContributor`, exposing reactive commands for toggling C64 UI sections (Disk, Load/Save, Config) and joystick controls.
- **macOS:** shortcuts are wired up as a `NativeMenu` on the `Application`, appearing in the OS-level menu bar and exposed via the macOS Accessibility API (`AXMenuItem`) — self-describing and discoverable by automation.
- **Windows/Linux:** shortcuts are registered as `KeyBinding`s directly on the main window (native menu would render as unwanted in-window chrome on these platforms).
- New doc: `APPS_AVALONIA_AUTOMATION.md` — covers how to use `peekaboo` and AppleScript to automate the desktop app.

### Standardize emulator display name
Replaces all inconsistent variants (`DotNet6502 Emulator`, `DotNet-6502 Emulator`, `Highbyte.DotNet6502 emulator`, `DotNet 6502 emulator`) with **`DotNet 6502 Emulator`** across UI, source, docs, macOS bundle, Homebrew cask, and Scoop manifest. Release workflow now reads the `.app` bundle name directly from the release zip when updating the Homebrew cask, making `publish.sh` the single source of truth.