### PR TITLE
Improve Avalonia log UI and tab navigation shortcuts

### DIFF
--- a/doc/APPS_AVALONIA_AUTOMATION.md
+++ b/doc/APPS_AVALONIA_AUTOMATION.md
@@ -112,35 +112,58 @@ A non-exhaustive list of the most useful AutomationIds, grouped by view. All of 
 - `StatisticsView` (root)
 - `C64InfoView` (root, keyboard mapping reference)
 
-# Keyboard shortcuts (system menu contributions)
+# Keyboard shortcuts
 
-Some controls inside nested `UserControl`s do not traverse cleanly to the macOS AX tree (see "known gaps" below — the left-pane `C64MenuView` sections are the most visible example). To keep those operations reachable for agents and keyboard users, the active system's menu ViewModel implements `ISystemMenuContributor` ([`Core/SystemSetup/ISystemMenuContributor.cs`](../src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/SystemSetup/ISystemMenuContributor.cs)) and contributes:
-- A `NativeMenu` that Avalonia installs on the **macOS system menu bar** (shown under a top-level header for the active system, e.g. `C64`). On macOS, `NativeMenu` items appear in the OS-level menu bar *outside* the app window — which is the desired UX. The macOS Accessibility API also exposes these items with their `Gesture` string, making shortcuts self-describing: an AI agent can discover them at runtime via `peekaboo menu list` without needing any prior documentation.
-- A parallel list of `KeyBinding`s applied to the main window on **Windows / Linux**. `NativeMenu` on these platforms would render as in-window chrome, which is not desired, so `KeyBinding`s are used instead. The shortcuts fire regardless of which child control has focus, but they are invisible to accessibility tools — an automation agent needs to know them in advance (e.g. from this document).
+The app exposes two layers of shortcuts:
 
-`MainViewModel.ActiveMenuContributor` swaps when `SelectedSystemName` changes; `MainView.axaml.cs` applies the new menu / keybindings, and clears the previous one on teardown.
+1. **General tab-navigation shortcuts** — always active, independent of which emulator system is running.
+2. **System-specific shortcuts** — active only when a particular system is selected (e.g. C64). The active system's menu ViewModel implements `ISystemMenuContributor` ([`Core/SystemSetup/ISystemMenuContributor.cs`](../src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/SystemSetup/ISystemMenuContributor.cs)).
+
+On macOS both layers appear in the OS-level **system menu bar** (outside the app window) — general shortcuts under a `View` top-level menu, system-specific shortcuts under the system name (e.g. `C64`). The macOS Accessibility API exposes these with their `Gesture` string, so an AI agent can discover them at runtime without prior documentation:
+
+```sh
+peekaboo menu list --app "DotNet 6502 Emulator"
+```
+
+On **Windows / Linux**, `NativeMenu` would render as in-window chrome (not desired), so `KeyBinding`s registered on the main window are used instead. They fire regardless of which child control has focus, but are invisible to accessibility tools — an agent needs to know them from this document.
+
+## Tab navigation shortcuts (always active)
+
+These shortcuts jump directly to a named tab regardless of tab order — reordering tabs in code does **not** break automation scripts.
+
+| Tab             | macOS    | Windows / Linux    |
+| --------------- | -------- | ------------------ |
+| Information     | `⌘⌥I` | `Ctrl+Alt+I`       |
+| Config status   | `⌘⌥C` | `Ctrl+Alt+C`       |
+| Log             | `⌘⌥L` | `Ctrl+Alt+L`       |
+| Scripts         | `⌘⌥S` | `Ctrl+Alt+S`       |
+| General info    | `⌘⌥G` | `Ctrl+Alt+G`       |
+| Debug           | `⌘⌥D` | `Ctrl+Alt+D`       |
+
+On macOS, click via the menu bar instead of counting arrow-key presses:
+
+```sh
+peekaboo menu click --app "DotNet 6502 Emulator" --path "DotNet 6502 Emulator > View > Log"
+```
 
 ## C64 shortcuts (active when the C64 system is selected)
 
 | Action                           | macOS               | Windows / Linux       |
 | -------------------------------- | ------------------- | --------------------- |
 | Toggle Disk Drive section        | `⌘⌥⇧D`         | `Ctrl+Alt+Shift+D`    |
-| Toggle Load/Save section         | `⌘⌥L`            | `Ctrl+Alt+L`          |
-| Toggle Configuration section     | `⌘⌥C`            | `Ctrl+Alt+C`          |
+| Toggle Load/Save section         | `⌘⌥⇧L`         | `Ctrl+Alt+Shift+L`    |
+| Toggle Configuration section     | `⌘⌥⇧C`         | `Ctrl+Alt+Shift+C`    |
 | Active joystick → Port 1         | `⌘⌥1`            | `Ctrl+Alt+1`          |
 | Active joystick → Port 2         | `⌘⌥2`            | `Ctrl+Alt+2`          |
 | Toggle Joystick KB               | `⌘⌥K`            | `Ctrl+Alt+K`          |
 | Keyboard joystick → Port 1       | `⌘⌥⇧1`         | `Ctrl+Alt+Shift+1`    |
 | Keyboard joystick → Port 2       | `⌘⌥⇧2`         | `Ctrl+Alt+Shift+2`    |
 
-On macOS, the shortcuts are discoverable by walking the app's menu bar via peekaboo:
+On macOS, click via the menu bar:
 
 ```sh
-peekaboo menu list --app "DotNet 6502 Emulator"
-peekaboo menu click --app "DotNet 6502 Emulator" --path "C64 > Toggle Configuration section"
+peekaboo menu click --app "DotNet 6502 Emulator" --path "DotNet 6502 Emulator > C64 > Toggle Configuration section"
 ```
-
-On Windows / Linux, the same shortcuts are dispatched by the main window's key bindings; an automation harness simulates the key combo instead of clicking a menu.
 
 # What is NOT surfaced (known gaps)
 
@@ -148,7 +171,24 @@ On Windows / Linux, the same shortcuts are dispatched by the main window's key b
 
    This is most likely an Avalonia `TabItemAutomationPeer` / macOS NSAccessibility bridge limitation, not a bug in this codebase. Worth filing an issue upstream in `avaloniaui/Avalonia`.
 
-   **Workaround**: click the tab by screen coordinates (see the peekaboo section below), or use keyboard navigation (`Ctrl+Tab` / arrow keys when the tab control is focused).
+   **Workaround**: use keyboard navigation — this is the **reliable** approach. Find the `InformationTabControl` element via `peekaboo see`, click it to give it focus, then press the right-arrow key once per tab step:
+
+   ```sh
+   # Capture the AX tree and find InformationTabControl's elem_NN
+   peekaboo see --app "DotNet 6502 Emulator" --json | jq '.. | objects | select(.identifier == "InformationTabControl") | .id'
+   # → e.g. "elem_49"
+
+   # Focus the tab control
+   peekaboo click --on elem_49 --app "DotNet 6502 Emulator" --window-index 0
+
+   # Navigate right to reach the target tab (count depends on which tab is currently active)
+   # Tab order: Information → ConfigStatus → Log → Scripts → GeneralInfo → Debug
+   peekaboo press right   # repeat as needed
+   ```
+
+   The number of right-arrow presses depends on the **currently active tab**, not a fixed offset. If "Information" is active, pressing right twice reaches "Log". If another tab is already active, adjust accordingly.
+
+   **Avoid** clicking by screen coordinates for tabs: coordinates are window-size-dependent and scale across display densities. **Avoid** `peekaboo click "Log"`: text-query matching is global and can hit an element with the same label in another app or inside the tab's content area (e.g. Ghostty's "Log Out" menu).
 
 2. **Collapsed/conditional content** only appears in the AX tree when its container is rendered. Examples:
    - `C64MenuView` section contents (`DiskSectionContent`, `LoadSaveSectionContent`, `ConfigSectionContent`) — only visible when the section header is expanded.
@@ -224,7 +264,7 @@ peekaboo click --coords "440,595" --app "DotNet 6502 Emulator" --window-index 0
 
 - **Don't use `--no-auto-focus` from a terminal.** The terminal emulator (e.g. Ghostty) reclaims focus between commands, so a `--no-auto-focus` click lands on the terminal window at the same screen coordinates — `click` still reports "✅ Click successful" but against the wrong app. Let peekaboo's auto-focus bring the Avalonia window forward.
 
-- **Text-query clicks can hit the wrong element.** `peekaboo click "Log"` may match a `TextBlock` labelled "Log" *inside* the tab content rather than the tab header, because the header is behind the Avalonia TabItem AX gap described above. When targeting tabs specifically, use coordinates.
+- **Text-query clicks are unreliable for tabs — and can hit other apps.** `peekaboo click "Log"` searches globally across all visible AX elements. It can match a label *inside the tab content*, a menu item in another app (e.g. Ghostty's "Log Out" item), or any other element named "Log" that happens to be on screen. For tab navigation, always use the keyboard approach described in "Known Gaps" item 1 above.
 
 - **Screenshot coordinates vs. screen coordinates.** The annotated screenshot from `peekaboo see --annotate` is scaled to roughly 0.75× the window-point size. To convert a pixel position in the screenshot to a click coordinate, scale by ~1.33× and add the window's screen offset (`peekaboo list` shows the window Position).
 
@@ -258,8 +298,8 @@ START=$(peekaboo see --app "DotNet 6502 Emulator" --json \
 peekaboo click --on "$START" --snapshot "$SNAP" \
                --app "DotNet 6502 Emulator" --window-index 0
 
-# 2. Click Log tab by coordinates (tab row is ~y=595 at the given window size)
-peekaboo click --coords "440,595" --app "DotNet 6502 Emulator" --window-index 0
+# 2. Navigate to the Log tab via its named menu shortcut (order-independent)
+peekaboo menu click --app "DotNet 6502 Emulator" --path "DotNet 6502 Emulator > View > Log"
 
 # Verify
 peekaboo see --app "DotNet 6502 Emulator" --annotate /tmp/after.png

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/C64MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/C64MenuViewModel.cs
@@ -495,8 +495,8 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
         return new NativeMenuItemBase[]
         {
             BuildMenuItem("Toggle Disk Drive section", new KeyGesture(Key.D, macShift), ToggleDiskSectionCommand),
-            BuildMenuItem("Toggle Load/Save section", new KeyGesture(Key.L, macBase), ToggleLoadSaveSectionCommand),
-            BuildMenuItem("Toggle Configuration section", new KeyGesture(Key.C, macBase), ToggleConfigSectionCommand),
+            BuildMenuItem("Toggle Load/Save section", new KeyGesture(Key.L, macShift), ToggleLoadSaveSectionCommand),
+            BuildMenuItem("Toggle Configuration section", new KeyGesture(Key.C, macShift), ToggleConfigSectionCommand),
             new NativeMenuItemSeparator(),
             BuildMenuItem("Active joystick: Port 1", new KeyGesture(Key.D1, macBase), SetActiveJoystickCommand, 1),
             BuildMenuItem("Active joystick: Port 2", new KeyGesture(Key.D2, macBase), SetActiveJoystickCommand, 2),
@@ -520,8 +520,8 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
         return new[]
         {
             BuildKeyBinding(new KeyGesture(Key.D, nonMacShift), ToggleDiskSectionCommand),
-            BuildKeyBinding(new KeyGesture(Key.L, nonMacBase), ToggleLoadSaveSectionCommand),
-            BuildKeyBinding(new KeyGesture(Key.C, nonMacBase), ToggleConfigSectionCommand),
+            BuildKeyBinding(new KeyGesture(Key.L, nonMacShift), ToggleLoadSaveSectionCommand),
+            BuildKeyBinding(new KeyGesture(Key.C, nonMacShift), ToggleConfigSectionCommand),
             BuildKeyBinding(new KeyGesture(Key.D1, nonMacBase), SetActiveJoystickCommand, 1),
             BuildKeyBinding(new KeyGesture(Key.D2, nonMacBase), SetActiveJoystickCommand, 2),
             BuildKeyBinding(new KeyGesture(Key.K, nonMacBase), ToggleJoystickKeyboardCommand),

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
@@ -1061,7 +1061,7 @@ public class LogDisplayEntry
     public LogDisplayEntry(LogEntry logEntry)
     {
         LogLevel = logEntry.LogLevel;
-        Message = logEntry.Message;
+        Message = logEntry.Message.TrimEnd();
         Symbol = GetSymbolForLogLevel(logEntry.LogLevel);
         FormattedDisplay = $"{Symbol} {Message}";
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
@@ -339,7 +339,7 @@
                                     
                                     <!-- Log content -->
                                     <ScrollViewer Grid.Column="0" x:Name="LogScrollViewer" Classes="auto-scroll">
-                                    <ItemsControl ItemsSource="{Binding LogMessages}" Classes="vertical-tight">
+                                    <ItemsControl ItemsSource="{Binding LogMessages}" Classes="vertical-tight" Padding="0,0,0,14">
                                         <ItemsControl.ItemsPanel>
                                             <ItemsPanelTemplate>
                                                 <StackPanel />
@@ -353,7 +353,7 @@
                                                 <Setter Property="TextWrapping" Value="NoWrap"/>
                                                 <Setter Property="Margin" Value="0"/>
                                                 <Setter Property="HorizontalAlignment" Value="Left"/>
-                                                <Setter Property="VerticalAlignment" Value="Center"/>
+                                                <Setter Property="VerticalAlignment" Value="Top"/>
                                             </Style>
                                             <Style Selector="TextBlock.log-trace">
                                                 <Setter Property="Foreground" Value="{DynamicResource SecondaryText}"/>
@@ -383,17 +383,36 @@
                                                 <Setter Property="Margin" Value="0"/>
                                                 <Setter Property="VerticalAlignment" Value="Center"/>
                                             </Style>
+                                            <Style Selector="SelectableTextBlock.log-message">
+                                                <Setter Property="Padding" Value="0"/>
+                                                <Setter Property="FontFamily" Value="Consolas,Monaco,'Courier New',monospace"/>
+                                                <Setter Property="FontSize" Value="10"/>
+                                                <Setter Property="Foreground" Value="{DynamicResource SecondaryText}"/>
+                                                <Setter Property="TextWrapping" Value="NoWrap"/>
+                                                <Setter Property="Margin" Value="0"/>
+                                                <Setter Property="VerticalAlignment" Value="Top"/>
+                                            </Style>
                                         </ItemsControl.Styles>
                                         <ItemsControl.ItemTemplate>
                                             <DataTemplate>
-                                                <Grid Margin="0,0,0,2">
+                                                <Grid Margin="0,0,0,2" ClipToBounds="True">
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="12"/>
+                                                    </Grid.RowDefinitions>
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="16" />  <!-- Fixed width for symbol alignment -->
                                                         <ColumnDefinition Width="*" />   <!-- Flexible width for message -->
                                                     </Grid.ColumnDefinitions>
-                                                    
+                                                    <Grid.ContextMenu>
+                                                        <ContextMenu>
+                                                            <MenuItem Header="Copy message"
+                                                                      Click="LogEntryContextMenu_CopyMessage_Click"
+                                                                      AutomationProperties.AutomationId="LogCopyMessageMenuItem"/>
+                                                        </ContextMenu>
+                                                    </Grid.ContextMenu>
+
                                                     <!-- Symbol container with proper alignment -->
-                                                    <TextBlock Grid.Column="0" 
+                                                    <TextBlock Grid.Column="0"
                                                         Text="{Binding Symbol}"
                                                         Classes="log-symbol"
                                                         Classes.log-trace="{Binding IsTrace}"
@@ -402,9 +421,9 @@
                                                         Classes.log-warning="{Binding IsWarning}"
                                                         Classes.log-error="{Binding IsError}"
                                                         Classes.log-critical="{Binding IsCritical}"/>
-                                                    
-                                                    <!-- Message text -->
-                                                    <TextBlock Grid.Column="1" 
+
+                                                    <!-- Message text (selectable for Cmd+C / Ctrl+C) -->
+                                                    <SelectableTextBlock Grid.Column="1"
                                                         Text="{Binding Message}"
                                                         Classes="log-message"/>
                                                 </Grid>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
@@ -432,17 +432,29 @@
                                     </ItemsControl>
                                 </ScrollViewer>
                                 
-                                <!-- Clear button column -->
+                                <!-- Log action buttons column -->
                                 <Border Grid.Column="1" Classes="v-top" Margin="4,0,0,0">
-                                    <Button Command="{Binding ClearLogCommand}"
-                                            AutomationProperties.AutomationId="ClearLogButton"
-                                            Classes="small"
-                                            Width="60"
-                                            Height="20"
-                                            FontSize="10"
-                                            ToolTip.Tip="Clear log messages">
-                                        Clear
-                                    </Button>
+                                    <StackPanel Spacing="4">
+                                        <Button Click="CopyAllLog_Click"
+                                                AutomationProperties.AutomationId="CopyAllLogButton"
+                                                AutomationProperties.Name="Copy all log"
+                                                Classes="small"
+                                                Width="60"
+                                                Height="20"
+                                                FontSize="10"
+                                                ToolTip.Tip="Copy all log messages to clipboard">
+                                            Copy all
+                                        </Button>
+                                        <Button Command="{Binding ClearLogCommand}"
+                                                AutomationProperties.AutomationId="ClearLogButton"
+                                                Classes="small"
+                                                Width="60"
+                                                Height="20"
+                                                FontSize="10"
+                                                ToolTip.Tip="Clear log messages">
+                                            Clear
+                                        </Button>
+                                    </StackPanel>
                                 </Border>
                                 </Grid>
                             </Border>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia;
@@ -580,6 +581,20 @@ public partial class MainView : UserControl
                 data.Add(DataTransferItem.CreateText(entry.Message));
                 await clipboard.SetDataAsync(data);
             }
+        });
+
+    private void CopyAllLog_Click(object? sender, RoutedEventArgs e)
+        => SafeAsyncHelper.Execute(async () =>
+        {
+            if (_subscribedViewModel == null) return;
+            if (TopLevel.GetTopLevel(this) is not { } topLevel) return;
+            if (topLevel.Clipboard is not { } clipboard) return;
+
+            var text = string.Join(Environment.NewLine,
+            _subscribedViewModel.LogMessages.Select(m => m.Message));
+            using var data = new DataTransfer();
+            data.Add(DataTransferItem.CreateText(text));
+            await clipboard.SetDataAsync(data);
         });
 
     private void LogMessages_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml.cs
@@ -15,6 +15,7 @@ using Highbyte.DotNet6502.Systems;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using ReactiveUI;
 using AvaloniaAnimation = Avalonia.Animation;
 
 namespace Highbyte.DotNet6502.App.Avalonia.Core.Views;
@@ -38,6 +39,20 @@ public partial class MainView : UserControl
     // KeyBindings added to the MainWindow on behalf of the current system menu contributor.
     // Tracked so we can remove them when the active contributor swaps or the view detaches.
     private readonly System.Collections.Generic.List<KeyBinding> _contributorKeyBindings = new();
+
+    // Permanent tab-navigation KeyBindings (Windows/Linux). Added once on attach; never swapped.
+    private readonly System.Collections.Generic.List<KeyBinding> _generalKeyBindings = new();
+
+    // Tab navigation shortcut definitions — order determines NativeMenu display order.
+    private static readonly (Key Key, string TabItemName, string Label)[] TabNavigationShortcuts =
+    {
+        (Key.I, "InformationTabItem",  "Information"),
+        (Key.C, "ConfigStatusTabItem", "Config status"),
+        (Key.L, "LogTabItem",          "Log"),
+        (Key.S, "ScriptsTabItem",      "Scripts"),
+        (Key.G, "GeneralInfoTabItem",  "General info"),
+        (Key.D, "DebugTabItem",        "Debug"),
+    };
 
     // Parameterless constructor - child views created by XAML!
     public MainView()
@@ -365,6 +380,14 @@ public partial class MainView : UserControl
         // Tear down any menu + keybindings we contributed while attached.
         ApplyMenuContributor(null);
 
+        // Remove permanent tab-navigation key bindings.
+        if (TopLevel.GetTopLevel(this) is Window window)
+        {
+            foreach (var kb in _generalKeyBindings)
+                window.KeyBindings.Remove(kb);
+        }
+        _generalKeyBindings.Clear();
+
         if (_subscribedViewModel != null)
         {
             _subscribedViewModel.PropertyChanged -= OnViewModelPropertyChanged;
@@ -432,6 +455,23 @@ public partial class MainView : UserControl
 
             appMenu.Items.Clear();
 
+            // Always add View menu for tab navigation (order-independent, works regardless of system).
+            var viewRoot = new NativeMenuItem { Header = "View" };
+            var viewMenu = new NativeMenu();
+            const KeyModifiers macViewMod = KeyModifiers.Meta | KeyModifiers.Alt;
+            foreach (var (key, tabItemName, label) in TabNavigationShortcuts)
+            {
+                var name = tabItemName;
+                viewMenu.Items.Add(new NativeMenuItem
+                {
+                    Header = label,
+                    Gesture = new KeyGesture(key, macViewMod),
+                    Command = ReactiveCommand.Create(() => SelectTab(name))
+                });
+            }
+            viewRoot.Menu = viewMenu;
+            appMenu.Items.Add(viewRoot);
+
             if (contributor != null)
             {
                 var systemRoot = new NativeMenuItem { Header = contributor.MenuLabel };
@@ -475,6 +515,47 @@ public partial class MainView : UserControl
         // keybindings — the earlier call during DataContextChanged could not find the window.
         if (_subscribedViewModel != null)
             ApplyMenuContributor(_subscribedViewModel.ActiveMenuContributor);
+
+        // Register always-on tab navigation shortcuts (Windows/Linux only; macOS uses NativeMenu).
+        ApplyGeneralKeyBindings();
+    }
+
+    // Selects a bottom tab by its Name attribute, regardless of tab order.
+    private void SelectTab(string tabItemName)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (this.FindControl<TabControl>("InformationTabControl") is not { } tabControl) return;
+            if (this.FindControl<TabItem>(tabItemName) is not { } tabItem) return;
+            tabControl.SelectedItem = tabItem;
+        });
+    }
+
+    // Registers permanent Ctrl+Alt+<key> KeyBindings on the Window for tab navigation.
+    // Windows/Linux only — on macOS the same shortcuts live in the "View" NativeMenu section.
+    private void ApplyGeneralKeyBindings()
+    {
+        if (PlatformDetection.IsRunningInWebAssembly()) return;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return;
+
+        if (TopLevel.GetTopLevel(this) is not Window window) return;
+
+        foreach (var kb in _generalKeyBindings)
+            window.KeyBindings.Remove(kb);
+        _generalKeyBindings.Clear();
+
+        const KeyModifiers mod = KeyModifiers.Control | KeyModifiers.Alt;
+        foreach (var (key, tabItemName, _) in TabNavigationShortcuts)
+        {
+            var name = tabItemName;
+            var kb = new KeyBinding
+            {
+                Gesture = new KeyGesture(key, mod),
+                Command = ReactiveCommand.Create(() => SelectTab(name))
+            };
+            window.KeyBindings.Add(kb);
+            _generalKeyBindings.Add(kb);
+        }
     }
 
     private void LogScrollViewer_ScrollChanged(object? sender, ScrollChangedEventArgs e)
@@ -486,6 +567,20 @@ public partial class MainView : UserControl
         bool isAtBottom = _logScrollViewer.Offset.Y >= _logScrollViewer.Extent.Height - _logScrollViewer.Viewport.Height - tolerance;
         _logAutoScrollEnabled = isAtBottom;
     }
+
+    private void LogEntryContextMenu_CopyMessage_Click(object? sender, RoutedEventArgs e)
+        => SafeAsyncHelper.Execute(async () =>
+        {
+            var dataContext = (sender as MenuItem)?.DataContext ?? ((sender as MenuItem)?.Parent as ContextMenu)?.DataContext;
+            if (dataContext is LogDisplayEntry entry
+                && TopLevel.GetTopLevel(this) is { } topLevel
+                && topLevel.Clipboard is { } clipboard)
+            {
+                using var data = new DataTransfer();
+                data.Add(DataTransferItem.CreateText(entry.Message));
+                await clipboard.SetDataAsync(data);
+            }
+        });
 
     private void LogMessages_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
     {


### PR DESCRIPTION
## Changes

### Log tab improvements
- Log message text is now selectable (`SelectableTextBlock`) with right-click **Copy message** context menu
- Added **Copy all** button to copy all log messages to clipboard
- Trailing whitespace/newlines trimmed from log messages at source (`LogDisplayEntry.TrimEnd()`) so copied text is clean
- Fixed log list bottom padding so the last entry isn't clipped by the scroll bar

### Tab navigation shortcuts (new)
- Added always-on keyboard shortcuts to jump directly to any bottom tab by name, independent of tab order
  - macOS: `⌘⌥I/C/L/S/G/D` (via macOS native menu bar under **View**)
  - Windows/Linux: `Ctrl+Alt+I/C/L/S/G/D` (window-level `KeyBinding`s)

### C64 shortcut conflict fix
- Moved **Toggle Load/Save** and **Toggle Configuration** C64 shortcuts from `⌘⌥L` / `⌘⌥C` to `⌘⌥⇧L` / `⌘⌥⇧C` (and equivalents on Windows/Linux) to avoid collision with the new tab-navigation shortcuts

### Automation docs updated (`APPS_AVALONIA_AUTOMATION.md`)
- Documents the new two-layer shortcut scheme (general + system-specific)
- Replaces fragile coordinate-based tab navigation guidance with the keyboard shortcut approach
- Clarifies that text-query tab clicks are unreliable (can match other apps' elements)