### PR TITLE
feat: add VIC-20 system plugin proof of concept

### DIFF
--- a/docs/systems/adding-a-system.md
+++ b/docs/systems/adding-a-system.md
@@ -16,7 +16,7 @@ configurer, the `--system` CLI argument).
 ## What you will create
 
 A new system touches three tiers — a **system core**, an **engine plugin**, and a **shell
-plugin** — per the model described in [Architecture](../architecture.md). System cores and
+plugin** — per the model described in [architecture.md](./../architecture.md). System cores and
 engine plugins live under `src/libraries/`; shell projects live under `src/apps/`. Add every
 new project to the solution (`dotnet-6502.sln`).
 
@@ -27,7 +27,7 @@ and `Highbyte.DotNet6502.Systems`.
 
 ### `ISystem`
 
-Implement [`ISystem`](../libraries/core/dotnet6502-systems.md). For a minimum no-op system, wire a
+Implement [dotnet6502-systems.md](./../libraries/core/dotnet6502-systems.md). For a minimum no-op system, wire a
 real `CPU` + `Memory` (so it executes 6502 code) but leave the rendering/input/audio members at
 their defaults:
 
@@ -67,16 +67,16 @@ render-provider selection). It is fine to start with everything valid and no opt
     sufficient. Omitting it results in a compile error that is not immediately obvious from
     the interface name alone.
 
-    ```csharp
+```csharp
     public bool AudioEnabled { get; set; } = false;
-    ```
+```
 
 ### `ISystemConfigurer`
 
 `ISystemConfigurer` is what the host calls to build the system. Implement its members directly:
 
 | Member | Minimum behaviour |
-|---|---|
+| --- | --- |
 | `SystemName` | Return your `SystemName` constant. |
 | `GetConfigurationVariants` | Return e.g. `["DEFAULT"]`. |
 | `GetNewHostSystemConfig` / `PersistHostSystemConfig` | Create / save the host config (see Step 2). |
@@ -109,11 +109,11 @@ public sealed class Vic20HostConfig : HostSystemConfigBase<Vic20SystemConfig>
     `ConfigSectionName` to `appsettings.json` — an empty `SystemConfig` object is fine. The
     host is silent if the section is missing, so omitting it is easy to miss.
 
-    ```json
+```json
     "Highbyte.DotNet6502.Vic20.Avalonia": {
       "SystemConfig": {}
     }
-    ```
+```
 
 Then the engine plugin itself — mark the assembly and implement `ISystemEnginePlugin`:
 
@@ -141,9 +141,9 @@ That is enough for the system to **appear in the app and run** (as a no-op).
     reference to the system class inside that plugin project — it sees `Vic20` as the nested
     namespace, not the type. Fix it with a using alias at the top of the affected file:
 
-    ```csharp
+```csharp
     using Vic20System = Highbyte.DotNet6502.Systems.Vic20.Vic20;
-    ```
+```
 
 ## Step 3 — The shell project (Avalonia)
 
@@ -198,7 +198,7 @@ Once the no-op system appears, add real behaviour incrementally — each layer i
         direction. Using placeholder values (e.g. 2 cols / 2 rows) produces a portrait window
         even for systems whose hardware display is landscape.
 3. **Input** — implement `IInputConsumer` on the system; map host keys via `HostKey` /
-   `IHostInputState`. See the [C64 keyboard mapping](c64/keyboard.md) for the pattern.
+   `IHostInputState`. See the [keyboard.md](./c64/keyboard.md) for the pattern.
 4. **Audio** — expose an `IAudioProvider`; the system-agnostic host audio targets
    (`Impl.NAudio`, `Impl.AspNet`) consume it with no per-system audio library.
 5. **Per-host UI** — flesh out the shell plugin: a menu ViewModel, an info panel, a config dialog.
@@ -211,10 +211,10 @@ Once the no-op system appears, add real behaviour incrementally — each layer i
 !!! warning "Browser hosts — Avalonia Browser and Blazor WASM"
     Both browser hosts need extra care, for two reasons:
 
-    1. **No filesystem scan.** A browser host cannot enumerate plugin DLLs on disk, so it relies on
+  1. **No filesystem scan.** A browser host cannot enumerate plugin DLLs on disk, so it relies on
        a build-emitted plugin manifest — see
-       [`Systems.Plugins`](../libraries/core/dotnet6502-systems-plugins.md).
-    2. **Trimming / AOT.** Browser publishes run the IL trimmer, which removes assemblies that are
+       [dotnet6502-systems-plugins.md](./../libraries/core/dotnet6502-systems-plugins.md).
+  2. **Trimming / AOT.** Browser publishes run the IL trimmer, which removes assemblies that are
        only referenced indirectly via `[SystemPlugin]` attributes. Each browser app's `.csproj`
        therefore keeps a `TrimmerRootAssembly` block that pins the per-system projects **by name**.
        Unlike the shell `ProjectReference` glob, this block **cannot be globbed** — you must extend
@@ -223,28 +223,28 @@ Once the no-op system appears, add real behaviour incrementally — each layer i
     Add your system's three projects to the `TrimmerRootAssembly` block in **both** browser
     csproj files:
 
-    - `src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/...csproj` —
+  - `src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/...csproj` —
       `App.Avalonia.Shell.<System>`, `Impl.Avalonia.<System>`, `Systems.<System>`.
-    - `src/apps/BlazorWASM/Highbyte.DotNet6502.App.WASM/...csproj` —
+  - `src/apps/BlazorWASM/Highbyte.DotNet6502.App.WASM/...csproj` —
       `App.WASM.Shell.<System>`, `Impl.AspNet.<System>`, `Systems.<System>`.
 
     For example, in the Avalonia Browser app's csproj:
 
-    ```xml
+```xml
     <ItemGroup>
       <!-- existing systems ... -->
       <TrimmerRootAssembly Include="Highbyte.DotNet6502.App.Avalonia.Shell.Vic20" />
       <TrimmerRootAssembly Include="Highbyte.DotNet6502.Impl.Avalonia.Vic20" />
       <TrimmerRootAssembly Include="Highbyte.DotNet6502.Systems.Vic20" />
     </ItemGroup>
-    ```
+```
 
     Omitting these entries makes the system work in a Debug run but silently disappear from a
     published (trimmed/AOT) browser build.
 
 ## See also
 
-- [`Highbyte.DotNet6502.Systems`](../libraries/core/dotnet6502-systems.md) — the abstractions you implement.
-- [`Highbyte.DotNet6502.Systems.Plugins`](../libraries/core/dotnet6502-systems-plugins.md) — plugin contracts + discovery.
-- [Implementation libraries overview](../libraries/implementation/overview.md) — `Impl.<Tech>` vs `Impl.<Tech>.<System>`.
-- [C64 libraries](c64/libraries.md) / [Generic libraries](generic/libraries.md) — worked examples to copy from.
+- [dotnet6502-systems.md](./../libraries/core/dotnet6502-systems.md) — the abstractions you implement.
+- [dotnet6502-systems-plugins.md](./../libraries/core/dotnet6502-systems-plugins.md) — plugin contracts + discovery.
+- [overview.md](./../libraries/implementation/overview.md) — `Impl.<Tech>` vs `Impl.<Tech>.<System>`.
+- [libraries.md](./c64/libraries.md) / [libraries.md](./generic/libraries.md) — worked examples to copy from.

--- a/docs/systems/adding-a-system.md
+++ b/docs/systems/adding-a-system.md
@@ -61,6 +61,16 @@ intended starting point. Add real rendering later (see *Filling it in*).
 A small config object — implement `ISystemConfig` (validation, `IsDirty`/`ClearDirty`,
 render-provider selection). It is fine to start with everything valid and no options.
 
+!!! note "Audio-less systems must still implement `AudioEnabled`"
+    `ISystemConfig` has a `bool AudioEnabled { get; set; }` member. Even if your system
+    produces no audio, you must declare it — a plain auto-property that returns `false` is
+    sufficient. Omitting it results in a compile error that is not immediately obvious from
+    the interface name alone.
+
+    ```csharp
+    public bool AudioEnabled { get; set; } = false;
+    ```
+
 ### `ISystemConfigurer`
 
 `ISystemConfigurer` is what the host calls to build the system. Implement its members directly:
@@ -94,6 +104,17 @@ public sealed class Vic20HostConfig : HostSystemConfigBase<Vic20SystemConfig>
 }
 ```
 
+!!! tip "Add a config section to `appsettings.json` even when there are no settings yet"
+    The Avalonia host binds the config section by name at startup. Add an entry matching
+    `ConfigSectionName` to `appsettings.json` — an empty `SystemConfig` object is fine. The
+    host is silent if the section is missing, so omitting it is easy to miss.
+
+    ```json
+    "Highbyte.DotNet6502.Vic20.Avalonia": {
+      "SystemConfig": {}
+    }
+    ```
+
 Then the engine plugin itself — mark the assembly and implement `ISystemEnginePlugin`:
 
 ```csharp
@@ -113,6 +134,16 @@ public sealed class Vic20AvaloniaEnginePlugin : ISystemEnginePlugin
 ```
 
 That is enough for the system to **appear in the app and run** (as a no-op).
+
+!!! warning "Namespace collision when the system name matches the project suffix"
+    If your system name (e.g. `Vic20`) is the same as the last segment of the engine plugin's
+    namespace (`Highbyte.DotNet6502.Impl.Avalonia.Vic20`), the compiler cannot resolve a bare
+    reference to the system class inside that plugin project — it sees `Vic20` as the nested
+    namespace, not the type. Fix it with a using alias at the top of the affected file:
+
+    ```csharp
+    using Vic20System = Highbyte.DotNet6502.Systems.Vic20.Vic20;
+    ```
 
 ## Step 3 — The shell project (Avalonia)
 
@@ -138,6 +169,12 @@ public sealed class Vic20AvaloniaShellPlugin : ISystemShellPlugin
 The system now shows up in the Avalonia Desktop app's system list, is selectable, and steps frames
 — with no per-system menu or config dialog yet.
 
+!!! note "Shell project needs `<ImplicitUsings>enable</ImplicitUsings>`"
+    The shell `.csproj` should include `<ImplicitUsings>enable</ImplicitUsings>` in its
+    `PropertyGroup`. Without it, types like `IServiceProvider` (which appears in the
+    `ISystemShellPlugin` method signatures) are not in scope, producing confusing compile
+    errors about missing types rather than missing usings.
+
 ## Step 4 — Build and verify
 
 Add the three projects to `dotnet-6502.sln`, build, and run the Avalonia Desktop app. Confirm the
@@ -152,6 +189,14 @@ Once the no-op system appears, add real behaviour incrementally — each layer i
 2. **Rendering** — have the system expose an `IRenderProvider`; add a render target. Reuse a host's
    generic render target where possible (the C64 and Generic systems both render through the
    generic Avalonia bitmap target).
+
+    !!! tip "Derive border constants from the system's known pixel budget"
+        The border dimensions in `IScreen` (`VisibleLeftRightBorderWidth`,
+        `VisibleTopBottomBorderHeight`) control the aspect ratio of the rendered window. Start
+        from the system's actual visible pixel area (e.g. NTSC VIC-20: 256×200 px) and subtract
+        the text area (`cols × charWidth` × `rows × charHeight`) to get the border in each
+        direction. Using placeholder values (e.g. 2 cols / 2 rows) produces a portrait window
+        even for systems whose hardware display is landscape.
 3. **Input** — implement `IInputConsumer` on the system; map host keys via `HostKey` /
    `IHostInputState`. See the [C64 keyboard mapping](c64/keyboard.md) for the pattern.
 4. **Audio** — expose an `IAudioProvider`; the system-agnostic host audio targets

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
@@ -42,6 +42,8 @@ public class MainViewModel : ViewModelBase, IDisposable
     private readonly IReadOnlyDictionary<string, ISystemShellPlugin> _shellPlugins;
     private readonly IServiceProvider _serviceProvider;
 
+    private const int DefaultSystemDisplayOrder = 1000;
+
     private ISystemShellPlugin? ActivePlugin
         => SelectedSystemName != null && _shellPlugins.TryGetValue(SelectedSystemName, out var p) ? p : null;
 
@@ -73,6 +75,15 @@ public class MainViewModel : ViewModelBase, IDisposable
             cache[plugin.SystemName] = contribution;
         }
         return contribution;
+    }
+
+    private IEnumerable<string> OrderSystemsForDisplay(IEnumerable<string> systems)
+    {
+        return systems
+            .OrderBy(system => _shellPlugins.TryGetValue(system, out var plugin)
+                ? plugin.DisplayOrder
+                : DefaultSystemDisplayOrder)
+            .ThenBy(system => system, StringComparer.OrdinalIgnoreCase);
     }
 
     public bool IsSystemPluginActive => ActivePlugin != null;
@@ -615,7 +626,7 @@ public class MainViewModel : ViewModelBase, IDisposable
 
         _availableSystems = _hostApp
             .WhenAnyValue(x => x.AvailableSystemNames)
-            .Select(systems => new ObservableCollection<string>(systems))
+            .Select(systems => new ObservableCollection<string>(OrderSystemsForDisplay(systems)))
             .ToProperty(this, x => x.AvailableSystems);
 
         _availableSystemVariants = _hostApp

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.json
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.json
@@ -85,6 +85,10 @@
     }
   },
 
+  "Highbyte.DotNet6502.Vic20.Avalonia": {
+    "SystemConfig": {}
+  },
+
   "Highbyte.DotNet6502.GenericComputer.Avalonia": {
 
     "SystemConfig": {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.json
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.json
@@ -34,7 +34,7 @@
   },
 
   "Highbyte.DotNet6502.AvaloniaConfig": {
-    "DefaultEmulator": "VIC-20",
+    "DefaultEmulator": "C64",
     "DefaultDrawScale": 2.0,
     // ShowErrorDialog: true = Log to console/logger and show error dialog for unhandled exceptions (default)
     //                  false = Log to console/logger and trigger debugger (or exit if no debugger attached)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.json
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.json
@@ -34,7 +34,7 @@
   },
 
   "Highbyte.DotNet6502.AvaloniaConfig": {
-    "DefaultEmulator": "C64",
+    "DefaultEmulator": "VIC-20",
     "DefaultDrawScale": 2.0,
     // ShowErrorDialog: true = Log to console/logger and show error dialog for unhandled exceptions (default)
     //                  false = Log to console/logger and trigger debugger (or exit if no debugger attached)
@@ -86,7 +86,14 @@
   },
 
   "Highbyte.DotNet6502.Vic20.Avalonia": {
-    "SystemConfig": {}
+    "SystemConfig": {
+      "ROMDirectory": "%USERPROFILE%/Downloads/VIC20",
+      "ROMs": [
+        { "Name": "basic",   "File": "basic.901486-01.bin" },
+        { "Name": "kernal",  "File": "kernal.901486-07.bin" },
+        { "Name": "chargen", "File": "characters.901460-03.bin" }
+      ]
+    }
   },
 
   "Highbyte.DotNet6502.GenericComputer.Avalonia": {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.json
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.json
@@ -87,7 +87,7 @@
 
   "Highbyte.DotNet6502.Vic20.Avalonia": {
     "SystemConfig": {
-      "ROMDirectory": "%USERPROFILE%/Downloads/VIC20",
+      "ROMDirectory": "%HOME%/Downloads/VIC20",
       "ROMs": [
         { "Name": "basic",   "File": "basic.901486-01.bin" },
         { "Name": "kernal",  "File": "kernal.901486-07.bin" },

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/C64AvaloniaShellPlugin.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/C64AvaloniaShellPlugin.cs
@@ -23,6 +23,8 @@ public sealed class C64AvaloniaShellPlugin : ISystemShellPlugin, IAvaloniaNative
 {
     public string SystemName => C64.SystemName;
 
+    public int DisplayOrder => 10;
+
     public void RegisterShellServices(IServiceCollection services)
     {
         services.AddTransient<C64MenuViewModel>();

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/GenericComputerAvaloniaShellPlugin.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/GenericComputerAvaloniaShellPlugin.cs
@@ -21,6 +21,8 @@ public sealed class GenericComputerAvaloniaShellPlugin : ISystemShellPlugin
 {
     public string SystemName => GenericComputer.SystemName;
 
+    public int DisplayOrder => 100;
+
     public void RegisterShellServices(IServiceCollection services)
     {
         // No UI services — the Generic computer has no Avalonia-specific shell UI.

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/Highbyte.DotNet6502.App.Avalonia.Shell.Generic.csproj
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/Highbyte.DotNet6502.App.Avalonia.Shell.Generic.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.csproj
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="ReactiveUI" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,6 +31,9 @@
     </Compile>
     <Compile Update="Views\Vic20ConfigDialogView.axaml.cs">
       <DependentUpon>Vic20ConfigDialogView.axaml</DependentUpon>
+    </Compile>
+    <Compile Update="Views\Vic20ConfigDialog.axaml.cs">
+      <DependentUpon>Vic20ConfigDialog.axaml</DependentUpon>
     </Compile>
   </ItemGroup>
 </Project>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.csproj
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.csproj
@@ -4,9 +4,13 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Avalonia" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <PackageReference Include="ReactiveUI" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
@@ -15,5 +19,17 @@
     <ProjectReference Include="..\..\..\libraries\Highbyte.DotNet6502.Systems.Vic20\Highbyte.DotNet6502.Systems.Vic20.csproj" />
     <ProjectReference Include="..\..\..\libraries\Highbyte.DotNet6502.Systems.Plugins\Highbyte.DotNet6502.Systems.Plugins.csproj" />
     <ProjectReference Include="..\..\..\libraries\Highbyte.DotNet6502.Impl.Avalonia.Vic20\Highbyte.DotNet6502.Impl.Avalonia.Vic20.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Views\Vic20MenuView.axaml.cs">
+      <DependentUpon>Vic20MenuView.axaml</DependentUpon>
+    </Compile>
+    <Compile Update="Views\Vic20InfoView.axaml.cs">
+      <DependentUpon>Vic20InfoView.axaml</DependentUpon>
+    </Compile>
+    <Compile Update="Views\Vic20ConfigDialogView.axaml.cs">
+      <DependentUpon>Vic20ConfigDialogView.axaml</DependentUpon>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.csproj
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Highbyte.DotNet6502.App.Avalonia.Core\Highbyte.DotNet6502.App.Avalonia.Core.csproj" />
+    <ProjectReference Include="..\..\..\libraries\Highbyte.DotNet6502.Systems.Vic20\Highbyte.DotNet6502.Systems.Vic20.csproj" />
+    <ProjectReference Include="..\..\..\libraries\Highbyte.DotNet6502.Systems.Plugins\Highbyte.DotNet6502.Systems.Plugins.csproj" />
+    <ProjectReference Include="..\..\..\libraries\Highbyte.DotNet6502.Impl.Avalonia.Vic20\Highbyte.DotNet6502.Impl.Avalonia.Vic20.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Vic20AvaloniaShellPlugin.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Vic20AvaloniaShellPlugin.cs
@@ -1,0 +1,25 @@
+using Highbyte.DotNet6502.Systems.Plugins;
+using Highbyte.DotNet6502.Systems.Vic20;
+using Microsoft.Extensions.DependencyInjection;
+
+[assembly: SystemPlugin(typeof(Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.Vic20AvaloniaShellPlugin))]
+
+namespace Highbyte.DotNet6502.App.Avalonia.Shell.Vic20;
+
+/// <summary>
+/// Shell-side plugin for the VIC-20 on the Avalonia host.
+/// All contributions are null — the VIC-20 proof-of-contract exercise relies on the host's
+/// system-agnostic chrome only (no custom menu, info panel, or config dialog).
+/// </summary>
+public sealed class Vic20AvaloniaShellPlugin : ISystemShellPlugin
+{
+    public string SystemName => global::Highbyte.DotNet6502.Systems.Vic20.Vic20.SystemName;
+
+    public void RegisterShellServices(IServiceCollection services) { }
+
+    public object? CreateMenuContribution(IServiceProvider sp) => null;
+
+    public object? CreateInfoContribution(IServiceProvider sp) => null;
+
+    public object? CreateConfigDialogContribution(IServiceProvider sp) => null;
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Vic20AvaloniaShellPlugin.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Vic20AvaloniaShellPlugin.cs
@@ -18,11 +18,14 @@ public sealed class Vic20AvaloniaShellPlugin : ISystemShellPlugin
 {
     public string SystemName => global::Highbyte.DotNet6502.Systems.Vic20.Vic20.SystemName;
 
+    public int DisplayOrder => 20;
+
     public void RegisterShellServices(IServiceCollection services)
     {
         services.AddTransient<Vic20MenuViewModel>();
         services.AddTransient<Vic20InfoViewModel>();
         services.AddTransient<Vic20ConfigDialogViewModel>();
+        services.AddTransient<Vic20RomPromptService>();
     }
 
     public object? CreateMenuContribution(IServiceProvider sp) => sp.GetService<Vic20MenuViewModel>();

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Vic20AvaloniaShellPlugin.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Vic20AvaloniaShellPlugin.cs
@@ -1,3 +1,4 @@
+using Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.ViewModels;
 using Highbyte.DotNet6502.Systems.Plugins;
 using Highbyte.DotNet6502.Systems.Vic20;
 using Microsoft.Extensions.DependencyInjection;
@@ -7,19 +8,26 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Highbyte.DotNet6502.App.Avalonia.Shell.Vic20;
 
 /// <summary>
-/// Shell-side plugin for the VIC-20 on the Avalonia host.
-/// All contributions are null — the VIC-20 proof-of-contract exercise relies on the host's
-/// system-agnostic chrome only (no custom menu, info panel, or config dialog).
+/// Shell-side plugin for the VIC-20 on the Avalonia host. Contributes a minimal but
+/// non-null menu / info / config-dialog surface so the proof-of-contract exercise also
+/// validates the three UI contribution paths (not just engine-side wiring). The contents
+/// are intentionally tiny — the point is that the contribution objects are reachable
+/// and that the host's ViewLocator can resolve their views.
 /// </summary>
 public sealed class Vic20AvaloniaShellPlugin : ISystemShellPlugin
 {
     public string SystemName => global::Highbyte.DotNet6502.Systems.Vic20.Vic20.SystemName;
 
-    public void RegisterShellServices(IServiceCollection services) { }
+    public void RegisterShellServices(IServiceCollection services)
+    {
+        services.AddTransient<Vic20MenuViewModel>();
+        services.AddTransient<Vic20InfoViewModel>();
+        services.AddTransient<Vic20ConfigDialogViewModel>();
+    }
 
-    public object? CreateMenuContribution(IServiceProvider sp) => null;
+    public object? CreateMenuContribution(IServiceProvider sp) => sp.GetService<Vic20MenuViewModel>();
 
-    public object? CreateInfoContribution(IServiceProvider sp) => null;
+    public object? CreateInfoContribution(IServiceProvider sp) => sp.GetService<Vic20InfoViewModel>();
 
-    public object? CreateConfigDialogContribution(IServiceProvider sp) => null;
+    public object? CreateConfigDialogContribution(IServiceProvider sp) => sp.GetService<Vic20ConfigDialogViewModel>();
 }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Vic20RomPromptService.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Vic20RomPromptService.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Highbyte.DotNet6502.App.Avalonia.Core;
+using Highbyte.DotNet6502.Systems.Vic20.Config;
+using Microsoft.Extensions.Logging;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Shell.Vic20;
+
+public sealed class Vic20RomPromptService
+{
+    private readonly OverlayDialogHelper _overlayDialogHelper;
+    private readonly ILogger _logger;
+
+    public Vic20RomPromptService(
+        OverlayDialogHelper overlayDialogHelper,
+        ILoggerFactory loggerFactory)
+    {
+        _overlayDialogHelper = overlayDialogHelper;
+        _logger = loggerFactory.CreateLogger(nameof(Vic20RomPromptService));
+    }
+
+    public Task<bool> ShowConfigDownloadAcknowledgementAsync(UserControl owner)
+        => ShowDownloadPromptAsync(
+            title: "ROM License Acknowledgement",
+            leadText: "You are about to download Commodore VIC-20 ROM files from:",
+            acknowledgeText: "Do you acknowledge these requirements and wish to proceed?",
+            confirmText: "Yes",
+            cancelText: "No",
+            owner: owner);
+
+    private Task<bool> ShowDownloadPromptAsync(
+        string title,
+        string leadText,
+        string acknowledgeText,
+        string confirmText,
+        string cancelText,
+        UserControl? owner)
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        Grid? overlayHost = null;
+        Panel? overlayPanel = null;
+
+        void CloseOverlay(bool result)
+        {
+            if (overlayPanel != null && overlayHost != null)
+                overlayHost.Children.Remove(overlayPanel);
+            tcs.TrySetResult(result);
+        }
+
+        var confirmButton = new Button
+        {
+            Content = confirmText,
+            Classes = { "small", "primary" }
+        };
+        confirmButton.Click += (_, _) => CloseOverlay(true);
+
+        var cancelButton = new Button
+        {
+            Content = cancelText,
+            Classes = { "small", "cancel" }
+        };
+        cancelButton.Click += (_, _) => CloseOverlay(false);
+
+        var urlButton = new Button
+        {
+            Content = Vic20SystemConfig.DEFAULT_ROM_DOWNLOAD_BASE_URL,
+            Classes = { "link" },
+            FontSize = 10,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Padding = new Thickness(0),
+            Margin = new Thickness(0),
+            Background = Brushes.Transparent,
+            BorderThickness = new Thickness(0),
+            Cursor = new Cursor(StandardCursorType.Hand)
+        };
+        urlButton.Click += (_, _) => SafeAsyncHelper.Execute(() => LaunchUriIfAvailableAsync(owner, Vic20SystemConfig.DEFAULT_ROM_DOWNLOAD_BASE_URL));
+
+        var dialogContent = new Border
+        {
+            Background = new SolidColorBrush(Color.FromRgb(26, 32, 44)),
+            BorderBrush = new SolidColorBrush(Color.FromRgb(74, 85, 104)),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(8),
+            Padding = new Thickness(0),
+            MaxWidth = 520,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+            Child = new StackPanel
+            {
+                Children =
+                {
+                    new Border
+                    {
+                        Background = new SolidColorBrush(Color.FromRgb(45, 55, 72)),
+                        Padding = new Thickness(8, 6),
+                        CornerRadius = new CornerRadius(4, 4, 0, 0),
+                        Child = new TextBlock
+                        {
+                            Text = title,
+                            FontSize = 14,
+                            FontWeight = FontWeight.Bold,
+                            HorizontalAlignment = HorizontalAlignment.Center
+                        }
+                    },
+                    new StackPanel
+                    {
+                        Margin = new Thickness(12),
+                        Spacing = 8,
+                        Children =
+                        {
+                            new TextBlock
+                            {
+                                Text = leadText,
+                                FontSize = 10,
+                                TextWrapping = TextWrapping.Wrap
+                            },
+                            urlButton,
+                            new TextBlock
+                            {
+                                Text = "Please be aware that you probably need to:",
+                                FontSize = 10,
+                                TextWrapping = TextWrapping.Wrap,
+                                Margin = new Thickness(0, 8, 0, 0)
+                            },
+                            new TextBlock
+                            {
+                                Text = "Have a license from Commodore/Cloanto, or own a Commodore VIC-20 computer",
+                                FontSize = 10,
+                                TextWrapping = TextWrapping.Wrap,
+                                Margin = new Thickness(8, 0, 0, 0)
+                            },
+                            new TextBlock
+                            {
+                                Text = "to be allowed to download and use these ROM files.",
+                                FontSize = 10,
+                                TextWrapping = TextWrapping.Wrap
+                            },
+                            new TextBlock
+                            {
+                                Text = acknowledgeText,
+                                FontSize = 10,
+                                TextWrapping = TextWrapping.Wrap,
+                                FontWeight = FontWeight.Bold,
+                                Margin = new Thickness(0, 8, 0, 0)
+                            },
+                            new StackPanel
+                            {
+                                Orientation = Orientation.Horizontal,
+                                HorizontalAlignment = HorizontalAlignment.Right,
+                                Spacing = 10,
+                                Margin = new Thickness(0, 8, 0, 0),
+                                Children =
+                                {
+                                    confirmButton,
+                                    cancelButton
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        overlayPanel = new Panel
+        {
+            Background = new SolidColorBrush(Color.FromArgb(180, 0, 0, 0)),
+            ZIndex = 1000,
+            Children = { dialogContent }
+        };
+
+        try
+        {
+            overlayHost = owner != null
+                ? _overlayDialogHelper.ShowOverlayDialog(overlayPanel, owner)
+                : _overlayDialogHelper.ShowOverlayDialogOnMainView(overlayPanel);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to show VIC-20 ROM prompt overlay.");
+            return Task.FromResult(false);
+        }
+
+        return tcs.Task;
+    }
+
+    private async Task LaunchUriIfAvailableAsync(UserControl? owner, string uri)
+    {
+        if (owner != null)
+        {
+            if (TopLevel.GetTopLevel(owner) is { Launcher: { } ownerLauncher })
+            {
+                await ownerLauncher.LaunchUriAsync(new Uri(uri));
+                return;
+            }
+        }
+
+        if (Application.Current?.ApplicationLifetime is global::Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop &&
+            desktop.MainWindow?.Launcher is { } desktopLauncher)
+        {
+            await desktopLauncher.LaunchUriAsync(new Uri(uri));
+            return;
+        }
+
+        if (Application.Current?.ApplicationLifetime is global::Avalonia.Controls.ApplicationLifetimes.ISingleViewApplicationLifetime singleView &&
+            TopLevel.GetTopLevel(singleView.MainView) is { Launcher: { } launcher })
+        {
+            await launcher.LaunchUriAsync(new Uri(uri));
+        }
+    }
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/ViewModels/Vic20ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/ViewModels/Vic20ConfigDialogViewModel.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Highbyte.DotNet6502.App.Avalonia.Core;
+using Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
+using Highbyte.DotNet6502.Impl.Avalonia.Vic20;
+using Highbyte.DotNet6502.Systems.Vic20.Config;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.ViewModels;
+
+/// <summary>
+/// Minimal config-dialog contribution for the VIC-20 shell plugin. Reads the current
+/// <see cref="Vic20HostConfig"/> from the host and shows ROM directory / ROM file list
+/// read-only. Kept tiny on purpose — the goal is to prove the plugin's config-dialog
+/// contribution is reachable through the host, not to build a full configuration UI.
+/// </summary>
+public class Vic20ConfigDialogViewModel : ViewModelBase
+{
+    public Vic20ConfigDialogViewModel(AvaloniaHostApp hostApp)
+    {
+        if (hostApp == null) throw new ArgumentNullException(nameof(hostApp));
+
+        var config = hostApp.CurrentHostSystemConfig as Vic20HostConfig;
+        ROMDirectory = config?.SystemConfig.ROMDirectory ?? string.Empty;
+
+        var roms = config?.SystemConfig.ROMs ?? new System.Collections.Generic.List<Highbyte.DotNet6502.Systems.ROM>();
+        ROMs = new ObservableCollection<RomEntry>(
+            roms.Select(r => new RomEntry(r.Name, r.File ?? string.Empty)));
+    }
+
+    public string ROMDirectory { get; }
+
+    public ObservableCollection<RomEntry> ROMs { get; }
+
+    public record RomEntry(string Name, string File);
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/ViewModels/Vic20ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/ViewModels/Vic20ConfigDialogViewModel.cs
@@ -1,36 +1,639 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
+using System.Net.Http;
+using System.Reactive;
+using System.Threading.Tasks;
 using Highbyte.DotNet6502.App.Avalonia.Core;
 using Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
+using Highbyte.DotNet6502.Impl.Avalonia;
 using Highbyte.DotNet6502.Impl.Avalonia.Vic20;
+using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Vic20.Config;
+using Highbyte.DotNet6502.Systems.Utils;
+using Highbyte.DotNet6502.Utils;
+using ReactiveUI;
 
 namespace Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.ViewModels;
 
-/// <summary>
-/// Minimal config-dialog contribution for the VIC-20 shell plugin. Reads the current
-/// <see cref="Vic20HostConfig"/> from the host and shows ROM directory / ROM file list
-/// read-only. Kept tiny on purpose — the goal is to prove the plugin's config-dialog
-/// contribution is reachable through the host, not to build a full configuration UI.
-/// </summary>
 public class Vic20ConfigDialogViewModel : ViewModelBase
 {
+    private const long MaxRomFileSizeBytes = 8 * 1024;
+
+    private readonly AvaloniaHostApp _hostApp;
+    private readonly Vic20HostConfig _originalConfig;
+    private readonly Vic20HostConfig _workingConfig;
+    private readonly HttpClient _httpClient;
+    private readonly ObservableCollection<string> _validationErrors = new();
+
+    private bool _isBusy;
+    private string? _statusMessage;
+    private string? _validationMessage;
+    private string _romDirectory = string.Empty;
+    private string _corsProxyOverrideURL = string.Empty;
+
+    public ReactiveCommand<Unit, Unit> DownloadRomsToByteArrayCommand { get; }
+    public ReactiveCommand<Unit, Unit> DownloadRomsToFilesCommand { get; }
+    public ReactiveCommand<Unit, Unit> ClearRomsCommand { get; }
+    public ReactiveCommand<Unit, Unit> ResetCorsProxyOverrideURLCommand { get; }
+    public ReactiveCommand<Unit, Unit> SaveCommand { get; }
+    public ReactiveCommand<Unit, Unit> CancelCommand { get; }
+
     public Vic20ConfigDialogViewModel(AvaloniaHostApp hostApp)
     {
-        if (hostApp == null) throw new ArgumentNullException(nameof(hostApp));
+        _hostApp = hostApp ?? throw new ArgumentNullException(nameof(hostApp));
+        _originalConfig = hostApp.CurrentHostSystemConfig as Vic20HostConfig
+            ?? throw new Exception("hostApp.CurrentHostSystemConfig must be type Vic20HostConfig");
+        _workingConfig = (Vic20HostConfig)_originalConfig.Clone();
+        _httpClient = new HttpClient();
 
-        var config = hostApp.CurrentHostSystemConfig as Vic20HostConfig;
-        ROMDirectory = config?.SystemConfig.ROMDirectory ?? string.Empty;
+        RomDirectory = _workingConfig.SystemConfig.ROMDirectory;
+        CorsProxyOverrideURL = _workingConfig.CorsProxyOverrideURL ?? string.Empty;
 
-        var roms = config?.SystemConfig.ROMs ?? new System.Collections.Generic.List<Highbyte.DotNet6502.Systems.ROM>();
-        ROMs = new ObservableCollection<RomEntry>(
-            roms.Select(r => new RomEntry(r.Name, r.File ?? string.Empty)));
+        UpdateRomStatuses();
+        UpdateValidationMessageFromConfig();
+
+        DownloadRomsToByteArrayCommand = ReactiveCommandHelper.CreateSafeCommand(
+            AutoDownloadRomsToByteArrayAsync,
+            outputScheduler: RxSchedulers.MainThreadScheduler);
+
+        DownloadRomsToFilesCommand = ReactiveCommandHelper.CreateSafeCommand(
+            AutoDownloadROMsToFilesAsync,
+            outputScheduler: RxSchedulers.MainThreadScheduler);
+
+        ClearRomsCommand = ReactiveCommandHelper.CreateSafeCommand(
+            () =>
+            {
+                UnloadRoms();
+                return Task.CompletedTask;
+            },
+            outputScheduler: RxSchedulers.MainThreadScheduler);
+
+        ResetCorsProxyOverrideURLCommand = ReactiveCommandHelper.CreateSafeCommand(
+            () =>
+            {
+                CorsProxyOverrideURL = string.Empty;
+                return Task.CompletedTask;
+            },
+            outputScheduler: RxSchedulers.MainThreadScheduler);
+
+        SaveCommand = ReactiveCommandHelper.CreateSafeCommand(
+            async () =>
+            {
+                if (await TryApplyChangesAsync())
+                    ConfigurationChanged?.Invoke(this, true);
+            },
+            outputScheduler: RxSchedulers.MainThreadScheduler);
+
+        CancelCommand = ReactiveCommandHelper.CreateSafeCommand(
+            () =>
+            {
+                ConfigurationChanged?.Invoke(this, false);
+                return Task.CompletedTask;
+            },
+            outputScheduler: RxSchedulers.MainThreadScheduler);
     }
 
-    public string ROMDirectory { get; }
+    public event EventHandler<bool>? ConfigurationChanged;
+    public event EventHandler<Vic20RomLicenseAcknowledgementEventArgs>? RomLicenseAcknowledgementRequested;
 
-    public ObservableCollection<RomEntry> ROMs { get; }
+    public ObservableCollection<Vic20RomStatusViewModel> RomStatuses { get; } = new();
 
-    public record RomEntry(string Name, string File);
+    public bool IsRunningInWebAssembly { get; } = PlatformDetection.IsRunningInWebAssembly();
+
+    public bool IsBusy
+    {
+        get => _isBusy;
+        private set
+        {
+            if (_isBusy == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _isBusy, value);
+            this.RaisePropertyChanged(nameof(IsNotBusy));
+            this.RaisePropertyChanged(nameof(CanSave));
+        }
+    }
+
+    public bool IsNotBusy => !IsBusy;
+
+    public bool CanSave => IsNotBusy && !HasValidationErrors;
+
+    public string? StatusMessage
+    {
+        get => _statusMessage;
+        private set
+        {
+            if (_statusMessage == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _statusMessage, value);
+            this.RaisePropertyChanged(nameof(HasStatusMessage));
+        }
+    }
+
+    public string? ValidationMessage
+    {
+        get => _validationMessage;
+        private set
+        {
+            if (_validationMessage == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _validationMessage, value);
+            this.RaisePropertyChanged(nameof(HasValidationMessage));
+        }
+    }
+
+    public bool HasStatusMessage => !string.IsNullOrEmpty(StatusMessage);
+    public bool HasValidationMessage => !string.IsNullOrEmpty(ValidationMessage);
+    public ObservableCollection<string> ValidationErrors => _validationErrors;
+    public bool HasValidationErrors => _validationErrors.Count > 0;
+
+    public string RomStatusSummary =>
+        $"{RomStatuses.Count(r => r.IsRequired && r.IsLoaded)}/{Vic20SystemConfig.RequiredROMs.Count} ROMs loaded";
+
+    public string RomDirectory
+    {
+        get => _romDirectory;
+        set
+        {
+            if (_romDirectory == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _romDirectory, value);
+            _workingConfig.SystemConfig.ROMDirectory = value;
+            UpdateValidationMessageFromConfig();
+        }
+    }
+
+    public string CorsProxyOverrideURL
+    {
+        get => _corsProxyOverrideURL;
+        set
+        {
+            if (_corsProxyOverrideURL == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _corsProxyOverrideURL, value);
+            _workingConfig.CorsProxyOverrideURL = string.IsNullOrEmpty(value) ? null : value;
+        }
+    }
+
+    public static string CorsProxyOverrideURLWatermark => Vic20HostConfig.DefaultCorsProxyURL;
+
+    public string OkButtonText => IsRunningInWebAssembly ? "Save" : "Ok";
+
+    public Task AutoDownloadRomsToByteArrayAsync()
+        => DownloadRomsToByteArrayAsync(requireAcknowledgement: true);
+
+    public async Task<bool> DownloadRomsToByteArrayAsync(bool requireAcknowledgement)
+    {
+        if (requireAcknowledgement && !await RequestRomLicenseAcknowledgementAsync())
+        {
+            StatusMessage = "ROM download cancelled.";
+            return false;
+        }
+
+        try
+        {
+            IsBusy = true;
+            StatusMessage = "Downloading ROMs...";
+            ValidationMessage = string.Empty;
+
+            foreach (var romDownload in _workingConfig.SystemConfig.ROMDownloadUrls)
+            {
+                var proxyUrl = _workingConfig.GetCorsProxyURL();
+                var fullROMUrl = !string.IsNullOrEmpty(proxyUrl)
+                    ? $"{proxyUrl}{Uri.EscapeDataString(romDownload.Value)}"
+                    : romDownload.Value;
+
+                var romBytes = await _httpClient.GetByteArrayAsync(fullROMUrl);
+                _workingConfig.SystemConfig.SetROM(romDownload.Key, data: romBytes);
+            }
+
+            StatusMessage = "ROMs downloaded successfully.";
+            return true;
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Error downloading ROMs: {ex.Message}";
+            return false;
+        }
+        finally
+        {
+            IsBusy = false;
+            UpdateRomStatuses();
+            UpdateValidationMessageFromConfig();
+        }
+    }
+
+    public async Task AutoDownloadROMsToFilesAsync()
+    {
+        if (!await RequestRomLicenseAcknowledgementAsync())
+        {
+            StatusMessage = string.Empty;
+            return;
+        }
+
+        try
+        {
+            IsBusy = true;
+            StatusMessage = "Downloading ROMs...";
+            ValidationMessage = string.Empty;
+
+            var romFolder = PathHelper.ExpandOSEnvironmentVariables(_workingConfig.SystemConfig.ROMDirectory);
+            if (!Directory.Exists(romFolder))
+                Directory.CreateDirectory(romFolder);
+
+            _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
+            _httpClient.DefaultRequestHeaders.Accept.ParseAdd("*/*");
+
+            foreach (var romDownload in _workingConfig.SystemConfig.ROMDownloadUrls)
+            {
+                var romName = romDownload.Key;
+                var romUrl = romDownload.Value;
+                var filename = Path.GetFileName(new Uri(romUrl).LocalPath);
+                var dest = Path.Combine(romFolder, filename);
+                try
+                {
+                    using var response = await _httpClient.GetAsync(romUrl);
+                    if (!response.IsSuccessStatusCode)
+                        throw new Exception($"Failed to get '{romUrl}' ({(int)response.StatusCode})");
+
+                    await using var fs = new FileStream(dest, FileMode.Create, FileAccess.Write, FileShare.None);
+                    await response.Content.CopyToAsync(fs);
+                    _workingConfig.SystemConfig.SetROM(romName, filename);
+                }
+                catch (Exception ex)
+                {
+                    if (File.Exists(dest))
+                        File.Delete(dest);
+                    throw new Exception($"Error downloading {romUrl}: {ex.Message}", ex);
+                }
+            }
+
+            StatusMessage = "ROMs downloaded successfully.";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Error downloading ROMs: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+            UpdateRomStatuses();
+            UpdateValidationMessageFromConfig();
+        }
+    }
+
+    public Task LoadRomsFromDataAsync(IEnumerable<(string fileName, byte[] data)> romDataList)
+    {
+        if (romDataList == null)
+            return Task.CompletedTask;
+
+        var romData = romDataList.ToList();
+        var errors = new List<string>();
+        foreach (var (fileName, data) in romData)
+        {
+            try
+            {
+                if (data.Length > MaxRomFileSizeBytes)
+                {
+                    errors.Add($"File {fileName} is larger than {MaxRomFileSizeBytes} bytes.");
+                    continue;
+                }
+
+                var romName = DetectRomName(fileName);
+                if (romName == null)
+                {
+                    errors.Add($"Could not determine ROM type for file {fileName}. Expected names containing 'kern', 'bas', or 'char'.");
+                    continue;
+                }
+
+                _workingConfig.SystemConfig.SetROM(romName, data: data);
+            }
+            catch (Exception ex)
+            {
+                errors.Add($"Failed to load {fileName}: {ex.Message}");
+            }
+        }
+
+        UpdateRomStatuses();
+        UpdateValidationMessageFromConfig();
+
+        if (errors.Count == 0)
+        {
+            StatusMessage = "ROM files loaded.";
+            ValidationMessage = string.Empty;
+        }
+        else
+        {
+            StatusMessage = errors.Count < romData.Count ? "Some ROMs loaded with warnings." : null;
+            ValidationMessage = string.Join(Environment.NewLine, errors);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public void UnloadRoms()
+    {
+        _workingConfig.SystemConfig.ROMs = new List<ROM>();
+        UpdateRomStatuses();
+        UpdateValidationMessageFromConfig();
+        StatusMessage = "All ROMs cleared.";
+    }
+
+    public async Task<bool> TryApplyChangesAsync()
+    {
+        try
+        {
+            IsBusy = true;
+            StatusMessage = "Saving...";
+            ValidationMessage = string.Empty;
+
+            if (!_workingConfig.IsValid(out var validationErrors))
+            {
+                StatusMessage = null;
+                ValidationMessage = string.Join(Environment.NewLine, validationErrors);
+                return false;
+            }
+
+            _originalConfig.SystemConfig.ROMDirectory = _workingConfig.SystemConfig.ROMDirectory;
+            _originalConfig.CorsProxyOverrideURL = _workingConfig.CorsProxyOverrideURL;
+            _originalConfig.SystemConfig.ROMs = ROM.Clone(_workingConfig.SystemConfig.ROMs);
+
+            _hostApp.UpdateHostSystemConfig(_originalConfig);
+            await _hostApp.PersistCurrentHostSystemConfig();
+
+            StatusMessage = "Configuration saved.";
+            return true;
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Error saving config: {ex.Message}";
+            return false;
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private void UpdateRomStatuses()
+    {
+        var roms = _workingConfig.SystemConfig.ROMs;
+        var desiredStatuses = new List<Vic20RomStatusData>();
+
+        foreach (var required in Vic20SystemConfig.RequiredROMs)
+        {
+            var rom = roms.FirstOrDefault(r => string.Equals(r.Name, required, StringComparison.OrdinalIgnoreCase));
+            desiredStatuses.Add(CreateRomStatusData(required, rom, isRequired: true));
+        }
+
+        foreach (var additional in roms.Where(r => !Vic20SystemConfig.RequiredROMs.Contains(r.Name)))
+        {
+            desiredStatuses.Add(CreateRomStatusData(additional.Name, additional, isRequired: false));
+        }
+
+        var existingByName = RomStatuses.ToDictionary(r => r.Name, StringComparer.OrdinalIgnoreCase);
+
+        for (var i = 0; i < desiredStatuses.Count; i++)
+        {
+            var statusData = desiredStatuses[i];
+            if (existingByName.TryGetValue(statusData.Name, out var existing))
+            {
+                existing.UpdateFromData(statusData);
+                var currentIndex = RomStatuses.IndexOf(existing);
+                if (currentIndex != i)
+                    RomStatuses.Move(currentIndex, i);
+                existingByName.Remove(statusData.Name);
+            }
+            else
+            {
+                var romName = statusData.Name;
+                RomStatuses.Insert(i, new Vic20RomStatusViewModel(
+                    romName,
+                    statusData.IsLoaded,
+                    statusData.IsRequired,
+                    statusData.Details,
+                    statusData.ForegroundColor,
+                    statusData.RomFile,
+                    filePath => UpdateRomFile(romName, filePath),
+                    IsRunningInWebAssembly));
+            }
+        }
+
+        foreach (var obsolete in existingByName.Values)
+            RomStatuses.Remove(obsolete);
+
+        this.RaisePropertyChanged(nameof(RomStatuses));
+        this.RaisePropertyChanged(nameof(RomStatusSummary));
+    }
+
+    private Vic20RomStatusData CreateRomStatusData(string romName, ROM? rom, bool isRequired)
+    {
+        var romFile = rom?.File ?? string.Empty;
+        var romDataLength = rom?.Data?.Length ?? 0;
+        var hasData = romDataLength > 0;
+        var hasFile = !string.IsNullOrWhiteSpace(romFile);
+
+        var fileExists = false;
+        if (hasFile && rom != null)
+        {
+            try
+            {
+                var romFilePath = rom.GetROMFilePath(_workingConfig.SystemConfig.ROMDirectory);
+                fileExists = File.Exists(romFilePath);
+            }
+            catch
+            {
+                var expandedPath = PathHelper.ExpandOSEnvironmentVariables(romFile);
+                fileExists = File.Exists(expandedPath);
+            }
+        }
+
+        var isLoaded = IsRunningInWebAssembly
+            ? hasData
+            : hasData || (hasFile && fileExists);
+
+        var details = IsRunningInWebAssembly
+            ? hasData ? $"{romDataLength} bytes" : "Not loaded"
+            : !hasFile ? "ROM file not set" : fileExists ? romFile : $"{romFile} (missing)";
+
+        var foregroundColor = IsRunningInWebAssembly
+            ? isLoaded ? "#68D391" : "#F56565"
+            : !hasFile ? "#F56565" : fileExists ? "#68D391" : "#F6AD55";
+
+        return new Vic20RomStatusData(romName, isLoaded, isRequired, details, foregroundColor, romFile);
+    }
+
+    private void UpdateRomFile(string romName, string romFile)
+    {
+        var trimmedFile = string.IsNullOrWhiteSpace(romFile) ? null : romFile.Trim();
+        ROM? existingRom = null;
+        if (_workingConfig.SystemConfig.HasROM(romName))
+            existingRom = _workingConfig.SystemConfig.GetROM(romName);
+
+        if (trimmedFile != null)
+            _workingConfig.SystemConfig.SetROM(romName, file: trimmedFile, data: null);
+        else
+            _workingConfig.SystemConfig.SetROM(romName, file: null, data: existingRom?.Data);
+
+        UpdateRomStatuses();
+        UpdateValidationMessageFromConfig();
+    }
+
+    private void UpdateValidationMessageFromConfig()
+    {
+        if (!_workingConfig.IsValid(out var validationErrors))
+        {
+            ValidationMessage = string.Join(Environment.NewLine, validationErrors);
+            _validationErrors.Clear();
+            foreach (var error in validationErrors)
+                _validationErrors.Add(error);
+        }
+        else
+        {
+            ValidationMessage = string.Empty;
+            _validationErrors.Clear();
+        }
+
+        this.RaisePropertyChanged(nameof(HasValidationErrors));
+        this.RaisePropertyChanged(nameof(CanSave));
+    }
+
+    private static string? DetectRomName(string fileName)
+    {
+        if (fileName.Contains("kern", StringComparison.OrdinalIgnoreCase))
+            return Vic20SystemConfig.KERNAL_ROM_NAME;
+        if (fileName.Contains("bas", StringComparison.OrdinalIgnoreCase))
+            return Vic20SystemConfig.BASIC_ROM_NAME;
+        if (fileName.Contains("char", StringComparison.OrdinalIgnoreCase))
+            return Vic20SystemConfig.CHARGEN_ROM_NAME;
+
+        var nameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
+        return Vic20SystemConfig.RequiredROMs.FirstOrDefault(required =>
+            nameWithoutExtension.Contains(required, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private Task<bool> RequestRomLicenseAcknowledgementAsync()
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        var args = new Vic20RomLicenseAcknowledgementEventArgs(tcs);
+        RomLicenseAcknowledgementRequested?.Invoke(this, args);
+        return tcs.Task;
+    }
 }
+
+public class Vic20RomLicenseAcknowledgementEventArgs : EventArgs
+{
+    private readonly TaskCompletionSource<bool> _taskCompletionSource;
+
+    public Vic20RomLicenseAcknowledgementEventArgs(TaskCompletionSource<bool> taskCompletionSource)
+    {
+        _taskCompletionSource = taskCompletionSource;
+    }
+
+    public void SetResult(bool acknowledged)
+    {
+        _taskCompletionSource.TrySetResult(acknowledged);
+    }
+}
+
+public class Vic20RomStatusViewModel : ReactiveObject
+{
+    private readonly Action<string>? _onRomFileChanged;
+    private bool _suppressRomFileChanged;
+    private bool _isLoaded;
+    private string _details;
+    private string _foregroundColor;
+    private string _romFile;
+
+    public Vic20RomStatusViewModel(
+        string name,
+        bool isLoaded,
+        bool isRequired,
+        string details,
+        string foregroundColor,
+        string romFile,
+        Action<string>? onRomFileChanged,
+        bool isRunningInWebAssembly)
+    {
+        Name = name;
+        _isLoaded = isLoaded;
+        IsRequired = isRequired;
+        _details = details;
+        _foregroundColor = foregroundColor;
+        _romFile = romFile;
+        _onRomFileChanged = onRomFileChanged;
+        IsRunningInWebAssembly = isRunningInWebAssembly;
+    }
+
+    public string Name { get; }
+    public bool IsRequired { get; }
+    public bool IsRunningInWebAssembly { get; }
+
+    public bool IsLoaded
+    {
+        get => _isLoaded;
+        set => this.RaiseAndSetIfChanged(ref _isLoaded, value);
+    }
+
+    public string Details
+    {
+        get => _details;
+        set => this.RaiseAndSetIfChanged(ref _details, value);
+    }
+
+    public string ForegroundColor
+    {
+        get => _foregroundColor;
+        set => this.RaiseAndSetIfChanged(ref _foregroundColor, value);
+    }
+
+    public string RomFile
+    {
+        get => _romFile;
+        set => SetRomFile(value, suppressCallback: false);
+    }
+
+    public void UpdateFromData(Vic20RomStatusData data)
+    {
+        IsLoaded = data.IsLoaded;
+        Details = data.Details;
+        ForegroundColor = data.ForegroundColor;
+        SetRomFile(data.RomFile, suppressCallback: true);
+    }
+
+    private void SetRomFile(string value, bool suppressCallback)
+    {
+        if (_romFile == value)
+            return;
+
+        this.RaiseAndSetIfChanged(ref _romFile, value);
+
+        if (suppressCallback || _suppressRomFileChanged)
+            return;
+
+        try
+        {
+            _suppressRomFileChanged = true;
+            _onRomFileChanged?.Invoke(value);
+        }
+        finally
+        {
+            _suppressRomFileChanged = false;
+        }
+    }
+}
+
+public record Vic20RomStatusData(
+    string Name,
+    bool IsLoaded,
+    bool IsRequired,
+    string Details,
+    string ForegroundColor,
+    string RomFile);

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/ViewModels/Vic20InfoViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/ViewModels/Vic20InfoViewModel.cs
@@ -1,0 +1,30 @@
+using System;
+using Highbyte.DotNet6502.App.Avalonia.Core;
+using Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
+using Highbyte.DotNet6502.Systems.Vic20.Config;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.ViewModels;
+
+/// <summary>
+/// Minimal info-panel contribution for the VIC-20 shell plugin. Surfaces a handful of
+/// static system facts so the plugin's info contribution is non-null and bindable through
+/// the host's ViewLocator. Not a documentation page — its purpose is to prove the
+/// contribution path works.
+/// </summary>
+public class Vic20InfoViewModel : ViewModelBase
+{
+    public Vic20InfoViewModel(AvaloniaHostApp hostApp)
+    {
+        if (hostApp == null) throw new ArgumentNullException(nameof(hostApp));
+    }
+
+    public string SystemName => global::Highbyte.DotNet6502.Systems.Vic20.Vic20.SystemName;
+
+    public string TextMode => $"{Vic20Config.Cols} × {Vic20Config.Rows} text mode";
+
+    public string RefreshRate => "NTSC, ~60 Hz";
+
+    public string MemoryLayout => "Screen RAM $1E00, color RAM $9600, BASIC $C000, KERNAL $E000";
+
+    public string RequiredROMs => string.Join(", ", Vic20SystemConfig.RequiredROMs);
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/ViewModels/Vic20MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/ViewModels/Vic20MenuViewModel.cs
@@ -1,19 +1,12 @@
 using System;
-using System.Reactive;
-using System.Threading.Tasks;
 using Highbyte.DotNet6502.App.Avalonia.Core;
 using Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
-using Highbyte.DotNet6502.Systems;
-using ReactiveUI;
+using Highbyte.DotNet6502.Impl.Avalonia.Vic20;
 
 namespace Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.ViewModels;
 
 /// <summary>
-/// Minimal menu contribution for the VIC-20 shell plugin. Exposes a Reset command so the
-/// plugin's menu surface is non-null and demonstrably wired to the running system through
-/// the shared <see cref="AvaloniaHostApp"/>. Kept intentionally tiny — this is the proof
-/// that <c>ISystemShellPlugin.CreateMenuContribution</c> and the host's ViewLocator /
-/// ContentControl binding work end-to-end, not a polished menu.
+/// Minimal menu contribution for the VIC-20 shell plugin.
 /// </summary>
 public class Vic20MenuViewModel : ViewModelBase
 {
@@ -21,28 +14,19 @@ public class Vic20MenuViewModel : ViewModelBase
 
     public AvaloniaHostApp HostApp => _hostApp;
 
-    public ReactiveCommand<Unit, Unit> ResetCommand { get; }
-
     public Vic20MenuViewModel(AvaloniaHostApp hostApp)
     {
         _hostApp = hostApp ?? throw new ArgumentNullException(nameof(hostApp));
-
-        ResetCommand = ReactiveCommand.CreateFromTask(
-            ResetAsync,
-            this.WhenAnyValue(x => x.IsResetEnabled));
-
-        _hostApp.WhenAnyValue(x => x.EmulatorState)
-            .Subscribe(_ => this.RaisePropertyChanged(nameof(IsResetEnabled)));
     }
 
-    public bool IsResetEnabled =>
-        _hostApp.EmulatorState == EmulatorState.Running ||
-        _hostApp.EmulatorState == EmulatorState.Paused;
-
-    private async Task ResetAsync()
+    public bool HasConfigValidationErrors
     {
-        if (!IsResetEnabled)
-            return;
-        await _hostApp.Reset();
+        get
+        {
+            if (_hostApp.CurrentHostSystemConfig is not Vic20HostConfig vic20HostConfig)
+                return false;
+
+            return !vic20HostConfig.IsValid(out _);
+        }
     }
 }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/ViewModels/Vic20MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/ViewModels/Vic20MenuViewModel.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Reactive;
+using System.Threading.Tasks;
+using Highbyte.DotNet6502.App.Avalonia.Core;
+using Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
+using Highbyte.DotNet6502.Systems;
+using ReactiveUI;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.ViewModels;
+
+/// <summary>
+/// Minimal menu contribution for the VIC-20 shell plugin. Exposes a Reset command so the
+/// plugin's menu surface is non-null and demonstrably wired to the running system through
+/// the shared <see cref="AvaloniaHostApp"/>. Kept intentionally tiny — this is the proof
+/// that <c>ISystemShellPlugin.CreateMenuContribution</c> and the host's ViewLocator /
+/// ContentControl binding work end-to-end, not a polished menu.
+/// </summary>
+public class Vic20MenuViewModel : ViewModelBase
+{
+    private readonly AvaloniaHostApp _hostApp;
+
+    public AvaloniaHostApp HostApp => _hostApp;
+
+    public ReactiveCommand<Unit, Unit> ResetCommand { get; }
+
+    public Vic20MenuViewModel(AvaloniaHostApp hostApp)
+    {
+        _hostApp = hostApp ?? throw new ArgumentNullException(nameof(hostApp));
+
+        ResetCommand = ReactiveCommand.CreateFromTask(
+            ResetAsync,
+            this.WhenAnyValue(x => x.IsResetEnabled));
+
+        _hostApp.WhenAnyValue(x => x.EmulatorState)
+            .Subscribe(_ => this.RaisePropertyChanged(nameof(IsResetEnabled)));
+    }
+
+    public bool IsResetEnabled =>
+        _hostApp.EmulatorState == EmulatorState.Running ||
+        _hostApp.EmulatorState == EmulatorState.Paused;
+
+    private async Task ResetAsync()
+    {
+        if (!IsResetEnabled)
+            return;
+        await _hostApp.Reset();
+    }
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20ConfigDialog.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20ConfigDialog.axaml
@@ -1,0 +1,22 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.ViewModels"
+        xmlns:views="using:Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.Views"
+        x:Class="Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.Views.Vic20ConfigDialog"
+        x:DataType="vm:Vic20ConfigDialogViewModel"
+        AutomationProperties.AutomationId="Vic20ConfigDialog"
+        AutomationProperties.Name="VIC-20 configuration"
+        Title="VIC-20 Configuration"
+        Width="640"
+        Height="520"
+        MinWidth="500"
+        MinHeight="400"
+        WindowStartupLocation="CenterOwner"
+        CanResize="True"
+        WindowDecorations="Full"
+        ShowInTaskbar="False"
+        Background="{DynamicResource ViewDefaultBg}">
+
+    <views:Vic20ConfigDialogView x:Name="ConfigView"
+                                 ConfigurationChanged="OnConfigurationChanged"/>
+</Window>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20ConfigDialog.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20ConfigDialog.axaml.cs
@@ -1,0 +1,83 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.Views;
+
+public partial class Vic20ConfigDialog : Window
+{
+    public bool? DialogResultValue { get; private set; }
+
+    private static PixelPoint? s_lastPosition;
+    private static Size? s_lastSize;
+    private static WindowState? s_lastWindowState;
+    private bool _isPositionInitialized;
+
+    public Vic20ConfigDialog()
+    {
+        InitializeComponent();
+        DialogResultValue = false;
+        RestoreWindowBounds();
+        Opened += OnOpened;
+        PositionChanged += OnPositionChanged;
+        Closed += OnClosed;
+    }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    private void RestoreWindowBounds()
+    {
+        if (s_lastSize.HasValue)
+        {
+            Width = s_lastSize.Value.Width;
+            Height = s_lastSize.Value.Height;
+        }
+
+        if (s_lastPosition.HasValue)
+        {
+            WindowStartupLocation = WindowStartupLocation.Manual;
+            Position = s_lastPosition.Value;
+        }
+
+        if (s_lastWindowState.HasValue && s_lastWindowState.Value != WindowState.Minimized)
+            WindowState = s_lastWindowState.Value;
+    }
+
+    private void OnOpened(object? sender, EventArgs e)
+    {
+        if (s_lastPosition.HasValue && !_isPositionInitialized)
+        {
+            Position = s_lastPosition.Value;
+            _isPositionInitialized = true;
+        }
+    }
+
+    private void OnPositionChanged(object? sender, PixelPointEventArgs e)
+    {
+        if (WindowState != WindowState.Minimized)
+            s_lastPosition = e.Point;
+
+        if (!_isPositionInitialized)
+            _isPositionInitialized = true;
+    }
+
+    public void OnConfigurationChanged(object? sender, bool saved)
+    {
+        DialogResultValue = saved;
+        Close(saved);
+    }
+
+    private void OnClosed(object? sender, EventArgs e)
+    {
+        if (WindowState != WindowState.Minimized && _isPositionInitialized)
+        {
+            s_lastSize = new Size(Width, Height);
+            s_lastWindowState = WindowState;
+        }
+
+        Opened -= OnOpened;
+        PositionChanged -= OnPositionChanged;
+        Closed -= OnClosed;
+    }
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20ConfigDialogView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20ConfigDialogView.axaml
@@ -6,26 +6,152 @@
              AutomationProperties.AutomationId="Vic20ConfigDialogView"
              AutomationProperties.Name="VIC-20 configuration panel"
              Focusable="False">
-    <StackPanel Margin="6" Spacing="6">
-        <TextBlock Text="VIC-20 configuration (read-only)" FontWeight="Bold" />
-        <StackPanel Spacing="2">
-            <TextBlock Text="ROM directory:" />
-            <TextBlock Text="{Binding ROMDirectory}" FontFamily="Consolas,Menlo,monospace" />
-        </StackPanel>
-        <StackPanel Spacing="2">
-            <TextBlock Text="ROM files:" />
-            <ItemsControl ItemsSource="{Binding ROMs}">
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate DataType="vm:Vic20ConfigDialogViewModel+RomEntry">
-                        <TextBlock FontFamily="Consolas,Menlo,monospace">
-                            <Run Text="  " />
-                            <Run Text="{Binding Name}" />
-                            <Run Text=" → " />
-                            <Run Text="{Binding File}" />
-                        </TextBlock>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
-        </StackPanel>
-    </StackPanel>
+
+    <Grid RowDefinitions="Auto,*,Auto,Auto" Margin="8,0,8,8">
+        <Border Grid.Row="0" CornerRadius="4" Classes="panel-container">
+            <TextBlock Text="VIC-20 Configuration"
+                       Classes="h-center h2"/>
+        </Border>
+
+        <ScrollViewer Grid.Row="1" Classes="vertical-only">
+            <WrapPanel Orientation="Horizontal">
+                <StackPanel Width="460" Classes="wrap-item">
+                    <Border Classes="content-section">
+                        <StackPanel Classes="spacing-tight">
+                            <TextBlock Text="ROM Management"/>
+                            <TextBlock Text="The emulator requires Basic, Kernal, and Character ROMs."
+                                       Classes="small secondary-text"/>
+                            <TextBlock Text="{Binding RomStatusSummary}"
+                                       Classes="accent bold"/>
+
+                            <ItemsControl ItemsSource="{Binding RomStatuses}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:Vic20RomStatusViewModel">
+                                        <StackPanel Classes="spacing-tight">
+                                            <Grid ColumnDefinitions="90,*" Classes="spacing-tight"
+                                                  IsVisible="{Binding IsRunningInWebAssembly}">
+                                                <TextBlock Grid.Column="0"
+                                                           Text="{Binding Name, StringFormat='{}{0}:'}"
+                                                           Classes="secondary-text"/>
+                                                <TextBlock Grid.Column="1"
+                                                           Text="{Binding Details}"
+                                                           Foreground="{Binding ForegroundColor}"/>
+                                            </Grid>
+
+                                            <Grid ColumnDefinitions="90,*" Classes="spacing-tight"
+                                                  IsVisible="{Binding !IsRunningInWebAssembly}">
+                                                <TextBlock Grid.Column="0"
+                                                           Text="{Binding Name, StringFormat='{}{0}:'}"
+                                                           Classes="secondary-text"/>
+                                                <TextBox Grid.Column="1"
+                                                         AutomationProperties.AutomationId="{Binding Name, StringFormat='Vic20RomFileTextBox.{0}'}"
+                                                         AutomationProperties.Name="{Binding Name, StringFormat='{}{0} ROM file name'}"
+                                                         Text="{Binding RomFile, Mode=TwoWay}"
+                                                         PlaceholderText="File name"
+                                                         Classes="field-aligned"/>
+                                            </Grid>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+
+                            <StackPanel Classes="spacing-tight">
+                                <Grid ColumnDefinitions="90,*" Classes="spacing-tight"
+                                      IsVisible="{Binding !IsRunningInWebAssembly}">
+                                    <TextBlock Grid.Column="0"
+                                               Text="ROM directory:"
+                                               Classes="secondary-text"/>
+                                    <TextBox Grid.Column="1"
+                                             AutomationProperties.AutomationId="Vic20RomDirectoryTextBox"
+                                             AutomationProperties.Name="VIC-20 ROM directory"
+                                             Text="{Binding RomDirectory}"
+                                             PlaceholderText="Directory path"
+                                             Classes="field-aligned"/>
+                                </Grid>
+                            </StackPanel>
+
+                            <StackPanel Orientation="Horizontal" Classes="spacing-normal">
+                                <Button Content="Clear"
+                                        AutomationProperties.AutomationId="Vic20ClearRomsButton"
+                                        Command="{Binding ClearRomsCommand}"
+                                        MinWidth="90"
+                                        Classes="danger"
+                                        IsVisible="{Binding IsRunningInWebAssembly}"
+                                        IsEnabled="{Binding IsNotBusy}"/>
+                                <Button Content="Load ROMs from files"
+                                        AutomationProperties.AutomationId="Vic20LoadRomsButton"
+                                        MinWidth="150"
+                                        Classes="extraWide"
+                                        IsVisible="{Binding IsRunningInWebAssembly}"
+                                        IsEnabled="{Binding IsNotBusy}"
+                                        Click="LoadRoms_Click"/>
+                                <Button Content="Download ROMs"
+                                        AutomationProperties.AutomationId="Vic20DownloadRomsButton"
+                                        Command="{Binding DownloadRomsToByteArrayCommand}"
+                                        MinWidth="130"
+                                        Classes="primary wide"
+                                        IsVisible="{Binding IsRunningInWebAssembly}"
+                                        IsEnabled="{Binding IsNotBusy}"/>
+                                <Button Content="Download ROM Files"
+                                        AutomationProperties.AutomationId="Vic20DownloadRomFilesButton"
+                                        Command="{Binding DownloadRomsToFilesCommand}"
+                                        MinWidth="130"
+                                        Classes="primary extraWide"
+                                        IsVisible="{Binding !IsRunningInWebAssembly}"
+                                        IsEnabled="{Binding IsNotBusy}"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <StackPanel Width="460" Classes="wrap-item" IsVisible="{Binding IsRunningInWebAssembly}">
+                    <Border Classes="content-section">
+                        <StackPanel Classes="spacing-tight">
+                            <TextBlock Text="Web Download"/>
+                            <TextBlock Text="Override CORS proxy"
+                                       Classes="small secondary-text"/>
+                            <TextBox AutomationProperties.AutomationId="Vic20CorsProxyTextBox"
+                                     AutomationProperties.Name="VIC-20 CORS proxy URL"
+                                     Text="{Binding CorsProxyOverrideURL}"
+                                     PlaceholderText="{Binding CorsProxyOverrideURLWatermark}"
+                                     Classes="field-aligned"
+                                     KeyDown="CorsProxyTextBox_KeyDown"/>
+                            <Button Content="Reset"
+                                    AutomationProperties.AutomationId="Vic20ResetCorsProxyButton"
+                                    Command="{Binding ResetCorsProxyOverrideURLCommand}"
+                                    Classes="small"
+                                    HorizontalAlignment="Left"
+                                    IsEnabled="{Binding IsNotBusy}"/>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+            </WrapPanel>
+        </ScrollViewer>
+
+        <TextBlock Grid.Row="2"
+                   Text="{Binding ValidationMessage}"
+                   TextWrapping="Wrap"
+                   Foreground="#F56565"
+                   Classes="small"
+                   IsVisible="{Binding HasValidationMessage}"/>
+
+        <Grid Grid.Row="3" ColumnDefinitions="*,Auto,Auto" Classes="spacing-normal">
+            <TextBlock Grid.Column="0"
+                       Text="{Binding StatusMessage}"
+                       Classes="small secondary-text"
+                       IsVisible="{Binding HasStatusMessage}"/>
+            <Button Grid.Column="1"
+                    Content="Cancel"
+                    AutomationProperties.AutomationId="Vic20ConfigCancelButton"
+                    Command="{Binding CancelCommand}"
+                    Classes="cancel"
+                    IsEnabled="{Binding IsNotBusy}"/>
+            <Button Grid.Column="2"
+                    Content="{Binding OkButtonText}"
+                    AutomationProperties.AutomationId="Vic20ConfigOkButton"
+                    Command="{Binding SaveCommand}"
+                    Classes="primary"
+                    IsEnabled="{Binding CanSave}"/>
+        </Grid>
+    </Grid>
 </UserControl>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20ConfigDialogView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20ConfigDialogView.axaml
@@ -1,0 +1,31 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.ViewModels"
+             x:Class="Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.Views.Vic20ConfigDialogView"
+             x:DataType="vm:Vic20ConfigDialogViewModel"
+             AutomationProperties.AutomationId="Vic20ConfigDialogView"
+             AutomationProperties.Name="VIC-20 configuration panel"
+             Focusable="False">
+    <StackPanel Margin="6" Spacing="6">
+        <TextBlock Text="VIC-20 configuration (read-only)" FontWeight="Bold" />
+        <StackPanel Spacing="2">
+            <TextBlock Text="ROM directory:" />
+            <TextBlock Text="{Binding ROMDirectory}" FontFamily="Consolas,Menlo,monospace" />
+        </StackPanel>
+        <StackPanel Spacing="2">
+            <TextBlock Text="ROM files:" />
+            <ItemsControl ItemsSource="{Binding ROMs}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate DataType="vm:Vic20ConfigDialogViewModel+RomEntry">
+                        <TextBlock FontFamily="Consolas,Menlo,monospace">
+                            <Run Text="  " />
+                            <Run Text="{Binding Name}" />
+                            <Run Text=" → " />
+                            <Run Text="{Binding File}" />
+                        </TextBlock>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20ConfigDialogView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20ConfigDialogView.axaml.cs
@@ -1,14 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
+using Avalonia.Platform.Storage;
+using Highbyte.DotNet6502.App.Avalonia.Core;
+using Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using AvaloniaApp = Highbyte.DotNet6502.App.Avalonia.Core.App;
 
 namespace Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.Views;
 
 public partial class Vic20ConfigDialogView : UserControl
 {
+    private ILogger? _logger;
+    private ILogger Logger => _logger ??= AppLogger.CreateLogger(nameof(Vic20ConfigDialogView));
+
+    private Vic20ConfigDialogViewModel? _previousViewModel;
+    private Vic20ConfigDialogViewModel? ViewModel => DataContext as Vic20ConfigDialogViewModel;
+    private EventHandler<bool>? _configurationChangedHandlers;
+
+    public event EventHandler<bool>? ConfigurationChanged
+    {
+        add
+        {
+            _configurationChangedHandlers += value;
+            if (ViewModel != null)
+                ViewModel.ConfigurationChanged += value;
+        }
+        remove
+        {
+            _configurationChangedHandlers -= value;
+            if (ViewModel != null)
+                ViewModel.ConfigurationChanged -= value;
+        }
+    }
+
     public Vic20ConfigDialogView()
     {
         InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
     }
 
     private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (_previousViewModel != null)
+        {
+            if (_configurationChangedHandlers != null)
+                _previousViewModel.ConfigurationChanged -= _configurationChangedHandlers;
+            _previousViewModel.RomLicenseAcknowledgementRequested -= OnRomLicenseAcknowledgementRequested;
+        }
+
+        if (ViewModel != null)
+        {
+            if (_configurationChangedHandlers != null)
+                ViewModel.ConfigurationChanged += _configurationChangedHandlers;
+            ViewModel.RomLicenseAcknowledgementRequested += OnRomLicenseAcknowledgementRequested;
+        }
+
+        _previousViewModel = ViewModel;
+    }
+
+    private void OnRomLicenseAcknowledgementRequested(object? sender, Vic20RomLicenseAcknowledgementEventArgs e)
+        => SafeAsyncHelper.Execute(async () =>
+        {
+            var serviceProvider = (Application.Current as AvaloniaApp)?.GetServiceProvider();
+            if (serviceProvider == null)
+            {
+                Logger.LogError("Could not get service provider");
+                e.SetResult(false);
+                return;
+            }
+
+            var romPromptService = serviceProvider.GetRequiredService<Vic20RomPromptService>();
+            var result = await romPromptService.ShowConfigDownloadAcknowledgementAsync(this);
+            e.SetResult(result);
+        });
+
+    private void CorsProxyTextBox_KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (sender is not TextBox textBox) return;
+        if ((e.KeyModifiers & (KeyModifiers.Meta | KeyModifiers.Control)) == 0) return;
+
+        if (e.Key == Key.C)
+        {
+            textBox.Copy();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.V)
+        {
+            textBox.Paste();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.X)
+        {
+            textBox.Cut();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.A)
+        {
+            textBox.SelectAll();
+            e.Handled = true;
+        }
+    }
+
+    private void LoadRoms_Click(object? sender, RoutedEventArgs e)
+        => SafeAsyncHelper.Execute(LoadRomsAsync);
+
+    private async Task LoadRomsAsync()
+    {
+        if (TopLevel.GetTopLevel(this)?.StorageProvider == null)
+            return;
+        var storageProvider = TopLevel.GetTopLevel(this)!.StorageProvider;
+
+        var options = new FilePickerOpenOptions
+        {
+            Title = "Select VIC-20 ROM files",
+            AllowMultiple = true,
+            FileTypeFilter = new List<FilePickerFileType>
+            {
+                new("ROM files")
+                {
+                    Patterns = new[] { "*.bin", "*.rom" }
+                },
+                FilePickerFileTypes.All
+            }
+        };
+
+        var files = await storageProvider.OpenFilePickerAsync(options);
+        if (files == null || files.Count == 0)
+            return;
+
+        var romDataList = new List<(string fileName, byte[] data)>();
+        foreach (var file in files)
+        {
+            try
+            {
+                using var stream = await file.OpenReadAsync();
+                var data = new byte[stream.Length];
+                await stream.ReadExactlyAsync(data);
+                romDataList.Add((file.Name, data));
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Failed to read ROM file {FileName}", file.Name);
+            }
+        }
+
+        if (romDataList.Count > 0 && ViewModel != null)
+            await ViewModel.LoadRomsFromDataAsync(romDataList);
+    }
 }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20ConfigDialogView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20ConfigDialogView.axaml.cs
@@ -1,0 +1,14 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.Views;
+
+public partial class Vic20ConfigDialogView : UserControl
+{
+    public Vic20ConfigDialogView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20InfoView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20InfoView.axaml
@@ -1,0 +1,19 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.ViewModels"
+             x:Class="Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.Views.Vic20InfoView"
+             x:DataType="vm:Vic20InfoViewModel"
+             AutomationProperties.AutomationId="Vic20InfoView"
+             AutomationProperties.Name="VIC-20 information panel"
+             Focusable="False">
+    <StackPanel Margin="6" Spacing="4">
+        <TextBlock Text="VIC-20 (stub system plugin)" FontWeight="Bold" />
+        <TextBlock Text="{Binding TextMode}" />
+        <TextBlock Text="{Binding RefreshRate}" />
+        <TextBlock Text="{Binding MemoryLayout}" TextWrapping="Wrap" />
+        <TextBlock>
+            <Run Text="Required ROMs: " />
+            <Run Text="{Binding RequiredROMs}" />
+        </TextBlock>
+    </StackPanel>
+</UserControl>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20InfoView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20InfoView.axaml
@@ -6,14 +6,93 @@
              AutomationProperties.AutomationId="Vic20InfoView"
              AutomationProperties.Name="VIC-20 information panel"
              Focusable="False">
-    <StackPanel Margin="6" Spacing="4">
-        <TextBlock Text="VIC-20 (stub system plugin)" FontWeight="Bold" />
-        <TextBlock Text="{Binding TextMode}" />
-        <TextBlock Text="{Binding RefreshRate}" />
-        <TextBlock Text="{Binding MemoryLayout}" TextWrapping="Wrap" />
-        <TextBlock>
-            <Run Text="Required ROMs: " />
-            <Run Text="{Binding RequiredROMs}" />
-        </TextBlock>
-    </StackPanel>
+
+    <UserControl.Styles>
+        <StyleInclude Source="avares://Highbyte.DotNet6502.App.Avalonia.Core/Styles/NonFocusableStyles.axaml"/>
+    </UserControl.Styles>
+
+    <ScrollViewer Classes="auto-scroll">
+        <StackPanel Classes="spacing-tight">
+            <TextBlock Text="VIC-20 keyboard mapping"
+                       Classes=""/>
+
+            <Border Classes="section-container">
+                <Grid Classes="spacing-none">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" MinWidth="150"/>
+                        <ColumnDefinition Width="*" MinWidth="120"/>
+                        <ColumnDefinition Width="*" MinWidth="150"/>
+                    </Grid.ColumnDefinitions>
+
+                    <Border Grid.Row="0" Grid.Column="0" Classes="table-header-cell">
+                        <TextBlock Text="Command" Classes="small bold"/>
+                    </Border>
+                    <Border Grid.Row="0" Grid.Column="1" Classes="table-header-cell">
+                        <TextBlock Text="VIC-20 key" Classes="small bold"/>
+                    </Border>
+                    <Border Grid.Row="0" Grid.Column="2" Classes="table-header-cell-last">
+                        <TextBlock Text="PC / Mac key" Classes="small bold"/>
+                    </Border>
+
+                    <Border Grid.Row="1" Grid.Column="0" Classes="table-cell">
+                        <TextBlock Text="Stop running Basic program" Classes="small" TextWrapping="Wrap"/>
+                    </Border>
+                    <Border Grid.Row="1" Grid.Column="1" Classes="table-cell">
+                        <TextBlock Text="Run/Stop" Classes="small"/>
+                    </Border>
+                    <Border Grid.Row="1" Grid.Column="2" Classes="table-cell-last-column">
+                        <TextBlock Text="Esc" Classes="small"/>
+                    </Border>
+
+                    <Border Grid.Row="2" Grid.Column="0" Classes="table-cell">
+                        <TextBlock Text="Move cursor" Classes="small" TextWrapping="Wrap"/>
+                    </Border>
+                    <Border Grid.Row="2" Grid.Column="1" Classes="table-cell">
+                        <TextBlock Text="Cursor keys" Classes="small"/>
+                    </Border>
+                    <Border Grid.Row="2" Grid.Column="2" Classes="table-cell-last-column">
+                        <TextBlock Text="Arrow keys" Classes="small"/>
+                    </Border>
+
+                    <Border Grid.Row="3" Grid.Column="0" Classes="table-cell">
+                        <TextBlock Text="Change text color 1-8" Classes="small" TextWrapping="Wrap"/>
+                    </Border>
+                    <Border Grid.Row="3" Grid.Column="1" Classes="table-cell">
+                        <TextBlock Text="CTRL + numbers 1-8" Classes="small" TextWrapping="Wrap"/>
+                    </Border>
+                    <Border Grid.Row="3" Grid.Column="2" Classes="table-cell-last-column">
+                        <TextBlock Text="LeftCtrl + numbers 1-8" Classes="small" TextWrapping="Wrap"/>
+                    </Border>
+
+                    <Border Grid.Row="4" Grid.Column="0" Classes="table-cell">
+                        <TextBlock Text="Delete character" Classes="small" TextWrapping="Wrap"/>
+                    </Border>
+                    <Border Grid.Row="4" Grid.Column="1" Classes="table-cell">
+                        <TextBlock Text="Del" Classes="small"/>
+                    </Border>
+                    <Border Grid.Row="4" Grid.Column="2" Classes="table-cell-last-column">
+                        <TextBlock Text="Backspace or Delete" Classes="small" TextWrapping="Wrap"/>
+                    </Border>
+
+                    <Border Grid.Row="5" Grid.Column="0" Classes="table-cell-last-row">
+                        <TextBlock Text="Function keys" Classes="small" TextWrapping="Wrap"/>
+                    </Border>
+                    <Border Grid.Row="5" Grid.Column="1" Classes="table-cell-last-row">
+                        <TextBlock Text="F1, F3, F5, F7" Classes="small" TextWrapping="Wrap"/>
+                    </Border>
+                    <Border Grid.Row="5" Grid.Column="2" Classes="table-cell-last">
+                        <TextBlock Text="F1, F3, F5, F7" Classes="small" TextWrapping="Wrap"/>
+                    </Border>
+                </Grid>
+            </Border>
+        </StackPanel>
+    </ScrollViewer>
 </UserControl>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20InfoView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20InfoView.axaml.cs
@@ -1,0 +1,14 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.Views;
+
+public partial class Vic20InfoView : UserControl
+{
+    public Vic20InfoView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20MenuView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20MenuView.axaml
@@ -1,0 +1,16 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.ViewModels"
+             x:Class="Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.Views.Vic20MenuView"
+             x:DataType="vm:Vic20MenuViewModel"
+             AutomationProperties.AutomationId="Vic20MenuView"
+             AutomationProperties.Name="VIC-20 menu panel"
+             Focusable="False">
+    <StackPanel Margin="6" Spacing="6">
+        <TextBlock Text="VIC-20" FontWeight="Bold" />
+        <Button Content="Reset"
+                Command="{Binding ResetCommand}"
+                IsEnabled="{Binding IsResetEnabled}"
+                HorizontalAlignment="Left" />
+    </StackPanel>
+</UserControl>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20MenuView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20MenuView.axaml
@@ -8,9 +8,17 @@
              Focusable="False">
     <StackPanel Margin="6" Spacing="6">
         <TextBlock Text="VIC-20" FontWeight="Bold" />
-        <Button Content="Reset"
-                Command="{Binding ResetCommand}"
-                IsEnabled="{Binding IsResetEnabled}"
-                HorizontalAlignment="Left" />
+        <Button Name="Vic20Config"
+                Content="VIC20 Config"
+                AutomationProperties.AutomationId="Vic20ConfigButton"
+                AutomationProperties.Name="Open VIC-20 configuration dialog"
+                Click="OpenVic20Config_Click"
+                HorizontalAlignment="Left">
+            <Button.Transitions>
+                <Transitions>
+                    <BrushTransition Property="Background" Duration="0:0:0.7"/>
+                </Transitions>
+            </Button.Transitions>
+        </Button>
     </StackPanel>
 </UserControl>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20MenuView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20MenuView.axaml.cs
@@ -1,14 +1,215 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Highbyte.DotNet6502.App.Avalonia.Core;
+using Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.ViewModels;
+using Highbyte.DotNet6502.Impl.Avalonia;
+using Highbyte.DotNet6502.Impl.Avalonia.Vic20;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using AvaloniaApp = Highbyte.DotNet6502.App.Avalonia.Core.App;
 
 namespace Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.Views;
 
 public partial class Vic20MenuView : UserControl
 {
+    private ILogger? _logger;
+    private ILogger Logger => _logger ??= AppLogger.CreateLogger(nameof(Vic20MenuView));
+    private Vic20MenuViewModel? ViewModel => DataContext as Vic20MenuViewModel;
+    private CancellationTokenSource? _buttonFlashCancellation;
+
     public Vic20MenuView()
     {
         InitializeComponent();
+
+        AttachedToVisualTree += (_, _) =>
+        {
+            if (ViewModel != null)
+                UpdateSectionStatesIfNeeded();
+        };
     }
 
     private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    private void UpdateSectionStatesIfNeeded()
+    {
+        try
+        {
+            if (ViewModel == null)
+                return;
+
+            if (ViewModel.HasConfigValidationErrors)
+            {
+                var vic20ConfigButton = this.FindControl<Button>("Vic20Config");
+                if (vic20ConfigButton != null)
+                    StartButtonFlash(vic20ConfigButton, Colors.DarkOrange, stopAfterClick: true);
+            }
+            else
+            {
+                CancelButtonFlash();
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"UpdateSectionStatesIfNeeded: Skipping update due to uninitialized state - {ex.Message}");
+        }
+    }
+
+    private void CancelButtonFlash()
+    {
+        var cts = _buttonFlashCancellation;
+        if (cts == null)
+            return;
+
+        _buttonFlashCancellation = null;
+        SafeAsyncHelper.Execute(async () =>
+        {
+            await cts.CancelAsync();
+            cts.Dispose();
+        });
+    }
+
+    private void StartButtonFlash(Button button, Color flashColor, bool stopAfterClick)
+        => SafeAsyncHelper.Execute(async () =>
+        {
+            var existingCancellation = _buttonFlashCancellation;
+            if (existingCancellation != null)
+            {
+                _buttonFlashCancellation = null;
+                await existingCancellation.CancelAsync();
+                existingCancellation.Dispose();
+            }
+
+            var buttonFlashCancellation = new CancellationTokenSource();
+            _buttonFlashCancellation = buttonFlashCancellation;
+            var originalBrush = button.Background;
+            var flashBrush = new SolidColorBrush(flashColor);
+
+            EventHandler<RoutedEventArgs>? tempHandler = null;
+            tempHandler = (_, _) =>
+            {
+                SafeAsyncHelper.Execute(async () =>
+                {
+                    await buttonFlashCancellation.CancelAsync();
+                    button.Click -= tempHandler;
+                });
+            };
+            if (stopAfterClick)
+                button.Click += tempHandler;
+
+            try
+            {
+                while (!buttonFlashCancellation.Token.IsCancellationRequested)
+                {
+                    button.Background = flashBrush;
+                    await Task.Delay(700, buttonFlashCancellation.Token);
+
+                    button.Background = originalBrush;
+                    await Task.Delay(2000, buttonFlashCancellation.Token);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                button.Background = originalBrush;
+            }
+            finally
+            {
+                button.Click -= tempHandler;
+                buttonFlashCancellation.Dispose();
+
+                if (ReferenceEquals(_buttonFlashCancellation, buttonFlashCancellation))
+                    _buttonFlashCancellation = null;
+            }
+        });
+
+    private void OpenVic20Config_Click(object? sender, RoutedEventArgs e)
+        => SafeAsyncHelper.Execute(async () =>
+        {
+            if (ViewModel?.HostApp == null)
+                return;
+
+            if (ViewModel.HostApp.CurrentHostSystemConfig is not Vic20HostConfig)
+                return;
+
+            if (PlatformDetection.IsRunningInWebAssembly())
+                await Vic20ConfigUserControlOverlayAsync();
+            else
+                await ShowVic20ConfigDialogAsync();
+        });
+
+    private async Task ShowVic20ConfigDialogAsync()
+    {
+        var serviceProvider = (Application.Current as AvaloniaApp)?.GetServiceProvider();
+        if (serviceProvider == null)
+        {
+            Logger.LogError("Could not get service provider");
+            return;
+        }
+
+        var dialog = new Vic20ConfigDialog
+        {
+            DataContext = new Vic20ConfigDialogViewModel(ViewModel!.HostApp)
+        };
+
+        bool? result;
+        if (TopLevel.GetTopLevel(this) is Window owner)
+        {
+            result = await dialog.ShowDialog<bool?>(owner);
+        }
+        else
+        {
+            var tcs = new TaskCompletionSource<bool?>();
+            dialog.Closed += (_, _) => tcs.TrySetResult(dialog.DialogResultValue);
+            dialog.Show();
+            result = await tcs.Task;
+        }
+
+        if (result == true)
+            await ViewModel!.HostApp.ValidateConfigAsync();
+
+        UpdateSectionStatesIfNeeded();
+    }
+
+    private async Task Vic20ConfigUserControlOverlayAsync()
+    {
+        var serviceProvider = (Application.Current as AvaloniaApp)?.GetServiceProvider();
+        if (serviceProvider == null)
+        {
+            Logger.LogError("Could not get service provider");
+            return;
+        }
+
+        var configControl = new Vic20ConfigDialogView
+        {
+            DataContext = new Vic20ConfigDialogViewModel(ViewModel!.HostApp)
+        };
+
+        var taskCompletionSource = new TaskCompletionSource<bool>();
+        configControl.ConfigurationChanged += (_, saved) =>
+        {
+            taskCompletionSource.TrySetResult(saved);
+        };
+
+        var overlayDialogHelper = serviceProvider.GetRequiredService<OverlayDialogHelper>();
+        var overlayPanel = overlayDialogHelper.BuildOverlayDialogPanel(configControl);
+        var mainGrid = overlayDialogHelper.ShowOverlayDialog(overlayPanel, this);
+
+        try
+        {
+            var result = await taskCompletionSource.Task;
+            if (result)
+                await ViewModel!.HostApp.ValidateConfigAsync();
+
+            UpdateSectionStatesIfNeeded();
+        }
+        finally
+        {
+            mainGrid.Children.Remove(overlayPanel);
+        }
+    }
 }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20MenuView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20MenuView.axaml.cs
@@ -1,0 +1,14 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.Views;
+
+public partial class Vic20MenuView : UserControl
+{
+    public Vic20MenuView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+}

--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Vic20/Highbyte.DotNet6502.Impl.Avalonia.Vic20.csproj
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Vic20/Highbyte.DotNet6502.Impl.Avalonia.Vic20.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <PackageId>Highbyte.DotNet6502.Impl.Avalonia.Vic20</PackageId>
+    <Authors>Highbyte</Authors>
+    <PackageDescription>Avalonia VIC-20 engine plugin for the Highbyte.DotNet6502 emulator.</PackageDescription>
+    <RepositoryUrl>https://github.com/highbyte/dotnet-6502</RepositoryUrl>
+    <Version>0.1.0-alpha</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Highbyte.DotNet6502\Highbyte.DotNet6502.csproj" />
+    <ProjectReference Include="..\Highbyte.DotNet6502.Systems\Highbyte.DotNet6502.Systems.csproj" />
+    <ProjectReference Include="..\Highbyte.DotNet6502.Systems.Vic20\Highbyte.DotNet6502.Systems.Vic20.csproj" />
+    <ProjectReference Include="..\Highbyte.DotNet6502.Systems.Plugins\Highbyte.DotNet6502.Systems.Plugins.csproj" />
+    <ProjectReference Include="..\Highbyte.DotNet6502.Impl.Avalonia\Highbyte.DotNet6502.Impl.Avalonia.csproj" />
+    <ProjectReference Include="..\Highbyte.DotNet6502.Impl.NAudio\Highbyte.DotNet6502.Impl.NAudio.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+  </ItemGroup>
+
+</Project>

--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Vic20/Vic20AvaloniaEnginePlugin.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Vic20/Vic20AvaloniaEnginePlugin.cs
@@ -1,0 +1,31 @@
+using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Plugins;
+using Highbyte.DotNet6502.Systems.Vic20;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+[assembly: SystemPlugin(typeof(Highbyte.DotNet6502.Impl.Avalonia.Vic20.Vic20AvaloniaEnginePlugin))]
+
+namespace Highbyte.DotNet6502.Impl.Avalonia.Vic20;
+
+/// <summary>
+/// Engine-side plugin for the VIC-20 on the Avalonia + NAudio host pair.
+/// Registers the <see cref="Vic20Setup"/> (the <see cref="ISystemConfigurer"/>) into DI.
+/// </summary>
+public sealed class Vic20AvaloniaEnginePlugin : ISystemEnginePlugin
+{
+    public string SystemName => global::Highbyte.DotNet6502.Systems.Vic20.Vic20.SystemName;
+
+    public string HostTechName => "Avalonia.NAudio";
+
+    public void Register(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddSingleton<ISystemConfigurer>(sp =>
+        {
+            var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+            var config = sp.GetRequiredService<IConfiguration>();
+            return new Vic20Setup(loggerFactory, config);
+        });
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Vic20/Vic20HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Vic20/Vic20HostConfig.cs
@@ -1,0 +1,14 @@
+using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Vic20.Config;
+
+namespace Highbyte.DotNet6502.Impl.Avalonia.Vic20;
+
+/// <summary>VIC-20 host config for the Avalonia host.</summary>
+public class Vic20HostConfig : HostSystemConfigBase<Vic20SystemConfig>
+{
+    public const string ConfigSectionName = "Highbyte.DotNet6502.Vic20.Avalonia";
+
+    public override bool AudioSupported => false;
+
+    public override object Clone() => (Vic20HostConfig)base.Clone();
+}

--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Vic20/Vic20HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Vic20/Vic20HostConfig.cs
@@ -1,5 +1,6 @@
 using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Vic20.Config;
+using Highbyte.DotNet6502.Impl.Avalonia;
 
 namespace Highbyte.DotNet6502.Impl.Avalonia.Vic20;
 
@@ -7,8 +8,18 @@ namespace Highbyte.DotNet6502.Impl.Avalonia.Vic20;
 public class Vic20HostConfig : HostSystemConfigBase<Vic20SystemConfig>
 {
     public const string ConfigSectionName = "Highbyte.DotNet6502.Vic20.Avalonia";
+    public const string DefaultCorsProxyURL = "https://api.codetabs.com/v1/proxy?quest=";
 
     public override bool AudioSupported => false;
+
+    public string? CorsProxyOverrideURL { get; set; } = null;
+
+    public string? GetCorsProxyURL()
+    {
+        if (!PlatformDetection.IsRunningInWebAssembly())
+            return null;
+        return string.IsNullOrEmpty(CorsProxyOverrideURL) ? DefaultCorsProxyURL : CorsProxyOverrideURL;
+    }
 
     public override object Clone() => (Vic20HostConfig)base.Clone();
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Vic20/Vic20Setup.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Vic20/Vic20Setup.cs
@@ -1,0 +1,29 @@
+using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Input;
+using Highbyte.DotNet6502.Systems.Vic20;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Vic20System = Highbyte.DotNet6502.Systems.Vic20.Vic20;
+
+namespace Highbyte.DotNet6502.Impl.Avalonia.Vic20;
+
+/// <summary>
+/// VIC-20 system configurer for the Avalonia host. Inherits all host-agnostic logic from
+/// <see cref="Vic20SystemConfigurerCore"/> and wires the Avalonia input stub.
+/// </summary>
+public class Vic20Setup : Vic20SystemConfigurerCore
+{
+    public Vic20Setup(ILoggerFactory loggerFactory, IConfiguration configuration)
+        : base(loggerFactory, configuration, () => new Vic20HostConfig(), Vic20HostConfig.ConfigSectionName)
+    {
+    }
+
+    public override Task<SystemRunner> BuildSystemRunner(ISystem system, IHostSystemConfig hostSystemConfig)
+    {
+        // Step 4 (idea doc): keyboard handler stub — keys reach the system but are routed to /dev/null.
+        // A real Avalonia input handler would be wired here once the plugin contract is fully proven.
+        var vic20 = (Vic20System)system;
+        vic20.InputConsumer = new NullInputConsumer(vic20);
+        return Task.FromResult(new SystemRunner(vic20));
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Vic20/Vic20Setup.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Vic20/Vic20Setup.cs
@@ -1,6 +1,6 @@
 using Highbyte.DotNet6502.Systems;
-using Highbyte.DotNet6502.Systems.Input;
 using Highbyte.DotNet6502.Systems.Vic20;
+using Highbyte.DotNet6502.Systems.Vic20.Input;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Vic20System = Highbyte.DotNet6502.Systems.Vic20.Vic20;
@@ -8,22 +8,24 @@ using Vic20System = Highbyte.DotNet6502.Systems.Vic20.Vic20;
 namespace Highbyte.DotNet6502.Impl.Avalonia.Vic20;
 
 /// <summary>
-/// VIC-20 system configurer for the Avalonia host. Inherits all host-agnostic logic from
-/// <see cref="Vic20SystemConfigurerCore"/> and wires the Avalonia input stub.
+/// VIC-20 system configurer for the Avalonia host.
+/// Inherits all host-agnostic logic from <see cref="Vic20SystemConfigurerCore"/>
+/// and wires the real Avalonia input handler.
 /// </summary>
 public class Vic20Setup : Vic20SystemConfigurerCore
 {
+    private readonly ILoggerFactory _loggerFactory;
+
     public Vic20Setup(ILoggerFactory loggerFactory, IConfiguration configuration)
         : base(loggerFactory, configuration, () => new Vic20HostConfig(), Vic20HostConfig.ConfigSectionName)
     {
+        _loggerFactory = loggerFactory;
     }
 
     public override Task<SystemRunner> BuildSystemRunner(ISystem system, IHostSystemConfig hostSystemConfig)
     {
-        // Step 4 (idea doc): keyboard handler stub — keys reach the system but are routed to /dev/null.
-        // A real Avalonia input handler would be wired here once the plugin contract is fully proven.
         var vic20 = (Vic20System)system;
-        vic20.InputConsumer = new NullInputConsumer(vic20);
+        vic20.InputConsumer = new Vic20InputHandler(vic20, _loggerFactory);
         return Task.FromResult(new SystemRunner(vic20));
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Plugins/ISystemShellPlugin.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Plugins/ISystemShellPlugin.cs
@@ -17,6 +17,12 @@ public interface ISystemShellPlugin
     string SystemName { get; }
 
     /// <summary>
+    /// Relative display order for host UI system lists. Lower values appear first;
+    /// hosts should use <see cref="SystemName"/> as a stable tie-breaker.
+    /// </summary>
+    int DisplayOrder => 1000;
+
+    /// <summary>
     /// Register the plugin's ViewModels / Views / helper services in DI.
     /// Called once at app startup before the shell resolves anything.
     /// </summary>

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20Config.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20Config.cs
@@ -1,0 +1,36 @@
+namespace Highbyte.DotNet6502.Systems.Vic20.Config;
+
+/// <summary>
+/// VIC-20 screen and memory layout constants for the emulator.
+/// These follow the unexpanded VIC-20 memory map.
+/// </summary>
+public class Vic20Config
+{
+    // Standard VIC-20 text-mode dimensions
+    public const int Cols = 22;
+    public const int Rows = 23;
+    // NTSC VIC-20 border: ~5 char columns each side, ~1 row top/bottom.
+    // This gives a 256×200 visible pixel area (wider than tall), matching real hardware.
+    public const int BorderCols = 5;
+    public const int BorderRows = 1;
+
+    // VIC-20 screen RAM: default location in unexpanded machine
+    public ushort ScreenStartAddress { get; set; } = 0x1E00;
+
+    // VIC-20 color RAM: always at this address regardless of RAM expansion
+    public ushort ColorStartAddress { get; set; } = 0x9600;
+
+    // Simplified color control: two separate addresses for bg and border
+    public ushort BackgroundColorAddress { get; set; } = 0x900F;
+    public ushort BorderColorAddress { get; set; } = 0x900E;
+
+    // VIC-20 boots to a blue screen with white text
+    public byte DefaultFgColor { get; set; } = 0x01;  // White
+    public byte DefaultBgColor { get; set; } = 0x06;  // Blue
+    public byte DefaultBorderColor { get; set; } = 0x03; // Cyan
+
+    // CPU cycles per frame: VIC-20 NTSC runs at ~14318 cycles/frame at 60 Hz
+    public ulong CpuCyclesPerFrame { get; set; } = 14318;
+
+    public float ScreenRefreshFrequencyHz { get; set; } = 60.0f;
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20Config.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20Config.cs
@@ -14,11 +14,11 @@ public class Vic20Config
     public const int BorderCols = 5;
     public const int BorderRows = 1;
 
-    // VIC-20 screen RAM: default location in unexpanded machine
-    public ushort ScreenStartAddress { get; set; } = 0x1E00;
+    // VIC-20 screen RAM: VIC-I $9005 bits[7:4]=$C encodes screen at $1000 (start of 4KB user RAM)
+    public ushort ScreenStartAddress { get; set; } = 0x1000;
 
     // VIC-20 color RAM: always at this address regardless of RAM expansion
-    public ushort ColorStartAddress { get; set; } = 0x9600;
+    public ushort ColorStartAddress { get; set; } = 0x9400;
 
     // VIC-I register $900F packs both:
     //   bits 7-4: background color (16 colors)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20Config.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20Config.cs
@@ -20,14 +20,18 @@ public class Vic20Config
     // VIC-20 color RAM: always at this address regardless of RAM expansion
     public ushort ColorStartAddress { get; set; } = 0x9600;
 
-    // Simplified color control: two separate addresses for bg and border
+    // VIC-I register $900F packs both:
+    //   bits 7-4: background color (16 colors)
+    //   bit  3  : reverse video (1=normal, 0=reverse)
+    //   bits 2-0: border color   (8 colors)
+    // $900E is NOT border — it is sound volume (bits 3-0) + auxiliary color (bits 7-4).
     public ushort BackgroundColorAddress { get; set; } = 0x900F;
-    public ushort BorderColorAddress { get; set; } = 0x900E;
+    public ushort BorderColorAddress { get; set; } = 0x900F;
 
-    // VIC-20 boots to a blue screen with white text
-    public byte DefaultFgColor { get; set; } = 0x01;  // White
-    public byte DefaultBgColor { get; set; } = 0x06;  // Blue
-    public byte DefaultBorderColor { get; set; } = 0x03; // Cyan
+    // VIC-20 boots to a white screen with cyan border and blue text.
+    public byte DefaultFgColor { get; set; } = 0x06;  // Blue (3-bit)
+    public byte DefaultBgColor { get; set; } = 0x01;  // White (4-bit)
+    public byte DefaultBorderColor { get; set; } = 0x03; // Cyan (3-bit)
 
     // CPU cycles per frame: VIC-20 NTSC runs at ~14318 cycles/frame at 60 Hz
     public ulong CpuCyclesPerFrame { get; set; } = 14318;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20SystemConfig.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using System.Runtime.InteropServices;
 using Highbyte.DotNet6502.Utils;
 using Highbyte.DotNet6502.Systems.Vic20.Render;
 
@@ -11,6 +12,11 @@ public class Vic20SystemConfig : ISystemConfig
     public const string CHARGEN_ROM_NAME = "chargen";
 
     public static readonly List<string> RequiredROMs = new() { BASIC_ROM_NAME, KERNAL_ROM_NAME, CHARGEN_ROM_NAME };
+
+    public static string DEFAULT_ROM_DOWNLOAD_BASE_URL = "https://www.zimmers.net/anonftp/pub/cbm/firmware/computers/vic20";
+    public static string DEFAULT_BASIC_ROM_DOWNLOAD_URL = $"{DEFAULT_ROM_DOWNLOAD_BASE_URL}/basic.901486-01.bin";
+    public static string DEFAULT_KERNAL_ROM_DOWNLOAD_URL = $"{DEFAULT_ROM_DOWNLOAD_BASE_URL}/kernal.901486-07.bin";
+    public static string DEFAULT_CHARGEN_ROM_DOWNLOAD_URL = $"{DEFAULT_ROM_DOWNLOAD_BASE_URL}/characters.901460-03.bin";
 
     // SHA1 checksums for known VIC-20 ROM versions (version label → sha1 hex, lowercase)
     public static Dictionary<string, string> DefaultBasicROMChecksums = new()
@@ -58,6 +64,13 @@ public class Vic20SystemConfig : ISystemConfig
         set { _romDirectory = value; _isDirty = true; }
     }
 
+    public Dictionary<string, string> ROMDownloadUrls { get; } = new()
+    {
+        { BASIC_ROM_NAME, DEFAULT_BASIC_ROM_DOWNLOAD_URL },
+        { KERNAL_ROM_NAME, DEFAULT_KERNAL_ROM_DOWNLOAD_URL },
+        { CHARGEN_ROM_NAME, DEFAULT_CHARGEN_ROM_DOWNLOAD_URL }
+    };
+
     private List<ROM> _roms = new();
     public List<ROM> ROMs
     {
@@ -85,6 +98,30 @@ public class Vic20SystemConfig : ISystemConfig
 
     public bool HasROM(string romName) => _roms.Any(x => x.Name == romName);
     public ROM GetROM(string romName) => _roms.Single(x => x.Name == romName);
+
+    public void SetROM(string romName, string? file = null, byte[]? data = null)
+    {
+        if (HasROM(romName))
+        {
+            var rom = GetROM(romName);
+            rom.File = file;
+            rom.Data = data;
+        }
+        else
+        {
+            var rom = new ROM
+            {
+                Name = romName,
+                File = file,
+                Data = data
+            };
+
+            ApplyDefaultChecksums(rom);
+            ROMs.Add(rom);
+        }
+
+        _isDirty = true;
+    }
 
     [JsonIgnore]
     public Type? AudioProviderType => null;
@@ -129,6 +166,16 @@ public class Vic20SystemConfig : ISystemConfig
 
     public Vic20SystemConfig()
     {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")) ||
+            RuntimeInformation.OSArchitecture == Architecture.Wasm)
+        {
+            _romDirectory = string.Empty;
+        }
+        else
+        {
+            _romDirectory = "%USERPROFILE%/Documents/VIC20/VICE/VIC20";
+        }
+
         SetRenderProviderType(GetSupportedRenderProviderTypes().First());
     }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20SystemConfig.cs
@@ -1,0 +1,94 @@
+using System.Text.Json.Serialization;
+using Highbyte.DotNet6502.Systems.Vic20.Render;
+
+namespace Highbyte.DotNet6502.Systems.Vic20.Config;
+
+public class Vic20SystemConfig : ISystemConfig
+{
+    private bool _isDirty = false;
+    public bool IsDirty => _isDirty;
+
+    [JsonIgnore]
+    public Type? RenderProviderType { get; private set; }
+
+    [JsonPropertyName("RenderProviderType")]
+    public string? RenderProviderTypeName
+    {
+        get => RenderProviderType?.AssemblyQualifiedName;
+        set => SetRenderProviderType(value != null ? Type.GetType(value) : null);
+    }
+
+    [JsonIgnore]
+    public Type? RenderTargetType { get; private set; }
+
+    [JsonPropertyName("RenderTargetType")]
+    public string? RenderTargetTypeName
+    {
+        get => RenderTargetType?.AssemblyQualifiedName;
+        set => SetRenderTargetType(value != null ? Type.GetType(value) : null);
+    }
+
+    public bool AudioEnabled { get; set; } = false;
+
+    [JsonIgnore]
+    public Type? AudioProviderType => null;
+
+    [JsonIgnore]
+    public Type? AudioTargetType => null;
+
+    public List<Type> GetSupportedRenderProviderTypes() =>
+        new() { typeof(Vic20VideoCommandStream) };
+
+    public List<Type> GetSupportedAudioProviderTypes() => new();
+
+    public void SetRenderProviderType(Type? renderProviderType)
+    {
+        if (renderProviderType == null)
+        {
+            RenderProviderType = null;
+            return;
+        }
+        if (!GetSupportedRenderProviderTypes().Contains(renderProviderType))
+            throw new DotNet6502Exception($"Unsupported render provider: {renderProviderType.FullName}");
+        RenderProviderType = renderProviderType;
+    }
+
+    public void SetRenderTargetType(Type? renderTargetType)
+    {
+        RenderTargetType = renderTargetType;
+        _isDirty = true;
+    }
+
+    public void SetAudioProviderType(Type? audioProviderType)
+    {
+        if (audioProviderType != null)
+            throw new DotNet6502Exception("VIC-20 has no audio providers in this stub.");
+    }
+
+    public void SetAudioTargetType(Type? audioTargetType)
+    {
+        if (audioTargetType != null)
+            throw new DotNet6502Exception("VIC-20 has no audio targets in this stub.");
+    }
+
+    public Vic20SystemConfig()
+    {
+        SetRenderProviderType(GetSupportedRenderProviderTypes().First());
+    }
+
+    public void ClearDirty() => _isDirty = false;
+
+    public object Clone() => (Vic20SystemConfig)MemberwiseClone();
+
+    public void Validate()
+    {
+        if (!IsValid(out var errors))
+            throw new DotNet6502Exception($"Config errors: {string.Join(", ", errors)}");
+    }
+
+    public bool IsValid(out List<string> validationErrors)
+    {
+        validationErrors = new List<string>();
+        return true;
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20SystemConfig.cs
@@ -1,10 +1,31 @@
 using System.Text.Json.Serialization;
+using Highbyte.DotNet6502.Utils;
 using Highbyte.DotNet6502.Systems.Vic20.Render;
 
 namespace Highbyte.DotNet6502.Systems.Vic20.Config;
 
 public class Vic20SystemConfig : ISystemConfig
 {
+    public const string BASIC_ROM_NAME = "basic";
+    public const string KERNAL_ROM_NAME = "kernal";
+    public const string CHARGEN_ROM_NAME = "chargen";
+
+    public static readonly List<string> RequiredROMs = new() { BASIC_ROM_NAME, KERNAL_ROM_NAME, CHARGEN_ROM_NAME };
+
+    // SHA1 checksums for known VIC-20 ROM versions (version label → sha1 hex, lowercase)
+    public static Dictionary<string, string> DefaultBasicROMChecksums = new()
+    {
+        { "901486-01", "587d1e90950675ab6b12d91248a3f0d640d02e8d" },
+    };
+    public static Dictionary<string, string> DefaultKernalROMChecksums = new()
+    {
+        { "901486-07 (PAL-B)", "ce0137ed69f003a299f43538fa9eee27898e621e" },
+    };
+    public static Dictionary<string, string> DefaultChargenROMChecksums = new()
+    {
+        { "901460-03", "4fd85ab6647ee2ac7ba40f729323f2472d35b9b4" },
+    };
+
     private bool _isDirty = false;
     public bool IsDirty => _isDirty;
 
@@ -29,6 +50,41 @@ public class Vic20SystemConfig : ISystemConfig
     }
 
     public bool AudioEnabled { get; set; } = false;
+
+    private string _romDirectory = string.Empty;
+    public string ROMDirectory
+    {
+        get => _romDirectory;
+        set { _romDirectory = value; _isDirty = true; }
+    }
+
+    private List<ROM> _roms = new();
+    public List<ROM> ROMs
+    {
+        get => _roms;
+        set
+        {
+            _roms = value;
+            foreach (var rom in _roms)
+                ApplyDefaultChecksums(rom);
+            _isDirty = true;
+        }
+    }
+
+    private void ApplyDefaultChecksums(ROM rom)
+    {
+        if (rom.ValidVersionChecksums.Count != 0)
+            return;
+        if (rom.Name == BASIC_ROM_NAME)
+            rom.ValidVersionChecksums = new Dictionary<string, string>(DefaultBasicROMChecksums);
+        else if (rom.Name == KERNAL_ROM_NAME)
+            rom.ValidVersionChecksums = new Dictionary<string, string>(DefaultKernalROMChecksums);
+        else if (rom.Name == CHARGEN_ROM_NAME)
+            rom.ValidVersionChecksums = new Dictionary<string, string>(DefaultChargenROMChecksums);
+    }
+
+    public bool HasROM(string romName) => _roms.Any(x => x.Name == romName);
+    public ROM GetROM(string romName) => _roms.Single(x => x.Name == romName);
 
     [JsonIgnore]
     public Type? AudioProviderType => null;
@@ -78,7 +134,12 @@ public class Vic20SystemConfig : ISystemConfig
 
     public void ClearDirty() => _isDirty = false;
 
-    public object Clone() => (Vic20SystemConfig)MemberwiseClone();
+    public object Clone()
+    {
+        var clone = (Vic20SystemConfig)MemberwiseClone();
+        clone._roms = ROM.Clone(_roms);
+        return clone;
+    }
 
     public void Validate()
     {
@@ -89,6 +150,25 @@ public class Vic20SystemConfig : ISystemConfig
     public bool IsValid(out List<string> validationErrors)
     {
         validationErrors = new List<string>();
-        return true;
+
+        var loadedNames = _roms.Select(x => x.Name).ToList();
+        var missing = RequiredROMs.Where(r => !loadedNames.Contains(r)).ToList();
+        if (missing.Count > 0)
+            validationErrors.Add($"Missing ROMs: {string.Join(", ", missing)}.");
+
+        var romDir = PathHelper.ExpandOSEnvironmentVariables(_romDirectory);
+        if (!string.IsNullOrEmpty(romDir) && !Directory.Exists(romDir))
+            validationErrors.Add($"{nameof(ROMDirectory)} does not exist: {romDir}");
+
+        if (validationErrors.Count == 0)
+        {
+            foreach (var rom in _roms)
+            {
+                if (!rom.Validate(out var romErrors, _romDirectory))
+                    validationErrors.AddRange(romErrors);
+            }
+        }
+
+        return validationErrors.Count == 0;
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Highbyte.DotNet6502.Systems.Vic20.csproj
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Highbyte.DotNet6502.Systems.Vic20.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <PackageId>Highbyte.DotNet6502.Systems.Vic20</PackageId>
+    <Authors>Highbyte</Authors>
+    <PackageDescription>VIC-20 system library for the Highbyte.DotNet6502 CPU emulator.</PackageDescription>
+    <RepositoryUrl>https://github.com/highbyte/dotnet-6502</RepositoryUrl>
+    <Version>0.1.0-alpha</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Highbyte.DotNet6502\Highbyte.DotNet6502.csproj" />
+    <ProjectReference Include="..\Highbyte.DotNet6502.Systems\Highbyte.DotNet6502.Systems.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Input/Vic20HostKeyboard.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Input/Vic20HostKeyboard.cs
@@ -1,0 +1,108 @@
+using Highbyte.DotNet6502.Systems.Input;
+using Highbyte.DotNet6502.Systems.Vic20.TimerAndPeripheral;
+
+namespace Highbyte.DotNet6502.Systems.Vic20.Input;
+
+/// <summary>
+/// Maps host-neutral <see cref="HostKey"/> values to VIC-20 keyboard-matrix keys.
+///
+/// Modelled directly on C64HostKeyboard so the structure is familiar.
+/// Multi-key host combinations (Shift+key) that produce a single VIC-20 key
+/// are listed with both host keys in the array — the most-specific match wins.
+/// </summary>
+public class Vic20HostKeyboard
+{
+    /// <summary>
+    /// Maps host key combination → one or more VIC-20 matrix keys to press simultaneously.
+    /// Dictionary key is an array of host keys that must ALL be held for the mapping to fire.
+    /// </summary>
+    public Dictionary<HostKey[], Vic20Key[]> HostKeyToVic20KeyMap = new()
+    {
+        // Letters
+        { new[] { HostKey.KeyA }, new[] { Vic20Key.A } },
+        { new[] { HostKey.KeyB }, new[] { Vic20Key.B } },
+        { new[] { HostKey.KeyC }, new[] { Vic20Key.C } },
+        { new[] { HostKey.KeyD }, new[] { Vic20Key.D } },
+        { new[] { HostKey.KeyE }, new[] { Vic20Key.E } },
+        { new[] { HostKey.KeyF }, new[] { Vic20Key.F } },
+        { new[] { HostKey.KeyG }, new[] { Vic20Key.G } },
+        { new[] { HostKey.KeyH }, new[] { Vic20Key.H } },
+        { new[] { HostKey.KeyI }, new[] { Vic20Key.I } },
+        { new[] { HostKey.KeyJ }, new[] { Vic20Key.J } },
+        { new[] { HostKey.KeyK }, new[] { Vic20Key.K } },
+        { new[] { HostKey.KeyL }, new[] { Vic20Key.L } },
+        { new[] { HostKey.KeyM }, new[] { Vic20Key.M } },
+        { new[] { HostKey.KeyN }, new[] { Vic20Key.N } },
+        { new[] { HostKey.KeyO }, new[] { Vic20Key.O } },
+        { new[] { HostKey.KeyP }, new[] { Vic20Key.P } },
+        { new[] { HostKey.KeyQ }, new[] { Vic20Key.Q } },
+        { new[] { HostKey.KeyR }, new[] { Vic20Key.R } },
+        { new[] { HostKey.KeyS }, new[] { Vic20Key.S } },
+        { new[] { HostKey.KeyT }, new[] { Vic20Key.T } },
+        { new[] { HostKey.KeyU }, new[] { Vic20Key.U } },
+        { new[] { HostKey.KeyV }, new[] { Vic20Key.V } },
+        { new[] { HostKey.KeyW }, new[] { Vic20Key.W } },
+        { new[] { HostKey.KeyX }, new[] { Vic20Key.X } },
+        { new[] { HostKey.KeyY }, new[] { Vic20Key.Y } },
+        { new[] { HostKey.KeyZ }, new[] { Vic20Key.Z } },
+
+        // Digits
+        { new[] { HostKey.Digit0 }, new[] { Vic20Key.Zero } },
+        { new[] { HostKey.Digit1 }, new[] { Vic20Key.One } },
+        { new[] { HostKey.Digit2 }, new[] { Vic20Key.Two } },
+        { new[] { HostKey.Digit3 }, new[] { Vic20Key.Three } },
+        { new[] { HostKey.Digit4 }, new[] { Vic20Key.Four } },
+        { new[] { HostKey.Digit5 }, new[] { Vic20Key.Five } },
+        { new[] { HostKey.Digit6 }, new[] { Vic20Key.Six } },
+        { new[] { HostKey.Digit7 }, new[] { Vic20Key.Seven } },
+        { new[] { HostKey.Digit8 }, new[] { Vic20Key.Eight } },
+        { new[] { HostKey.Digit9 }, new[] { Vic20Key.Nine } },
+
+        // Common symbols (unshifted)
+        { new[] { HostKey.Minus  }, new[] { Vic20Key.Minus   } },
+        { new[] { HostKey.Equal  }, new[] { Vic20Key.Equal   } },
+        { new[] { HostKey.Period }, new[] { Vic20Key.Period  } },
+        { new[] { HostKey.Comma  }, new[] { Vic20Key.Comma   } },
+        { new[] { HostKey.Slash  }, new[] { Vic20Key.Slash   } },
+        { new[] { HostKey.Semicolon }, new[] { Vic20Key.Semicolon } },
+
+        // Shift+symbol combinations → VIC-20 symbols
+        { new[] { HostKey.ShiftLeft,  HostKey.Equal   }, new[] { Vic20Key.Plus     } }, // +
+        { new[] { HostKey.ShiftRight, HostKey.Equal   }, new[] { Vic20Key.Plus     } },
+        { new[] { HostKey.ShiftLeft,  HostKey.Semicolon }, new[] { Vic20Key.Colon  } }, // :
+        { new[] { HostKey.ShiftRight, HostKey.Semicolon }, new[] { Vic20Key.Colon  } },
+        { new[] { HostKey.ShiftLeft,  HostKey.Digit8  }, new[] { Vic20Key.Asterisk } }, // *
+        { new[] { HostKey.ShiftRight, HostKey.Digit8  }, new[] { Vic20Key.Asterisk } },
+
+        // Navigation / editing
+        { new[] { HostKey.Enter     }, new[] { Vic20Key.Return    } },
+        { new[] { HostKey.Space     }, new[] { Vic20Key.Space     } },
+        { new[] { HostKey.Backspace }, new[] { Vic20Key.Delete    } },
+        { new[] { HostKey.Delete    }, new[] { Vic20Key.Delete    } },
+        { new[] { HostKey.Home      }, new[] { Vic20Key.Home      } },
+
+        // Cursor keys — VIC-20 has one cursor-right key (shift = left) and one cursor-down (shift = up).
+        { new[] { HostKey.ArrowRight }, new[] { Vic20Key.CrsrRight } },
+        { new[] { HostKey.ArrowLeft  }, new[] { Vic20Key.LShift, Vic20Key.CrsrRight } },
+        { new[] { HostKey.ArrowDown  }, new[] { Vic20Key.CrsrDown  } },
+        { new[] { HostKey.ArrowUp    }, new[] { Vic20Key.LShift, Vic20Key.CrsrDown  } },
+
+        // Modifier keys
+        { new[] { HostKey.ShiftLeft  }, new[] { Vic20Key.LShift  } },
+        { new[] { HostKey.ShiftRight }, new[] { Vic20Key.RShift  } },
+        { new[] { HostKey.ControlLeft  }, new[] { Vic20Key.CBM   } }, // Ctrl → Commodore key
+        { new[] { HostKey.ControlRight }, new[] { Vic20Key.CBM   } },
+        { new[] { HostKey.Escape       }, new[] { Vic20Key.RunStop } }, // Esc → RUN/STOP
+
+        // Function keys
+        { new[] { HostKey.F1 }, new[] { Vic20Key.F1 } },
+        { new[] { HostKey.F3 }, new[] { Vic20Key.F3 } },
+        { new[] { HostKey.F5 }, new[] { Vic20Key.F5 } },
+        { new[] { HostKey.F7 }, new[] { Vic20Key.F7 } },
+        // F2/F4/F6/F8 are shift+F1/F3/F5/F7 on the VIC-20
+        { new[] { HostKey.F2 }, new[] { Vic20Key.LShift, Vic20Key.F1 } },
+        { new[] { HostKey.F4 }, new[] { Vic20Key.LShift, Vic20Key.F3 } },
+        { new[] { HostKey.F6 }, new[] { Vic20Key.LShift, Vic20Key.F5 } },
+        { new[] { HostKey.F8 }, new[] { Vic20Key.LShift, Vic20Key.F7 } },
+    };
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Input/Vic20InputHandler.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Input/Vic20InputHandler.cs
@@ -1,0 +1,97 @@
+using Highbyte.DotNet6502.Systems.Input;
+using Highbyte.DotNet6502.Systems.Instrumentation;
+using Highbyte.DotNet6502.Systems.Vic20.TimerAndPeripheral;
+using Microsoft.Extensions.Logging;
+
+namespace Highbyte.DotNet6502.Systems.Vic20.Input;
+
+/// <summary>
+/// Host-agnostic VIC-20 input handler.
+///
+/// Follows the same structure as C64InputHandler:
+///   Init()       — called once; stores the host input state provider.
+///   BeforeFrame() — called each frame; maps held host keys to VIC-20 matrix keys
+///                   and forwards them to Via1.Keyboard.SetKeysPressed().
+///   Cleanup()    — no-op.
+///
+/// The actual keyboard-matrix scanning is performed by the KERNAL via VIA register
+/// reads and writes during its 60 Hz IRQ handler — this handler only keeps the
+/// "pressed keys" list in Vic20Keyboard up to date.
+/// </summary>
+public class Vic20InputHandler : IInputConsumer
+{
+    private readonly Vic20 _vic20;
+    private readonly ILogger _logger;
+    private readonly Vic20HostKeyboard _hostKeyboard = new();
+
+    private IHostInputState _inputState = default!;
+
+    public ISystem System => _vic20;
+    public Instrumentations Instrumentations { get; } = new();
+
+    public Vic20InputHandler(Vic20 vic20, ILoggerFactory loggerFactory)
+    {
+        _vic20  = vic20;
+        _logger = loggerFactory.CreateLogger(nameof(Vic20InputHandler));
+    }
+
+    public void Init(IHostInputState inputState)
+    {
+        _inputState = inputState;
+    }
+
+    public void BeforeFrame()
+    {
+        _inputState.UpdatePerFrame();
+        var hostKeysDown = _inputState.KeysDown;
+        var vic20Keys = ResolveVic20Keys(hostKeysDown, out bool capsLockOn);
+        _vic20.Via1.Keyboard.SetKeysPressed(vic20Keys, capsLockOn);
+    }
+
+    public void Cleanup() { }
+
+    public List<string> GetDebugInfo() => new();
+
+    private List<Vic20Key> ResolveVic20Keys(
+        IReadOnlySet<HostKey> keysDown,
+        out bool capsLockOn)
+    {
+        capsLockOn = _inputState.CapsLockOn;
+
+        // Find the most-specific matching entries (more host keys in the chord = wins).
+        var foundMappings = new List<HostKey[]>();
+        foreach (var mapKeys in _hostKeyboard.HostKeyToVic20KeyMap.Keys)
+        {
+            int matchCount = 0;
+            foreach (var k in mapKeys)
+                if (keysDown.Contains(k)) matchCount++;
+
+            if (matchCount == mapKeys.Length)
+            {
+                // Displace any already-found mapping that shares a key with this one.
+                for (int i = foundMappings.Count - 1; i >= 0; i--)
+                {
+                    if (foundMappings[i].Any(x => mapKeys.Contains(x)))
+                        foundMappings.RemoveAt(i);
+                }
+                foundMappings.Add(mapKeys);
+            }
+        }
+
+        var result = new List<Vic20Key>();
+        foreach (var mapKeys in foundMappings)
+        {
+            foreach (var vic20Key in _hostKeyboard.HostKeyToVic20KeyMap[mapKeys])
+            {
+                if (!result.Contains(vic20Key))
+                    result.Add(vic20Key);
+            }
+        }
+
+        if (result.Count > 0)
+            _logger.LogTrace("VIC-20 input: host=[{h}] vic20=[{v}]",
+                string.Join(",", keysDown), string.Join(",", result));
+
+        return result;
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Render/Vic20VideoCommandStream.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Render/Vic20VideoCommandStream.cs
@@ -3,6 +3,7 @@ using Highbyte.DotNet6502.Systems.Rendering;
 using Highbyte.DotNet6502.Systems.Rendering.VideoCommands;
 using Highbyte.DotNet6502.Systems.Vic20.Config;
 using Highbyte.DotNet6502.Systems.Vic20.Video;
+using Vic20ScreenCode = Highbyte.DotNet6502.Systems.Vic20.Video.Vic20ScreenCode;
 
 namespace Highbyte.DotNet6502.Systems.Vic20.Render;
 
@@ -44,6 +45,9 @@ public class Vic20VideoCommandStream : IRenderProvider, IVideoCommandStream
 
     private void GenerateCommands()
     {
+        // Emit the glyph-to-Unicode mapper every frame so the command target uses
+        // VIC-20/PETSCII screen codes rather than raw ASCII (same pattern as C64).
+        _commands.Enqueue(new SetConfig(GlyphToUnicodeConverter: Vic20ScreenCode.ScreenCodeToUnicode));
         RenderBorder();
         RenderMainScreen();
     }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Render/Vic20VideoCommandStream.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Render/Vic20VideoCommandStream.cs
@@ -51,7 +51,8 @@ public class Vic20VideoCommandStream : IRenderProvider, IVideoCommandStream
     private void RenderMainScreen()
     {
         var mem = _vic20.Mem;
-        var bgColorByte = mem[_config.BackgroundColorAddress];
+        // VIC-I $900F: background color is in bits 7-4 (high nibble, 16 colors)
+        var bgColorIndex = (byte)((mem[_config.BackgroundColorAddress] >> 4) & 0x0F);
 
         var screenAddr = _config.ScreenStartAddress;
         var colorAddr = _config.ColorStartAddress;
@@ -61,14 +62,15 @@ public class Vic20VideoCommandStream : IRenderProvider, IVideoCommandStream
             for (var col = 0; col < Vic20Config.Cols; col++)
             {
                 var charByte = mem[screenAddr++];
-                var fgColorByte = mem[colorAddr++];
+                // Color RAM stores 3-bit foreground color in bits 2-0
+                var fgColorIndex = (byte)(mem[colorAddr++] & 0x07);
 
                 _commands.Enqueue(MakeDrawGlyph(
                     col + Vic20Config.BorderCols,
                     row + Vic20Config.BorderRows,
                     charByte,
-                    fgColorByte,
-                    bgColorByte));
+                    fgColorIndex,
+                    bgColorIndex));
             }
         }
     }
@@ -76,7 +78,8 @@ public class Vic20VideoCommandStream : IRenderProvider, IVideoCommandStream
     private void RenderBorder()
     {
         var mem = _vic20.Mem;
-        var borderColorByte = mem[_config.BorderColorAddress];
+        // VIC-I $900F: border color is in bits 2-0 (low 3 bits, 8 colors)
+        var borderColorByte = (byte)(mem[_config.BorderColorAddress] & 0x07);
 
         var totalCols = Vic20Config.Cols + Vic20Config.BorderCols * 2;
         var totalRows = Vic20Config.Rows + Vic20Config.BorderRows * 2;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Render/Vic20VideoCommandStream.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Render/Vic20VideoCommandStream.cs
@@ -1,0 +1,108 @@
+using System.Drawing;
+using Highbyte.DotNet6502.Systems.Rendering;
+using Highbyte.DotNet6502.Systems.Rendering.VideoCommands;
+using Highbyte.DotNet6502.Systems.Vic20.Config;
+using Highbyte.DotNet6502.Systems.Vic20.Video;
+
+namespace Highbyte.DotNet6502.Systems.Vic20.Render;
+
+/// <summary>
+/// Generates a stream of video commands each frame from VIC-20 screen and color RAM.
+/// Implements the command-stream render path (DrawGlyph commands consumed by AvaloniaCommandTarget).
+/// No rasterizer needed for the 22×23 text mode the VIC-20 uses by default.
+/// </summary>
+public class Vic20VideoCommandStream : IRenderProvider, IVideoCommandStream
+{
+    public string Name => "Vic20CommandStream";
+
+    private readonly Vic20 _vic20;
+    private readonly Vic20Config _config;
+
+    private readonly Queue<IVideoCommand> _commands = new();
+
+    public event EventHandler? FrameCompleted;
+
+    public Vic20VideoCommandStream(Vic20 vic20)
+    {
+        _vic20 = vic20;
+        _config = vic20.Vic20Config;
+    }
+
+    public void OnAfterInstruction() { }
+
+    public void OnEndFrame()
+    {
+        GenerateCommands();
+        FrameCompleted?.Invoke(this, EventArgs.Empty);
+    }
+
+    public IEnumerable<IVideoCommand> DequeueAll()
+    {
+        while (_commands.Count > 0)
+            yield return _commands.Dequeue();
+    }
+
+    private void GenerateCommands()
+    {
+        RenderBorder();
+        RenderMainScreen();
+    }
+
+    private void RenderMainScreen()
+    {
+        var mem = _vic20.Mem;
+        var bgColorByte = mem[_config.BackgroundColorAddress];
+
+        var screenAddr = _config.ScreenStartAddress;
+        var colorAddr = _config.ColorStartAddress;
+
+        for (var row = 0; row < Vic20Config.Rows; row++)
+        {
+            for (var col = 0; col < Vic20Config.Cols; col++)
+            {
+                var charByte = mem[screenAddr++];
+                var fgColorByte = mem[colorAddr++];
+
+                _commands.Enqueue(MakeDrawGlyph(
+                    col + Vic20Config.BorderCols,
+                    row + Vic20Config.BorderRows,
+                    charByte,
+                    fgColorByte,
+                    bgColorByte));
+            }
+        }
+    }
+
+    private void RenderBorder()
+    {
+        var mem = _vic20.Mem;
+        var borderColorByte = mem[_config.BorderColorAddress];
+
+        var totalCols = Vic20Config.Cols + Vic20Config.BorderCols * 2;
+        var totalRows = Vic20Config.Rows + Vic20Config.BorderRows * 2;
+
+        for (var row = 0; row < totalRows; row++)
+        {
+            for (var col = 0; col < totalCols; col++)
+            {
+                var isBorder = row < Vic20Config.BorderRows
+                    || row >= Vic20Config.Rows + Vic20Config.BorderRows
+                    || col < Vic20Config.BorderCols
+                    || col >= Vic20Config.Cols + Vic20Config.BorderCols;
+
+                if (isBorder)
+                    _commands.Enqueue(MakeDrawGlyph(col, row, 0, borderColorByte, borderColorByte));
+            }
+        }
+    }
+
+    private DrawGlyph MakeDrawGlyph(int x, int y, byte character, byte fgColorByte, byte bgColorByte)
+    {
+        if (!ColorMaps.Vic20ColorMap.TryGetValue(fgColorByte, out var fgColor))
+            fgColor = Color.White;
+        if (!ColorMaps.Vic20ColorMap.TryGetValue(bgColorByte, out var bgColor))
+            bgColor = Color.Black;
+
+        return new DrawGlyph(x, y, character, fgColor, bgColor);
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/TimerAndPeripheral/Via1.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/TimerAndPeripheral/Via1.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.Logging;
+
+namespace Highbyte.DotNet6502.Systems.Vic20.TimerAndPeripheral;
+
+/// <summary>
+/// VIA #1 (at $9110-$911F) — user port / serial bus VIA.
+///
+/// Handles:
+///   - CA1 interrupt: driven by the VIC-I raster pulse (simulated once per frame).
+///     The KERNAL enables CA1 (IER bit 1 = $82) and uses this 50/60 Hz interrupt for
+///     keyboard scan and cursor blink — NOT Timer 1, which the KERNAL leaves unused here.
+///   - Port A ($9111): user port / serial bus lines — returns $FF (all idle, no device).
+///   - IFR/IER: interrupt flag/enable registers (CA1 + Timer 1 implemented).
+///   - Timer 1: present but not used by the KERNAL for keyboard timing.
+///
+/// The keyboard matrix is wired to VIA #2 (Port B = columns, Port A = rows).
+/// The <see cref="Vic20Keyboard"/> object lives here because it owns the key state;
+/// VIA2 forwards column writes and row reads to it via this reference.
+/// </summary>
+public class Via1 : ViaBase
+{
+    public Vic20Keyboard Keyboard { get; }
+
+    public Via1(Vic20 vic20, ILoggerFactory loggerFactory)
+        : base(vic20, new ViaIRQ(useNMI: false))
+    {
+        Keyboard = new Vic20Keyboard(loggerFactory);
+    }
+
+    public override void MapIOLocations(Memory mem)
+    {
+        // Port A — keyboard row sense (read clears CA1 flag — VIA 6522 handshake behaviour)
+        mem.MapReader(ViaAddr.VIA1_PORTA,     PortALoad);
+        mem.MapWriter(ViaAddr.VIA1_PORTA,     StubStore);  // writes to PA not used for keyboard
+
+        // Port B — not used for keyboard on VIA1 (VIA2 drives columns); stub.
+        mem.MapReader(ViaAddr.VIA1_PORTB,     StubLoad);
+        mem.MapWriter(ViaAddr.VIA1_PORTB,     StubStore);
+
+        // DDR
+        mem.MapReader(ViaAddr.VIA1_DDRA,      DDRALoad);
+        mem.MapWriter(ViaAddr.VIA1_DDRA,      DDRAStore);
+        mem.MapReader(ViaAddr.VIA1_DDRB,      DDRBLoad);
+        mem.MapWriter(ViaAddr.VIA1_DDRB,      DDRBStore);
+
+        // Timer 1
+        mem.MapReader(ViaAddr.VIA1_T1CL,      T1CLLoad);
+        mem.MapWriter(ViaAddr.VIA1_T1CL,      T1LLStore);  // T1C-L write = latch low only
+        mem.MapReader(ViaAddr.VIA1_T1CH,      T1CHLoad);   // side-effect: clears IFR T1
+        mem.MapWriter(ViaAddr.VIA1_T1CH,      T1CHStore);  // T1C-H write = load counter + start timer
+        mem.MapReader(ViaAddr.VIA1_T1LL,      T1LLLoad);
+        mem.MapWriter(ViaAddr.VIA1_T1LL,      T1LLStore);
+        mem.MapReader(ViaAddr.VIA1_T1LH,      T1LHLoad);
+        mem.MapWriter(ViaAddr.VIA1_T1LH,      T1LHStore);  // T1L-H write = latch only, no start
+
+        // IFR / IER
+        mem.MapReader(ViaAddr.VIA1_IFR,       IFRLoad);
+        mem.MapWriter(ViaAddr.VIA1_IFR,       IFRStore);
+        mem.MapReader(ViaAddr.VIA1_IER,       IERLoad);
+        mem.MapWriter(ViaAddr.VIA1_IER,       IERStore);
+
+        // ACR (controls T1 free-run vs one-shot)
+        mem.MapReader(ViaAddr.VIA1_ACR,       ACRLoad);
+        mem.MapWriter(ViaAddr.VIA1_ACR,       ACRStore);
+
+        // Unimplemented registers — write-verify coherent stubs (KERNAL reads back what it wrote).
+        mem.MapRW(ViaAddr.VIA1_T2CL, new Memory.MemValue());
+        mem.MapRW(ViaAddr.VIA1_T2CH, new Memory.MemValue());
+        mem.MapRW(ViaAddr.VIA1_SR,   new Memory.MemValue());
+        mem.MapRW(ViaAddr.VIA1_PCR,  new Memory.MemValue());
+        mem.MapReader(ViaAddr.VIA1_PORTA_NHS, PortALoadNoHandshake);  // no CA1 clear
+        mem.MapWriter(ViaAddr.VIA1_PORTA_NHS, StubStore);
+    }
+
+    // VIA1 Port A is the user port / serial bus — return $FF (all lines idle / no device).
+    // Reading with handshake (PORTA) also clears the CA1 IFR flag.
+    private byte PortALoad(ushort _)
+    {
+        AcknowledgeCA1();
+        return 0xFF;
+    }
+
+    private byte PortALoadNoHandshake(ushort _) => 0xFF;
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/TimerAndPeripheral/Via2.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/TimerAndPeripheral/Via2.cs
@@ -1,0 +1,71 @@
+namespace Highbyte.DotNet6502.Systems.Vic20.TimerAndPeripheral;
+
+/// <summary>
+/// VIA #2 (at $9120-$912F) — keyboard / joystick VIA.
+///
+/// Handles:
+///   - Port B ($9120): keyboard column strobe — KERNAL writes active-low column mask here.
+///   - Port A ($9121): keyboard row sense — KERNAL reads active-low row bitmask here.
+///     Both ports forward to <see cref="Via1.Keyboard"/> which holds the key state.
+///
+/// All other registers (Timer 1/2, SR, ACR, PCR, IFR/IER) are coherent stubs —
+/// the KERNAL writes to them (e.g. VIA2 Timer 1 for IEC serial timing) but the
+/// emulator does not need to service them for basic keyboard/cursor operation.
+/// </summary>
+public class Via2 : ViaBase
+{
+    private readonly Via1 _via1; // column select is forwarded to VIA1's keyboard
+
+    public Via2(Vic20 vic20, Via1 via1)
+        : base(vic20, new ViaIRQ(useNMI: false))
+    {
+        _via1 = via1;
+    }
+
+    // VIA2 has no timer that needs processing for basic keyboard operation.
+    public override void ProcessTimers(ulong cyclesExecuted) { }
+
+    public override void MapIOLocations(Memory mem)
+    {
+        // Port B — keyboard column strobe (KERNAL writes here to select columns).
+        mem.MapReader(ViaAddr.VIA2_PORTB, PortBLoad);
+        mem.MapWriter(ViaAddr.VIA2_PORTB, PortBStore);
+
+        // Port A — keyboard row sense (KERNAL reads rows here after writing column to Port B).
+        mem.MapReader(ViaAddr.VIA2_PORTA,     PortALoad);
+        mem.MapWriter(ViaAddr.VIA2_PORTA,     StubStore);
+        mem.MapReader(ViaAddr.VIA2_PORTA_NHS, PortALoad);
+        mem.MapWriter(ViaAddr.VIA2_PORTA_NHS, StubStore);
+
+        // DDR
+        mem.MapReader(ViaAddr.VIA2_DDRA, DDRALoad);
+        mem.MapWriter(ViaAddr.VIA2_DDRA, DDRAStore);
+        mem.MapReader(ViaAddr.VIA2_DDRB, DDRBLoad);
+        mem.MapWriter(ViaAddr.VIA2_DDRB, DDRBStore);
+
+        // IFR / IER — stub (VIA2 IRQs not used for keyboard).
+        mem.MapReader(ViaAddr.VIA2_IFR, StubLoad);
+        mem.MapWriter(ViaAddr.VIA2_IFR, StubStore);
+        mem.MapRW(ViaAddr.VIA2_IER, new Memory.MemValue());
+
+        // All remaining registers — write-verify coherent stubs (KERNAL reads back what it wrote).
+        mem.MapRW(ViaAddr.VIA2_T1CL, new Memory.MemValue());
+        mem.MapRW(ViaAddr.VIA2_T1CH, new Memory.MemValue());
+        mem.MapRW(ViaAddr.VIA2_T1LL, new Memory.MemValue());
+        mem.MapRW(ViaAddr.VIA2_T1LH, new Memory.MemValue());
+        mem.MapRW(ViaAddr.VIA2_T2CL, new Memory.MemValue());
+        mem.MapRW(ViaAddr.VIA2_T2CH, new Memory.MemValue());
+        mem.MapRW(ViaAddr.VIA2_SR,   new Memory.MemValue());
+        mem.MapRW(ViaAddr.VIA2_ACR,  new Memory.MemValue());
+        mem.MapRW(ViaAddr.VIA2_PCR,  new Memory.MemValue());
+    }
+
+    private byte _portBValue = 0xFF;
+    private byte PortALoad(ushort _) => _via1.Keyboard.GetPressedRowsForSelectedColumns();
+    private byte PortBLoad(ushort _) => _portBValue;
+    private void PortBStore(ushort _, byte value)
+    {
+        _portBValue = value;
+        _via1.Keyboard.SetSelectedColumns(value);
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/TimerAndPeripheral/ViaAddr.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/TimerAndPeripheral/ViaAddr.cs
@@ -1,0 +1,65 @@
+namespace Highbyte.DotNet6502.Systems.Vic20.TimerAndPeripheral;
+
+/// <summary>
+/// VIA #1 io chip addresses: $9110-$911F
+/// VIA #2 io chip addresses: $9120-$912F
+/// Ref: VIC-20 Programmer's Reference Guide, Chapter 3
+/// </summary>
+public static class ViaAddr
+{
+    // --------------------
+    // VIA #1
+    // --------------------
+
+    // VIA #1 Port B (keyboard cols via VIA2) / Port A (keyboard rows)
+    public const ushort VIA1_PORTB      = 0x9110;
+    public const ushort VIA1_PORTA      = 0x9111;
+    public const ushort VIA1_DDRB       = 0x9112;
+    public const ushort VIA1_DDRA       = 0x9113;
+
+    // VIA #1 Timer 1 (used by KERNAL for 60 Hz keyboard scan + cursor blink)
+    public const ushort VIA1_T1CL       = 0x9114; // Timer 1 counter low  (read)
+    public const ushort VIA1_T1CH       = 0x9115; // Timer 1 counter high (read clears IFR T1 flag)
+    public const ushort VIA1_T1LL       = 0x9116; // Timer 1 latch low
+    public const ushort VIA1_T1LH       = 0x9117; // Timer 1 latch high (write starts timer)
+
+    // VIA #1 Timer 2
+    public const ushort VIA1_T2CL       = 0x9118;
+    public const ushort VIA1_T2CH       = 0x9119;
+
+    // VIA #1 Auxiliary / Peripheral Control + Interrupt registers
+    public const ushort VIA1_SR         = 0x911A;
+    public const ushort VIA1_ACR        = 0x911B; // Auxiliary Control Register (bit 6 = T1 free-run)
+    public const ushort VIA1_PCR        = 0x911C;
+    public const ushort VIA1_IFR        = 0x911D; // Interrupt Flag Register
+    public const ushort VIA1_IER        = 0x911E; // Interrupt Enable Register
+    public const ushort VIA1_PORTA_NHS  = 0x911F; // Port A, no handshake
+
+    // --------------------
+    // VIA #2
+    // --------------------
+
+    // VIA #2 Port B (keyboard column strobe output) / Port A (user port / serial)
+    public const ushort VIA2_PORTB      = 0x9120;
+    public const ushort VIA2_PORTA      = 0x9121;
+    public const ushort VIA2_DDRB       = 0x9122;
+    public const ushort VIA2_DDRA       = 0x9123;
+
+    // VIA #2 Timer 1
+    public const ushort VIA2_T1CL       = 0x9124;
+    public const ushort VIA2_T1CH       = 0x9125;
+    public const ushort VIA2_T1LL       = 0x9126;
+    public const ushort VIA2_T1LH       = 0x9127;
+
+    // VIA #2 Timer 2
+    public const ushort VIA2_T2CL       = 0x9128;
+    public const ushort VIA2_T2CH       = 0x9129;
+
+    // VIA #2 Auxiliary / Peripheral Control + Interrupt registers
+    public const ushort VIA2_SR         = 0x912A;
+    public const ushort VIA2_ACR        = 0x912B;
+    public const ushort VIA2_PCR        = 0x912C;
+    public const ushort VIA2_IFR        = 0x912D;
+    public const ushort VIA2_IER        = 0x912E;
+    public const ushort VIA2_PORTA_NHS  = 0x912F;
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/TimerAndPeripheral/ViaBase.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/TimerAndPeripheral/ViaBase.cs
@@ -1,0 +1,86 @@
+namespace Highbyte.DotNet6502.Systems.Vic20.TimerAndPeripheral;
+
+/// <summary>
+/// Abstract base class for VIA 6522 chip instances.
+/// Mirrors the structure of CiaBase in the C64 library — each concrete subclass
+/// overrides <see cref="MapIOLocations"/> and adds port-specific logic (keyboard
+/// matrix rows on VIA1, column strobe on VIA2).
+/// </summary>
+public abstract class ViaBase
+{
+    protected readonly Vic20 _vic20;
+    protected readonly ViaIRQ _viaIRQ;
+    protected readonly ViaTimer1 _timer1;
+
+    // DDR shadow registers (stored in memory is fine for stubs, but we keep
+    // local copies to avoid mapping conflicts with the chip registers).
+    protected byte DDRA;
+    protected byte DDRB;
+
+    protected ViaBase(Vic20 vic20, ViaIRQ viaIRQ)
+    {
+        _vic20  = vic20;
+        _viaIRQ = viaIRQ;
+        _timer1 = new ViaTimer1(vic20, viaIRQ);
+    }
+
+    public virtual void ProcessTimers(ulong cyclesExecuted)
+    {
+        _timer1.ProcessTimer(cyclesExecuted);
+    }
+
+    /// <summary>
+    /// Raise the CA1 interrupt (simulates the VIC-I raster pulse on VIA1).
+    /// Call once per video frame from the emulator loop.
+    /// </summary>
+    public void TriggerCA1(CPU cpu)
+    {
+        _viaIRQ.SetCA1Condition();
+        if (_viaIRQ.IsCA1Enabled)
+            _viaIRQ.Trigger(cpu, "VIA_CA1");
+    }
+
+    /// <summary>Acknowledge (clear) the CA1 flag — called by Port A reads with handshake.</summary>
+    protected void AcknowledgeCA1() => _viaIRQ.ClearCA1Condition();
+
+    public abstract void MapIOLocations(Memory mem);
+
+    // ---------- Timer 1 read/write delegates (used by MapIOLocations) ----------
+
+    protected byte  T1CLLoad (ushort _) => _timer1.ReadCounterLo();
+    protected byte  T1CHLoad (ushort _) => _timer1.ReadCounterHi();   // side-effect: clears IFR T1
+    protected byte  T1LLLoad (ushort _) => _timer1.ReadLatchLo();
+    protected byte  T1LHLoad (ushort _) => _timer1.ReadLatchHi();
+    protected void  T1LLStore(ushort _, byte v) => _timer1.WriteLatchLo(v);
+    protected void  T1LHStore(ushort _, byte v) => _timer1.WriteLatchHiOnly(v); // latch only, no start
+    protected void  T1CHStore(ushort _, byte v) => _timer1.WriteCounterHi(v);   // loads counter + starts
+
+    // ---------- IFR / IER delegates ----------
+
+    protected byte IFRLoad (ushort _)        => _viaIRQ.ReadIFR();
+    protected void IFRStore(ushort _, byte v) => _viaIRQ.WriteIFR(v);
+    protected byte IERLoad (ushort _)        => _viaIRQ.ReadIER();
+    protected void IERStore(ushort _, byte v) => _viaIRQ.WriteIER(v);
+
+    // ---------- DDR read/write ----------
+
+    protected byte  DDRALoad (ushort _)        => DDRA;
+    protected void  DDRAStore(ushort _, byte v) => DDRA = v;
+    protected byte  DDRBLoad (ushort _)        => DDRB;
+    protected void  DDRBStore(ushort _, byte v) => DDRB = v;
+
+    // ---------- ACR read/write (bit 6 = T1 free-run vs one-shot) ----------
+
+    private byte _acr;
+    protected byte  ACRLoad (ushort _) => _acr;
+    protected void  ACRStore(ushort _, byte v)
+    {
+        _acr = v;
+        _timer1.SetFreeRunning((v & 0x40) != 0); // VIA 6522: bit 6 = 1 → free-running
+    }
+
+    // ---------- Stub for unimplemented registers (ignores reads/writes) ----------
+
+    protected byte  StubLoad (ushort _)        => 0x00;
+    protected void  StubStore(ushort _, byte v) { }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/TimerAndPeripheral/ViaIRQ.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/TimerAndPeripheral/ViaIRQ.cs
@@ -1,0 +1,91 @@
+namespace Highbyte.DotNet6502.Systems.Vic20.TimerAndPeripheral;
+
+/// <summary>
+/// VIA 6522 interrupt flag and enable state, modelled after the C64's CiaIRQ but with
+/// VIA-correct behaviour:
+/// - IFR is NOT auto-cleared on read (must write 1 to a bit to clear it, or read T1C-H for T1).
+/// - IER bit 7 always reads as 1; writing with bit 7 set enables, bit 7 clear disables.
+///
+/// Implements Timer 1 (bit 6) and CA1 (bit 1).
+/// On VIA1, CA1 is connected to the VIC-I raster interrupt output — this is the
+/// 50/60 Hz signal that drives the KERNAL keyboard scan and cursor blink (not Timer 1).
+/// </summary>
+public class ViaIRQ
+{
+    private readonly bool _useNMI;
+
+    // Timer 1 interrupt state
+    private bool _timer1Enabled;
+    private bool _timer1Condition;
+
+    // CA1 interrupt state (VIA1: VIC-I raster signal; drives keyboard scan + cursor blink)
+    private bool _ca1Enabled;
+    private bool _ca1Condition;
+
+    public const int CA1BitPos    = 1;   // IFR/IER bit 1 = CA1
+    public const int Timer1BitPos = 6;   // IFR/IER bit 6 = Timer 1
+    public const int AnyBitPos    = 7;   // IFR bit 7 = any enabled + triggered source
+
+    public ViaIRQ(bool useNMI) => _useNMI = useNMI;
+
+    public void Trigger(CPU cpu, string source)
+    {
+        if (_useNMI)
+            cpu.CPUInterrupts.SetNMISourceActive(source);
+        else
+            cpu.CPUInterrupts.SetIRQSourceActive(source, autoAcknowledge: true);
+    }
+
+    public bool IsTimer1Enabled   => _timer1Enabled;
+    public bool IsTimer1Triggered => _timer1Condition;
+    public bool IsCA1Enabled      => _ca1Enabled;
+    public bool IsCA1Triggered    => _ca1Condition;
+
+    public void SetTimer1Condition()   => _timer1Condition = true;
+    public void ClearTimer1Condition() => _timer1Condition = false;
+
+    /// <summary>
+    /// Raise the CA1 interrupt flag. Call when the VIC-I raster pulse fires (once per frame).
+    /// Clears automatically when the CPU reads Port A (AcknowledgeCA1).
+    /// </summary>
+    public void SetCA1Condition()   => _ca1Condition = true;
+    public void ClearCA1Condition() => _ca1Condition = false;
+
+    // IFR read — NOT cleared on read (VIA behaviour).
+    // Bit 7 is set when any enabled source has triggered.
+    public byte ReadIFR()
+    {
+        byte ifr = 0;
+        if (_timer1Condition) ifr |= (1 << Timer1BitPos);
+        if (_ca1Condition)    ifr |= (1 << CA1BitPos);
+        bool anyActive = (_timer1Condition && _timer1Enabled) || (_ca1Condition && _ca1Enabled);
+        if (anyActive) ifr |= (1 << AnyBitPos);
+        return ifr;
+    }
+
+    // IFR write — writing a 1 to a bit clears that flag.
+    public void WriteIFR(byte value)
+    {
+        if ((value & (1 << Timer1BitPos)) != 0) _timer1Condition = false;
+        if ((value & (1 << CA1BitPos))    != 0) _ca1Condition    = false;
+    }
+
+    // IER read — bit 7 always reads as 1 (VIA behaviour).
+    public byte ReadIER()
+    {
+        byte ier = (1 << AnyBitPos);
+        if (_timer1Enabled) ier |= (1 << Timer1BitPos);
+        if (_ca1Enabled)    ier |= (1 << CA1BitPos);
+        return ier;
+    }
+
+    // IER write — bit 7 = 1 → set enables; bit 7 = 0 → clear enables.
+    public void WriteIER(byte value)
+    {
+        bool set = (value & (1 << AnyBitPos)) != 0;
+        if ((value & (1 << Timer1BitPos)) != 0)
+            _timer1Enabled = set;
+        if ((value & (1 << CA1BitPos)) != 0)
+            _ca1Enabled = set;
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/TimerAndPeripheral/ViaTimer1.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/TimerAndPeripheral/ViaTimer1.cs
@@ -1,0 +1,96 @@
+namespace Highbyte.DotNet6502.Systems.Vic20.TimerAndPeripheral;
+
+/// <summary>
+/// VIA 6522 Timer 1 — 16-bit countdown, modelled after the C64's CiaTimer but with the
+/// VIA-specific behaviour differences:
+///
+/// - Writing T1L-H ($9117 / $9127) both loads the counter from the latch AND starts
+///   the timer (CIA requires a separate start-bit write in the Control Register).
+/// - Free-running (continuous) mode is the default; one-shot is selected by ACR bit 6.
+/// - Reading T1C-H ($9115 / $9125) automatically clears the IFR Timer 1 flag.
+///
+/// Timer 2 is not needed for basic VIC-20 keyboard and cursor operation so only
+/// Timer 1 is implemented here.
+/// </summary>
+public class ViaTimer1
+{
+    private readonly Vic20 _vic20;
+    private readonly ViaIRQ _irq;
+
+    private ushort _latch;
+    private ushort _counter;
+    private bool   _running;
+    private bool   _freeRunning = false;  // ACR bit 6: 1 = free-run (VIA ACR resets to $00 = one-shot)
+
+    public ushort Counter => _counter;
+    public ushort Latch   => _latch;
+
+    public ViaTimer1(Vic20 vic20, ViaIRQ irq)
+    {
+        _vic20 = vic20;
+        _irq   = irq;
+    }
+
+    public void SetFreeRunning(bool freeRunning) => _freeRunning = freeRunning;
+
+    // Write to T1L-L ($9116) — latch low only, no effect on running counter.
+    public void WriteLatchLo(byte value)
+    {
+        _latch = (ushort)((_latch & 0xFF00) | value);
+    }
+
+    // Write to T1L-H ($9117) — latch high only, does NOT start timer (VIA 6522 spec).
+    public void WriteLatchHiOnly(byte value)
+    {
+        _latch = (ushort)((_latch & 0x00FF) | ((ushort)value << 8));
+    }
+
+    // Write to T1C-H ($9115) — loads counter from latch, starts timer, clears IFR (VIA 6522 spec).
+    public void WriteCounterHi(byte value)
+    {
+        _latch   = (ushort)((_latch & 0x00FF) | ((ushort)value << 8));
+        _counter = _latch;
+        _irq.ClearTimer1Condition();
+        _running = true;
+    }
+
+    // Read T1C-H — clears the IFR Timer 1 flag as a side-effect (VIA behaviour).
+    public byte ReadCounterHi()
+    {
+        _irq.ClearTimer1Condition();
+        return (byte)(_counter >> 8);
+    }
+
+    public byte ReadCounterLo() => (byte)(_counter & 0xFF);
+    public byte ReadLatchLo()   => (byte)(_latch   & 0xFF);
+    public byte ReadLatchHi()   => (byte)(_latch   >> 8);
+
+    public void ProcessTimer(ulong cyclesExecuted)
+    {
+        if (!_running) return;
+
+        if (_counter >= cyclesExecuted)
+            _counter -= (ushort)cyclesExecuted;
+        else
+            _counter = 0;
+
+        if (_counter == 0)
+        {
+            _irq.SetTimer1Condition();
+
+            if (_irq.IsTimer1Enabled)
+                _irq.Trigger(_vic20.CPU, "VIA_T1");
+
+            if (_freeRunning)
+            {
+                // Reload from latch and keep running — IFR flag cleared on reload.
+                _counter = _latch;
+                _irq.ClearTimer1Condition();
+            }
+            else
+            {
+                _running = false;
+            }
+        }
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/TimerAndPeripheral/Vic20Keyboard.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/TimerAndPeripheral/Vic20Keyboard.cs
@@ -1,0 +1,217 @@
+using Highbyte.DotNet6502.Utils;
+using Microsoft.Extensions.Logging;
+
+namespace Highbyte.DotNet6502.Systems.Vic20.TimerAndPeripheral;
+
+/// <summary>
+/// VIC-20 8×8 keyboard matrix.
+///
+/// Scan convention (matches VIC-20 KERNAL 901486-07):
+///   Column drive  — KERNAL writes active-low column mask to VIA2 Port B ($9120).
+///   Row sense     — KERNAL reads VIA2 Port A ($9121); a 0-bit means key is pressed in that row.
+///
+/// Matrix layout derived from the KERNAL decode table at $EC5E
+/// (_matrix[sense_row, scan_col], indexed as Y = scan_col*8 + sense_row):
+///
+///           scan0  scan1  scan2   scan3    scan4   scan5   scan6   scan7
+/// sense0:    1      ←      CBM    RunStop  Space   LShift  Q       2
+/// sense1:    3      W      A      RShift   Z       S       E       4
+/// sense2:    5      R      D      X        C       F       T       6
+/// sense3:    7      Y      G      V        B       H       U       8
+/// sense4:    9      I      J      N        M       K       O       0
+/// sense5:    +      P      L      ,        .       :       @       -
+/// sense6:    £      *      ;      /        ShLk    =       ↑      Home
+/// sense7:   Del   Ret    CrLR   CrUD      F1      F3      F5      F7
+///
+/// Notes:
+///   CrLR = Cursor Left/Right physical key (unshifted = right, shift = left)
+///   CrUD = Cursor Up/Down physical key (unshifted = down, shift = up)
+///   £    = Pound sign character key
+///   ←/↑  = Back Arrow / Up Arrow character keys (PETSCII $5F / $5E)
+/// </summary>
+public class Vic20Keyboard
+{
+    private readonly Vic20Key[,] _matrix = new Vic20Key[8, 8];
+    private readonly List<Vic20Key> _pressedKeys = new();
+    private byte _selectedColumnMask = 0xFF; // all columns deselected by default
+    private readonly ILogger _logger;
+
+    public Vic20Keyboard(ILoggerFactory loggerFactory)
+    {
+        _logger = loggerFactory.CreateLogger(nameof(Vic20Keyboard));
+        InitMatrix();
+    }
+
+    private void InitMatrix()
+    {
+        // Matrix positions from KERNAL 901486-07 decode table at $EC5E.
+        // _matrix[sense_row, scan_col] where:
+        //   scan_col = Port B bit driven low (0=PB0..7=PB7)
+        //   sense_row = Port A bit sensed   (0=PA0..7=PA7)
+
+        // scan col 0 (PB0 = 0): odd digits + symbols
+        _matrix[0, 0] = Vic20Key.One;
+        _matrix[1, 0] = Vic20Key.Three;
+        _matrix[2, 0] = Vic20Key.Five;
+        _matrix[3, 0] = Vic20Key.Seven;
+        _matrix[4, 0] = Vic20Key.Nine;
+        _matrix[5, 0] = Vic20Key.Plus;
+        _matrix[6, 0] = Vic20Key.Pound;
+        _matrix[7, 0] = Vic20Key.Delete;
+
+        // scan col 1 (PB1 = 0)
+        _matrix[0, 1] = Vic20Key.BackArrow; // ← character (PETSCII $5F)
+        _matrix[1, 1] = Vic20Key.W;
+        _matrix[2, 1] = Vic20Key.R;
+        _matrix[3, 1] = Vic20Key.Y;
+        _matrix[4, 1] = Vic20Key.I;
+        _matrix[5, 1] = Vic20Key.P;
+        _matrix[6, 1] = Vic20Key.Asterisk;
+        _matrix[7, 1] = Vic20Key.Return;
+
+        // scan col 2 (PB2 = 0)
+        _matrix[0, 2] = Vic20Key.CBM;
+        _matrix[1, 2] = Vic20Key.A;
+        _matrix[2, 2] = Vic20Key.D;
+        _matrix[3, 2] = Vic20Key.G;
+        _matrix[4, 2] = Vic20Key.J;
+        _matrix[5, 2] = Vic20Key.L;
+        _matrix[6, 2] = Vic20Key.Semicolon;
+        _matrix[7, 2] = Vic20Key.CrsrRight;
+
+        // scan col 3 (PB3 = 0)
+        _matrix[0, 3] = Vic20Key.RunStop;
+        _matrix[1, 3] = Vic20Key.RShift;
+        _matrix[2, 3] = Vic20Key.X;
+        _matrix[3, 3] = Vic20Key.V;
+        _matrix[4, 3] = Vic20Key.N;
+        _matrix[5, 3] = Vic20Key.Comma;
+        _matrix[6, 3] = Vic20Key.Slash;
+        _matrix[7, 3] = Vic20Key.CrsrDown;
+
+        // scan col 4 (PB4 = 0)
+        _matrix[0, 4] = Vic20Key.Space;
+        _matrix[1, 4] = Vic20Key.Z;
+        _matrix[2, 4] = Vic20Key.C;
+        _matrix[3, 4] = Vic20Key.B;
+        _matrix[4, 4] = Vic20Key.M;
+        _matrix[5, 4] = Vic20Key.Period;
+        _matrix[6, 4] = Vic20Key.ShiftLock;
+        _matrix[7, 4] = Vic20Key.F1;
+
+        // scan col 5 (PB5 = 0)
+        _matrix[0, 5] = Vic20Key.LShift;
+        _matrix[1, 5] = Vic20Key.S;
+        _matrix[2, 5] = Vic20Key.F;
+        _matrix[3, 5] = Vic20Key.H;
+        _matrix[4, 5] = Vic20Key.K;
+        _matrix[5, 5] = Vic20Key.Colon;
+        _matrix[6, 5] = Vic20Key.Equal;
+        _matrix[7, 5] = Vic20Key.F3;
+
+        // scan col 6 (PB6 = 0)
+        _matrix[0, 6] = Vic20Key.Q;
+        _matrix[1, 6] = Vic20Key.E;
+        _matrix[2, 6] = Vic20Key.T;
+        _matrix[3, 6] = Vic20Key.U;
+        _matrix[4, 6] = Vic20Key.O;
+        _matrix[5, 6] = Vic20Key.At;
+        _matrix[6, 6] = Vic20Key.UpArrow;
+        _matrix[7, 6] = Vic20Key.F5;
+
+        // scan col 7 (PB7 = 0): even digits + symbols
+        _matrix[0, 7] = Vic20Key.Two;
+        _matrix[1, 7] = Vic20Key.Four;
+        _matrix[2, 7] = Vic20Key.Six;
+        _matrix[3, 7] = Vic20Key.Eight;
+        _matrix[4, 7] = Vic20Key.Zero;
+        _matrix[5, 7] = Vic20Key.Minus;
+        _matrix[6, 7] = Vic20Key.Home;
+        _matrix[7, 7] = Vic20Key.F7;
+    }
+
+    /// <summary>Called by the host input consumer each frame with the current key state.</summary>
+    public void SetKeysPressed(List<Vic20Key> keys, bool capsLockOn)
+    {
+        _pressedKeys.Clear();
+        foreach (var key in keys)
+            _pressedKeys.Add(key);
+        if (capsLockOn)
+            _pressedKeys.Add(Vic20Key.LShift);
+        if (keys.Count > 0)
+            _logger.LogTrace($"VIC-20 keys pressed: {string.Join(",", keys)}");
+    }
+
+    /// <summary>
+    /// Called when KERNAL writes to VIA2 Port B ($9120) to select keyboard columns.
+    /// Active-low: a 0-bit selects that column.
+    /// </summary>
+    public void SetSelectedColumns(byte columnMask) => _selectedColumnMask = columnMask;
+
+    /// <summary>
+    /// Called when KERNAL reads VIA1 Port A ($9111) to sense keyboard rows.
+    /// Returns active-low byte — a 0-bit means that key is pressed in any selected column.
+    /// </summary>
+    public byte GetPressedRowsForSelectedColumns()
+    {
+        byte rows = 0xFF; // all bits set = no keys pressed
+
+        for (int col = 0; col < 8; col++)
+        {
+            if ((_selectedColumnMask & (1 << col)) == 0) // column is selected (bit = 0)
+            {
+                for (int row = 0; row < 8; row++)
+                {
+                    if (_pressedKeys.Contains(_matrix[row, col]))
+                        rows = (byte)(rows & ~(1 << row)); // clear row bit = key pressed
+                }
+            }
+        }
+        return rows;
+    }
+
+    public bool IsKeyPressed(Vic20Key key) => _pressedKeys.Contains(key);
+}
+
+public enum Vic20Key
+{
+    None,
+
+    // Letters
+    A, B, C, D, E, F, G, H, I, J, K, L, M,
+    N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+
+    // Digits
+    Zero, One, Two, Three, Four, Five, Six, Seven, Eight, Nine,
+
+    // Symbols
+    At,         // @
+    Plus,       // +
+    Minus,      // -
+    Asterisk,   // *
+    Slash,      // /
+    Equal,      // =
+    Colon,      // :
+    Semicolon,  // ;
+    Comma,      // ,
+    Period,     // .
+    Pound,      // £ (PETSCII $5C)
+    BackArrow,  // ← character (PETSCII $5F, not cursor left)
+    UpArrow,    // ↑ character (PETSCII $5E, not cursor up)
+
+    // Non-printable / special
+    Space,
+    Return,
+    Delete,
+    Home,
+    RunStop,    // RUN/STOP key (PETSCII $03)
+    LShift,
+    RShift,
+    ShiftLock,
+    CBM,        // Commodore key (PETSCII $04)
+    CrsrRight,  // Cursor right physical key (shift = left)
+    CrsrDown,   // Cursor down physical key (shift = up)
+
+    // Function keys (shift = F2/F4/F6/F8)
+    F1, F3, F5, F7,
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Vic20.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Vic20.cs
@@ -70,7 +70,7 @@ public class Vic20 : ISystem, ITextMode, IScreen
 
     public Vic20() : this(new Vic20Config(), new NullLoggerFactory()) { }
 
-    public Vic20(Vic20Config config, ILoggerFactory loggerFactory)
+    public Vic20(Vic20Config config, ILoggerFactory loggerFactory, Dictionary<string, byte[]>? romData = null)
     {
         _vic20Config = config;
         Mem = new Memory();
@@ -83,7 +83,13 @@ public class Vic20 : ISystem, ITextMode, IScreen
         CPU.InstructionExecuted += (_, e) =>
             OnCPUCyclesConsumed(e.CPU, e.Mem, e.InstructionExecState.CyclesConsumed);
 
+        if (romData != null)
+            MapROMs(romData);
+
         InitScreenMemory();
+
+        if (romData != null)
+            CPU.Reset(Mem);
 
         RenderProviders.Add(new Vic20VideoCommandStream(this));
         SetCurrentRenderProvider(typeof(Vic20VideoCommandStream));
@@ -101,11 +107,27 @@ public class Vic20 : ISystem, ITextMode, IScreen
             ?? throw new ArgumentException("Render provider type not found.");
     }
 
+    private void MapROMs(Dictionary<string, byte[]> romData)
+    {
+        // VIC-20 ROM layout:
+        //   $8000–$8FFF  Character ROM (4 KB) — VIC-I address space, also CPU-readable
+        //   $C000–$DFFF  BASIC ROM     (8 KB)
+        //   $E000–$FFFF  KERNAL ROM    (8 KB)
+        // Note: $A000–$BFFF is the BLK5 cartridge area (empty on stock VIC-20).
+        if (romData.TryGetValue(Vic20SystemConfig.CHARGEN_ROM_NAME, out var chargen))
+            Mem.MapROM(0x8000, chargen);
+        if (romData.TryGetValue(Vic20SystemConfig.BASIC_ROM_NAME, out var basic))
+            Mem.MapROM(0xC000, basic);
+        if (romData.TryGetValue(Vic20SystemConfig.KERNAL_ROM_NAME, out var kernal))
+            Mem.MapROM(0xE000, kernal);
+    }
+
     private void InitScreenMemory()
     {
-        // Blank the screen with spaces and default colors
-        Mem[_vic20Config.BackgroundColorAddress] = _vic20Config.DefaultBgColor;
-        Mem[_vic20Config.BorderColorAddress] = _vic20Config.DefaultBorderColor;
+        // VIC-I $900F packs: background (bits 7-4) | reverse=1 (bit 3) | border (bits 2-0)
+        Mem[0x900F] = (byte)(((_vic20Config.DefaultBgColor & 0x0F) << 4)
+                             | 0x08
+                             | (_vic20Config.DefaultBorderColor & 0x07));
 
         var screenAddr = _vic20Config.ScreenStartAddress;
         var colorAddr = _vic20Config.ColorStartAddress;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Vic20.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Vic20.cs
@@ -1,0 +1,191 @@
+using Highbyte.DotNet6502.Systems.Input;
+using Highbyte.DotNet6502.Systems.Instrumentation;
+using Highbyte.DotNet6502.Systems.Instrumentation.Stats;
+using Highbyte.DotNet6502.Systems.Rendering;
+using Highbyte.DotNet6502.Systems.Vic20.Config;
+using Highbyte.DotNet6502.Systems.Vic20.Render;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Vic20;
+
+/// <summary>
+/// VIC-20 system stub. Exercises the system-plugin contract end-to-end:
+/// CPU + flat RAM, VIC-I text-mode video via the command-stream render path,
+/// and a no-op keyboard handler — all without any real VIC-20 chip emulation.
+/// </summary>
+public class Vic20 : ISystem, ITextMode, IScreen
+{
+    public const string SystemName = "VIC-20";
+
+    public string Name => SystemName;
+    public List<string> SystemInfo => new() { "VIC-20 (stub)" };
+    public List<KeyValuePair<string, Func<string>>> DebugInfo => new();
+
+    public CPU CPU { get; set; }
+    public Memory Mem { get; set; }
+    public IScreen Screen => this;
+
+    public ExecOptions DefaultExecOptions { get; set; }
+
+    // ITextMode
+    public int TextCols => Vic20Config.Cols;
+    public int TextRows => Vic20Config.Rows;
+    public int CharacterWidth => 8;
+    public int CharacterHeight => 8;
+
+    // IScreen
+    public int DrawableAreaWidth => TextCols * CharacterWidth;
+    public int DrawableAreaHeight => TextRows * CharacterHeight;
+    public int VisibleWidth => DrawableAreaWidth + 2 * (Vic20Config.BorderCols * CharacterWidth);
+    public int VisibleHeight => DrawableAreaHeight + 2 * (Vic20Config.BorderRows * CharacterHeight);
+    public bool HasBorder => true;
+    public int VisibleLeftRightBorderWidth => Vic20Config.BorderCols * CharacterWidth;
+    public int VisibleTopBottomBorderHeight => Vic20Config.BorderRows * CharacterHeight;
+    public float RefreshFrequencyHz => _vic20Config.ScreenRefreshFrequencyHz;
+
+    public ulong CPUCyclesPerFrame => _vic20Config.CpuCyclesPerFrame;
+
+    private readonly Vic20Config _vic20Config;
+    public Vic20Config Vic20Config => _vic20Config;
+
+    private ulong _cyclesConsumedCurrentVblank = 0;
+
+    private readonly LegacyExecEvaluator _oneFrameExecEvaluator;
+
+    private IRenderProvider? _renderProvider;
+    public IRenderProvider? RenderProvider => _renderProvider;
+    public List<IRenderProvider> RenderProviders { get; } = new();
+
+    public IInputConsumer? InputConsumer { get; set; }
+
+    // Instrumentations
+    public bool InstrumentationEnabled { get; set; } = false;
+    public Instrumentations Instrumentations { get; } = new();
+
+    private readonly ElapsedMillisecondsTimedStatSystem _renderProviderPerInstructionStat;
+    private readonly ElapsedMillisecondsTimedStatSystem _renderProviderPerFrameStat;
+
+    private const string StatsCategoryRenderProvider = "RenderProvider";
+
+    public Vic20() : this(new Vic20Config(), new NullLoggerFactory()) { }
+
+    public Vic20(Vic20Config config, ILoggerFactory loggerFactory)
+    {
+        _vic20Config = config;
+        Mem = new Memory();
+        CPU = new CPU(loggerFactory);
+        DefaultExecOptions = new ExecOptions();
+
+        _oneFrameExecEvaluator = new LegacyExecEvaluator(
+            new ExecOptions { CyclesRequested = CPUCyclesPerFrame });
+
+        CPU.InstructionExecuted += (_, e) =>
+            OnCPUCyclesConsumed(e.CPU, e.Mem, e.InstructionExecState.CyclesConsumed);
+
+        InitScreenMemory();
+
+        RenderProviders.Add(new Vic20VideoCommandStream(this));
+        SetCurrentRenderProvider(typeof(Vic20VideoCommandStream));
+
+        _renderProviderPerInstructionStat = Instrumentations.Add(
+            $"{StatsCategoryRenderProvider}-Instruction", new ElapsedMillisecondsTimedStatSystem(this));
+        _renderProviderPerFrameStat = Instrumentations.Add(
+            $"{StatsCategoryRenderProvider}-Frame", new ElapsedMillisecondsTimedStatSystem(this));
+    }
+
+    private void SetCurrentRenderProvider(Type? renderProviderType)
+    {
+        if (renderProviderType == null) { _renderProvider = null; return; }
+        _renderProvider = RenderProviders.SingleOrDefault(rp => rp.GetType() == renderProviderType)
+            ?? throw new ArgumentException("Render provider type not found.");
+    }
+
+    private void InitScreenMemory()
+    {
+        // Blank the screen with spaces and default colors
+        Mem[_vic20Config.BackgroundColorAddress] = _vic20Config.DefaultBgColor;
+        Mem[_vic20Config.BorderColorAddress] = _vic20Config.DefaultBorderColor;
+
+        var screenAddr = _vic20Config.ScreenStartAddress;
+        var colorAddr = _vic20Config.ColorStartAddress;
+        for (var i = 0; i < Vic20Config.Cols * Vic20Config.Rows; i++)
+        {
+            Mem[screenAddr++] = 0x20; // space
+            Mem[colorAddr++] = _vic20Config.DefaultFgColor;
+        }
+    }
+
+    public ExecEvaluatorTriggerResult ExecuteOneFrame(IExecEvaluator? execEvaluator = null)
+    {
+        _renderProviderPerInstructionStat.Reset();
+
+        _oneFrameExecEvaluator.ExecOptions.CyclesRequested =
+            CPUCyclesPerFrame - _cyclesConsumedCurrentVblank;
+
+        ExecState execState;
+        if (execEvaluator == null)
+            execState = CPU.Execute(Mem, _oneFrameExecEvaluator);
+        else
+            execState = CPU.Execute(Mem, _oneFrameExecEvaluator, execEvaluator);
+
+        if (execEvaluator != null)
+        {
+            var triggerResult = execEvaluator.Check(execState, CPU, Mem);
+            if (triggerResult.Triggered) return triggerResult;
+        }
+
+        _renderProviderPerInstructionStat.Stop();
+
+        _renderProviderPerFrameStat.Start();
+        _renderProvider?.OnEndFrame();
+        _renderProviderPerFrameStat.Stop();
+
+        return ExecEvaluatorTriggerResult.NotTriggered;
+    }
+
+    public ExecEvaluatorTriggerResult ExecuteOneInstruction(
+        out InstructionExecResult instructionExecResult,
+        IExecEvaluator? execEvaluator = null)
+    {
+        if (execEvaluator != null)
+        {
+            byte opcodeAtPC = Mem[CPU.PC];
+            bool isUnknown = !CPU.InstructionList.OpCodeDictionary.ContainsKey(opcodeAtPC);
+            var preExecResult = isUnknown
+                ? InstructionExecResult.UnknownInstructionResult(opcodeAtPC, CPU.PC)
+                : InstructionExecResult.KnownInstructionResult(opcodeAtPC, CPU.PC, 0);
+
+            var preCheckResult = execEvaluator.Check(preExecResult, CPU, Mem);
+            if (preCheckResult.Triggered)
+            {
+                instructionExecResult = preExecResult;
+                return preCheckResult;
+            }
+        }
+
+        var execState = CPU.ExecuteOneInstruction(Mem);
+        instructionExecResult = execState.LastInstructionExecResult;
+
+        _renderProviderPerInstructionStat.Start(cont: true);
+        _renderProvider?.OnAfterInstruction();
+        _renderProviderPerInstructionStat.Stop(cont: true);
+
+        return ExecEvaluatorTriggerResult.NotTriggered;
+    }
+
+    private void OnCPUCyclesConsumed(CPU cpu, Memory mem, ulong cyclesConsumed)
+    {
+        _cyclesConsumedCurrentVblank += cyclesConsumed;
+        if (_cyclesConsumedCurrentVblank >= CPUCyclesPerFrame)
+            _cyclesConsumedCurrentVblank = 0;
+    }
+
+    public void Reset(ushort? cpuStartPos = null)
+    {
+        if (cpuStartPos == null)
+            CPU.Reset(Mem);
+        else
+            CPU.PC = cpuStartPos.Value;
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Vic20.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Vic20.cs
@@ -4,22 +4,23 @@ using Highbyte.DotNet6502.Systems.Instrumentation.Stats;
 using Highbyte.DotNet6502.Systems.Rendering;
 using Highbyte.DotNet6502.Systems.Vic20.Config;
 using Highbyte.DotNet6502.Systems.Vic20.Render;
+using Highbyte.DotNet6502.Systems.Vic20.TimerAndPeripheral;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Highbyte.DotNet6502.Systems.Vic20;
 
 /// <summary>
-/// VIC-20 system stub. Exercises the system-plugin contract end-to-end:
-/// CPU + flat RAM, VIC-I text-mode video via the command-stream render path,
-/// and a no-op keyboard handler — all without any real VIC-20 chip emulation.
+/// VIC-20 system implementation.
+/// Runs the 6502 CPU instruction-by-instruction (matching the C64 pattern) so that
+/// VIA chip timers are advanced in lock-step with the CPU cycle count.
 /// </summary>
 public class Vic20 : ISystem, ITextMode, IScreen
 {
     public const string SystemName = "VIC-20";
 
     public string Name => SystemName;
-    public List<string> SystemInfo => new() { "VIC-20 (stub)" };
+    public List<string> SystemInfo => new() { "VIC-20" };
     public List<KeyValuePair<string, Func<string>>> DebugInfo => new();
 
     public CPU CPU { get; set; }
@@ -49,9 +50,9 @@ public class Vic20 : ISystem, ITextMode, IScreen
     private readonly Vic20Config _vic20Config;
     public Vic20Config Vic20Config => _vic20Config;
 
-    private ulong _cyclesConsumedCurrentVblank = 0;
-
-    private readonly LegacyExecEvaluator _oneFrameExecEvaluator;
+    // VIA chips — created before memory mapping so MapIOLocations can wire callbacks.
+    public Via1 Via1 { get; }
+    public Via2 Via2 { get; }
 
     private IRenderProvider? _renderProvider;
     public IRenderProvider? RenderProvider => _renderProvider;
@@ -65,7 +66,6 @@ public class Vic20 : ISystem, ITextMode, IScreen
 
     private readonly ElapsedMillisecondsTimedStatSystem _renderProviderPerInstructionStat;
     private readonly ElapsedMillisecondsTimedStatSystem _renderProviderPerFrameStat;
-
     private const string StatsCategoryRenderProvider = "RenderProvider";
 
     public Vic20() : this(new Vic20Config(), new NullLoggerFactory()) { }
@@ -77,14 +77,16 @@ public class Vic20 : ISystem, ITextMode, IScreen
         CPU = new CPU(loggerFactory);
         DefaultExecOptions = new ExecOptions();
 
-        _oneFrameExecEvaluator = new LegacyExecEvaluator(
-            new ExecOptions { CyclesRequested = CPUCyclesPerFrame });
-
-        CPU.InstructionExecuted += (_, e) =>
-            OnCPUCyclesConsumed(e.CPU, e.Mem, e.InstructionExecState.CyclesConsumed);
+        // Create VIA chips before ROM mapping so they can register memory callbacks.
+        Via1 = new Via1(this, loggerFactory);
+        Via2 = new Via2(this, Via1);
 
         if (romData != null)
             MapROMs(romData);
+
+        // Wire VIA I/O callbacks into the memory map.
+        Via1.MapIOLocations(Mem);
+        Via2.MapIOLocations(Mem);
 
         InitScreenMemory();
 
@@ -113,7 +115,6 @@ public class Vic20 : ISystem, ITextMode, IScreen
         //   $8000–$8FFF  Character ROM (4 KB) — VIC-I address space, also CPU-readable
         //   $C000–$DFFF  BASIC ROM     (8 KB)
         //   $E000–$FFFF  KERNAL ROM    (8 KB)
-        // Note: $A000–$BFFF is the BLK5 cartridge area (empty on stock VIC-20).
         if (romData.TryGetValue(Vic20SystemConfig.CHARGEN_ROM_NAME, out var chargen))
             Mem.MapROM(0x8000, chargen);
         if (romData.TryGetValue(Vic20SystemConfig.BASIC_ROM_NAME, out var basic))
@@ -130,34 +131,39 @@ public class Vic20 : ISystem, ITextMode, IScreen
                              | (_vic20Config.DefaultBorderColor & 0x07));
 
         var screenAddr = _vic20Config.ScreenStartAddress;
-        var colorAddr = _vic20Config.ColorStartAddress;
+        var colorAddr  = _vic20Config.ColorStartAddress;
         for (var i = 0; i < Vic20Config.Cols * Vic20Config.Rows; i++)
         {
             Mem[screenAddr++] = 0x20; // space
-            Mem[colorAddr++] = _vic20Config.DefaultFgColor;
+            Mem[colorAddr++]  = _vic20Config.DefaultFgColor;
         }
     }
 
+    /// <summary>
+    /// Executes one full video frame: runs the CPU instruction-by-instruction for the
+    /// correct number of cycles, then fires the VIA1 CA1 interrupt that simulates the
+    /// VIC-I raster pulse the KERNAL uses for keyboard scan and cursor blink.
+    /// </summary>
     public ExecEvaluatorTriggerResult ExecuteOneFrame(IExecEvaluator? execEvaluator = null)
     {
         _renderProviderPerInstructionStat.Reset();
 
-        _oneFrameExecEvaluator.ExecOptions.CyclesRequested =
-            CPUCyclesPerFrame - _cyclesConsumedCurrentVblank;
-
-        ExecState execState;
-        if (execEvaluator == null)
-            execState = CPU.Execute(Mem, _oneFrameExecEvaluator);
-        else
-            execState = CPU.Execute(Mem, _oneFrameExecEvaluator, execEvaluator);
-
-        if (execEvaluator != null)
+        ulong totalCyclesConsumed = 0;
+        while (totalCyclesConsumed < CPUCyclesPerFrame)
         {
-            var triggerResult = execEvaluator.Check(execState, CPU, Mem);
-            if (triggerResult.Triggered) return triggerResult;
+            var triggerResult = ExecuteOneInstruction(out var instrResult, execEvaluator);
+            totalCyclesConsumed += instrResult.CyclesConsumed;
+
+            if (triggerResult.Triggered)
+                return triggerResult;
         }
 
         _renderProviderPerInstructionStat.Stop();
+
+        // Fire the VIC-I raster interrupt — on real hardware this is a signal on VIA1 CA1
+        // that the KERNAL uses (with IER bit 1 = CA1 enabled) to run its IRQ handler,
+        // which does keyboard scan, cursor blink, and other housekeeping.
+        Via1.TriggerCA1(CPU);
 
         _renderProviderPerFrameStat.Start();
         _renderProvider?.OnEndFrame();
@@ -173,7 +179,7 @@ public class Vic20 : ISystem, ITextMode, IScreen
         if (execEvaluator != null)
         {
             byte opcodeAtPC = Mem[CPU.PC];
-            bool isUnknown = !CPU.InstructionList.OpCodeDictionary.ContainsKey(opcodeAtPC);
+            bool isUnknown  = !CPU.InstructionList.OpCodeDictionary.ContainsKey(opcodeAtPC);
             var preExecResult = isUnknown
                 ? InstructionExecResult.UnknownInstructionResult(opcodeAtPC, CPU.PC)
                 : InstructionExecResult.KnownInstructionResult(opcodeAtPC, CPU.PC, 0);
@@ -186,21 +192,17 @@ public class Vic20 : ISystem, ITextMode, IScreen
             }
         }
 
-        var execState = CPU.ExecuteOneInstruction(Mem);
-        instructionExecResult = execState.LastInstructionExecResult;
+        instructionExecResult = CPU.ExecuteOneInstruction(Mem).LastInstructionExecResult;
+
+        // Advance VIA timers — same pattern as C64's CIA timer processing.
+        Via1.ProcessTimers(instructionExecResult.CyclesConsumed);
+        Via2.ProcessTimers(instructionExecResult.CyclesConsumed);
 
         _renderProviderPerInstructionStat.Start(cont: true);
         _renderProvider?.OnAfterInstruction();
         _renderProviderPerInstructionStat.Stop(cont: true);
 
         return ExecEvaluatorTriggerResult.NotTriggered;
-    }
-
-    private void OnCPUCyclesConsumed(CPU cpu, Memory mem, ulong cyclesConsumed)
-    {
-        _cyclesConsumedCurrentVblank += cyclesConsumed;
-        if (_cyclesConsumedCurrentVblank >= CPUCyclesPerFrame)
-            _cyclesConsumedCurrentVblank = 0;
     }
 
     public void Reset(ushort? cpuStartPos = null)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Vic20SystemConfigurerCore.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Vic20SystemConfigurerCore.cs
@@ -1,0 +1,60 @@
+using Highbyte.DotNet6502.Systems.Vic20.Config;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Highbyte.DotNet6502.Systems.Vic20;
+
+/// <summary>
+/// Host-agnostic <see cref="ISystemConfigurer"/> for the VIC-20.
+/// Tech hosts (Avalonia, SilkNet, …) subclass and override <see cref="BuildSystemRunner"/> to
+/// wire their input handler. See the GenericComputerSystemConfigurerCore pattern.
+/// </summary>
+public class Vic20SystemConfigurerCore : ISystemConfigurer
+{
+    protected ILoggerFactory LoggerFactory { get; }
+    protected IConfiguration Configuration { get; }
+    private readonly Func<IHostSystemConfig> _hostConfigFactory;
+    private readonly string _configSectionName;
+
+    public Vic20SystemConfigurerCore(
+        ILoggerFactory loggerFactory,
+        IConfiguration configuration,
+        Func<IHostSystemConfig> hostConfigFactory,
+        string configSectionName)
+    {
+        LoggerFactory = loggerFactory;
+        Configuration = configuration;
+        _hostConfigFactory = hostConfigFactory;
+        _configSectionName = configSectionName;
+    }
+
+    protected Vic20SystemConfigurerCore(ILoggerFactory loggerFactory, Func<IHostSystemConfig> hostConfigFactory)
+        : this(loggerFactory, new ConfigurationBuilder().Build(), hostConfigFactory, configSectionName: "")
+    {
+    }
+
+    public string SystemName => Vic20.SystemName;
+
+    public virtual Task<List<string>> GetConfigurationVariants(ISystemConfig systemConfig)
+        => Task.FromResult(new List<string> { "Default" });
+
+    public virtual Task<IHostSystemConfig> GetNewHostSystemConfig()
+    {
+        var hostConfig = _hostConfigFactory();
+        Configuration.GetSection(_configSectionName).Bind(hostConfig);
+        return Task.FromResult(hostConfig);
+    }
+
+    public virtual Task PersistHostSystemConfig(IHostSystemConfig hostSystemConfig)
+        => Task.CompletedTask;
+
+    public Task<ISystem> BuildSystem(string configurationVariant, ISystemConfig systemConfig)
+    {
+        var vic20Config = new Vic20Config();
+        ISystem vic20 = new Vic20(vic20Config, LoggerFactory);
+        return Task.FromResult(vic20);
+    }
+
+    public virtual Task<SystemRunner> BuildSystemRunner(ISystem system, IHostSystemConfig hostSystemConfig)
+        => Task.FromResult(new SystemRunner((Vic20)system));
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Vic20SystemConfigurerCore.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Vic20SystemConfigurerCore.cs
@@ -50,8 +50,14 @@ public class Vic20SystemConfigurerCore : ISystemConfigurer
 
     public Task<ISystem> BuildSystem(string configurationVariant, ISystemConfig systemConfig)
     {
+        var vic20SystemConfig = (Vic20SystemConfig)systemConfig;
         var vic20Config = new Vic20Config();
-        ISystem vic20 = new Vic20(vic20Config, LoggerFactory);
+
+        Dictionary<string, byte[]>? romData = null;
+        if (vic20SystemConfig.ROMs.Count > 0)
+            romData = ROM.LoadROMS(vic20SystemConfig.ROMDirectory, vic20SystemConfig.ROMs.ToArray());
+
+        ISystem vic20 = new Vic20(vic20Config, LoggerFactory, romData);
         return Task.FromResult(vic20);
     }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Video/ColorMaps.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Video/ColorMaps.cs
@@ -1,0 +1,29 @@
+using System.Drawing;
+
+namespace Highbyte.DotNet6502.Systems.Vic20.Video;
+
+/// <summary>
+/// VIC-20 16-color palette. The VIC-20 and C64 share the same color set.
+/// </summary>
+public static class ColorMaps
+{
+    public static readonly Dictionary<byte, Color> Vic20ColorMap = new()
+    {
+        { 0x00, Color.FromArgb(0,   0,   0)   },  // Black
+        { 0x01, Color.FromArgb(255, 255, 255)  },  // White
+        { 0x02, Color.FromArgb(136, 0,   0)   },  // Red
+        { 0x03, Color.FromArgb(170, 255, 238)  },  // Cyan
+        { 0x04, Color.FromArgb(204, 68,  204)  },  // Violet/purple
+        { 0x05, Color.FromArgb(0,   204, 85)   },  // Green
+        { 0x06, Color.FromArgb(0,   0,   170)  },  // Blue
+        { 0x07, Color.FromArgb(238, 238, 119)  },  // Yellow
+        { 0x08, Color.FromArgb(221, 136, 85)   },  // Orange
+        { 0x09, Color.FromArgb(102, 68,  0)    },  // Brown
+        { 0x0a, Color.FromArgb(255, 119, 119)  },  // Light red
+        { 0x0b, Color.FromArgb(51,  51,  51)   },  // Dark grey
+        { 0x0c, Color.FromArgb(119, 119, 119)  },  // Grey
+        { 0x0d, Color.FromArgb(170, 255, 102)  },  // Light green
+        { 0x0e, Color.FromArgb(0,   136, 255)  },  // Light blue
+        { 0x0f, Color.FromArgb(187, 187, 187)  },  // Light grey
+    };
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Video/Vic20ScreenCode.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Video/Vic20ScreenCode.cs
@@ -1,0 +1,63 @@
+namespace Highbyte.DotNet6502.Systems.Vic20.Video;
+
+/// <summary>
+/// Converts VIC-20 screen codes to printable strings suitable for the C64 Pro Mono font.
+///
+/// The VIC-20 uses the same screen-code encoding as the C64 (PETSCII-based):
+///   screen code 0x00-0x1F  → PETSCII 0x40-0x5F  (uppercase alphabet, @, etc.)
+///   screen code 0x20-0x3F  → PETSCII 0x20-0x3F  (space, digits, common symbols)
+///   screen code 0x40-0x5F  → PETSCII 0xC0-0xDF  (inverted/special graphics)
+///   etc.
+///
+/// The conversion logic is identical to Petscii.C64ScreenCodeToPetscII in the C64
+/// library. It lives here to avoid a cross-library dependency.
+/// </summary>
+public static class Vic20ScreenCode
+{
+    public static string ScreenCodeToUnicode(byte screenCode)
+    {
+        // Special-case: inverted space (screen code 0xA0, 0xE0)
+        if (screenCode == 0xA0 || screenCode == 0xE0)
+            return "█"; // full-block glyph
+
+        var petsciiCode = ScreenCodeToPetscii(screenCode);
+        var asciiCode   = PetsciiToAscii(petsciiCode);
+
+        if (asciiCode == 0x00)
+            return " "; // uninitialized / null → show as space
+
+        // Lowercase a-z in the ASCII result → display as uppercase (C64/VIC-20 look)
+        if (asciiCode >= 0x61 && asciiCode <= 0x7A)
+            return ((char)(asciiCode - 0x20)).ToString();
+
+        return ((char)asciiCode).ToString();
+    }
+
+    // Same formula as Petscii.C64ScreenCodeToPetscII (http://sta.c64.org/cbm64scrtopet.html)
+    private static byte ScreenCodeToPetscii(byte sc) => sc switch
+    {
+        >= 0   and <= 31  => (byte)(sc + 64),
+        >= 32  and <= 63  => sc,
+        >= 64  and <= 93  => (byte)(sc + 128),
+        94                => 255,
+        95                => 223,
+        >= 96  and <= 127 => (byte)(sc + 64),
+        >= 128 and <= 159 => (byte)(sc - 128),
+        >= 160 and <= 191 => (byte)(sc - 128),
+        >= 192 and <= 223 => (byte)(sc - 64),
+        _                 => (byte)(sc - 64),
+    };
+
+    // Same formula as Petscii.PetscIIToAscII
+    private static byte PetsciiToAscii(byte p)
+    {
+        if (p >= 97  && p <= 122) return (byte)(p - 32); // PETSCII a-z → ASCII A-Z
+        if (p >= 65  && p <= 90)  return (byte)(p + 32); // PETSCII A-Z → ASCII a-z
+        if (p >= 192 && p <= 223)
+        {
+            var a = (byte)(p - 96);
+            return (a >= 97 && a <= 122) ? (byte)(a - 32) : a;
+        }
+        return p;
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems/ISystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/ISystemConfig.cs
@@ -54,5 +54,11 @@ public interface ISystemConfig : ICloneable
     public Type? AudioProviderType { get; }
     public Type? AudioTargetType { get; }
 
+    /// <summary>
+    /// Whether audio output is enabled for this system. Systems with no audio must still
+    /// implement this property — declare it as a plain auto-property that always returns
+    /// <c>false</c> (and whose setter is a no-op or ignored). Omitting it causes a compile
+    /// error that is not immediately obvious without reading the full interface.
+    /// </summary>
     public bool AudioEnabled { get; set; }
 }


### PR DESCRIPTION
**Summary**

Adds a working Commodore VIC-20 emulator as a complete end-to-end proof that the plugin architecture supports adding a truly new, hardware-different system — not just a C64 variation. The VIC-20 uses a different CPU support chip family (MOS 6522 VIA instead of 6526 CIA), a different video chip (VIC-I / MOS 6560 instead of VIC-II), and has no SID — so it exercises every plugin contract independently.

**What works at end of branch:**
- KERNAL + BASIC ROMs boot to the "CBM BASIC V2 / 3583 BYTES FREE" prompt
- Cursor blinks at ~60 Hz driven by the VIA1 CA1 raster interrupt (not Timer 1)
- Keyboard input accepted and decoded correctly via the VIA1 Port B column scan / VIA2 Port A row sense; matrix positions derived from the KERNAL decode table at `$EC5E`
- Text mode video rendered from screen RAM at `$1000` with correct VIC-I color RAM (`$9400`)
- All three ROMs loaded (KERNAL, BASIC, character generator) with correct address layout

**New components**

| Layer | Project |
|---|---|
| System library | `Highbyte.DotNet6502.Systems.Vic20` |
| VIA chip emulation | `Via1`, `Via2`, `ViaBase`, `ViaIRQ`, `ViaTimer1`, `ViaAddr` |
| Keyboard matrix | `Vic20Keyboard` (8×8, derived from KERNAL ROM), `Vic20HostKeyboard`, `Vic20InputHandler` |
| Video | `Vic20VideoCommandStream`, `ColorMaps`, `Vic20ScreenCode` |
| Avalonia engine plugin | `Highbyte.DotNet6502.Impl.Avalonia.Vic20` |
| Avalonia shell plugin | `Highbyte.DotNet6502.App.Avalonia.Shell.Vic20` (menu, info panel, config dialog) |

**Docs**

`docs/systems/adding-a-system.md` updated with gaps uncovered during the VIC-20 implementation (VIA interrupt wiring, ROM layout, matrix derivation).

**Not in scope**

Sound (VIC-I $900A–$900E), joystick (VIA1 Port B / VIA2 Port A fire), expansion RAM, tape/disk stubs, IEC serial, multicolor/bitmap graphics modes.

