### PR TITLE
Add unified status bar with emulator state, system, FPS, and connection indicators

### DIFF
--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
@@ -86,7 +86,38 @@ public class MainViewModel : ViewModelBase, IDisposable
 
     // Computed properties for control enabled states based on EmulatorState
     public bool IsEmulatorRunning => EmulatorState == EmulatorState.Running;
+    public bool IsEmulatorPaused => EmulatorState == EmulatorState.Paused;
     public bool IsEmulatorUninitialized => EmulatorState == EmulatorState.Uninitialized;
+
+    public string StatusEmulatorStateText => EmulatorState switch
+    {
+        EmulatorState.Running => "Running",
+        EmulatorState.Paused => "Paused",
+        _ => "Idle",
+    };
+
+    public string StatusSystemText
+    {
+        get
+        {
+            var name = SelectedSystemName;
+            var variant = SelectedSystemVariant;
+            if (string.IsNullOrEmpty(name) || name == "DEFAULT SYSTEM")
+                return string.Empty;
+            if (string.IsNullOrEmpty(variant) || variant == "DEFAULT VARIANT")
+                return name;
+            return $"{name} ({variant})";
+        }
+    }
+
+    private string _statusFpsText = string.Empty;
+    public string StatusFpsText
+    {
+        get => _statusFpsText;
+        private set => this.RaiseAndSetIfChanged(ref _statusFpsText, value);
+    }
+
+    private global::Avalonia.Threading.DispatcherTimer? _statusFpsTimer;
 
     // Debug tab visibility from config
     public bool IsDebugTabVisible => _emulatorConfig.ShowDebugTools || PlatformDetection.IsRunningOnDesktop();
@@ -572,9 +603,21 @@ public class MainViewModel : ViewModelBase, IDisposable
               {
                   // Notify all computed properties that depend on EmulatorState
                   this.RaisePropertyChanged(nameof(IsEmulatorRunning));
+                  this.RaisePropertyChanged(nameof(IsEmulatorPaused));
                   this.RaisePropertyChanged(nameof(IsEmulatorUninitialized));
                   this.RaisePropertyChanged(nameof(AudioSettingsEnabled));
+                  this.RaisePropertyChanged(nameof(StatusEmulatorStateText));
               });
+
+        this.WhenAnyValue(x => x.SelectedSystemName, x => x.SelectedSystemVariant)
+            .Subscribe(_ => this.RaisePropertyChanged(nameof(StatusSystemText)));
+
+        _statusFpsTimer = new global::Avalonia.Threading.DispatcherTimer
+        {
+            Interval = TimeSpan.FromSeconds(1),
+        };
+        _statusFpsTimer.Tick += (_, _) => UpdateStatusFps();
+        _statusFpsTimer.Start();
 
         _scale = _hostApp
             .WhenAnyValue(x => x.Scale)
@@ -1302,6 +1345,29 @@ public class MainViewModel : ViewModelBase, IDisposable
         this.RaisePropertyChanged(toolTipPropertyName);
     }
 
+    private void UpdateStatusFps()
+    {
+        if (EmulatorState != EmulatorState.Running)
+        {
+            StatusFpsText = string.Empty;
+            return;
+        }
+
+        try
+        {
+            var fpsStat = _hostApp.GetStats()
+                .FirstOrDefault(s => s.name.EndsWith("OnUpdateFPS", StringComparison.OrdinalIgnoreCase));
+            if (fpsStat.stat is Highbyte.DotNet6502.Systems.Instrumentation.Stats.AveragedStat averaged && averaged.Value.HasValue)
+                StatusFpsText = $"{Math.Round(averaged.Value.Value)} fps";
+            else
+                StatusFpsText = string.Empty;
+        }
+        catch
+        {
+            StatusFpsText = string.Empty;
+        }
+    }
+
     private async Task UpdateRemoteClientIndicatorAsync(bool isConnected)
     {
         _remoteClientIndicatorCts?.Cancel();
@@ -1367,6 +1433,12 @@ public class MainViewModel : ViewModelBase, IDisposable
         _remoteClientIndicatorCts?.Cancel();
         _remoteClientIndicatorCts?.Dispose();
         _remoteClientIndicatorCts = null;
+
+        if (_statusFpsTimer != null)
+        {
+            _statusFpsTimer.Stop();
+            _statusFpsTimer = null;
+        }
 
         // Unsubscribe from monitor events
         if (_currentMonitor != null)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
@@ -371,24 +371,18 @@ public class MainViewModel : ViewModelBase, IDisposable
         private set => this.RaiseAndSetIfChanged(ref _isRemoteClientConnected, value);
     }
 
-    private bool _isRemoteClientBannerVisible;
-    public bool IsRemoteClientBannerVisible
+    private double _remoteClientIndicatorOpacity;
+    public double RemoteClientIndicatorOpacity
     {
-        get => _isRemoteClientBannerVisible;
-        private set => this.RaiseAndSetIfChanged(ref _isRemoteClientBannerVisible, value);
+        get => _remoteClientIndicatorOpacity;
+        private set => this.RaiseAndSetIfChanged(ref _remoteClientIndicatorOpacity, value);
     }
 
-    private double _remoteClientBannerOpacity;
-    public double RemoteClientBannerOpacity
-    {
-        get => _remoteClientBannerOpacity;
-        private set => this.RaiseAndSetIfChanged(ref _remoteClientBannerOpacity, value);
-    }
+    private static readonly TimeSpan RemoteClientIndicatorMinimumVisibleDuration = TimeSpan.FromSeconds(1);
+    private System.Threading.CancellationTokenSource? _remoteClientIndicatorCts;
+    private DateTimeOffset? _remoteClientIndicatorShownAtUtc;
 
-    private static readonly TimeSpan RemoteClientBannerFadeDuration = TimeSpan.FromMilliseconds(250);
-    private static readonly TimeSpan RemoteClientBannerMinimumVisibleDuration = TimeSpan.FromSeconds(1);
-    private System.Threading.CancellationTokenSource? _remoteClientBannerAnimationCts;
-    private DateTimeOffset? _remoteClientBannerShownAtUtc;
+    public double ExternalDebuggerIndicatorOpacity => IsExternalDebuggerAttached ? 1.0 : 0.0;
 
     private int _remoteControlPort = IRemoteControlController.DefaultPort;
     private string _remoteControlPortText = IRemoteControlController.DefaultPort.ToString(CultureInfo.InvariantCulture);
@@ -561,6 +555,17 @@ public class MainViewModel : ViewModelBase, IDisposable
             .WhenAnyValue(x => x.IsExternalDebuggerAttached)
             .ToProperty(this, x => x.IsExternalDebuggerAttached);
 
+        this.WhenAnyValue(x => x.IsExternalDebuggerAttached)
+            .Subscribe(_ => this.RaisePropertyChanged(nameof(ExternalDebuggerIndicatorOpacity)));
+
+        _remoteClientIndicatorOpacity = _isRemoteClientConnected ? 1.0 : 0.0;
+        if (_isRemoteClientConnected)
+            _remoteClientIndicatorShownAtUtc = DateTimeOffset.UtcNow;
+
+        this.WhenAnyValue(x => x.IsRemoteClientConnected)
+            .Skip(1)
+            .Subscribe(connected => _ = UpdateRemoteClientIndicatorAsync(connected));
+
         // Subscribe to EmulatorState changes AFTER ToProperty to ensure the value is updated first
         this.WhenAnyValue(x => x.EmulatorState)
              .Subscribe(_ =>
@@ -672,10 +677,6 @@ public class MainViewModel : ViewModelBase, IDisposable
             }
             _remoteControlPortText = _remoteControlPort.ToString(CultureInfo.InvariantCulture);
             _remoteControlBindAddressText = _remoteControlBindAddress;
-            _isRemoteClientBannerVisible = _isRemoteClientConnected;
-            _remoteClientBannerOpacity = _isRemoteClientConnected ? 1.0 : 0.0;
-            if (_isRemoteClientConnected)
-                _remoteClientBannerShownAtUtc = DateTimeOffset.UtcNow;
             _remoteControlController.StateChanged += OnRemoteControllerStateChanged;
         }
 
@@ -1175,8 +1176,6 @@ public class MainViewModel : ViewModelBase, IDisposable
             }
             this.RaisePropertyChanged(nameof(RemoteControlStatusText));
             this.RaisePropertyChanged(nameof(RemoteControlToggleButtonText));
-
-            _ = UpdateRemoteClientBannerAsync(isRemoteClientConnected);
         });
     }
 
@@ -1303,62 +1302,34 @@ public class MainViewModel : ViewModelBase, IDisposable
         this.RaisePropertyChanged(toolTipPropertyName);
     }
 
-    private async Task UpdateRemoteClientBannerAsync(bool isConnected)
+    private async Task UpdateRemoteClientIndicatorAsync(bool isConnected)
     {
-        _remoteClientBannerAnimationCts?.Cancel();
-        _remoteClientBannerAnimationCts?.Dispose();
+        _remoteClientIndicatorCts?.Cancel();
+        _remoteClientIndicatorCts?.Dispose();
 
-        var animationCts = new System.Threading.CancellationTokenSource();
-        _remoteClientBannerAnimationCts = animationCts;
-        var cancellationToken = animationCts.Token;
+        var cts = new System.Threading.CancellationTokenSource();
+        _remoteClientIndicatorCts = cts;
+        var cancellationToken = cts.Token;
 
         try
         {
             if (isConnected)
             {
-                _remoteClientBannerShownAtUtc = DateTimeOffset.UtcNow;
-
-                if (IsRemoteClientBannerVisible)
-                {
-                    RemoteClientBannerOpacity = 1.0;
-                    return;
-                }
-
-                IsRemoteClientBannerVisible = true;
-                RemoteClientBannerOpacity = 0.0;
-
-                await Task.Delay(TimeSpan.FromMilliseconds(16), cancellationToken);
-                cancellationToken.ThrowIfCancellationRequested();
-
-                RemoteClientBannerOpacity = 1.0;
+                _remoteClientIndicatorShownAtUtc = DateTimeOffset.UtcNow;
+                RemoteClientIndicatorOpacity = 1.0;
                 return;
             }
 
-            if (!IsRemoteClientBannerVisible)
-                return;
-
-            if (RemoteClientBannerOpacity < 1.0)
+            if (_remoteClientIndicatorShownAtUtc.HasValue)
             {
-                RemoteClientBannerOpacity = 1.0;
-                await Task.Delay(RemoteClientBannerFadeDuration, cancellationToken);
+                var elapsed = DateTimeOffset.UtcNow - _remoteClientIndicatorShownAtUtc.Value;
+                var remaining = RemoteClientIndicatorMinimumVisibleDuration - elapsed;
+                if (remaining > TimeSpan.Zero)
+                    await Task.Delay(remaining, cancellationToken);
             }
 
-            if (_remoteClientBannerShownAtUtc.HasValue)
-            {
-                var elapsedVisibleTime = DateTimeOffset.UtcNow - _remoteClientBannerShownAtUtc.Value;
-                var remainingVisibleTime = RemoteClientBannerMinimumVisibleDuration - elapsedVisibleTime;
-                if (remainingVisibleTime > TimeSpan.Zero)
-                    await Task.Delay(remainingVisibleTime, cancellationToken);
-            }
-
-            RemoteClientBannerOpacity = 0.0;
-            await Task.Delay(RemoteClientBannerFadeDuration, cancellationToken);
-
-            if (!IsRemoteClientConnected)
-            {
-                IsRemoteClientBannerVisible = false;
-                _remoteClientBannerShownAtUtc = null;
-            }
+            RemoteClientIndicatorOpacity = 0.0;
+            _remoteClientIndicatorShownAtUtc = null;
         }
         catch (OperationCanceledException)
         {
@@ -1393,9 +1364,9 @@ public class MainViewModel : ViewModelBase, IDisposable
         if (_remoteControlController != null)
             _remoteControlController.StateChanged -= OnRemoteControllerStateChanged;
 
-        _remoteClientBannerAnimationCts?.Cancel();
-        _remoteClientBannerAnimationCts?.Dispose();
-        _remoteClientBannerAnimationCts = null;
+        _remoteClientIndicatorCts?.Cancel();
+        _remoteClientIndicatorCts?.Dispose();
+        _remoteClientIndicatorCts = null;
 
         // Unsubscribe from monitor events
         if (_currentMonitor != null)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
@@ -33,7 +33,6 @@
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="200" />
@@ -912,7 +911,7 @@
                                                         BorderBrush="#500080FF"
                                                         BorderThickness="1"
                                                         VerticalAlignment="Center"
-                                                        Opacity="{Binding RemoteClientBannerOpacity}"
+                                                        Opacity="{Binding RemoteClientIndicatorOpacity}"
                                                         IsHitTestVisible="False">
                                                     <Border.Transitions>
                                                         <Transitions>
@@ -1069,60 +1068,7 @@
             </ScrollViewer>
         </Border>
 
-        <!-- External Debugger Banner (Bottom) -->
-        <Border Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3"
-                IsVisible="{Binding IsExternalDebuggerAttached}"
-                Background="#40FF8C00"
-                BorderBrush="#FFFF8C00"
-                BorderThickness="0,1,0,0"
-                Height="24">
-            <Border.Styles>
-                <Style Selector="Border">
-                    <Style.Animations>
-                        <Animation Duration="0:0:1.5" IterationCount="Infinite" PlaybackDirection="Alternate">
-                            <KeyFrame Cue="0%">
-                                <Setter Property="Opacity" Value="0.6"/>
-                            </KeyFrame>
-                            <KeyFrame Cue="100%">
-                                <Setter Property="Opacity" Value="1.0"/>
-                            </KeyFrame>
-                        </Animation>
-                    </Style.Animations>
-                </Style>
-            </Border.Styles>
-            <TextBlock Text="⚠ External Debugger Attached"
-                       HorizontalAlignment="Center"
-                       VerticalAlignment="Center"
-                       Foreground="#FFFF8C00"
-                       FontWeight="Bold"
-                       FontSize="11"/>
-        </Border>
-        <!-- Remote Client Connected Banner (Bottom) -->
-        <Border Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="3"
-                IsVisible="{Binding IsRemoteClientBannerVisible}"
-                Opacity="{Binding RemoteClientBannerOpacity}"
-                Background="#400080FF"
-                BorderBrush="#FF0080FF"
-                BorderThickness="0,1,0,0"
-                Height="24">
-            <Border.Transitions>
-                <Transitions>
-                    <DoubleTransition Property="Opacity" Duration="0:0:0.25"/>
-                </Transitions>
-            </Border.Transitions>
-            <TextBlock AutomationProperties.AutomationId="RemoteClientConnectedBanner"
-                       AutomationProperties.Name="Remote client connected indicator"
-                       FontSize="11"
-                       FontWeight="Bold"
-                       HorizontalAlignment="Center"
-                       VerticalAlignment="Center"
-                       Foreground="#FF0080FF">
-                <TextBlock.Text>
-                    <MultiBinding StringFormat="&#x2022; Remote Control Connected (port {0})">
-                        <Binding Path="RemoteControlPort"/>
-                    </MultiBinding>
-                </TextBlock.Text>
-            </TextBlock>
-        </Border>
+        <!-- Status Bar (Bottom; always present) -->
+        <views:StatusBar Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3"/>
     </Grid>
 </UserControl>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
@@ -243,6 +243,7 @@
 
         <!-- Main Emulator Display Area (Center) -->
         <Border Grid.Row="0" Grid.Column="1" Grid.RowSpan="3"
+            Name="CenterPanel"
             Background="{DynamicResource ViewDefaultBg}"
             Classes="panel-container">
             
@@ -1069,6 +1070,8 @@
         </Border>
 
         <!-- Status Bar (Bottom; always present) -->
-        <views:StatusBar Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3"/>
+        <views:StatusBar Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3"
+                         HorizontalAlignment="Left"
+                         Width="{Binding ElementName=CenterPanel, Path=Bounds.Right}"/>
     </Grid>
 </UserControl>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/StatusBar.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/StatusBar.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:vm="using:Highbyte.DotNet6502.App.Avalonia.Core.ViewModels"
+    xmlns:converters="using:Avalonia.Data.Converters"
     x:Class="Highbyte.DotNet6502.App.Avalonia.Core.Views.StatusBar"
     x:DataType="vm:MainViewModel">
     <Border Padding="0,2,0,4"
@@ -14,12 +15,58 @@
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
-            <!-- Left zone: emulator state, CPU info (placeholder) -->
+            <!-- Left zone: emulator state, system, FPS -->
             <StackPanel Grid.Column="0"
                         Orientation="Horizontal"
                         Margin="8,0"
-                        Spacing="12"
-                        VerticalAlignment="Center"/>
+                        Spacing="10"
+                        VerticalAlignment="Center">
+
+                <StackPanel Orientation="Horizontal"
+                            Spacing="5"
+                            VerticalAlignment="Center"
+                            AutomationProperties.AutomationId="StatusBarEmulatorState">
+                    <Panel Width="7" Height="7" Margin="0,1,0,0" VerticalAlignment="Center">
+                        <Ellipse Width="7" Height="7" Fill="#FF4CAF50" IsVisible="{Binding IsEmulatorRunning}"/>
+                        <Ellipse Width="7" Height="7" Fill="#FFFFA000" IsVisible="{Binding IsEmulatorPaused}"/>
+                        <Ellipse Width="7" Height="7" Fill="#FF9E9E9E" IsVisible="{Binding IsEmulatorUninitialized}"/>
+                    </Panel>
+                    <TextBlock Text="{Binding StatusEmulatorStateText}"
+                               Width="55"
+                               FontSize="11"
+                               FontWeight="Bold"
+                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                               VerticalAlignment="Center"/>
+                </StackPanel>
+
+                <Border Width="1"
+                        Height="12"
+                        Background="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                        VerticalAlignment="Center"
+                        IsVisible="{Binding StatusSystemText, Converter={x:Static converters:StringConverters.IsNotNullOrEmpty}}"/>
+
+                <TextBlock Text="{Binding StatusSystemText}"
+                           AutomationProperties.AutomationId="StatusBarSystem"
+                           Width="100"
+                           FontSize="11"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
+                           VerticalAlignment="Center"
+                           IsVisible="{Binding StatusSystemText, Converter={x:Static converters:StringConverters.IsNotNullOrEmpty}}"/>
+
+                <Border Width="1"
+                        Height="12"
+                        Background="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                        VerticalAlignment="Center"
+                        IsVisible="{Binding StatusFpsText, Converter={x:Static converters:StringConverters.IsNotNullOrEmpty}}"/>
+
+                <TextBlock Text="{Binding StatusFpsText}"
+                           AutomationProperties.AutomationId="StatusBarFps"
+                           Width="55"
+                           FontSize="11"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
+                           VerticalAlignment="Center"
+                           IsVisible="{Binding StatusFpsText, Converter={x:Static converters:StringConverters.IsNotNullOrEmpty}}"/>
+            </StackPanel>
 
             <!-- Center zone: transient messages (placeholder) -->
             <StackPanel Grid.Column="1"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/StatusBar.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/StatusBar.axaml
@@ -6,8 +6,9 @@
     x:DataType="vm:MainViewModel">
     <Border Padding="0,2,0,4"
             Background="{DynamicResource ViewDefaultBg}"
-            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
-            BorderThickness="0,1,0,0">
+            BorderBrush="#4A5568"
+            BorderThickness="1"
+            CornerRadius="4">
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/StatusBar.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/StatusBar.axaml
@@ -1,0 +1,78 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:vm="using:Highbyte.DotNet6502.App.Avalonia.Core.ViewModels"
+    x:Class="Highbyte.DotNet6502.App.Avalonia.Core.Views.StatusBar"
+    x:DataType="vm:MainViewModel">
+    <Border Padding="0,2,0,4"
+            Background="{DynamicResource ViewDefaultBg}"
+            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
+            BorderThickness="0,1,0,0">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- Left zone: emulator state, CPU info (placeholder) -->
+            <StackPanel Grid.Column="0"
+                        Orientation="Horizontal"
+                        Margin="8,0"
+                        Spacing="12"
+                        VerticalAlignment="Center"/>
+
+            <!-- Center zone: transient messages (placeholder) -->
+            <StackPanel Grid.Column="1"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Spacing="8"/>
+
+            <!-- Right zone: connection indicators -->
+            <StackPanel Grid.Column="2"
+                        Orientation="Horizontal"
+                        Margin="8,0"
+                        Spacing="12"
+                        VerticalAlignment="Center">
+
+                <StackPanel AutomationProperties.AutomationId="StatusBarDebuggerIndicator"
+                            AutomationProperties.Name="External debugger attached indicator"
+                            Orientation="Horizontal"
+                            Spacing="5"
+                            VerticalAlignment="Center"
+                            Opacity="{Binding ExternalDebuggerIndicatorOpacity}">
+                    <StackPanel.Transitions>
+                        <Transitions>
+                            <DoubleTransition Property="Opacity" Duration="0:0:0.25"/>
+                        </Transitions>
+                    </StackPanel.Transitions>
+                    <Ellipse Width="7" Height="7" Fill="#FFFF8C00" VerticalAlignment="Center" Margin="0,1,0,0"/>
+                    <TextBlock Text="Debugger"
+                               Foreground="#FFFF8C00"
+                               FontSize="11"
+                               FontWeight="Bold"
+                               VerticalAlignment="Center"/>
+                </StackPanel>
+
+                <StackPanel AutomationProperties.AutomationId="StatusBarRemoteClientIndicator"
+                            AutomationProperties.Name="Remote client connected indicator"
+                            Orientation="Horizontal"
+                            Spacing="5"
+                            VerticalAlignment="Center"
+                            Opacity="{Binding RemoteClientIndicatorOpacity}">
+                    <StackPanel.Transitions>
+                        <Transitions>
+                            <DoubleTransition Property="Opacity" Duration="0:0:0.25"/>
+                        </Transitions>
+                    </StackPanel.Transitions>
+                    <Ellipse Width="7" Height="7" Fill="#FF0080FF" VerticalAlignment="Center" Margin="0,1,0,0"/>
+                    <TextBlock Text="Remote"
+                               Foreground="#FF0080FF"
+                               FontSize="11"
+                               FontWeight="Bold"
+                               VerticalAlignment="Center"/>
+                </StackPanel>
+            </StackPanel>
+        </Grid>
+    </Border>
+</UserControl>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/StatusBar.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/StatusBar.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Core.Views;
+
+public partial class StatusBar : UserControl
+{
+    public StatusBar()
+    {
+        InitializeComponent();
+    }
+}

--- a/tools/vscode-extension/CHANGELOG.md
+++ b/tools/vscode-extension/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the **6502 Debugger for dotnet-6502** VSCode extension wi
 
 ## [Unreleased]
 
-## [0.2.1] - 2026-04-29
+## [0.2.1] - 2026-04-30
 Fixes remote debugging so it works with source.
 
 ## [0.2.0] - 2026-04-24


### PR DESCRIPTION
## Summary
- Replaces the two stacked banner rows (orange external-debugger + blue remote-client) with a single permanent 24-px status bar at the bottom of the Avalonia Desktop main window.
- Eliminates the visual flicker / window resize that occurred each time the remote-client banner faded in or out, or when the user toggled the remote-control server on/off.
- Introduces a three-zone status bar layout (left / center / right) and populates the left zone with **emulator state**, **selected system**, and **FPS**; the right zone keeps the existing **Debugger** / **Remote** connection indicators (now compact pill-style "● Label" with a smooth opacity fade and a 1-second minimum-visible time on the remote indicator).
- Center zone is intentionally left empty — reserved for future transient messages (load notifications, snapshot saved, etc.).

## Why a status bar
The previous design used two separate full-width tinted banners that were toggled in/out of the layout by `IsVisible`. Each toggle caused the grid row to grow/shrink by 24 px, which the OS rendered as a brief window resize. A single always-present status bar eliminates the layout shift entirely; only the *contents* of the bar fade in and out via opacity transitions.

## What's in the bar today

**Left zone:**
- `● Running` / `❚ Paused` / `● Idle` indicator (green / amber / gray dot + bold label)
- Selected system name + variant (e.g. `C64 (PAL)`); hidden when no system is selected
- FPS read from the existing `OnUpdateFPS` `PerSecondTimedStat`, refreshed once per second; hidden when the emulator isn't running

Each chunk has a fixed width and is separated by thin vertical dividers, so changing state text doesn't shift neighbouring chunks.

**Right zone:**
- Orange `● Debugger` indicator — opacity fades on `IsExternalDebuggerAttached`
- Blue `● Remote` indicator — opacity fades on `IsRemoteClientConnected`, with a 1-second minimum-visible window so very brief client connections don't flicker

## Implementation notes
- The bar's content is centered with `Padding="0,2,0,4"` on the outer Border (compensates for the 1-px top divider) plus a `Margin="0,1,0,0"` on each `Ellipse` (compensates for the natural baseline bias of TextBlock so dots and text visually line up). These offsets were tuned with pixel-level screenshots — the docstring in `StatusBar.axaml` is worth re-reading if the bar's font size or weight changes later.
