### PR TITLE
feat(c64): add SwiftLink modem support and improve interrupt timing compatibility

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,7 +35,7 @@
             "preLaunchTask": "build avalonia browser app",
             "cwd": "${workspaceFolder}/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser",
             "url": "http://localhost:5000",
-            "browser": "chrome"
+            //"browser": "chrome"
         },
         {
             "name": "SadConsole - Launch",

--- a/docs/desktop-apps/avalonia-desktop.md
+++ b/docs/desktop-apps/avalonia-desktop.md
@@ -32,6 +32,9 @@ See [Desktop apps installation](installation.md) for package manager and manual 
 - Audio via [NAudio](https://github.com/naudio/NAudio). Defaults to the sample-based SID
   provider; switch to the command-stream provider in the C64 config dialog if you need
   lower CPU. The SID emulation mode (`Auto` / `Fast`) is selectable in the same dialog.
+- Optional SwiftLink cartridge support with `RawTcp` and `HayesModem` transport modes. This is
+  the native host currently recommended for SwiftLink-based software such as Compunet Reborn. See
+  [Systems / C64 / SwiftLink support](../systems/c64/swiftlink.md).
 
 ### System: Generic computer
 

--- a/docs/systems/c64/compatible-programs.md
+++ b/docs/systems/c64/compatible-programs.md
@@ -27,3 +27,9 @@ A list of applications that seem to work decently with the [C64 emulator](overvi
 | Bubble Bobble      | <https://csdb.dk/release/download.php?id=187937> | `Bubble Bobble.d64` → `bubble bobble`  | Basic      | Rasterizer, Custom (v1+), GPU Packet   | Character mode, sprites. |
 
 For advanced use, see [Useful tools](useful-tools.md) for how to extract PRG files from D64 disk images.
+
+## Online / modem-style software
+
+| Program | Media | SwiftLink requirement | Comment |
+| --- | --- | --- | --- |
+| Compunet Reborn | `compunet-reborn-live.d64` or `compunet-reborn-live.prg` | SwiftLink at `$DE00`, `NMI`, `HayesModem` mode recommended | Reaches the login prompt reliably on native hosts. Not available in browser-hosted builds. |

--- a/docs/systems/c64/overview.md
+++ b/docs/systems/c64/overview.md
@@ -37,6 +37,11 @@ Core library: [`Highbyte.DotNet6502.Systems.Commodore64`](../../libraries/system
 - **Limited 1541 disk drive support**
     - Attach `.d64` disk images.
     - Load directory and files to the C64 using the Basic `LOAD` command.
+- **SwiftLink-compatible ACIA support**
+    - Optional SwiftLink cartridge at `$DE00` or `$DF00`.
+    - `RawTcp` and `HayesModem` host transport modes.
+    - `IRQ` or `NMI` interrupt routing.
+    - `Compatible` and `FastBuffered` receive modes.
 - Blazor Browser (WASM), Avalonia Browser (WASM) and Desktop, SilkNetNative Desktop, and SadConsole Desktop UI:s.
 
 ## 1541 Disk Drive Support
@@ -48,6 +53,21 @@ The C64 emulator now includes limited support for the Commodore 1541 disk drive.
 - Example: `LOAD "$",8` to list the directory, or `LOAD "FILENAME",8` to load a file.
 
 *Note: Only basic directory and file loading is supported. Advanced disk operations, file writing, and copy protection schemes are not supported.*
+
+## SwiftLink support
+
+The C64 emulator includes optional SwiftLink-compatible ACIA support for software that expects a
+SwiftLink cartridge.
+
+You can:
+
+- Enable a SwiftLink cartridge in the C64 config.
+- Select base address `$DE00` or `$DF00`.
+- Route interrupts over `IRQ` or `NMI`.
+- Choose `RawTcp` for custom byte-pipe scenarios or `HayesModem` for modem-style software.
+
+For host availability, modem support, and configuration details, see
+[SwiftLink support](swiftlink.md).
 
 ## Implementation libraries
 

--- a/docs/systems/c64/swiftlink.md
+++ b/docs/systems/c64/swiftlink.md
@@ -1,0 +1,63 @@
+# SwiftLink support
+
+The C64 emulator includes **SwiftLink-compatible ACIA support** for software that expects a
+SwiftLink cartridge at `$DE00` or `$DF00`.
+
+## What is supported
+
+- Optional SwiftLink cartridge in the C64 config.
+- Base address selection: `$DE00` or `$DF00`.
+- Interrupt line selection: `IRQ` or `NMI`.
+- Receive mode selection:
+  - `Compatible` — default, paced for better software compatibility.
+  - `FastBuffered` — lower-latency host buffering for custom raw TCP scenarios.
+- Two host transport modes:
+  - `RawTcp` — direct byte pipe to a configured host and port.
+  - `HayesModem` — host-side Hayes-compatible modem layer for modem-style C64 software.
+
+## Hayes modem mode
+
+`HayesModem` mode lets C64 software talk to a host-side modem emulator instead of sending modem
+commands to the remote service directly.
+
+Currently implemented:
+
+- `AT`
+- `ATZ`
+- `AT&F`
+- `ATI`
+- `ATH`
+- `ATDT host:port`
+- `CONNECT 1200`
+- `NO CARRIER`
+
+This is enough for modem-style software such as **Compunet Reborn** to reach the logon screen on
+native hosts.
+
+## Host availability
+
+SwiftLink support depends on the host app exposing a usable TCP transport.
+
+- **Avalonia Desktop**: supported
+- **Headless**: supported
+- **Avalonia Browser**: not supported
+- **Blazor WASM**: not supported
+
+Browser-hosted apps do not currently expose SwiftLink because the browser sandbox does not provide
+the native TCP socket behavior used by the desktop/headless transport implementations.
+
+## Config notes
+
+- `Connect automatically when emulator starts` is useful for `RawTcp` mode.
+- In `HayesModem` mode, the C64 software is expected to dial using `ATDT...`, so auto-connect does
+  not establish the remote session on its own.
+- `Compatible` receive mode is recommended for real third-party software.
+- `FastBuffered` is mainly intended for custom raw TCP integrations where lower latency matters
+  more than strict compatibility.
+
+## Related docs
+
+- [C64 overview](overview.md)
+- [Compatible programs](compatible-programs.md)
+- [Avalonia Desktop app](../../desktop-apps/avalonia-desktop.md)
+- [Avalonia Browser app](../../web-apps/avalonia-browser.md)

--- a/docs/web-apps/avalonia-browser.md
+++ b/docs/web-apps/avalonia-browser.md
@@ -40,6 +40,9 @@ To self-host, see [Run from command line](#run-from-command-line) below.
   Defaults to the sample-based SID provider; switch to the command-stream provider in the
   C64 config dialog if you need lower CPU. The SID emulation mode (`Auto` / `Fast`) is
   selectable in the same dialog.
+- SwiftLink is **not currently available** in the browser build. Browser-hosted WebAssembly does
+  not expose the native TCP socket behavior used by the desktop/headless SwiftLink transports. See
+  [Systems / C64 / SwiftLink support](../systems/c64/swiftlink.md).
 
 ### System: Generic computer
 

--- a/dotnet-6502.sln
+++ b/dotnet-6502.sln
@@ -92,6 +92,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Highbyte.DotNet6502.App.Sad
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Highbyte.DotNet6502.Impl.SadConsole.Generic", "src\libraries\Highbyte.DotNet6502.Impl.SadConsole.Generic\Highbyte.DotNet6502.Impl.SadConsole.Generic.csproj", "{DE514A04-2F74-4144-AC6A-534904E4A746}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Highbyte.DotNet6502.Systems.Commodore64.Transport", "src\libraries\Highbyte.DotNet6502.Systems.Commodore64.Transport\Highbyte.DotNet6502.Systems.Commodore64.Transport.csproj", "{B020E9BD-AB86-4F37-8CF2-7C96E9E52BDB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -498,6 +500,18 @@ Global
 		{DE514A04-2F74-4144-AC6A-534904E4A746}.Release|x64.Build.0 = Release|Any CPU
 		{DE514A04-2F74-4144-AC6A-534904E4A746}.Release|x86.ActiveCfg = Release|Any CPU
 		{DE514A04-2F74-4144-AC6A-534904E4A746}.Release|x86.Build.0 = Release|Any CPU
+		{B020E9BD-AB86-4F37-8CF2-7C96E9E52BDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B020E9BD-AB86-4F37-8CF2-7C96E9E52BDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B020E9BD-AB86-4F37-8CF2-7C96E9E52BDB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B020E9BD-AB86-4F37-8CF2-7C96E9E52BDB}.Debug|x64.Build.0 = Debug|Any CPU
+		{B020E9BD-AB86-4F37-8CF2-7C96E9E52BDB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B020E9BD-AB86-4F37-8CF2-7C96E9E52BDB}.Debug|x86.Build.0 = Debug|Any CPU
+		{B020E9BD-AB86-4F37-8CF2-7C96E9E52BDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B020E9BD-AB86-4F37-8CF2-7C96E9E52BDB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B020E9BD-AB86-4F37-8CF2-7C96E9E52BDB}.Release|x64.ActiveCfg = Release|Any CPU
+		{B020E9BD-AB86-4F37-8CF2-7C96E9E52BDB}.Release|x64.Build.0 = Release|Any CPU
+		{B020E9BD-AB86-4F37-8CF2-7C96E9E52BDB}.Release|x86.ActiveCfg = Release|Any CPU
+		{B020E9BD-AB86-4F37-8CF2-7C96E9E52BDB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -540,6 +554,7 @@ Global
 		{AD8D63D1-3C09-41FC-AA00-24397AC1D242} = {5E7EC0AF-E837-5B7A-FB41-A4DCCA877D1F}
 		{BE129B6F-D8AF-4621-A5B6-4E7F4D50CAAA} = {9593981F-BBAF-772C-5E92-B9FA193065AB}
 		{DE514A04-2F74-4144-AC6A-534904E4A746} = {5E7EC0AF-E837-5B7A-FB41-A4DCCA877D1F}
+		{B020E9BD-AB86-4F37-8CF2-7C96E9E52BDB} = {5E7EC0AF-E837-5B7A-FB41-A4DCCA877D1F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0F55B6C2-E4B4-4F2C-9D2A-D63A17F3B5C4}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -168,6 +168,7 @@ nav:
           - Libraries: systems/c64/libraries.md
           - Keyboard mapping: systems/c64/keyboard.md
           - ROMs: systems/c64/roms.md
+          - SwiftLink support: systems/c64/swiftlink.md
           - Basic code completion: systems/c64/code-completion.md
           - Compatible programs: systems/c64/compatible-programs.md
           - Useful tools: systems/c64/useful-tools.md

--- a/src/apps/Avalonia/Avalonia.sln
+++ b/src/apps/Avalonia/Avalonia.sln
@@ -47,6 +47,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Highbyte.DotNet6502.Impl.NA
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Highbyte.DotNet6502.Impl.NAudio.Commodore64", "..\..\libraries\Highbyte.DotNet6502.Impl.NAudio.Commodore64\Highbyte.DotNet6502.Impl.NAudio.Commodore64.csproj", "{26DDBE85-174B-4444-B5A5-535FD344DB2F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Highbyte.DotNet6502.Systems.Commodore64.Transport", "..\..\libraries\Highbyte.DotNet6502.Systems.Commodore64.Transport\Highbyte.DotNet6502.Systems.Commodore64.Transport.csproj", "{743D266F-2D95-488F-93CF-7D03820FA275}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -261,6 +263,18 @@ Global
 		{26DDBE85-174B-4444-B5A5-535FD344DB2F}.Release|x64.Build.0 = Release|Any CPU
 		{26DDBE85-174B-4444-B5A5-535FD344DB2F}.Release|x86.ActiveCfg = Release|Any CPU
 		{26DDBE85-174B-4444-B5A5-535FD344DB2F}.Release|x86.Build.0 = Release|Any CPU
+		{743D266F-2D95-488F-93CF-7D03820FA275}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{743D266F-2D95-488F-93CF-7D03820FA275}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{743D266F-2D95-488F-93CF-7D03820FA275}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{743D266F-2D95-488F-93CF-7D03820FA275}.Debug|x64.Build.0 = Debug|Any CPU
+		{743D266F-2D95-488F-93CF-7D03820FA275}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{743D266F-2D95-488F-93CF-7D03820FA275}.Debug|x86.Build.0 = Debug|Any CPU
+		{743D266F-2D95-488F-93CF-7D03820FA275}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{743D266F-2D95-488F-93CF-7D03820FA275}.Release|Any CPU.Build.0 = Release|Any CPU
+		{743D266F-2D95-488F-93CF-7D03820FA275}.Release|x64.ActiveCfg = Release|Any CPU
+		{743D266F-2D95-488F-93CF-7D03820FA275}.Release|x64.Build.0 = Release|Any CPU
+		{743D266F-2D95-488F-93CF-7D03820FA275}.Release|x86.ActiveCfg = Release|Any CPU
+		{743D266F-2D95-488F-93CF-7D03820FA275}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.json
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.json
@@ -47,11 +47,6 @@
   },
 
   "Highbyte.DotNet6502.C64.Avalonia": {
-    // Default SwiftLink/Compunet test settings for desktop runs.
-    "SwiftLinkTransportMode": "HayesModem",
-    "SwiftLinkTcpHost": "vme.compunet.live",
-    "SwiftLinkTcpPort": 6400,
-    "SwiftLinkConnectOnBoot": false,
 
     "SystemConfig": {
 
@@ -80,10 +75,23 @@
 
       "ColorMapName": "Default",
       "AudioEnabled": true,
-      "SwiftLinkEnabled": true,
-      "SwiftLinkCartridgeIOAddress": "DE00",
-      "SwiftLinkInterruptMode": "NMI",
-      "SwiftLinkReceiveMode": "Compatible"
+
+      // Use settings by default that allow SwiftLink to be used without Compunet. Also see SwiftLinkHost settings below.
+      "SwiftLink": {
+        "Enabled": false,
+        "CartridgeIOAddress": "DE00",
+        "InterruptMode": "NMI",
+        "ReceiveMode": "Compatible"
+      }
+
+    },
+
+    // SwiftLinkHost settings compatible with Compunet by default
+    "SwiftLinkHost": {
+      "TransportMode": "HayesModem",
+      "TcpHost": "vme.compunet.live",
+      "TcpPort": 6400,
+      "ConnectOnBoot": false
     },
 
     "InputConfig": {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.json
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.json
@@ -47,6 +47,11 @@
   },
 
   "Highbyte.DotNet6502.C64.Avalonia": {
+    // Default SwiftLink/Compunet test settings for desktop runs.
+    "SwiftLinkTransportMode": "HayesModem",
+    "SwiftLinkTcpHost": "vme.compunet.live",
+    "SwiftLinkTcpPort": 6400,
+    "SwiftLinkConnectOnBoot": false,
 
     "SystemConfig": {
 
@@ -74,7 +79,11 @@
       ],
 
       "ColorMapName": "Default",
-      "AudioEnabled": true
+      "AudioEnabled": true,
+      "SwiftLinkEnabled": true,
+      "SwiftLinkCartridgeIOAddress": "DE00",
+      "SwiftLinkInterruptMode": "NMI",
+      "SwiftLinkReceiveMode": "Compatible"
     },
 
     "InputConfig": {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64ConfigDialogViewModel.cs
@@ -54,7 +54,9 @@ public class C64ConfigDialogViewModel : ViewModelBase
     private string _selectedKeyboardLayout = AutoKeyboardLayoutLabel;
     private bool _swiftLinkEnabled;
     private C64CartridgeIOAddress _selectedSwiftLinkCartridgeIOAddress;
+    private C64SwiftLinkTransportMode _selectedSwiftLinkTransportMode;
     private C64SwiftLinkInterruptMode _selectedSwiftLinkInterruptMode;
+    private C64SwiftLinkReceiveMode _selectedSwiftLinkReceiveMode;
     private string _swiftLinkTcpHost = string.Empty;
     private int _swiftLinkTcpPort;
     private bool _swiftLinkConnectOnBoot;
@@ -108,7 +110,9 @@ public class C64ConfigDialogViewModel : ViewModelBase
         SelectedKeyboardLayout = _workingConfig.InputConfig.KeyboardLayout?.ToString() ?? AutoKeyboardLayoutLabel;
         SwiftLinkEnabled = _workingConfig.SystemConfig.SwiftLinkEnabled;
         SelectedSwiftLinkCartridgeIOAddress = _workingConfig.SystemConfig.SwiftLinkCartridgeIOAddress;
+        SelectedSwiftLinkTransportMode = _workingConfig.SwiftLinkTransportMode;
         SelectedSwiftLinkInterruptMode = _workingConfig.SystemConfig.SwiftLinkInterruptMode;
+        SelectedSwiftLinkReceiveMode = _workingConfig.SystemConfig.SwiftLinkReceiveMode;
         SwiftLinkTcpHost = _workingConfig.SwiftLinkTcpHost;
         SwiftLinkTcpPort = _workingConfig.SwiftLinkTcpPort;
         SwiftLinkConnectOnBoot = _workingConfig.SwiftLinkConnectOnBoot;
@@ -189,8 +193,12 @@ public class C64ConfigDialogViewModel : ViewModelBase
     public ObservableCollection<KeyMappingEntry> KeyboardMappings { get; } = new();
     public ObservableCollection<C64CartridgeIOAddress> AvailableSwiftLinkCartridgeIOAddresses { get; } =
         new(Enum.GetValues<C64CartridgeIOAddress>());
+    public ObservableCollection<C64SwiftLinkTransportMode> AvailableSwiftLinkTransportModes { get; } =
+        new(Enum.GetValues<C64SwiftLinkTransportMode>());
     public ObservableCollection<C64SwiftLinkInterruptMode> AvailableSwiftLinkInterruptModes { get; } =
         new(Enum.GetValues<C64SwiftLinkInterruptMode>());
+    public ObservableCollection<C64SwiftLinkReceiveMode> AvailableSwiftLinkReceiveModes { get; } =
+        new(Enum.GetValues<C64SwiftLinkReceiveMode>());
     // "Auto" (auto-detect) plus each explicit C64KeyboardLayout, as strings for the dropdown.
     public ObservableCollection<string> AvailableKeyboardLayouts { get; } =
         new(new[] { AutoKeyboardLayoutLabel }.Concat(Enum.GetNames<C64KeyboardLayout>()));
@@ -288,6 +296,32 @@ public class C64ConfigDialogViewModel : ViewModelBase
 
             this.RaiseAndSetIfChanged(ref _selectedSwiftLinkInterruptMode, value);
             _workingConfig.SystemConfig.SwiftLinkInterruptMode = value;
+        }
+    }
+
+    public C64SwiftLinkReceiveMode SelectedSwiftLinkReceiveMode
+    {
+        get => _selectedSwiftLinkReceiveMode;
+        set
+        {
+            if (_selectedSwiftLinkReceiveMode == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _selectedSwiftLinkReceiveMode, value);
+            _workingConfig.SystemConfig.SwiftLinkReceiveMode = value;
+        }
+    }
+
+    public C64SwiftLinkTransportMode SelectedSwiftLinkTransportMode
+    {
+        get => _selectedSwiftLinkTransportMode;
+        set
+        {
+            if (_selectedSwiftLinkTransportMode == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _selectedSwiftLinkTransportMode, value);
+            _workingConfig.SwiftLinkTransportMode = value;
         }
     }
 
@@ -1350,7 +1384,9 @@ public class C64ConfigDialogViewModel : ViewModelBase
         _originalConfig.SystemConfig.SwiftLinkEnabled = _workingConfig.SystemConfig.SwiftLinkEnabled;
         _originalConfig.SystemConfig.SwiftLinkCartridgeIOAddress = _workingConfig.SystemConfig.SwiftLinkCartridgeIOAddress;
         _originalConfig.SystemConfig.SwiftLinkInterruptMode = _workingConfig.SystemConfig.SwiftLinkInterruptMode;
+        _originalConfig.SystemConfig.SwiftLinkReceiveMode = _workingConfig.SystemConfig.SwiftLinkReceiveMode;
         _originalConfig.SystemConfig.ColorMapName = _workingConfig.SystemConfig.ColorMapName;
+        _originalConfig.SwiftLinkTransportMode = _workingConfig.SwiftLinkTransportMode;
         _originalConfig.SwiftLinkTcpHost = _workingConfig.SwiftLinkTcpHost;
         _originalConfig.SwiftLinkTcpPort = _workingConfig.SwiftLinkTcpPort;
         _originalConfig.SwiftLinkConnectOnBoot = _workingConfig.SwiftLinkConnectOnBoot;

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64ConfigDialogViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -14,6 +15,7 @@ using Highbyte.DotNet6502.Impl.Avalonia;
 using Highbyte.DotNet6502.Impl.Avalonia.Commodore64;
 using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Commodore64.Audio.Sample;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 using Highbyte.DotNet6502.Systems.Commodore64.Input;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
 using Highbyte.DotNet6502.Systems.Commodore64.Utils.BasicAssistant;
@@ -59,6 +61,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
     private C64SwiftLinkReceiveMode _selectedSwiftLinkReceiveMode;
     private string _swiftLinkTcpHost = string.Empty;
     private int _swiftLinkTcpPort;
+    private string _swiftLinkTcpPortText = string.Empty;
     private bool _swiftLinkConnectOnBoot;
     private string _romDirectory = string.Empty;
     private RenderProviderOption? _selectedRenderProvider;
@@ -108,14 +111,14 @@ public class C64ConfigDialogViewModel : ViewModelBase
         SelectedKeyboardJoystick = _workingConfig.SystemConfig.KeyboardJoystick;
         SelectedHostJoystick = _workingConfig.InputConfig.CurrentJoystick;
         SelectedKeyboardLayout = _workingConfig.InputConfig.KeyboardLayout?.ToString() ?? AutoKeyboardLayoutLabel;
-        SwiftLinkEnabled = _workingConfig.SystemConfig.SwiftLinkEnabled;
-        SelectedSwiftLinkCartridgeIOAddress = _workingConfig.SystemConfig.SwiftLinkCartridgeIOAddress;
-        SelectedSwiftLinkTransportMode = _workingConfig.SwiftLinkTransportMode;
-        SelectedSwiftLinkInterruptMode = _workingConfig.SystemConfig.SwiftLinkInterruptMode;
-        SelectedSwiftLinkReceiveMode = _workingConfig.SystemConfig.SwiftLinkReceiveMode;
-        SwiftLinkTcpHost = _workingConfig.SwiftLinkTcpHost;
-        SwiftLinkTcpPort = _workingConfig.SwiftLinkTcpPort;
-        SwiftLinkConnectOnBoot = _workingConfig.SwiftLinkConnectOnBoot;
+        SwiftLinkEnabled = _workingConfig.SystemConfig.SwiftLink.Enabled;
+        SelectedSwiftLinkCartridgeIOAddress = _workingConfig.SystemConfig.SwiftLink.CartridgeIOAddress;
+        SelectedSwiftLinkTransportMode = _workingConfig.SwiftLinkHost.TransportMode;
+        SelectedSwiftLinkInterruptMode = _workingConfig.SystemConfig.SwiftLink.InterruptMode;
+        SelectedSwiftLinkReceiveMode = _workingConfig.SystemConfig.SwiftLink.ReceiveMode;
+        SwiftLinkTcpHost = _workingConfig.SwiftLinkHost.TcpHost;
+        SwiftLinkTcpPort = _workingConfig.SwiftLinkHost.TcpPort;
+        SwiftLinkConnectOnBoot = _workingConfig.SwiftLinkHost.ConnectOnBoot;
 
         AudioEnabled = _workingConfig.SystemConfig.AudioEnabled;
 
@@ -269,7 +272,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
                 return;
 
             this.RaiseAndSetIfChanged(ref _swiftLinkEnabled, value);
-            _workingConfig.SystemConfig.SwiftLinkEnabled = value;
+            _workingConfig.SystemConfig.SwiftLink.Enabled = value;
         }
     }
 
@@ -282,7 +285,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
                 return;
 
             this.RaiseAndSetIfChanged(ref _selectedSwiftLinkCartridgeIOAddress, value);
-            _workingConfig.SystemConfig.SwiftLinkCartridgeIOAddress = value;
+            _workingConfig.SystemConfig.SwiftLink.CartridgeIOAddress = value;
         }
     }
 
@@ -295,7 +298,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
                 return;
 
             this.RaiseAndSetIfChanged(ref _selectedSwiftLinkInterruptMode, value);
-            _workingConfig.SystemConfig.SwiftLinkInterruptMode = value;
+            _workingConfig.SystemConfig.SwiftLink.InterruptMode = value;
         }
     }
 
@@ -308,7 +311,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
                 return;
 
             this.RaiseAndSetIfChanged(ref _selectedSwiftLinkReceiveMode, value);
-            _workingConfig.SystemConfig.SwiftLinkReceiveMode = value;
+            _workingConfig.SystemConfig.SwiftLink.ReceiveMode = value;
         }
     }
 
@@ -321,9 +324,19 @@ public class C64ConfigDialogViewModel : ViewModelBase
                 return;
 
             this.RaiseAndSetIfChanged(ref _selectedSwiftLinkTransportMode, value);
-            _workingConfig.SwiftLinkTransportMode = value;
+            _workingConfig.SwiftLinkHost.TransportMode = value;
+            this.RaisePropertyChanged(nameof(IsSwiftLinkConnectOnBootAvailable));
+            this.RaisePropertyChanged(nameof(SwiftLinkConnectOnBootToolTip));
         }
     }
+
+    public bool IsSwiftLinkConnectOnBootAvailable
+        => SelectedSwiftLinkTransportMode == C64SwiftLinkTransportMode.RawTcp;
+
+    public string SwiftLinkConnectOnBootToolTip
+        => IsSwiftLinkConnectOnBootAvailable
+            ? "Automatically opens the configured raw TCP SwiftLink connection when the emulator starts."
+            : "Only applies to Raw TCP mode. Hayes modem mode waits for the emulated C64 software to dial with an ATDT command.";
 
     public string SwiftLinkTcpHost
     {
@@ -334,7 +347,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
                 return;
 
             this.RaiseAndSetIfChanged(ref _swiftLinkTcpHost, value);
-            _workingConfig.SwiftLinkTcpHost = value;
+            _workingConfig.SwiftLinkHost.TcpHost = value;
         }
     }
 
@@ -347,7 +360,30 @@ public class C64ConfigDialogViewModel : ViewModelBase
                 return;
 
             this.RaiseAndSetIfChanged(ref _swiftLinkTcpPort, value);
-            _workingConfig.SwiftLinkTcpPort = value;
+            this.RaiseAndSetIfChanged(ref _swiftLinkTcpPortText, value.ToString(CultureInfo.InvariantCulture), nameof(SwiftLinkTcpPortText));
+            _workingConfig.SwiftLinkHost.TcpPort = value;
+        }
+    }
+
+    public string SwiftLinkTcpPortText
+    {
+        get => _swiftLinkTcpPortText;
+        set
+        {
+            if (_swiftLinkTcpPortText == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _swiftLinkTcpPortText, value);
+
+            if (int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var parsedPort))
+            {
+                parsedPort = Math.Clamp(parsedPort, 1, 65535);
+                if (_swiftLinkTcpPort != parsedPort)
+                {
+                    this.RaiseAndSetIfChanged(ref _swiftLinkTcpPort, parsedPort, nameof(SwiftLinkTcpPort));
+                    _workingConfig.SwiftLinkHost.TcpPort = parsedPort;
+                }
+            }
         }
     }
 
@@ -360,7 +396,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
                 return;
 
             this.RaiseAndSetIfChanged(ref _swiftLinkConnectOnBoot, value);
-            _workingConfig.SwiftLinkConnectOnBoot = value;
+            _workingConfig.SwiftLinkHost.ConnectOnBoot = value;
         }
     }
 
@@ -1381,15 +1417,9 @@ public class C64ConfigDialogViewModel : ViewModelBase
         _originalConfig.SystemConfig.AudioEnabled = _workingConfig.SystemConfig.AudioEnabled;
         _originalConfig.SystemConfig.KeyboardJoystickEnabled = _workingConfig.SystemConfig.KeyboardJoystickEnabled;
         _originalConfig.SystemConfig.KeyboardJoystick = _workingConfig.SystemConfig.KeyboardJoystick;
-        _originalConfig.SystemConfig.SwiftLinkEnabled = _workingConfig.SystemConfig.SwiftLinkEnabled;
-        _originalConfig.SystemConfig.SwiftLinkCartridgeIOAddress = _workingConfig.SystemConfig.SwiftLinkCartridgeIOAddress;
-        _originalConfig.SystemConfig.SwiftLinkInterruptMode = _workingConfig.SystemConfig.SwiftLinkInterruptMode;
-        _originalConfig.SystemConfig.SwiftLinkReceiveMode = _workingConfig.SystemConfig.SwiftLinkReceiveMode;
+        _originalConfig.SystemConfig.SwiftLink = _workingConfig.SystemConfig.SwiftLink.Clone();
         _originalConfig.SystemConfig.ColorMapName = _workingConfig.SystemConfig.ColorMapName;
-        _originalConfig.SwiftLinkTransportMode = _workingConfig.SwiftLinkTransportMode;
-        _originalConfig.SwiftLinkTcpHost = _workingConfig.SwiftLinkTcpHost;
-        _originalConfig.SwiftLinkTcpPort = _workingConfig.SwiftLinkTcpPort;
-        _originalConfig.SwiftLinkConnectOnBoot = _workingConfig.SwiftLinkConnectOnBoot;
+        _originalConfig.SwiftLinkHost = _workingConfig.SwiftLinkHost.Clone();
 
         if (_workingConfig.SystemConfig.RenderProviderType != null)
             _originalConfig.SystemConfig.SetRenderProviderType(_workingConfig.SystemConfig.RenderProviderType);

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64ConfigDialogViewModel.cs
@@ -273,6 +273,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
 
             this.RaiseAndSetIfChanged(ref _swiftLinkEnabled, value);
             _workingConfig.SystemConfig.SwiftLink.Enabled = value;
+            UpdateValidationMessageFromConfig();
         }
     }
 
@@ -286,6 +287,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
 
             this.RaiseAndSetIfChanged(ref _selectedSwiftLinkCartridgeIOAddress, value);
             _workingConfig.SystemConfig.SwiftLink.CartridgeIOAddress = value;
+            UpdateValidationMessageFromConfig();
         }
     }
 
@@ -299,6 +301,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
 
             this.RaiseAndSetIfChanged(ref _selectedSwiftLinkInterruptMode, value);
             _workingConfig.SystemConfig.SwiftLink.InterruptMode = value;
+            UpdateValidationMessageFromConfig();
         }
     }
 
@@ -312,6 +315,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
 
             this.RaiseAndSetIfChanged(ref _selectedSwiftLinkReceiveMode, value);
             _workingConfig.SystemConfig.SwiftLink.ReceiveMode = value;
+            UpdateValidationMessageFromConfig();
         }
     }
 
@@ -327,6 +331,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
             _workingConfig.SwiftLinkHost.TransportMode = value;
             this.RaisePropertyChanged(nameof(IsSwiftLinkConnectOnBootAvailable));
             this.RaisePropertyChanged(nameof(SwiftLinkConnectOnBootToolTip));
+            UpdateValidationMessageFromConfig();
         }
     }
 
@@ -348,6 +353,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
 
             this.RaiseAndSetIfChanged(ref _swiftLinkTcpHost, value);
             _workingConfig.SwiftLinkHost.TcpHost = value;
+            UpdateValidationMessageFromConfig();
         }
     }
 
@@ -362,6 +368,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
             this.RaiseAndSetIfChanged(ref _swiftLinkTcpPort, value);
             this.RaiseAndSetIfChanged(ref _swiftLinkTcpPortText, value.ToString(CultureInfo.InvariantCulture), nameof(SwiftLinkTcpPortText));
             _workingConfig.SwiftLinkHost.TcpPort = value;
+            UpdateValidationMessageFromConfig();
         }
     }
 
@@ -377,13 +384,14 @@ public class C64ConfigDialogViewModel : ViewModelBase
 
             if (int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var parsedPort))
             {
-                parsedPort = Math.Clamp(parsedPort, 1, 65535);
                 if (_swiftLinkTcpPort != parsedPort)
                 {
                     this.RaiseAndSetIfChanged(ref _swiftLinkTcpPort, parsedPort, nameof(SwiftLinkTcpPort));
                     _workingConfig.SwiftLinkHost.TcpPort = parsedPort;
                 }
             }
+
+            UpdateValidationMessageFromConfig();
         }
     }
 
@@ -397,6 +405,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
 
             this.RaiseAndSetIfChanged(ref _swiftLinkConnectOnBoot, value);
             _workingConfig.SwiftLinkHost.ConnectOnBoot = value;
+            UpdateValidationMessageFromConfig();
         }
     }
 
@@ -1388,7 +1397,17 @@ public class C64ConfigDialogViewModel : ViewModelBase
 
     private void UpdateValidationMessageFromConfig()
     {
-        if (!_workingConfig.IsValid(out var validationErrors))
+        var validationErrors = new List<string>();
+        if (!_workingConfig.IsValid(out validationErrors))
+        {
+            // validationErrors already populated by host/system config validation
+        }
+
+        var swiftLinkPortInputError = GetSwiftLinkPortInputValidationError();
+        if (!string.IsNullOrEmpty(swiftLinkPortInputError))
+            validationErrors.Add(swiftLinkPortInputError);
+
+        if (validationErrors.Count > 0)
         {
             ValidationMessage = string.Join(Environment.NewLine, validationErrors);
 
@@ -1408,6 +1427,20 @@ public class C64ConfigDialogViewModel : ViewModelBase
         // Notify UI about changes
         this.RaisePropertyChanged(nameof(HasValidationErrors));
         this.RaisePropertyChanged(nameof(CanSave));
+    }
+
+    private string? GetSwiftLinkPortInputValidationError()
+    {
+        if (string.IsNullOrWhiteSpace(SwiftLinkTcpPortText))
+            return $"{nameof(C64HostConfig.SwiftLinkHost)}.{nameof(C64SwiftLinkHostConfig.TcpPort)} must be between 1 and 65535.";
+
+        if (!int.TryParse(SwiftLinkTcpPortText, NumberStyles.None, CultureInfo.InvariantCulture, out var parsedPort))
+            return $"{nameof(C64HostConfig.SwiftLinkHost)}.{nameof(C64SwiftLinkHostConfig.TcpPort)} must be between 1 and 65535.";
+
+        if (parsedPort is < 1 or > 65535)
+            return $"{nameof(C64HostConfig.SwiftLinkHost)}.{nameof(C64SwiftLinkHostConfig.TcpPort)} must be between 1 and 65535.";
+
+        return null;
     }
 
     private void ApplyWorkingConfigToOriginal()

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64ConfigDialogViewModel.cs
@@ -54,6 +54,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
     private string _selectedKeyboardLayout = AutoKeyboardLayoutLabel;
     private bool _swiftLinkEnabled;
     private C64CartridgeIOAddress _selectedSwiftLinkCartridgeIOAddress;
+    private C64SwiftLinkInterruptMode _selectedSwiftLinkInterruptMode;
     private string _swiftLinkTcpHost = string.Empty;
     private int _swiftLinkTcpPort;
     private bool _swiftLinkConnectOnBoot;
@@ -107,6 +108,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
         SelectedKeyboardLayout = _workingConfig.InputConfig.KeyboardLayout?.ToString() ?? AutoKeyboardLayoutLabel;
         SwiftLinkEnabled = _workingConfig.SystemConfig.SwiftLinkEnabled;
         SelectedSwiftLinkCartridgeIOAddress = _workingConfig.SystemConfig.SwiftLinkCartridgeIOAddress;
+        SelectedSwiftLinkInterruptMode = _workingConfig.SystemConfig.SwiftLinkInterruptMode;
         SwiftLinkTcpHost = _workingConfig.SwiftLinkTcpHost;
         SwiftLinkTcpPort = _workingConfig.SwiftLinkTcpPort;
         SwiftLinkConnectOnBoot = _workingConfig.SwiftLinkConnectOnBoot;
@@ -187,6 +189,8 @@ public class C64ConfigDialogViewModel : ViewModelBase
     public ObservableCollection<KeyMappingEntry> KeyboardMappings { get; } = new();
     public ObservableCollection<C64CartridgeIOAddress> AvailableSwiftLinkCartridgeIOAddresses { get; } =
         new(Enum.GetValues<C64CartridgeIOAddress>());
+    public ObservableCollection<C64SwiftLinkInterruptMode> AvailableSwiftLinkInterruptModes { get; } =
+        new(Enum.GetValues<C64SwiftLinkInterruptMode>());
     // "Auto" (auto-detect) plus each explicit C64KeyboardLayout, as strings for the dropdown.
     public ObservableCollection<string> AvailableKeyboardLayouts { get; } =
         new(new[] { AutoKeyboardLayoutLabel }.Concat(Enum.GetNames<C64KeyboardLayout>()));
@@ -271,6 +275,19 @@ public class C64ConfigDialogViewModel : ViewModelBase
 
             this.RaiseAndSetIfChanged(ref _selectedSwiftLinkCartridgeIOAddress, value);
             _workingConfig.SystemConfig.SwiftLinkCartridgeIOAddress = value;
+        }
+    }
+
+    public C64SwiftLinkInterruptMode SelectedSwiftLinkInterruptMode
+    {
+        get => _selectedSwiftLinkInterruptMode;
+        set
+        {
+            if (_selectedSwiftLinkInterruptMode == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _selectedSwiftLinkInterruptMode, value);
+            _workingConfig.SystemConfig.SwiftLinkInterruptMode = value;
         }
     }
 
@@ -1332,6 +1349,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
         _originalConfig.SystemConfig.KeyboardJoystick = _workingConfig.SystemConfig.KeyboardJoystick;
         _originalConfig.SystemConfig.SwiftLinkEnabled = _workingConfig.SystemConfig.SwiftLinkEnabled;
         _originalConfig.SystemConfig.SwiftLinkCartridgeIOAddress = _workingConfig.SystemConfig.SwiftLinkCartridgeIOAddress;
+        _originalConfig.SystemConfig.SwiftLinkInterruptMode = _workingConfig.SystemConfig.SwiftLinkInterruptMode;
         _originalConfig.SystemConfig.ColorMapName = _workingConfig.SystemConfig.ColorMapName;
         _originalConfig.SwiftLinkTcpHost = _workingConfig.SwiftLinkTcpHost;
         _originalConfig.SwiftLinkTcpPort = _workingConfig.SwiftLinkTcpPort;

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64ConfigDialogViewModel.cs
@@ -52,6 +52,11 @@ public class C64ConfigDialogViewModel : ViewModelBase
     private int _selectedKeyboardJoystick;
     private int _selectedHostJoystick;
     private string _selectedKeyboardLayout = AutoKeyboardLayoutLabel;
+    private bool _swiftLinkEnabled;
+    private C64CartridgeIOAddress _selectedSwiftLinkCartridgeIOAddress;
+    private string _swiftLinkTcpHost = string.Empty;
+    private int _swiftLinkTcpPort;
+    private bool _swiftLinkConnectOnBoot;
     private string _romDirectory = string.Empty;
     private RenderProviderOption? _selectedRenderProvider;
     private RenderTargetOption? _selectedRenderTarget;
@@ -100,6 +105,11 @@ public class C64ConfigDialogViewModel : ViewModelBase
         SelectedKeyboardJoystick = _workingConfig.SystemConfig.KeyboardJoystick;
         SelectedHostJoystick = _workingConfig.InputConfig.CurrentJoystick;
         SelectedKeyboardLayout = _workingConfig.InputConfig.KeyboardLayout?.ToString() ?? AutoKeyboardLayoutLabel;
+        SwiftLinkEnabled = _workingConfig.SystemConfig.SwiftLinkEnabled;
+        SelectedSwiftLinkCartridgeIOAddress = _workingConfig.SystemConfig.SwiftLinkCartridgeIOAddress;
+        SwiftLinkTcpHost = _workingConfig.SwiftLinkTcpHost;
+        SwiftLinkTcpPort = _workingConfig.SwiftLinkTcpPort;
+        SwiftLinkConnectOnBoot = _workingConfig.SwiftLinkConnectOnBoot;
 
         AudioEnabled = _workingConfig.SystemConfig.AudioEnabled;
 
@@ -175,6 +185,8 @@ public class C64ConfigDialogViewModel : ViewModelBase
     public ObservableCollection<SidEmulationModeOption> SidEmulationModes { get; } = new();
     public ObservableCollection<int> AvailableJoysticks { get; }
     public ObservableCollection<KeyMappingEntry> KeyboardMappings { get; } = new();
+    public ObservableCollection<C64CartridgeIOAddress> AvailableSwiftLinkCartridgeIOAddresses { get; } =
+        new(Enum.GetValues<C64CartridgeIOAddress>());
     // "Auto" (auto-detect) plus each explicit C64KeyboardLayout, as strings for the dropdown.
     public ObservableCollection<string> AvailableKeyboardLayouts { get; } =
         new(new[] { AutoKeyboardLayoutLabel }.Concat(Enum.GetNames<C64KeyboardLayout>()));
@@ -235,6 +247,71 @@ public class C64ConfigDialogViewModel : ViewModelBase
 
     public string RomStatusSummary =>
         $"{RomStatuses.Count(r => r.IsRequired && r.IsLoaded)}/{C64SystemConfig.RequiredROMs.Count} ROMs loaded";
+
+    public bool SwiftLinkEnabled
+    {
+        get => _swiftLinkEnabled;
+        set
+        {
+            if (_swiftLinkEnabled == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _swiftLinkEnabled, value);
+            _workingConfig.SystemConfig.SwiftLinkEnabled = value;
+        }
+    }
+
+    public C64CartridgeIOAddress SelectedSwiftLinkCartridgeIOAddress
+    {
+        get => _selectedSwiftLinkCartridgeIOAddress;
+        set
+        {
+            if (_selectedSwiftLinkCartridgeIOAddress == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _selectedSwiftLinkCartridgeIOAddress, value);
+            _workingConfig.SystemConfig.SwiftLinkCartridgeIOAddress = value;
+        }
+    }
+
+    public string SwiftLinkTcpHost
+    {
+        get => _swiftLinkTcpHost;
+        set
+        {
+            if (_swiftLinkTcpHost == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _swiftLinkTcpHost, value);
+            _workingConfig.SwiftLinkTcpHost = value;
+        }
+    }
+
+    public int SwiftLinkTcpPort
+    {
+        get => _swiftLinkTcpPort;
+        set
+        {
+            if (_swiftLinkTcpPort == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _swiftLinkTcpPort, value);
+            _workingConfig.SwiftLinkTcpPort = value;
+        }
+    }
+
+    public bool SwiftLinkConnectOnBoot
+    {
+        get => _swiftLinkConnectOnBoot;
+        set
+        {
+            if (_swiftLinkConnectOnBoot == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _swiftLinkConnectOnBoot, value);
+            _workingConfig.SwiftLinkConnectOnBoot = value;
+        }
+    }
 
     public bool AudioEnabled
     {
@@ -1253,7 +1330,12 @@ public class C64ConfigDialogViewModel : ViewModelBase
         _originalConfig.SystemConfig.AudioEnabled = _workingConfig.SystemConfig.AudioEnabled;
         _originalConfig.SystemConfig.KeyboardJoystickEnabled = _workingConfig.SystemConfig.KeyboardJoystickEnabled;
         _originalConfig.SystemConfig.KeyboardJoystick = _workingConfig.SystemConfig.KeyboardJoystick;
+        _originalConfig.SystemConfig.SwiftLinkEnabled = _workingConfig.SystemConfig.SwiftLinkEnabled;
+        _originalConfig.SystemConfig.SwiftLinkCartridgeIOAddress = _workingConfig.SystemConfig.SwiftLinkCartridgeIOAddress;
         _originalConfig.SystemConfig.ColorMapName = _workingConfig.SystemConfig.ColorMapName;
+        _originalConfig.SwiftLinkTcpHost = _workingConfig.SwiftLinkTcpHost;
+        _originalConfig.SwiftLinkTcpPort = _workingConfig.SwiftLinkTcpPort;
+        _originalConfig.SwiftLinkConnectOnBoot = _workingConfig.SwiftLinkConnectOnBoot;
 
         if (_workingConfig.SystemConfig.RenderProviderType != null)
             _originalConfig.SystemConfig.SetRenderProviderType(_workingConfig.SystemConfig.RenderProviderType);

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
@@ -12,6 +12,7 @@ using Avalonia.Input;
 using Highbyte.DotNet6502.App.Avalonia.Core;
 using Highbyte.DotNet6502.App.Avalonia.Core.SystemSetup;
 using Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
+using Highbyte.DotNet6502.Impl.Avalonia;
 using Highbyte.DotNet6502.Impl.Avalonia.Commodore64;
 using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Commodore64.Input;
@@ -40,6 +41,7 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
     private readonly Dictionary<string, D64DownloadDiskInfo> _preloadedD64Images = new()
     {
         {"bubblebobble", new D64DownloadDiskInfo("Bubble Bobble", "https://csdb.dk/release/download.php?id=191127", downloadType: DownloadType.ZIP, keyboardJoystickEnabled: true, keyboardJoystickNumber: 2, requiresBitmap: true, audioEnabled: false, directLoadPRGName: "*")}, // Note: Bubble Bobble is not a bitmap game, but somehow this version fails to initialize the custom charset in text mode correctly in SkiaSharp renderer.
+        {"compunetreborn", new D64DownloadDiskInfo("Compunet Reborn", "https://compunet.live/static/compunet-reborn-live.d64", c64Variant: "C64PAL", availableInBrowser: false)},
         {"digiloi", new D64DownloadDiskInfo("Digiloi", "https://csdb.dk/release/download.php?id=213381", keyboardJoystickEnabled: true, keyboardJoystickNumber: 2, audioEnabled: true, directLoadPRGName: "*")},
         {"elite", new D64DownloadDiskInfo("Elite", "https://csdb.dk/release/download.php?id=70413", downloadType: DownloadType.ZIP, keyboardJoystickEnabled: true, keyboardJoystickNumber: 2, requiresBitmap: true, audioEnabled: true,directLoadPRGName: "*", c64Variant: "C64PAL")},
         {"lastninja", new D64DownloadDiskInfo("Last Ninja", "https://csdb.dk/release/download.php?id=101848", downloadType: DownloadType.ZIP, keyboardJoystickEnabled: true, keyboardJoystickNumber: 2, requiresBitmap: true, audioEnabled: true, directLoadPRGName: "*")},
@@ -567,13 +569,13 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
         // Initialize preloaded D64 programs
         PreloadedD64Programs.Clear();
         PreloadedD64Programs.Add(new KeyValuePair<string, string>("", "-- Select a program --"));
-        PreloadedD64Programs.Add(new KeyValuePair<string, string>("bubblebobble", "Bubble Bobble"));
-        PreloadedD64Programs.Add(new KeyValuePair<string, string>("digiloi", "Digiloi"));
-        PreloadedD64Programs.Add(new KeyValuePair<string, string>("elite", "Elite"));
-        PreloadedD64Programs.Add(new KeyValuePair<string, string>("lastninja", "Last Ninja"));
-        PreloadedD64Programs.Add(new KeyValuePair<string, string>("minizork", "Mini Zork"));
-        PreloadedD64Programs.Add(new KeyValuePair<string, string>("montezuma", "Montezuma's Revenge"));
-        PreloadedD64Programs.Add(new KeyValuePair<string, string>("rallyspeedway", "Rally Speedway"));
+        var preloadedDisks = PlatformDetection.IsRunningInWebAssembly()
+            ? _preloadedD64Images.Where(d => d.Value.AvailableInBrowser)
+            : _preloadedD64Images.AsEnumerable();
+        foreach (var disk in preloadedDisks.OrderBy(d => d.Value.DisplayName))
+        {
+            PreloadedD64Programs.Add(new KeyValuePair<string, string>(disk.Key, disk.Value.DisplayName));
+        }
 
         // Debug: List all embedded resource names
         // var resourceNames = _examplesAssembly.GetManifestResourceNames();

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64ConfigUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64ConfigUserControl.axaml
@@ -323,12 +323,12 @@
                     IsVisible="{Binding !IsRunningInWebAssembly}">
         <Border Classes="content-section">
             <StackPanel Classes="spacing-tight">
-            <TextBlock Text="SwiftLink TCP"
+            <TextBlock Text="SwiftLink"
                         Classes=""/>
-            <TextBlock Text="Expose a SwiftLink-compatible ACIA at $DE00 or $DF00 and connect it to a host TCP socket."
+            <TextBlock Text="Expose a SwiftLink-compatible ACIA at $DE00 or $DF00 and use either a raw TCP byte pipe or a local Hayes modem layer."
                         Classes="small secondary-text"/>
 
-            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" Classes="spacing-tight">
+            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Classes="spacing-tight">
                 <CheckBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
                         AutomationProperties.AutomationId="SwiftLinkEnableCheckBox"
                         AutomationProperties.Name="Enable SwiftLink"
@@ -348,9 +348,21 @@
                         MaxDropDownHeight="100"/>
 
                 <TextBlock Grid.Row="2" Grid.Column="0"
-                            Text="Interrupt line:"
+                            Text="Transport mode:"
                             Classes="secondary-text"/>
                 <ComboBox Grid.Row="2" Grid.Column="1"
+                        AutomationProperties.AutomationId="SwiftLinkTransportModeComboBox"
+                        AutomationProperties.Name="SwiftLink transport mode"
+                        ItemsSource="{Binding AvailableSwiftLinkTransportModes}"
+                        SelectedItem="{Binding SelectedSwiftLinkTransportMode}"
+                        Classes="small"
+                        MinWidth="140"
+                        MaxDropDownHeight="100"/>
+
+                <TextBlock Grid.Row="3" Grid.Column="0"
+                            Text="Interrupt line:"
+                            Classes="secondary-text"/>
+                <ComboBox Grid.Row="3" Grid.Column="1"
                         AutomationProperties.AutomationId="SwiftLinkInterruptModeComboBox"
                         AutomationProperties.Name="SwiftLink interrupt line"
                         ItemsSource="{Binding AvailableSwiftLinkInterruptModes}"
@@ -359,20 +371,32 @@
                         MinWidth="100"
                         MaxDropDownHeight="100"/>
 
-                <TextBlock Grid.Row="3" Grid.Column="0"
+                <TextBlock Grid.Row="4" Grid.Column="0"
+                            Text="Receive mode:"
+                            Classes="secondary-text"/>
+                <ComboBox Grid.Row="4" Grid.Column="1"
+                        AutomationProperties.AutomationId="SwiftLinkReceiveModeComboBox"
+                        AutomationProperties.Name="SwiftLink receive mode"
+                        ItemsSource="{Binding AvailableSwiftLinkReceiveModes}"
+                        SelectedItem="{Binding SelectedSwiftLinkReceiveMode}"
+                        Classes="small"
+                        MinWidth="140"
+                        MaxDropDownHeight="100"/>
+
+                <TextBlock Grid.Row="5" Grid.Column="0"
                             Text="TCP host:"
                             Classes="secondary-text"/>
-                <TextBox Grid.Row="3" Grid.Column="1"
+                <TextBox Grid.Row="5" Grid.Column="1"
                         AutomationProperties.AutomationId="SwiftLinkTcpHostTextBox"
                         AutomationProperties.Name="SwiftLink TCP host"
                         Text="{Binding SwiftLinkTcpHost}"
                         PlaceholderText="127.0.0.1"
                         Classes="field-aligned"/>
 
-                <TextBlock Grid.Row="4" Grid.Column="0"
+                <TextBlock Grid.Row="6" Grid.Column="0"
                             Text="TCP port:"
                             Classes="secondary-text"/>
-                <NumericUpDown Grid.Row="4" Grid.Column="1"
+                <NumericUpDown Grid.Row="6" Grid.Column="1"
                         AutomationProperties.AutomationId="SwiftLinkTcpPortNumericUpDown"
                         AutomationProperties.Name="SwiftLink TCP port"
                         Value="{Binding SwiftLinkTcpPort}"
@@ -382,7 +406,7 @@
                         Width="120"
                         HorizontalAlignment="Left"/>
 
-                <CheckBox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
+                <CheckBox Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2"
                         AutomationProperties.AutomationId="SwiftLinkConnectOnBootCheckBox"
                         AutomationProperties.Name="Connect SwiftLink on boot"
                         Content="Connect automatically when the emulator starts"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64ConfigUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64ConfigUserControl.axaml
@@ -328,7 +328,7 @@
             <TextBlock Text="Expose a SwiftLink-compatible ACIA at $DE00 or $DF00 and connect it to a host TCP socket."
                         Classes="small secondary-text"/>
 
-            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" Classes="spacing-tight">
+            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" Classes="spacing-tight">
                 <CheckBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
                         AutomationProperties.AutomationId="SwiftLinkEnableCheckBox"
                         AutomationProperties.Name="Enable SwiftLink"
@@ -348,19 +348,31 @@
                         MaxDropDownHeight="100"/>
 
                 <TextBlock Grid.Row="2" Grid.Column="0"
+                            Text="Interrupt line:"
+                            Classes="secondary-text"/>
+                <ComboBox Grid.Row="2" Grid.Column="1"
+                        AutomationProperties.AutomationId="SwiftLinkInterruptModeComboBox"
+                        AutomationProperties.Name="SwiftLink interrupt line"
+                        ItemsSource="{Binding AvailableSwiftLinkInterruptModes}"
+                        SelectedItem="{Binding SelectedSwiftLinkInterruptMode}"
+                        Classes="small"
+                        MinWidth="100"
+                        MaxDropDownHeight="100"/>
+
+                <TextBlock Grid.Row="3" Grid.Column="0"
                             Text="TCP host:"
                             Classes="secondary-text"/>
-                <TextBox Grid.Row="2" Grid.Column="1"
+                <TextBox Grid.Row="3" Grid.Column="1"
                         AutomationProperties.AutomationId="SwiftLinkTcpHostTextBox"
                         AutomationProperties.Name="SwiftLink TCP host"
                         Text="{Binding SwiftLinkTcpHost}"
                         PlaceholderText="127.0.0.1"
                         Classes="field-aligned"/>
 
-                <TextBlock Grid.Row="3" Grid.Column="0"
+                <TextBlock Grid.Row="4" Grid.Column="0"
                             Text="TCP port:"
                             Classes="secondary-text"/>
-                <NumericUpDown Grid.Row="3" Grid.Column="1"
+                <NumericUpDown Grid.Row="4" Grid.Column="1"
                         AutomationProperties.AutomationId="SwiftLinkTcpPortNumericUpDown"
                         AutomationProperties.Name="SwiftLink TCP port"
                         Value="{Binding SwiftLinkTcpPort}"
@@ -370,7 +382,7 @@
                         Width="120"
                         HorizontalAlignment="Left"/>
 
-                <CheckBox Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
+                <CheckBox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                         AutomationProperties.AutomationId="SwiftLinkConnectOnBootCheckBox"
                         AutomationProperties.Name="Connect SwiftLink on boot"
                         Content="Connect automatically when the emulator starts"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64ConfigUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64ConfigUserControl.axaml
@@ -396,21 +396,23 @@
                 <TextBlock Grid.Row="6" Grid.Column="0"
                             Text="TCP port:"
                             Classes="secondary-text"/>
-                <NumericUpDown Grid.Row="6" Grid.Column="1"
-                        AutomationProperties.AutomationId="SwiftLinkTcpPortNumericUpDown"
+                <TextBox Grid.Row="6" Grid.Column="1"
+                        AutomationProperties.AutomationId="SwiftLinkTcpPortInput"
                         AutomationProperties.Name="SwiftLink TCP port"
-                        Value="{Binding SwiftLinkTcpPort}"
-                        Minimum="1"
-                        Maximum="65535"
+                        Text="{Binding SwiftLinkTcpPortText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        Width="68"
+                        MaxLength="5"
                         Classes="small"
-                        Width="120"
-                        HorizontalAlignment="Left"/>
+                        HorizontalAlignment="Left"
+                        TextInput="OnDigitsOnlyTextInput"/>
 
                 <CheckBox Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2"
                         AutomationProperties.AutomationId="SwiftLinkConnectOnBootCheckBox"
                         AutomationProperties.Name="Connect SwiftLink on boot"
                         Content="Connect automatically when the emulator starts"
-                        IsChecked="{Binding SwiftLinkConnectOnBoot}"/>
+                        IsChecked="{Binding SwiftLinkConnectOnBoot}"
+                        IsEnabled="{Binding IsSwiftLinkConnectOnBootAvailable}"
+                        ToolTip.Tip="{Binding SwiftLinkConnectOnBootToolTip}"/>
             </Grid>
             </StackPanel>
         </Border>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64ConfigUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64ConfigUserControl.axaml
@@ -318,6 +318,68 @@
         </Border>
         </StackPanel>
 
+        <!-- SwiftLink Section -->
+        <StackPanel Width="460" Classes="wrap-item"
+                    IsVisible="{Binding !IsRunningInWebAssembly}">
+        <Border Classes="content-section">
+            <StackPanel Classes="spacing-tight">
+            <TextBlock Text="SwiftLink TCP"
+                        Classes=""/>
+            <TextBlock Text="Expose a SwiftLink-compatible ACIA at $DE00 or $DF00 and connect it to a host TCP socket."
+                        Classes="small secondary-text"/>
+
+            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" Classes="spacing-tight">
+                <CheckBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
+                        AutomationProperties.AutomationId="SwiftLinkEnableCheckBox"
+                        AutomationProperties.Name="Enable SwiftLink"
+                        Content="Enable SwiftLink cartridge"
+                        IsChecked="{Binding SwiftLinkEnabled}"/>
+
+                <TextBlock Grid.Row="1" Grid.Column="0"
+                            Text="Base address:"
+                            Classes="secondary-text"/>
+                <ComboBox Grid.Row="1" Grid.Column="1"
+                        AutomationProperties.AutomationId="SwiftLinkBaseAddressComboBox"
+                        AutomationProperties.Name="SwiftLink base address"
+                        ItemsSource="{Binding AvailableSwiftLinkCartridgeIOAddresses}"
+                        SelectedItem="{Binding SelectedSwiftLinkCartridgeIOAddress}"
+                        Classes="small"
+                        MinWidth="100"
+                        MaxDropDownHeight="100"/>
+
+                <TextBlock Grid.Row="2" Grid.Column="0"
+                            Text="TCP host:"
+                            Classes="secondary-text"/>
+                <TextBox Grid.Row="2" Grid.Column="1"
+                        AutomationProperties.AutomationId="SwiftLinkTcpHostTextBox"
+                        AutomationProperties.Name="SwiftLink TCP host"
+                        Text="{Binding SwiftLinkTcpHost}"
+                        PlaceholderText="127.0.0.1"
+                        Classes="field-aligned"/>
+
+                <TextBlock Grid.Row="3" Grid.Column="0"
+                            Text="TCP port:"
+                            Classes="secondary-text"/>
+                <NumericUpDown Grid.Row="3" Grid.Column="1"
+                        AutomationProperties.AutomationId="SwiftLinkTcpPortNumericUpDown"
+                        AutomationProperties.Name="SwiftLink TCP port"
+                        Value="{Binding SwiftLinkTcpPort}"
+                        Minimum="1"
+                        Maximum="65535"
+                        Classes="small"
+                        Width="120"
+                        HorizontalAlignment="Left"/>
+
+                <CheckBox Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
+                        AutomationProperties.AutomationId="SwiftLinkConnectOnBootCheckBox"
+                        AutomationProperties.Name="Connect SwiftLink on boot"
+                        Content="Connect automatically when the emulator starts"
+                        IsChecked="{Binding SwiftLinkConnectOnBoot}"/>
+            </Grid>
+            </StackPanel>
+        </Border>
+        </StackPanel>
+
         <!-- Network Section (browser only) -->
         <StackPanel Width="460" Classes="wrap-item"
                     IsVisible="{Binding IsRunningInWebAssembly}">

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64ConfigUserControl.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64ConfigUserControl.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -116,6 +117,14 @@ public partial class C64ConfigUserControl : UserControl
         else if (e.Key == Key.A)
         {
             textBox.SelectAll();
+            e.Handled = true;
+        }
+    }
+
+    private void OnDigitsOnlyTextInput(object? sender, TextInputEventArgs e)
+    {
+        if (!string.IsNullOrEmpty(e.Text) && e.Text.Any(ch => !char.IsDigit(ch)))
+        {
             e.Handled = true;
         }
     }

--- a/src/apps/BlazorWASM/Highbyte.DotNet6502.App.WASM.Shell.Commodore64/Pages/Commodore64/C64Menu.razor
+++ b/src/apps/BlazorWASM/Highbyte.DotNet6502.App.WASM.Shell.Commodore64/Pages/Commodore64/C64Menu.razor
@@ -36,7 +36,7 @@
             <label for="preloadedDiskSelector">Download & Run .D64 programs:</label>
             <select id="preloadedDiskSelector" @onchange="OnPreloadedDiskChanged">
                 <option value="">-- Select a program --</option>
-                @foreach (var disk in _preloadedD64Images)
+                @foreach (var disk in _preloadedD64Images.Where(d => d.Value.AvailableInBrowser))
                 {
                     <option value="@disk.Key">@disk.Value.DisplayName</option>
                 }
@@ -181,6 +181,7 @@
     private readonly Dictionary<string, D64DownloadDiskInfo> _preloadedD64Images = new()
     {
         {"bubblebobble", new D64DownloadDiskInfo("Bubble Bobble", "https://csdb.dk/release/download.php?id=191127", downloadType: DownloadType.ZIP, keyboardJoystickEnabled: true, keyboardJoystickNumber: 2, requiresBitmap: true, audioEnabled: false, directLoadPRGName: "*")}, // Note: Bubble Bobble is not a bitmap game, but somehow this version fails to initialize the custom charset in text mode correctly in SkiaSharp renderer.
+        {"compunetreborn", new D64DownloadDiskInfo("Compunet Reborn", "https://compunet.live/static/compunet-reborn-live.d64", c64Variant: "C64PAL", availableInBrowser: false)},
         {"digiloi", new D64DownloadDiskInfo("Digiloi", "https://csdb.dk/release/download.php?id=213381", keyboardJoystickEnabled: true, keyboardJoystickNumber: 2, audioEnabled: true, directLoadPRGName: "*")},
         {"elite", new D64DownloadDiskInfo("Elite", "https://csdb.dk/release/download.php?id=70413", downloadType: DownloadType.ZIP, keyboardJoystickEnabled: true, keyboardJoystickNumber: 2, requiresBitmap: true, audioEnabled: false,directLoadPRGName: "*", c64Variant: "C64PAL")},
         {"lastninja", new D64DownloadDiskInfo("Last Ninja", "https://csdb.dk/release/download.php?id=101848", downloadType: DownloadType.ZIP, keyboardJoystickEnabled: true, keyboardJoystickNumber: 2, requiresBitmap: true, audioEnabled: false, directLoadPRGName: "*")},

--- a/src/apps/Highbyte.DotNet6502.App.Headless/appsettings.json
+++ b/src/apps/Highbyte.DotNet6502.App.Headless/appsettings.json
@@ -16,8 +16,13 @@
   },
 
   "Highbyte.DotNet6502.C64.Headless": {
+    "SwiftLinkTcpHost": "127.0.0.1",
+    "SwiftLinkTcpPort": 5000,
+    "SwiftLinkConnectOnBoot": false,
     "SystemConfig": {
       "ROMDirectory": "%HOME%/Downloads/C64",
+      "SwiftLinkEnabled": false,
+      "SwiftLinkCartridgeIOAddress": "DE00",
       "ROMs": [
         {
           "Name": "basic",

--- a/src/apps/Highbyte.DotNet6502.App.Headless/appsettings.json
+++ b/src/apps/Highbyte.DotNet6502.App.Headless/appsettings.json
@@ -16,15 +16,19 @@
   },
 
   "Highbyte.DotNet6502.C64.Headless": {
-    "SwiftLinkTransportMode": "RawTcp",
-    "SwiftLinkTcpHost": "127.0.0.1",
-    "SwiftLinkTcpPort": 5000,
-    "SwiftLinkConnectOnBoot": false,
+    "SwiftLinkHost": {
+      "TransportMode": "RawTcp",
+      "TcpHost": "127.0.0.1",
+      "TcpPort": 5000,
+      "ConnectOnBoot": false
+    },
     "SystemConfig": {
       "ROMDirectory": "%HOME%/Downloads/C64",
-      "SwiftLinkEnabled": false,
-      "SwiftLinkCartridgeIOAddress": "DE00",
-      "SwiftLinkReceiveMode": "Compatible",
+      "SwiftLink": {
+        "Enabled": false,
+        "CartridgeIOAddress": "DE00",
+        "ReceiveMode": "Compatible"
+      },
       "ROMs": [
         {
           "Name": "basic",

--- a/src/apps/Highbyte.DotNet6502.App.Headless/appsettings.json
+++ b/src/apps/Highbyte.DotNet6502.App.Headless/appsettings.json
@@ -16,6 +16,7 @@
   },
 
   "Highbyte.DotNet6502.C64.Headless": {
+    "SwiftLinkTransportMode": "RawTcp",
     "SwiftLinkTcpHost": "127.0.0.1",
     "SwiftLinkTcpPort": 5000,
     "SwiftLinkConnectOnBoot": false,
@@ -23,6 +24,7 @@
       "ROMDirectory": "%HOME%/Downloads/C64",
       "SwiftLinkEnabled": false,
       "SwiftLinkCartridgeIOAddress": "DE00",
+      "SwiftLinkReceiveMode": "Compatible",
       "ROMs": [
         {
           "Name": "basic",

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet.Commodore64/C64HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet.Commodore64/C64HostConfig.cs
@@ -73,4 +73,12 @@ public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>, IC64SwiftLin
         clone._swiftLinkHost.SetDirtyCallback(clone.MarkDirty);
         return clone;
     }
+
+    public override bool IsValid(out List<string> validationErrors)
+    {
+        var isValid = base.IsValid(out validationErrors);
+        if (!SwiftLinkHost.IsValid(out var swiftLinkHostValidationErrors, nameof(SwiftLinkHost)))
+            validationErrors.AddRange(swiftLinkHostValidationErrors);
+        return isValid && validationErrors.Count == 0;
+    }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet.Commodore64/C64HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet.Commodore64/C64HostConfig.cs
@@ -16,6 +16,13 @@ public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>, IC64SwiftLin
 
     public C64InputConfig InputConfig { get; set; } = new C64InputConfig();
 
+    private C64SwiftLinkTransportMode _swiftLinkTransportMode;
+    public C64SwiftLinkTransportMode SwiftLinkTransportMode
+    {
+        get => _swiftLinkTransportMode;
+        set { _swiftLinkTransportMode = value; MarkDirty(); }
+    }
+
     private string _swiftLinkTcpHost = "127.0.0.1";
     public string SwiftLinkTcpHost
     {
@@ -58,6 +65,7 @@ public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>, IC64SwiftLin
     {
         BasicAIAssistantDefaultEnabled = false;
         CodeSuggestionBackendType = CodeSuggestionBackendTypeEnum.CustomEndpoint;
+        SwiftLinkTransportMode = C64SwiftLinkTransportMode.RawTcp;
     }
 
     public override object Clone()

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet.Commodore64/C64HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet.Commodore64/C64HostConfig.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Highbyte.DotNet6502.AI.CodingAssistant;
 using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
 using Highbyte.DotNet6502.Systems.Commodore64.Input;
 
@@ -16,33 +17,29 @@ public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>, IC64SwiftLin
 
     public C64InputConfig InputConfig { get; set; } = new C64InputConfig();
 
-    private C64SwiftLinkTransportMode _swiftLinkTransportMode;
-    public C64SwiftLinkTransportMode SwiftLinkTransportMode
+    private C64SwiftLinkHostConfig _swiftLinkHost = new();
+    public C64SwiftLinkHostConfig SwiftLinkHost
     {
-        get => _swiftLinkTransportMode;
-        set { _swiftLinkTransportMode = value; MarkDirty(); }
+        get => _swiftLinkHost;
+        set
+        {
+            _swiftLinkHost = value ?? new C64SwiftLinkHostConfig();
+            _swiftLinkHost.SetDirtyCallback(MarkDirty);
+            MarkDirty();
+        }
     }
 
-    private string _swiftLinkTcpHost = "127.0.0.1";
-    public string SwiftLinkTcpHost
-    {
-        get => _swiftLinkTcpHost;
-        set { _swiftLinkTcpHost = value; MarkDirty(); }
-    }
+    [JsonIgnore]
+    public C64SwiftLinkTransportMode SwiftLinkTransportMode => SwiftLinkHost.TransportMode;
 
-    private int _swiftLinkTcpPort = 5000;
-    public int SwiftLinkTcpPort
-    {
-        get => _swiftLinkTcpPort;
-        set { _swiftLinkTcpPort = value; MarkDirty(); }
-    }
+    [JsonIgnore]
+    public string SwiftLinkTcpHost => SwiftLinkHost.TcpHost;
 
-    private bool _swiftLinkConnectOnBoot;
-    public bool SwiftLinkConnectOnBoot
-    {
-        get => _swiftLinkConnectOnBoot;
-        set { _swiftLinkConnectOnBoot = value; MarkDirty(); }
-    }
+    [JsonIgnore]
+    public int SwiftLinkTcpPort => SwiftLinkHost.TcpPort;
+
+    [JsonIgnore]
+    public bool SwiftLinkConnectOnBoot => SwiftLinkHost.ConnectOnBoot;
 
     public string CorsProxyURL { get; set; } = DefaultCorsProxyURL;
 
@@ -65,13 +62,15 @@ public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>, IC64SwiftLin
     {
         BasicAIAssistantDefaultEnabled = false;
         CodeSuggestionBackendType = CodeSuggestionBackendTypeEnum.CustomEndpoint;
-        SwiftLinkTransportMode = C64SwiftLinkTransportMode.RawTcp;
+        _swiftLinkHost.SetDirtyCallback(MarkDirty);
     }
 
     public override object Clone()
     {
         var clone = (C64HostConfig)base.Clone();
         clone.InputConfig = (C64InputConfig)InputConfig.Clone();
+        clone._swiftLinkHost = SwiftLinkHost.Clone();
+        clone._swiftLinkHost.SetDirtyCallback(clone.MarkDirty);
         return clone;
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet.Commodore64/C64HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet.Commodore64/C64HostConfig.cs
@@ -7,7 +7,7 @@ using Highbyte.DotNet6502.Systems.Commodore64.Input;
 namespace Highbyte.DotNet6502.Impl.AspNet.Commodore64;
 
 /// <summary>C64 host config for the WASM (Blazor) host.</summary>
-public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>
+public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>, IC64SwiftLinkTcpHostConfig
 {
     public const string ConfigSectionName = "Highbyte.DotNet6502.C64.WASM";
 
@@ -15,6 +15,27 @@ public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>
     public const string DefaultCorsProxyURL = "https://api.codetabs.com/v1/proxy?quest=";
 
     public C64InputConfig InputConfig { get; set; } = new C64InputConfig();
+
+    private string _swiftLinkTcpHost = "127.0.0.1";
+    public string SwiftLinkTcpHost
+    {
+        get => _swiftLinkTcpHost;
+        set { _swiftLinkTcpHost = value; MarkDirty(); }
+    }
+
+    private int _swiftLinkTcpPort = 5000;
+    public int SwiftLinkTcpPort
+    {
+        get => _swiftLinkTcpPort;
+        set { _swiftLinkTcpPort = value; MarkDirty(); }
+    }
+
+    private bool _swiftLinkConnectOnBoot;
+    public bool SwiftLinkConnectOnBoot
+    {
+        get => _swiftLinkConnectOnBoot;
+        set { _swiftLinkConnectOnBoot = value; MarkDirty(); }
+    }
 
     public string CorsProxyURL { get; set; } = DefaultCorsProxyURL;
 

--- a/src/libraries/Highbyte.DotNet6502.Impl.AspNet.Commodore64/C64Setup.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.AspNet.Commodore64/C64Setup.cs
@@ -40,6 +40,7 @@ public class C64Setup : C64SystemConfigurerCore
 
     // The WASM host always renders the C64 via the custom render provider.
     protected override Type? DefaultRenderProviderType => typeof(C64CustomRenderProvider);
+    protected override bool SupportsSwiftLinkTcpTransport => false;
 
     public override async Task<IHostSystemConfig> GetNewHostSystemConfig()
     {
@@ -104,7 +105,7 @@ public class C64Setup : C64SystemConfigurerCore
         var c64BasicCodingAssistant = new C64BasicCodingAssistant(c64, codeSuggestion, LoggerFactory);
         c64.InputConsumer = new C64InputHandler(c64, LoggerFactory, c64HostConfig.InputConfig, c64BasicCodingAssistant, c64HostConfig.BasicAIAssistantDefaultEnabled);
 
-        return new SystemRunner(c64);
+        return await base.BuildSystemRunner(system, hostSystemConfig);
     }
 
     private async Task<List<ROM>> GetROMsFromLocalStorageLegacy()

--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Commodore64/C64HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Commodore64/C64HostConfig.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 using Highbyte.DotNet6502.AI.CodingAssistant;
 using Highbyte.DotNet6502.Impl.Avalonia;
 using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
 using Highbyte.DotNet6502.Systems.Commodore64.Input;
 
@@ -20,33 +21,29 @@ public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>, IC64SwiftLin
 
     public C64InputConfig InputConfig { get; set; } = new C64InputConfig();
 
-    private C64SwiftLinkTransportMode _swiftLinkTransportMode;
-    public C64SwiftLinkTransportMode SwiftLinkTransportMode
+    private C64SwiftLinkHostConfig _swiftLinkHost = new();
+    public C64SwiftLinkHostConfig SwiftLinkHost
     {
-        get => _swiftLinkTransportMode;
-        set { _swiftLinkTransportMode = value; MarkDirty(); }
+        get => _swiftLinkHost;
+        set
+        {
+            _swiftLinkHost = value ?? new C64SwiftLinkHostConfig();
+            _swiftLinkHost.SetDirtyCallback(MarkDirty);
+            MarkDirty();
+        }
     }
 
-    private string _swiftLinkTcpHost = "127.0.0.1";
-    public string SwiftLinkTcpHost
-    {
-        get => _swiftLinkTcpHost;
-        set { _swiftLinkTcpHost = value; MarkDirty(); }
-    }
+    [JsonIgnore]
+    public C64SwiftLinkTransportMode SwiftLinkTransportMode => SwiftLinkHost.TransportMode;
 
-    private int _swiftLinkTcpPort = 5000;
-    public int SwiftLinkTcpPort
-    {
-        get => _swiftLinkTcpPort;
-        set { _swiftLinkTcpPort = value; MarkDirty(); }
-    }
+    [JsonIgnore]
+    public string SwiftLinkTcpHost => SwiftLinkHost.TcpHost;
 
-    private bool _swiftLinkConnectOnBoot;
-    public bool SwiftLinkConnectOnBoot
-    {
-        get => _swiftLinkConnectOnBoot;
-        set { _swiftLinkConnectOnBoot = value; MarkDirty(); }
-    }
+    [JsonIgnore]
+    public int SwiftLinkTcpPort => SwiftLinkHost.TcpPort;
+
+    [JsonIgnore]
+    public bool SwiftLinkConnectOnBoot => SwiftLinkHost.ConnectOnBoot;
 
     /// <summary>
     /// CORS proxy address override. If null/empty, the default CORS proxy URL is used when running
@@ -84,13 +81,15 @@ public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>, IC64SwiftLin
     {
         BasicAIAssistantDefaultEnabled = false;
         CodeSuggestionBackendType = CodeSuggestionBackendTypeEnum.CustomEndpoint;
-        SwiftLinkTransportMode = C64SwiftLinkTransportMode.RawTcp;
+        _swiftLinkHost.SetDirtyCallback(MarkDirty);
     }
 
     public override object Clone()
     {
         var clone = (C64HostConfig)base.Clone();
         clone.InputConfig = (C64InputConfig)InputConfig.Clone();
+        clone._swiftLinkHost = SwiftLinkHost.Clone();
+        clone._swiftLinkHost.SetDirtyCallback(clone.MarkDirty);
         return clone;
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Commodore64/C64HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Commodore64/C64HostConfig.cs
@@ -92,4 +92,12 @@ public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>, IC64SwiftLin
         clone._swiftLinkHost.SetDirtyCallback(clone.MarkDirty);
         return clone;
     }
+
+    public override bool IsValid(out List<string> validationErrors)
+    {
+        var isValid = base.IsValid(out validationErrors);
+        if (!SwiftLinkHost.IsValid(out var swiftLinkHostValidationErrors, nameof(SwiftLinkHost)))
+            validationErrors.AddRange(swiftLinkHostValidationErrors);
+        return isValid && validationErrors.Count == 0;
+    }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Commodore64/C64HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Commodore64/C64HostConfig.cs
@@ -20,6 +20,13 @@ public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>, IC64SwiftLin
 
     public C64InputConfig InputConfig { get; set; } = new C64InputConfig();
 
+    private C64SwiftLinkTransportMode _swiftLinkTransportMode;
+    public C64SwiftLinkTransportMode SwiftLinkTransportMode
+    {
+        get => _swiftLinkTransportMode;
+        set { _swiftLinkTransportMode = value; MarkDirty(); }
+    }
+
     private string _swiftLinkTcpHost = "127.0.0.1";
     public string SwiftLinkTcpHost
     {
@@ -77,6 +84,7 @@ public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>, IC64SwiftLin
     {
         BasicAIAssistantDefaultEnabled = false;
         CodeSuggestionBackendType = CodeSuggestionBackendTypeEnum.CustomEndpoint;
+        SwiftLinkTransportMode = C64SwiftLinkTransportMode.RawTcp;
     }
 
     public override object Clone()

--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Commodore64/C64HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Commodore64/C64HostConfig.cs
@@ -8,7 +8,7 @@ using Highbyte.DotNet6502.Systems.Commodore64.Input;
 namespace Highbyte.DotNet6502.Impl.Avalonia.Commodore64;
 
 /// <summary>C64 host config for the Avalonia host.</summary>
-public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>
+public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>, IC64SwiftLinkTcpHostConfig
 {
     public const string ConfigSectionName = "Highbyte.DotNet6502.C64.Avalonia";
 
@@ -19,6 +19,27 @@ public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>
         PlatformDetection.IsRunningOnDesktop() || PlatformDetection.IsRunningInWebAssembly();
 
     public C64InputConfig InputConfig { get; set; } = new C64InputConfig();
+
+    private string _swiftLinkTcpHost = "127.0.0.1";
+    public string SwiftLinkTcpHost
+    {
+        get => _swiftLinkTcpHost;
+        set { _swiftLinkTcpHost = value; MarkDirty(); }
+    }
+
+    private int _swiftLinkTcpPort = 5000;
+    public int SwiftLinkTcpPort
+    {
+        get => _swiftLinkTcpPort;
+        set { _swiftLinkTcpPort = value; MarkDirty(); }
+    }
+
+    private bool _swiftLinkConnectOnBoot;
+    public bool SwiftLinkConnectOnBoot
+    {
+        get => _swiftLinkConnectOnBoot;
+        set { _swiftLinkConnectOnBoot = value; MarkDirty(); }
+    }
 
     /// <summary>
     /// CORS proxy address override. If null/empty, the default CORS proxy URL is used when running

--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Commodore64/C64Setup.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Commodore64/C64Setup.cs
@@ -56,6 +56,6 @@ public class C64Setup : C64SystemConfigurerCore
         c64.InputConsumer = new C64InputHandler(c64, LoggerFactory, c64HostConfig.InputConfig,
             c64BasicCodingAssistant, c64HostConfig.BasicAIAssistantDefaultEnabled);
 
-        return new SystemRunner(c64);
+        return await base.BuildSystemRunner(system, hostSystemConfig);
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.Headless.Commodore64/C64HeadlessHostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Headless.Commodore64/C64HeadlessHostConfig.cs
@@ -40,4 +40,12 @@ public class C64HeadlessHostConfig : HostSystemConfigBase<C64SystemConfig>, IC64
         clone._swiftLinkHost.SetDirtyCallback(clone.MarkDirty);
         return clone;
     }
+
+    public override bool IsValid(out List<string> validationErrors)
+    {
+        var isValid = base.IsValid(out validationErrors);
+        if (!SwiftLinkHost.IsValid(out var swiftLinkHostValidationErrors, nameof(SwiftLinkHost)))
+            validationErrors.AddRange(swiftLinkHostValidationErrors);
+        return isValid && validationErrors.Count == 0;
+    }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.Headless.Commodore64/C64HeadlessHostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Headless.Commodore64/C64HeadlessHostConfig.cs
@@ -10,6 +10,13 @@ public class C64HeadlessHostConfig : HostSystemConfigBase<C64SystemConfig>, IC64
 
     public override bool AudioSupported => false;
 
+    private C64SwiftLinkTransportMode _swiftLinkTransportMode;
+    public C64SwiftLinkTransportMode SwiftLinkTransportMode
+    {
+        get => _swiftLinkTransportMode;
+        set { _swiftLinkTransportMode = value; MarkDirty(); }
+    }
+
     private string _swiftLinkTcpHost = "127.0.0.1";
     public string SwiftLinkTcpHost
     {
@@ -29,5 +36,10 @@ public class C64HeadlessHostConfig : HostSystemConfigBase<C64SystemConfig>, IC64
     {
         get => _swiftLinkConnectOnBoot;
         set { _swiftLinkConnectOnBoot = value; MarkDirty(); }
+    }
+
+    public C64HeadlessHostConfig()
+    {
+        SwiftLinkTransportMode = C64SwiftLinkTransportMode.RawTcp;
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.Headless.Commodore64/C64HeadlessHostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Headless.Commodore64/C64HeadlessHostConfig.cs
@@ -4,9 +4,30 @@ using Highbyte.DotNet6502.Systems.Commodore64.Config;
 namespace Highbyte.DotNet6502.Impl.Headless.Commodore64;
 
 /// <summary>C64 host config for the Headless host — no audio, no host-tech settings.</summary>
-public class C64HeadlessHostConfig : HostSystemConfigBase<C64SystemConfig>
+public class C64HeadlessHostConfig : HostSystemConfigBase<C64SystemConfig>, IC64SwiftLinkTcpHostConfig
 {
     public const string ConfigSectionName = "Highbyte.DotNet6502.C64.Headless";
 
     public override bool AudioSupported => false;
+
+    private string _swiftLinkTcpHost = "127.0.0.1";
+    public string SwiftLinkTcpHost
+    {
+        get => _swiftLinkTcpHost;
+        set { _swiftLinkTcpHost = value; MarkDirty(); }
+    }
+
+    private int _swiftLinkTcpPort = 5000;
+    public int SwiftLinkTcpPort
+    {
+        get => _swiftLinkTcpPort;
+        set { _swiftLinkTcpPort = value; MarkDirty(); }
+    }
+
+    private bool _swiftLinkConnectOnBoot;
+    public bool SwiftLinkConnectOnBoot
+    {
+        get => _swiftLinkConnectOnBoot;
+        set { _swiftLinkConnectOnBoot = value; MarkDirty(); }
+    }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.Headless.Commodore64/C64HeadlessHostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Headless.Commodore64/C64HeadlessHostConfig.cs
@@ -1,4 +1,5 @@
 using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
 
 namespace Highbyte.DotNet6502.Impl.Headless.Commodore64;
@@ -10,36 +11,33 @@ public class C64HeadlessHostConfig : HostSystemConfigBase<C64SystemConfig>, IC64
 
     public override bool AudioSupported => false;
 
-    private C64SwiftLinkTransportMode _swiftLinkTransportMode;
-    public C64SwiftLinkTransportMode SwiftLinkTransportMode
+    private C64SwiftLinkHostConfig _swiftLinkHost = new();
+    public C64SwiftLinkHostConfig SwiftLinkHost
     {
-        get => _swiftLinkTransportMode;
-        set { _swiftLinkTransportMode = value; MarkDirty(); }
+        get => _swiftLinkHost;
+        set
+        {
+            _swiftLinkHost = value ?? new C64SwiftLinkHostConfig();
+            _swiftLinkHost.SetDirtyCallback(MarkDirty);
+            MarkDirty();
+        }
     }
 
-    private string _swiftLinkTcpHost = "127.0.0.1";
-    public string SwiftLinkTcpHost
-    {
-        get => _swiftLinkTcpHost;
-        set { _swiftLinkTcpHost = value; MarkDirty(); }
-    }
-
-    private int _swiftLinkTcpPort = 5000;
-    public int SwiftLinkTcpPort
-    {
-        get => _swiftLinkTcpPort;
-        set { _swiftLinkTcpPort = value; MarkDirty(); }
-    }
-
-    private bool _swiftLinkConnectOnBoot;
-    public bool SwiftLinkConnectOnBoot
-    {
-        get => _swiftLinkConnectOnBoot;
-        set { _swiftLinkConnectOnBoot = value; MarkDirty(); }
-    }
+    public C64SwiftLinkTransportMode SwiftLinkTransportMode => SwiftLinkHost.TransportMode;
+    public string SwiftLinkTcpHost => SwiftLinkHost.TcpHost;
+    public int SwiftLinkTcpPort => SwiftLinkHost.TcpPort;
+    public bool SwiftLinkConnectOnBoot => SwiftLinkHost.ConnectOnBoot;
 
     public C64HeadlessHostConfig()
     {
-        SwiftLinkTransportMode = C64SwiftLinkTransportMode.RawTcp;
+        _swiftLinkHost.SetDirtyCallback(MarkDirty);
+    }
+
+    public override object Clone()
+    {
+        var clone = (C64HeadlessHostConfig)base.Clone();
+        clone._swiftLinkHost = SwiftLinkHost.Clone();
+        clone._swiftLinkHost.SetDirtyCallback(clone.MarkDirty);
+        return clone;
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.SadConsole.Commodore64/C64HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SadConsole.Commodore64/C64HostConfig.cs
@@ -1,5 +1,6 @@
 using Highbyte.DotNet6502.AI.CodingAssistant;
 using Highbyte.DotNet6502.Impl.SadConsole;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
 using SadConsole;
 
@@ -12,10 +13,11 @@ public class C64HostConfig : SadConsoleHostSystemConfigBase<C64SystemConfig>, IC
 
     public bool BasicAIAssistantDefaultEnabled { get; set; }
 
-    public C64SwiftLinkTransportMode SwiftLinkTransportMode { get; set; } = C64SwiftLinkTransportMode.RawTcp;
-    public string SwiftLinkTcpHost { get; set; } = "127.0.0.1";
-    public int SwiftLinkTcpPort { get; set; } = 5000;
-    public bool SwiftLinkConnectOnBoot { get; set; }
+    public C64SwiftLinkHostConfig SwiftLinkHost { get; set; } = new();
+    public C64SwiftLinkTransportMode SwiftLinkTransportMode => SwiftLinkHost.TransportMode;
+    public string SwiftLinkTcpHost => SwiftLinkHost.TcpHost;
+    public int SwiftLinkTcpPort => SwiftLinkHost.TcpPort;
+    public bool SwiftLinkConnectOnBoot => SwiftLinkHost.ConnectOnBoot;
 
     //TODO: CodeSuggestionBackendType setting should be common and not specific for a system
     public CodeSuggestionBackendTypeEnum CodeSuggestionBackendType { get; set; }
@@ -27,5 +29,12 @@ public class C64HostConfig : SadConsoleHostSystemConfigBase<C64SystemConfig>, IC
 
         Font = "Fonts/C64_ROM.font";
         DefaultFontSize = IFont.Sizes.Two;
+    }
+
+    public override object Clone()
+    {
+        var clone = (C64HostConfig)base.Clone();
+        clone.SwiftLinkHost = SwiftLinkHost.Clone();
+        return clone;
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.SadConsole.Commodore64/C64HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SadConsole.Commodore64/C64HostConfig.cs
@@ -6,11 +6,15 @@ using SadConsole;
 namespace Highbyte.DotNet6502.Impl.SadConsole.Commodore64;
 
 /// <summary>C64 host config for the SadConsole host.</summary>
-public class C64HostConfig : SadConsoleHostSystemConfigBase<C64SystemConfig>
+public class C64HostConfig : SadConsoleHostSystemConfigBase<C64SystemConfig>, IC64SwiftLinkTcpHostConfig
 {
     public const string ConfigSectionName = "Highbyte.DotNet6502.C64.SadConsole";
 
     public bool BasicAIAssistantDefaultEnabled { get; set; }
+
+    public string SwiftLinkTcpHost { get; set; } = "127.0.0.1";
+    public int SwiftLinkTcpPort { get; set; } = 5000;
+    public bool SwiftLinkConnectOnBoot { get; set; }
 
     //TODO: CodeSuggestionBackendType setting should be common and not specific for a system
     public CodeSuggestionBackendTypeEnum CodeSuggestionBackendType { get; set; }

--- a/src/libraries/Highbyte.DotNet6502.Impl.SadConsole.Commodore64/C64HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SadConsole.Commodore64/C64HostConfig.cs
@@ -37,4 +37,12 @@ public class C64HostConfig : SadConsoleHostSystemConfigBase<C64SystemConfig>, IC
         clone.SwiftLinkHost = SwiftLinkHost.Clone();
         return clone;
     }
+
+    public override bool IsValid(out List<string> validationErrors)
+    {
+        var isValid = base.IsValid(out validationErrors);
+        if (!SwiftLinkHost.IsValid(out var swiftLinkHostValidationErrors, nameof(SwiftLinkHost)))
+            validationErrors.AddRange(swiftLinkHostValidationErrors);
+        return isValid && validationErrors.Count == 0;
+    }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.SadConsole.Commodore64/C64HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SadConsole.Commodore64/C64HostConfig.cs
@@ -12,6 +12,7 @@ public class C64HostConfig : SadConsoleHostSystemConfigBase<C64SystemConfig>, IC
 
     public bool BasicAIAssistantDefaultEnabled { get; set; }
 
+    public C64SwiftLinkTransportMode SwiftLinkTransportMode { get; set; } = C64SwiftLinkTransportMode.RawTcp;
     public string SwiftLinkTcpHost { get; set; } = "127.0.0.1";
     public int SwiftLinkTcpPort { get; set; } = 5000;
     public bool SwiftLinkConnectOnBoot { get; set; }

--- a/src/libraries/Highbyte.DotNet6502.Impl.SadConsole.Commodore64/C64Setup.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SadConsole.Commodore64/C64Setup.cs
@@ -53,6 +53,6 @@ public class C64Setup : C64SystemConfigurerCore
         c64.InputConsumer = new C64InputHandler(c64, LoggerFactory, new C64InputConfig(),
             c64BasicCodingAssistant, c64HostConfig.BasicAIAssistantDefaultEnabled);
 
-        return Task.FromResult(new SystemRunner(c64));
+        return base.BuildSystemRunner(system, hostSystemConfig);
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.SilkNet.Commodore64/C64HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SilkNet.Commodore64/C64HostConfig.cs
@@ -6,12 +6,33 @@ using Highbyte.DotNet6502.Systems.Commodore64.Input;
 namespace Highbyte.DotNet6502.Impl.SilkNet.Commodore64;
 
 /// <summary>C64 host config for the SilkNet host.</summary>
-public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>
+public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>, IC64SwiftLinkTcpHostConfig
 {
     public const string ConfigSectionName = "Highbyte.DotNet6502.C64.SilkNetNative";
 
     public C64SilkNetOpenGlRendererConfig SilkNetOpenGlRendererConfig { get; set; } = new C64SilkNetOpenGlRendererConfig();
     public C64InputConfig InputConfig { get; set; } = new C64InputConfig();
+
+    private string _swiftLinkTcpHost = "127.0.0.1";
+    public string SwiftLinkTcpHost
+    {
+        get => _swiftLinkTcpHost;
+        set { _swiftLinkTcpHost = value; MarkDirty(); }
+    }
+
+    private int _swiftLinkTcpPort = 5000;
+    public int SwiftLinkTcpPort
+    {
+        get => _swiftLinkTcpPort;
+        set { _swiftLinkTcpPort = value; MarkDirty(); }
+    }
+
+    private bool _swiftLinkConnectOnBoot;
+    public bool SwiftLinkConnectOnBoot
+    {
+        get => _swiftLinkConnectOnBoot;
+        set { _swiftLinkConnectOnBoot = value; MarkDirty(); }
+    }
 
     public override object Clone()
     {

--- a/src/libraries/Highbyte.DotNet6502.Impl.SilkNet.Commodore64/C64HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SilkNet.Commodore64/C64HostConfig.cs
@@ -13,6 +13,13 @@ public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>, IC64SwiftLin
     public C64SilkNetOpenGlRendererConfig SilkNetOpenGlRendererConfig { get; set; } = new C64SilkNetOpenGlRendererConfig();
     public C64InputConfig InputConfig { get; set; } = new C64InputConfig();
 
+    private C64SwiftLinkTransportMode _swiftLinkTransportMode;
+    public C64SwiftLinkTransportMode SwiftLinkTransportMode
+    {
+        get => _swiftLinkTransportMode;
+        set { _swiftLinkTransportMode = value; MarkDirty(); }
+    }
+
     private string _swiftLinkTcpHost = "127.0.0.1";
     public string SwiftLinkTcpHost
     {
@@ -40,5 +47,10 @@ public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>, IC64SwiftLin
         clone.InputConfig = (C64InputConfig)InputConfig.Clone();
         clone.SilkNetOpenGlRendererConfig = (C64SilkNetOpenGlRendererConfig)SilkNetOpenGlRendererConfig.Clone();
         return clone;
+    }
+
+    public C64HostConfig()
+    {
+        SwiftLinkTransportMode = C64SwiftLinkTransportMode.RawTcp;
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.SilkNet.Commodore64/C64HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SilkNet.Commodore64/C64HostConfig.cs
@@ -45,4 +45,12 @@ public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>, IC64SwiftLin
     {
         _swiftLinkHost.SetDirtyCallback(MarkDirty);
     }
+
+    public override bool IsValid(out List<string> validationErrors)
+    {
+        var isValid = base.IsValid(out validationErrors);
+        if (!SwiftLinkHost.IsValid(out var swiftLinkHostValidationErrors, nameof(SwiftLinkHost)))
+            validationErrors.AddRange(swiftLinkHostValidationErrors);
+        return isValid && validationErrors.Count == 0;
+    }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.SilkNet.Commodore64/C64HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SilkNet.Commodore64/C64HostConfig.cs
@@ -1,5 +1,6 @@
 using Highbyte.DotNet6502.Impl.SilkNet.Commodore64.Render;
 using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
 using Highbyte.DotNet6502.Systems.Commodore64.Input;
 
@@ -13,44 +14,35 @@ public class C64HostConfig : HostSystemConfigBase<C64SystemConfig>, IC64SwiftLin
     public C64SilkNetOpenGlRendererConfig SilkNetOpenGlRendererConfig { get; set; } = new C64SilkNetOpenGlRendererConfig();
     public C64InputConfig InputConfig { get; set; } = new C64InputConfig();
 
-    private C64SwiftLinkTransportMode _swiftLinkTransportMode;
-    public C64SwiftLinkTransportMode SwiftLinkTransportMode
+    private C64SwiftLinkHostConfig _swiftLinkHost = new();
+    public C64SwiftLinkHostConfig SwiftLinkHost
     {
-        get => _swiftLinkTransportMode;
-        set { _swiftLinkTransportMode = value; MarkDirty(); }
+        get => _swiftLinkHost;
+        set
+        {
+            _swiftLinkHost = value ?? new C64SwiftLinkHostConfig();
+            _swiftLinkHost.SetDirtyCallback(MarkDirty);
+            MarkDirty();
+        }
     }
 
-    private string _swiftLinkTcpHost = "127.0.0.1";
-    public string SwiftLinkTcpHost
-    {
-        get => _swiftLinkTcpHost;
-        set { _swiftLinkTcpHost = value; MarkDirty(); }
-    }
-
-    private int _swiftLinkTcpPort = 5000;
-    public int SwiftLinkTcpPort
-    {
-        get => _swiftLinkTcpPort;
-        set { _swiftLinkTcpPort = value; MarkDirty(); }
-    }
-
-    private bool _swiftLinkConnectOnBoot;
-    public bool SwiftLinkConnectOnBoot
-    {
-        get => _swiftLinkConnectOnBoot;
-        set { _swiftLinkConnectOnBoot = value; MarkDirty(); }
-    }
+    public C64SwiftLinkTransportMode SwiftLinkTransportMode => SwiftLinkHost.TransportMode;
+    public string SwiftLinkTcpHost => SwiftLinkHost.TcpHost;
+    public int SwiftLinkTcpPort => SwiftLinkHost.TcpPort;
+    public bool SwiftLinkConnectOnBoot => SwiftLinkHost.ConnectOnBoot;
 
     public override object Clone()
     {
         var clone = (C64HostConfig)base.Clone();
         clone.InputConfig = (C64InputConfig)InputConfig.Clone();
         clone.SilkNetOpenGlRendererConfig = (C64SilkNetOpenGlRendererConfig)SilkNetOpenGlRendererConfig.Clone();
+        clone._swiftLinkHost = SwiftLinkHost.Clone();
+        clone._swiftLinkHost.SetDirtyCallback(clone.MarkDirty);
         return clone;
     }
 
     public C64HostConfig()
     {
-        SwiftLinkTransportMode = C64SwiftLinkTransportMode.RawTcp;
+        _swiftLinkHost.SetDirtyCallback(MarkDirty);
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.SilkNet.Commodore64/C64Setup.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.SilkNet.Commodore64/C64Setup.cs
@@ -25,6 +25,6 @@ public class C64Setup : C64SystemConfigurerCore
 
         c64.InputConsumer = new C64InputHandler(c64, LoggerFactory, c64HostConfig.InputConfig);
 
-        return Task.FromResult(new SystemRunner(c64));
+        return base.BuildSystemRunner(system, hostSystemConfig);
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/HayesModemTransport.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/HayesModemTransport.cs
@@ -22,7 +22,7 @@ public sealed class HayesModemTransport : ISwiftLinkTransport
     private ISwiftLinkTransport? _dataTransport;
     private ModemMode _mode = ModemMode.Command;
     private bool _lastCarrierDetected;
-
+    private bool _connectResponsePending;
     public HayesModemTransport(Func<string, int, ISwiftLinkTransport> dialTransportFactory, ILogger logger)
     {
         _dialTransportFactory = dialTransportFactory;
@@ -31,7 +31,7 @@ public sealed class HayesModemTransport : ISwiftLinkTransport
 
     public bool IsConnected => IsCarrierDetected;
 
-    public bool IsCarrierDetected => _mode == ModemMode.Data && _dataTransport?.IsConnected == true;
+    public bool IsCarrierDetected => (_mode == ModemMode.Data || _mode == ModemMode.AwaitingRemoteReady) && _dataTransport?.IsConnected == true;
 
     public bool IsDataSetReady => IsCarrierDetected;
 
@@ -54,8 +54,22 @@ public sealed class HayesModemTransport : ISwiftLinkTransport
         if (_receivedBytes.TryDequeue(out value))
             return true;
 
-        if (_mode == ModemMode.Data && _dataTransport != null)
-            return _dataTransport.TryDequeueReceivedByte(out value);
+        if ((_mode == ModemMode.Data || _mode == ModemMode.AwaitingRemoteReady) && _dataTransport != null)
+        {
+            if (_dataTransport.TryDequeueReceivedByte(out value))
+            {
+                if (_connectResponsePending)
+                {
+                    _mode = ModemMode.Data;
+                    _connectResponsePending = false;
+                    EnqueueResponse(ConnectResponse);
+                    _receivedBytes.Enqueue(value);
+                    return _receivedBytes.TryDequeue(out value);
+                }
+
+                return true;
+            }
+        }
 
         value = 0;
         return false;
@@ -169,11 +183,11 @@ public sealed class HayesModemTransport : ISwiftLinkTransport
             await dataTransport.ConnectAsync(cancellationToken);
 
             _dataTransport = dataTransport;
-            _mode = ModemMode.Data;
+            _mode = ModemMode.AwaitingRemoteReady;
             _lastCarrierDetected = true;
+            _connectResponsePending = true;
 
             _logger.LogInformation("SwiftLink Hayes modem connected to {Host}:{Port}.", host, port);
-            EnqueueResponse(ConnectResponse);
         }
         catch (Exception ex)
         {
@@ -182,6 +196,7 @@ public sealed class HayesModemTransport : ISwiftLinkTransport
             _dataTransport = null;
             _mode = ModemMode.Command;
             _lastCarrierDetected = false;
+            _connectResponsePending = false;
             EnqueueResponse(NoCarrierResponse);
         }
     }
@@ -192,6 +207,7 @@ public sealed class HayesModemTransport : ISwiftLinkTransport
         _dataTransport = null;
         _mode = ModemMode.Command;
         _lastCarrierDetected = false;
+        _connectResponsePending = false;
 
         if (dataTransport == null)
             return;
@@ -245,6 +261,7 @@ public sealed class HayesModemTransport : ISwiftLinkTransport
     private enum ModemMode
     {
         Command,
+        AwaitingRemoteReady,
         Data
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/HayesModemTransport.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/HayesModemTransport.cs
@@ -1,0 +1,250 @@
+using System.Collections.Concurrent;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Highbyte.DotNet6502.Systems.Commodore64.Transport;
+
+public sealed class HayesModemTransport : ISwiftLinkTransport
+{
+    private const string ConnectResponse = "CONNECT 1200";
+    private const string NoCarrierResponse = "NO CARRIER";
+    private const string OkResponse = "OK";
+    private const string ErrorResponse = "ERROR";
+    private const string InfoResponse = "DOTNET6502 SWIFTLINK MODEM";
+    private const string ResultCodePrefix = "\r\n";
+    private const string ResultCodeSuffix = "\r\n";
+
+    private readonly Func<string, int, ISwiftLinkTransport> _dialTransportFactory;
+    private readonly ConcurrentQueue<byte> _receivedBytes = new();
+    private readonly ILogger _logger;
+    private readonly StringBuilder _commandBuffer = new();
+
+    private ISwiftLinkTransport? _dataTransport;
+    private ModemMode _mode = ModemMode.Command;
+    private bool _lastCarrierDetected;
+
+    public HayesModemTransport(Func<string, int, ISwiftLinkTransport> dialTransportFactory, ILogger logger)
+    {
+        _dialTransportFactory = dialTransportFactory;
+        _logger = logger;
+    }
+
+    public bool IsConnected => IsCarrierDetected;
+
+    public bool IsCarrierDetected => _mode == ModemMode.Data && _dataTransport?.IsConnected == true;
+
+    public bool IsDataSetReady => IsCarrierDetected;
+
+    public ValueTask ConnectAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("SwiftLink Hayes modem transport ready in command mode.");
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisconnectAsync(CancellationToken cancellationToken = default)
+    {
+        await HangUpAsync(cancellationToken);
+        Reset();
+    }
+
+    public bool TryDequeueReceivedByte(out byte value)
+    {
+        PollCarrierState();
+
+        if (_receivedBytes.TryDequeue(out value))
+            return true;
+
+        if (_mode == ModemMode.Data && _dataTransport != null)
+            return _dataTransport.TryDequeueReceivedByte(out value);
+
+        value = 0;
+        return false;
+    }
+
+    public async ValueTask SendAsync(byte value, CancellationToken cancellationToken = default)
+    {
+        PollCarrierState();
+
+        if (_mode == ModemMode.Data)
+        {
+            var dataTransport = _dataTransport;
+            if (dataTransport == null)
+                return;
+
+            await dataTransport.SendAsync(value, cancellationToken);
+            return;
+        }
+
+        if (value == (byte)'\n')
+            return;
+
+        if (value != (byte)'\r')
+        {
+            _commandBuffer.Append((char)value);
+            return;
+        }
+
+        var command = _commandBuffer.ToString();
+        _commandBuffer.Clear();
+
+        if (command.Length == 0)
+            return;
+
+        await ExecuteCommandAsync(command, cancellationToken);
+    }
+
+    public void Reset()
+    {
+        _commandBuffer.Clear();
+        while (_receivedBytes.TryDequeue(out _))
+        {
+        }
+
+        _mode = ModemMode.Command;
+        _lastCarrierDetected = false;
+    }
+
+    public void Dispose()
+    {
+        HangUpAsync().AsTask().GetAwaiter().GetResult();
+        Reset();
+    }
+
+    private async ValueTask ExecuteCommandAsync(string command, CancellationToken cancellationToken)
+    {
+        var normalizedCommand = command.Trim();
+        _logger.LogInformation("SwiftLink Hayes modem received command: {Command}", normalizedCommand);
+
+        if (normalizedCommand.Equals("AT", StringComparison.OrdinalIgnoreCase))
+        {
+            EnqueueResponse(OkResponse);
+            return;
+        }
+
+        if (normalizedCommand.Equals("ATZ", StringComparison.OrdinalIgnoreCase)
+            || normalizedCommand.Equals("AT&F", StringComparison.OrdinalIgnoreCase))
+        {
+            await HangUpAsync(cancellationToken);
+            EnqueueResponse(OkResponse);
+            return;
+        }
+
+        if (normalizedCommand.Equals("ATI", StringComparison.OrdinalIgnoreCase))
+        {
+            EnqueueResponse(InfoResponse);
+            return;
+        }
+
+        if (normalizedCommand.Equals("ATH", StringComparison.OrdinalIgnoreCase))
+        {
+            await HangUpAsync(cancellationToken);
+            EnqueueResponse(OkResponse);
+            return;
+        }
+
+        if (normalizedCommand.StartsWith("ATDT", StringComparison.OrdinalIgnoreCase))
+        {
+            var dialTarget = normalizedCommand[4..].Trim();
+            await DialAsync(dialTarget, cancellationToken);
+            return;
+        }
+
+        EnqueueResponse(ErrorResponse);
+    }
+
+    private async ValueTask DialAsync(string dialTarget, CancellationToken cancellationToken)
+    {
+        if (!TryParseDialTarget(dialTarget, out var host, out var port))
+        {
+            _logger.LogWarning("SwiftLink Hayes modem could not parse dial target: {DialTarget}", dialTarget);
+            EnqueueResponse(ErrorResponse);
+            return;
+        }
+
+        await HangUpAsync(cancellationToken);
+
+        try
+        {
+            var dataTransport = _dialTransportFactory(host, port);
+            await dataTransport.ConnectAsync(cancellationToken);
+
+            _dataTransport = dataTransport;
+            _mode = ModemMode.Data;
+            _lastCarrierDetected = true;
+
+            _logger.LogInformation("SwiftLink Hayes modem connected to {Host}:{Port}.", host, port);
+            EnqueueResponse(ConnectResponse);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "SwiftLink Hayes modem failed to connect to {Host}:{Port}.", host, port);
+            _dataTransport?.Dispose();
+            _dataTransport = null;
+            _mode = ModemMode.Command;
+            _lastCarrierDetected = false;
+            EnqueueResponse(NoCarrierResponse);
+        }
+    }
+
+    private async ValueTask HangUpAsync(CancellationToken cancellationToken = default)
+    {
+        var dataTransport = _dataTransport;
+        _dataTransport = null;
+        _mode = ModemMode.Command;
+        _lastCarrierDetected = false;
+
+        if (dataTransport == null)
+            return;
+
+        try
+        {
+            await dataTransport.DisconnectAsync(cancellationToken);
+        }
+        finally
+        {
+            dataTransport.Dispose();
+        }
+    }
+
+    private void PollCarrierState()
+    {
+        var isCarrierDetected = IsCarrierDetected;
+        if (_lastCarrierDetected && !isCarrierDetected)
+        {
+            _logger.LogInformation("SwiftLink Hayes modem lost carrier.");
+            _mode = ModemMode.Command;
+            _dataTransport?.Dispose();
+            _dataTransport = null;
+            EnqueueResponse(NoCarrierResponse);
+        }
+
+        _lastCarrierDetected = isCarrierDetected;
+    }
+
+    private void EnqueueResponse(string response)
+    {
+        var fullResponse = $"{ResultCodePrefix}{response}{ResultCodeSuffix}";
+        _logger.LogDebug("SwiftLink Hayes modem enqueuing response: {Response}", response);
+        foreach (var ch in Encoding.ASCII.GetBytes(fullResponse))
+            _receivedBytes.Enqueue(ch);
+    }
+
+    private static bool TryParseDialTarget(string dialTarget, out string host, out int port)
+    {
+        host = string.Empty;
+        port = 0;
+
+        var lastColonIndex = dialTarget.LastIndexOf(':');
+        if (lastColonIndex <= 0 || lastColonIndex >= dialTarget.Length - 1)
+            return false;
+
+        host = dialTarget[..lastColonIndex];
+        return int.TryParse(dialTarget[(lastColonIndex + 1)..], out port) && port is > 0 and <= 65535;
+    }
+
+    private enum ModemMode
+    {
+        Command,
+        Data
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/Highbyte.DotNet6502.Systems.Commodore64.Transport.csproj
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/Highbyte.DotNet6502.Systems.Commodore64.Transport.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/Highbyte.DotNet6502.Systems.Commodore64.Transport.csproj
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/Highbyte.DotNet6502.Systems.Commodore64.Transport.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
 </Project>

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/ISwiftLinkTransport.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/ISwiftLinkTransport.cs
@@ -1,0 +1,11 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Transport;
+
+public interface ISwiftLinkTransport : IDisposable
+{
+    bool IsConnected { get; }
+    ValueTask ConnectAsync(CancellationToken cancellationToken = default);
+    ValueTask DisconnectAsync(CancellationToken cancellationToken = default);
+    bool TryDequeueReceivedByte(out byte value);
+    ValueTask SendAsync(byte value, CancellationToken cancellationToken = default);
+    void Reset();
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/ISwiftLinkTransport.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/ISwiftLinkTransport.cs
@@ -3,6 +3,8 @@ namespace Highbyte.DotNet6502.Systems.Commodore64.Transport;
 public interface ISwiftLinkTransport : IDisposable
 {
     bool IsConnected { get; }
+    bool IsCarrierDetected { get; }
+    bool IsDataSetReady { get; }
     ValueTask ConnectAsync(CancellationToken cancellationToken = default);
     ValueTask DisconnectAsync(CancellationToken cancellationToken = default);
     bool TryDequeueReceivedByte(out byte value);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/LoopbackTransport.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/LoopbackTransport.cs
@@ -1,0 +1,46 @@
+using System.Collections.Concurrent;
+
+namespace Highbyte.DotNet6502.Systems.Commodore64.Transport;
+
+public sealed class LoopbackTransport : ISwiftLinkTransport
+{
+    private readonly ConcurrentQueue<byte> _receivedBytes = new();
+
+    public bool IsConnected { get; private set; }
+
+    public ValueTask ConnectAsync(CancellationToken cancellationToken = default)
+    {
+        IsConnected = true;
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisconnectAsync(CancellationToken cancellationToken = default)
+    {
+        IsConnected = false;
+        Reset();
+        return ValueTask.CompletedTask;
+    }
+
+    public bool TryDequeueReceivedByte(out byte value)
+        => _receivedBytes.TryDequeue(out value);
+
+    public ValueTask SendAsync(byte value, CancellationToken cancellationToken = default)
+    {
+        if (IsConnected)
+            _receivedBytes.Enqueue(value);
+        return ValueTask.CompletedTask;
+    }
+
+    public void Reset()
+    {
+        while (_receivedBytes.TryDequeue(out _))
+        {
+        }
+    }
+
+    public void Dispose()
+    {
+        IsConnected = false;
+        Reset();
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/LoopbackTransport.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/LoopbackTransport.cs
@@ -7,6 +7,8 @@ public sealed class LoopbackTransport : ISwiftLinkTransport
     private readonly ConcurrentQueue<byte> _receivedBytes = new();
 
     public bool IsConnected { get; private set; }
+    public bool IsCarrierDetected => IsConnected;
+    public bool IsDataSetReady => IsConnected;
 
     public ValueTask ConnectAsync(CancellationToken cancellationToken = default)
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/TcpTransport.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/TcpTransport.cs
@@ -1,0 +1,145 @@
+using System.Collections.Concurrent;
+using System.Net.Sockets;
+
+namespace Highbyte.DotNet6502.Systems.Commodore64.Transport;
+
+public sealed class TcpTransport : ISwiftLinkTransport
+{
+    private readonly string _host;
+    private readonly int _port;
+    private readonly ConcurrentQueue<byte> _receivedBytes = new();
+    private readonly object _sync = new();
+
+    private TcpClient? _tcpClient;
+    private NetworkStream? _stream;
+    private CancellationTokenSource? _readerCts;
+    private Task? _readerTask;
+
+    public TcpTransport(string host, int port)
+    {
+        _host = host;
+        _port = port;
+    }
+
+    public bool IsConnected => _tcpClient?.Connected == true;
+
+    public async ValueTask ConnectAsync(CancellationToken cancellationToken = default)
+    {
+        if (IsConnected)
+            return;
+
+        var tcpClient = new TcpClient();
+        await tcpClient.ConnectAsync(_host, _port, cancellationToken);
+        var stream = tcpClient.GetStream();
+        var readerCts = new CancellationTokenSource();
+
+        lock (_sync)
+        {
+            _tcpClient = tcpClient;
+            _stream = stream;
+            _readerCts = readerCts;
+            _readerTask = Task.Run(() => ReaderLoopAsync(stream, readerCts.Token), CancellationToken.None);
+        }
+    }
+
+    public async ValueTask DisconnectAsync(CancellationToken cancellationToken = default)
+    {
+        Task? readerTask;
+        CancellationTokenSource? readerCts;
+        NetworkStream? stream;
+        TcpClient? tcpClient;
+
+        lock (_sync)
+        {
+            readerTask = _readerTask;
+            readerCts = _readerCts;
+            stream = _stream;
+            tcpClient = _tcpClient;
+            _readerTask = null;
+            _readerCts = null;
+            _stream = null;
+            _tcpClient = null;
+        }
+
+        readerCts?.Cancel();
+
+        if (stream != null)
+            await stream.DisposeAsync();
+        tcpClient?.Dispose();
+
+        if (readerTask != null)
+        {
+            try
+            {
+                await readerTask.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+            catch (IOException)
+            {
+            }
+        }
+
+        readerCts?.Dispose();
+        Reset();
+    }
+
+    public bool TryDequeueReceivedByte(out byte value)
+        => _receivedBytes.TryDequeue(out value);
+
+    public async ValueTask SendAsync(byte value, CancellationToken cancellationToken = default)
+    {
+        var stream = _stream;
+        if (stream == null)
+            return;
+
+        await stream.WriteAsync(new[] { value }, cancellationToken);
+    }
+
+    public void Reset()
+    {
+        while (_receivedBytes.TryDequeue(out _))
+        {
+        }
+    }
+
+    public void Dispose()
+    {
+        DisconnectAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    private async Task ReaderLoopAsync(NetworkStream stream, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[256];
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            int bytesRead;
+            try
+            {
+                bytesRead = await stream.ReadAsync(buffer, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (IOException)
+            {
+                break;
+            }
+            catch (ObjectDisposedException)
+            {
+                break;
+            }
+
+            if (bytesRead <= 0)
+                break;
+
+            for (var i = 0; i < bytesRead; i++)
+                _receivedBytes.Enqueue(buffer[i]);
+        }
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/TcpTransport.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/TcpTransport.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Net.Sockets;
+using System.Text;
 using Microsoft.Extensions.Logging;
 
 namespace Highbyte.DotNet6502.Systems.Commodore64.Transport;
@@ -29,6 +30,8 @@ public sealed class TcpTransport : ISwiftLinkTransport
     }
 
     public bool IsConnected => _isConnected;
+    public bool IsCarrierDetected => _isConnected;
+    public bool IsDataSetReady => _isConnected;
 
     public async ValueTask ConnectAsync(CancellationToken cancellationToken = default)
     {
@@ -181,7 +184,11 @@ public sealed class TcpTransport : ISwiftLinkTransport
                 break;
             }
 
-            _logger.LogDebug("SwiftLink TCP transport received {ByteCount} byte(s).", bytesRead);
+            _logger.LogDebug(
+                "SwiftLink TCP transport received {ByteCount} byte(s): {HexBytes} |{Ascii}|",
+                bytesRead,
+                FormatHexBytes(buffer, bytesRead),
+                FormatAsciiBytes(buffer, bytesRead));
 
             for (var i = 0; i < bytesRead; i++)
                 _receivedBytes.Enqueue(buffer[i]);
@@ -203,5 +210,28 @@ public sealed class TcpTransport : ISwiftLinkTransport
         catch (ObjectDisposedException)
         {
         }
+    }
+
+    private static string FormatHexBytes(byte[] buffer, int bytesRead)
+    {
+        var builder = new StringBuilder(bytesRead * 3);
+        for (var i = 0; i < bytesRead; i++)
+        {
+            if (i > 0)
+                builder.Append(' ');
+            builder.Append(buffer[i].ToString("X2"));
+        }
+        return builder.ToString();
+    }
+
+    private static string FormatAsciiBytes(byte[] buffer, int bytesRead)
+    {
+        var builder = new StringBuilder(bytesRead);
+        for (var i = 0; i < bytesRead; i++)
+        {
+            var value = buffer[i];
+            builder.Append(value is >= 0x20 and <= 0x7E ? (char)value : '.');
+        }
+        return builder.ToString();
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/TcpTransport.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64.Transport/TcpTransport.cs
@@ -1,33 +1,41 @@
 using System.Collections.Concurrent;
 using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
 
 namespace Highbyte.DotNet6502.Systems.Commodore64.Transport;
 
 public sealed class TcpTransport : ISwiftLinkTransport
 {
+    private static readonly TimeSpan ReaderShutdownTimeout = TimeSpan.FromSeconds(1);
+
     private readonly string _host;
     private readonly int _port;
     private readonly ConcurrentQueue<byte> _receivedBytes = new();
     private readonly object _sync = new();
 
+    private readonly ILogger _logger;
     private TcpClient? _tcpClient;
     private NetworkStream? _stream;
     private CancellationTokenSource? _readerCts;
     private Task? _readerTask;
+    private bool _isConnected;
+    private bool _warnedDisconnectedSend;
 
-    public TcpTransport(string host, int port)
+    public TcpTransport(string host, int port, ILogger logger)
     {
         _host = host;
         _port = port;
+        _logger = logger;
     }
 
-    public bool IsConnected => _tcpClient?.Connected == true;
+    public bool IsConnected => _isConnected;
 
     public async ValueTask ConnectAsync(CancellationToken cancellationToken = default)
     {
         if (IsConnected)
             return;
 
+        _logger.LogInformation("Connecting SwiftLink TCP transport to {Host}:{Port}.", _host, _port);
         var tcpClient = new TcpClient();
         await tcpClient.ConnectAsync(_host, _port, cancellationToken);
         var stream = tcpClient.GetStream();
@@ -39,7 +47,11 @@ public sealed class TcpTransport : ISwiftLinkTransport
             _stream = stream;
             _readerCts = readerCts;
             _readerTask = Task.Run(() => ReaderLoopAsync(stream, readerCts.Token), CancellationToken.None);
+            _isConnected = true;
+            _warnedDisconnectedSend = false;
         }
+
+        _logger.LogInformation("Connected SwiftLink TCP transport to {Host}:{Port}.", _host, _port);
     }
 
     public async ValueTask DisconnectAsync(CancellationToken cancellationToken = default)
@@ -59,9 +71,11 @@ public sealed class TcpTransport : ISwiftLinkTransport
             _readerCts = null;
             _stream = null;
             _tcpClient = null;
+            _isConnected = false;
         }
 
         readerCts?.Cancel();
+        TryShutdownSocket(tcpClient);
 
         if (stream != null)
             await stream.DisposeAsync();
@@ -71,10 +85,23 @@ public sealed class TcpTransport : ISwiftLinkTransport
         {
             try
             {
-                await readerTask.WaitAsync(cancellationToken);
+                var waitToken = cancellationToken;
+                if (!waitToken.CanBeCanceled)
+                {
+                    using var waitCts = new CancellationTokenSource(ReaderShutdownTimeout);
+                    await readerTask.WaitAsync(waitCts.Token);
+                }
+                else
+                {
+                    await readerTask.WaitAsync(waitToken);
+                }
             }
             catch (OperationCanceledException)
             {
+                _logger.LogWarning(
+                    "Timed out waiting for SwiftLink TCP transport reader loop to stop for {Host}:{Port}.",
+                    _host,
+                    _port);
             }
             catch (ObjectDisposedException)
             {
@@ -86,6 +113,7 @@ public sealed class TcpTransport : ISwiftLinkTransport
 
         readerCts?.Dispose();
         Reset();
+        _logger.LogInformation("Disconnected SwiftLink TCP transport from {Host}:{Port}.", _host, _port);
     }
 
     public bool TryDequeueReceivedByte(out byte value)
@@ -94,9 +122,17 @@ public sealed class TcpTransport : ISwiftLinkTransport
     public async ValueTask SendAsync(byte value, CancellationToken cancellationToken = default)
     {
         var stream = _stream;
-        if (stream == null)
+        if (stream == null || !_isConnected)
+        {
+            if (!_warnedDisconnectedSend)
+            {
+                _logger.LogWarning("SwiftLink send attempted while TCP transport is not connected.");
+                _warnedDisconnectedSend = true;
+            }
             return;
+        }
 
+        _logger.LogDebug("SwiftLink TCP transport sending byte 0x{Value:X2}.", value);
         await stream.WriteAsync(new[] { value }, cancellationToken);
     }
 
@@ -136,10 +172,36 @@ public sealed class TcpTransport : ISwiftLinkTransport
             }
 
             if (bytesRead <= 0)
+            {
+                _logger.LogInformation("SwiftLink TCP transport remote closed the connection.");
+                lock (_sync)
+                {
+                    _isConnected = false;
+                }
                 break;
+            }
+
+            _logger.LogDebug("SwiftLink TCP transport received {ByteCount} byte(s).", bytesRead);
 
             for (var i = 0; i < bytesRead; i++)
                 _receivedBytes.Enqueue(buffer[i]);
+        }
+    }
+
+    private void TryShutdownSocket(TcpClient? tcpClient)
+    {
+        if (tcpClient?.Client == null)
+            return;
+
+        try
+        {
+            tcpClient.Client.Shutdown(SocketShutdown.Both);
+        }
+        catch (SocketException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
         }
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -3,6 +3,7 @@ using Highbyte.DotNet6502.Monitor.SystemSpecific;
 using Highbyte.DotNet6502.Systems.Commodore64.Audio;
 using Highbyte.DotNet6502.Systems.Commodore64.Audio.Sample;
 using Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
 using Highbyte.DotNet6502.Systems.Commodore64.Models;
 using Highbyte.DotNet6502.Systems.Commodore64.Monitor;
@@ -288,15 +289,15 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
         var diskDrive1541 = new DiskDrive1541(loggerFactory);
         iecBus.Attach(diskDrive1541);
 
-        if (c64Config.SwiftLinkEnabled)
+        if (c64Config.SwiftLink.Enabled)
         {
             var swiftLink = new SwiftLinkDevice(
-                c64Config.SwiftLinkCartridgeIOAddress,
+                c64Config.SwiftLink.CartridgeIOAddress,
                 loggerFactory.CreateLogger(nameof(SwiftLinkDevice)))
             {
                 CpuInterrupts = cpu.CPUInterrupts,
-                InterruptMode = c64Config.SwiftLinkInterruptMode,
-                ReceiveMode = c64Config.SwiftLinkReceiveMode,
+                InterruptMode = c64Config.SwiftLink.InterruptMode,
+                ReceiveMode = c64Config.SwiftLink.ReceiveMode,
                 GetCurrentCycleCount = () => cpu.ExecState.CyclesConsumed,
             };
             c64.SwiftLink = swiftLink;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -297,6 +297,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
                 CpuInterrupts = cpu.CPUInterrupts,
                 InterruptMode = c64Config.SwiftLinkInterruptMode,
                 ReceiveMode = c64Config.SwiftLinkReceiveMode,
+                GetCurrentCycleCount = () => cpu.ExecState.CyclesConsumed,
             };
             c64.SwiftLink = swiftLink;
             c64.CartridgeDevices.Add(swiftLink);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -99,7 +99,6 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
 
     private byte _cpuPortDataDirectionRegister = CpuPortDataDirectionResetValue;
     private byte _cpuPortDataRegister = CpuPortDataResetValue;
-
     //public static ROM[] ROMS = new ROM[]
     //{   
     //    // name, file, checksum 
@@ -202,6 +201,11 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
         IECBus.TickDevices();
         foreach (var cartridgeDevice in CartridgeDevices)
             cartridgeDevice.Tick();
+
+        // General emulator timing fix: devices tick after the CPU instruction has already
+        // completed, so newly raised hardware IRQ/NMI lines must be serviced here to land
+        // on the next instruction boundary instead of one instruction late.
+        CPU.ProcessPendingInterrupts(Mem);
 
         // Advance video raster
         var cycleOnRasterLineBeforeInstruction = Vic2.CyclesConsumedCurrentVblank;
@@ -313,6 +317,14 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
 
         var mem = c64.CreateC64Memory(ram, io, romData);
         c64.Mem = mem;
+        if (c64.SwiftLink != null)
+        {
+            // SwiftLink-specific compatibility hook: some modem software temporarily banks
+            // out the mapped NMI vector area. SwiftLink can consult this callback and defer
+            // asserting its NMI source until the currently mapped vector is usable again.
+            c64.SwiftLink.CanDeliverNmi =
+                () => c64.Mem.FetchWord(CPU.NonMaskableIRQHandlerVector) != 0;
+        }
 
         c64.BasicTokenParser = new C64BasicTokenParser(c64, loggerFactory);
         c64.TextPaste = new C64TextPaste(c64, loggerFactory);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -296,6 +296,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             {
                 CpuInterrupts = cpu.CPUInterrupts,
                 InterruptMode = c64Config.SwiftLinkInterruptMode,
+                ReceiveMode = c64Config.SwiftLinkReceiveMode,
             };
             c64.SwiftLink = swiftLink;
             c64.CartridgeDevices.Add(swiftLink);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -27,6 +27,11 @@ namespace Highbyte.DotNet6502.Systems.Commodore64;
 
 public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
 {
+    private const byte CpuPortBankBitsMask = 0x07;
+    private const byte CpuPortDataDirectionResetValue = 0x2F;
+    private const byte CpuPortDataResetValue = 0x37;
+    private const byte CpuPortInputPullupMask = 0x17;
+
     public const string SystemName = "C64";
     public string Name => SystemName;
     public List<string> SystemInfo => BuildSystemInfo();
@@ -90,6 +95,9 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
     public C64TextPaste TextPaste { get; private set; } = default!;
     public C64InputInjector? InputInjector { get; private set; }
     IInputInjector? ISystem.InputInjector => InputInjector;
+
+    private byte _cpuPortDataDirectionRegister = CpuPortDataDirectionResetValue;
+    private byte _cpuPortDataRegister = CpuPortDataResetValue;
 
     //public static ROM[] ROMS = new ROM[]
     //{   
@@ -370,7 +378,10 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
 
     private void MapLocationsOnCurrentCPUBank(Memory mem, bool mapIO)
     {
-        // Address 0x01: IO Port. Controls bank switching and Cassette control
+        // Address 0x00: 6510 CPU data direction register.
+        mem.MapReader(0x00, IoPortDirectionLoad);
+        mem.MapWriter(0x00, IoPortDirectionStore);
+        // Address 0x01: 6510 CPU data register. Controls bank switching and cassette signals.
         mem.MapReader(0x01, IoPortLoad);
         mem.MapWriter(0x01, IoPortStore);
 
@@ -390,12 +401,12 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
     {
         var mem = c64.Mem;
 
-        // Initialize to bank 31
-        mem.SetMemoryConfiguration(31);
-        // GAME and EXROM on to start (cartridge). These "values" are not read/stored from a actual memory location, just 2 bits of data that the CPU uses together with the first 3 bits of 0x01 to determine which memory configuration to use
+        // Preserve the cartridge control bits (GAME/EXROM) while restoring the 6510
+        // processor port to the C64 startup defaults.
         c64.CurrentBank = 0x18;
-        // HIMEM, LOMEM, CHAREN on to start
-        mem.Write(1, 0x7);
+        c64._cpuPortDataDirectionRegister = CpuPortDataDirectionResetValue;
+        c64._cpuPortDataRegister = CpuPortDataResetValue;
+        c64.ApplyCpuPortMemoryConfiguration();
     }
 
     private static CPU CreateC64CPU(ILoggerFactory loggerFactory)
@@ -560,19 +571,46 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
         return true;
     }
 
+    private void IoPortDirectionStore(ushort _, byte value)
+    {
+        _cpuPortDataDirectionRegister = value;
+        ApplyCpuPortMemoryConfiguration();
+    }
+
+    private byte IoPortDirectionLoad(ushort _)
+    {
+        return _cpuPortDataDirectionRegister;
+    }
+
     private void IoPortStore(ushort _, byte value)
     {
-        var bank = CurrentBank;
-        bank.ClearBits(0x07);            // Clear the first 3 bits
-        bank |= (byte)(value & 0x07);    // Replace the first 3 bits with new ones
-        CurrentBank = bank;
-        Mem.SetMemoryConfiguration(CurrentBank);
+        _cpuPortDataRegister = value;
+        ApplyCpuPortMemoryConfiguration();
     }
 
     private byte IoPortLoad(ushort _)
     {
-        // For now, only the the first 3 bits which is the current bank
-        return (byte)(CurrentBank & 0x07);
+        return GetCpuPortEffectiveValue();
+    }
+
+    private void ApplyCpuPortMemoryConfiguration()
+    {
+        var bank = CurrentBank;
+        bank.ClearBits(CpuPortBankBitsMask);
+        bank |= (byte)(GetCpuPortEffectiveValue() & CpuPortBankBitsMask);
+        CurrentBank = bank;
+        Mem.SetMemoryConfiguration(CurrentBank);
+    }
+
+    private byte GetCpuPortEffectiveValue()
+    {
+        // On the C64 the lower 3 banking lines and cassette sense line are pulled high
+        // when configured as inputs. Compunet relies on INC/DEC $01 read-modify-write
+        // preserving those pull-up semantics.
+        var inputBits = (byte)(CpuPortInputPullupMask & ~_cpuPortDataDirectionRegister);
+        var outputBits = (byte)(_cpuPortDataRegister & _cpuPortDataDirectionRegister);
+        var upperBits = (byte)(_cpuPortDataRegister & 0b1100_0000);
+        return (byte)(upperBits | outputBits | inputBits);
     }
 
     /// <summary>

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -294,7 +294,8 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
                 c64Config.SwiftLinkCartridgeIOAddress,
                 loggerFactory.CreateLogger(nameof(SwiftLinkDevice)))
             {
-                CpuInterrupts = cpu.CPUInterrupts
+                CpuInterrupts = cpu.CPUInterrupts,
+                InterruptMode = c64Config.SwiftLinkInterruptMode,
             };
             c64.SwiftLink = swiftLink;
             c64.CartridgeDevices.Add(swiftLink);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -284,7 +284,10 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
         {
             var swiftLink = new SwiftLinkDevice(
                 c64Config.SwiftLinkCartridgeIOAddress,
-                loggerFactory.CreateLogger(nameof(SwiftLinkDevice)));
+                loggerFactory.CreateLogger(nameof(SwiftLinkDevice)))
+            {
+                CpuInterrupts = cpu.CPUInterrupts
+            };
             c64.SwiftLink = swiftLink;
             c64.CartridgeDevices.Add(swiftLink);
         }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Highbyte.DotNet6502.Monitor.SystemSpecific;
 using Highbyte.DotNet6502.Systems.Commodore64.Audio;
 using Highbyte.DotNet6502.Systems.Commodore64.Audio.Sample;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
 using Highbyte.DotNet6502.Systems.Commodore64.Models;
 using Highbyte.DotNet6502.Systems.Commodore64.Monitor;
@@ -24,7 +25,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Highbyte.DotNet6502.Systems.Commodore64;
 
-public class C64 : ISystem, ISystemMonitor, ISystemState
+public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
 {
     public const string SystemName = "C64";
     public string Name => SystemName;
@@ -46,6 +47,8 @@ public class C64 : ISystem, ISystemMonitor, ISystemState
     public Sid Sid { get; set; } = default!;
     public IECBus IECBus { get; set; } = default!;
     public Dictionary<string, byte[]> ROMData { get; set; } = default!;
+    public List<IC64CartridgeDevice> CartridgeDevices { get; } = new();
+    public SwiftLinkDevice? SwiftLink { get; private set; }
 
     public bool AudioEnabled { get; private set; }
     public TimerMode TimerMode { get; private set; }
@@ -188,6 +191,8 @@ public class C64 : ISystem, ISystemMonitor, ISystemState
 
         // Update IEC bus devices
         IECBus.TickDevices();
+        foreach (var cartridgeDevice in CartridgeDevices)
+            cartridgeDevice.Tick();
 
         // Advance video raster
         var cycleOnRasterLineBeforeInstruction = Vic2.CyclesConsumedCurrentVblank;
@@ -274,6 +279,15 @@ public class C64 : ISystem, ISystemMonitor, ISystemState
         var iecBus = new IECBus(iecHost);
         var diskDrive1541 = new DiskDrive1541(loggerFactory);
         iecBus.Attach(diskDrive1541);
+
+        if (c64Config.SwiftLinkEnabled)
+        {
+            var swiftLink = new SwiftLinkDevice(
+                c64Config.SwiftLinkCartridgeIOAddress,
+                loggerFactory.CreateLogger(nameof(SwiftLinkDevice)));
+            c64.SwiftLink = swiftLink;
+            c64.CartridgeDevices.Add(swiftLink);
+        }
 
         c64.CPU = cpu;
         c64.Vic2 = vic2;
@@ -364,6 +378,8 @@ public class C64 : ISystem, ISystemMonitor, ISystemState
             Cia1.MapIOLocations(mem);
             Cia2.MapIOLocations(mem);
             Sid.MapIOLocations(mem);
+            foreach (var cartridgeDevice in CartridgeDevices)
+                cartridgeDevice.MapIOLocations(mem);
         }
     }
 
@@ -579,6 +595,11 @@ public class C64 : ISystem, ISystemMonitor, ISystemState
         var row1 = $"Line: {Vic2.CurrentRasterLine} VblankCY: {Vic2.CyclesConsumedCurrentVblank} CPU bank: {CurrentBank} VIC2 bank: {Vic2.CurrentVIC2Bank}";
         var row2 = $"Model: {Model.Name} Freq: {Model.CPUFrequencyHz} VIC2 Model: {Vic2.Vic2Model.Name}";
         return new List<string>() { row1, row2 };
+    }
+
+    public void Cleanup()
+    {
+        SwiftLink?.Transport?.Dispose();
     }
 
     private List<KeyValuePair<string, Func<string>>> BuildDebugInfo()

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64SystemConfigurerCore.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64SystemConfigurerCore.cs
@@ -114,6 +114,7 @@ public class C64SystemConfigurerCore : ISystemConfigurer
             KeyboardJoystick = c64SystemConfig.KeyboardJoystick,
             SwiftLinkEnabled = c64SystemConfig.SwiftLinkEnabled,
             SwiftLinkCartridgeIOAddress = c64SystemConfig.SwiftLinkCartridgeIOAddress,
+            SwiftLinkInterruptMode = c64SystemConfig.SwiftLinkInterruptMode,
             ROMs = c64SystemConfig.ROMs,
             ROMDirectory = c64SystemConfig.ROMDirectory,
             RenderProviderType = c64SystemConfig.RenderProviderType ?? DefaultRenderProviderType,
@@ -134,7 +135,10 @@ public class C64SystemConfigurerCore : ISystemConfigurer
         var c64 = (C64)system;
         if (SupportsSwiftLinkTcpTransport && c64.SwiftLink != null && hostSystemConfig is IC64SwiftLinkTcpHostConfig swiftLinkHostConfig)
         {
-            var transport = new TcpTransport(swiftLinkHostConfig.SwiftLinkTcpHost, swiftLinkHostConfig.SwiftLinkTcpPort);
+            var transport = new TcpTransport(
+                swiftLinkHostConfig.SwiftLinkTcpHost,
+                swiftLinkHostConfig.SwiftLinkTcpPort,
+                LoggerFactory.CreateLogger(nameof(TcpTransport)));
             c64.SwiftLink.Transport = transport;
             if (swiftLinkHostConfig.SwiftLinkConnectOnBoot)
                 await transport.ConnectAsync();

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64SystemConfigurerCore.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64SystemConfigurerCore.cs
@@ -1,4 +1,5 @@
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 using Highbyte.DotNet6502.Systems.Commodore64.Transport;
 using Highbyte.DotNet6502.Systems.Commodore64.Models;
 using Microsoft.Extensions.Configuration;
@@ -112,10 +113,7 @@ public class C64SystemConfigurerCore : ISystemConfigurer
             AudioEnabled = c64SystemConfig.AudioEnabled,
             KeyboardJoystickEnabled = c64SystemConfig.KeyboardJoystickEnabled,
             KeyboardJoystick = c64SystemConfig.KeyboardJoystick,
-            SwiftLinkEnabled = c64SystemConfig.SwiftLinkEnabled,
-            SwiftLinkCartridgeIOAddress = c64SystemConfig.SwiftLinkCartridgeIOAddress,
-            SwiftLinkInterruptMode = c64SystemConfig.SwiftLinkInterruptMode,
-            SwiftLinkReceiveMode = c64SystemConfig.SwiftLinkReceiveMode,
+            SwiftLink = c64SystemConfig.SwiftLink.Clone(),
             ROMs = c64SystemConfig.ROMs,
             ROMDirectory = c64SystemConfig.ROMDirectory,
             RenderProviderType = c64SystemConfig.RenderProviderType ?? DefaultRenderProviderType,

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64SystemConfigurerCore.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64SystemConfigurerCore.cs
@@ -136,10 +136,19 @@ public class C64SystemConfigurerCore : ISystemConfigurer
         var c64 = (C64)system;
         if (SupportsSwiftLinkTcpTransport && c64.SwiftLink != null && hostSystemConfig is IC64SwiftLinkTcpHostConfig swiftLinkHostConfig)
         {
+            c64.SwiftLink.ReceivePacingCycles =
+                swiftLinkHostConfig.SwiftLinkTransportMode == C64SwiftLinkTransportMode.HayesModem
+                && c64.SwiftLink.ReceiveMode == C64SwiftLinkReceiveMode.Compatible
+                    ? GetCyclesPer1200BaudCharacter(c64)
+                    : 0;
+
             ISwiftLinkTransport transport = swiftLinkHostConfig.SwiftLinkTransportMode switch
             {
                 C64SwiftLinkTransportMode.HayesModem => new HayesModemTransport(
-                    (host, port) => new TcpTransport(host, port, LoggerFactory.CreateLogger(nameof(TcpTransport))),
+                    (host, port) => new TcpTransport(
+                        host,
+                        port,
+                        LoggerFactory.CreateLogger(nameof(TcpTransport))),
                     LoggerFactory.CreateLogger(nameof(HayesModemTransport))),
                 _ => new TcpTransport(
                     swiftLinkHostConfig.SwiftLinkTcpHost,
@@ -152,6 +161,13 @@ public class C64SystemConfigurerCore : ISystemConfigurer
         }
 
         return new SystemRunner(c64);
+    }
+
+    private static ulong GetCyclesPer1200BaudCharacter(C64 c64)
+    {
+        const double BitsPerCharacter = 10.0; // 8N1 framing
+        const double BaudRate = 1200.0;
+        return (ulong)Math.Ceiling(c64.CpuFrequencyHz * (BitsPerCharacter / BaudRate));
     }
 
     /// <summary>

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64SystemConfigurerCore.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64SystemConfigurerCore.cs
@@ -115,6 +115,7 @@ public class C64SystemConfigurerCore : ISystemConfigurer
             SwiftLinkEnabled = c64SystemConfig.SwiftLinkEnabled,
             SwiftLinkCartridgeIOAddress = c64SystemConfig.SwiftLinkCartridgeIOAddress,
             SwiftLinkInterruptMode = c64SystemConfig.SwiftLinkInterruptMode,
+            SwiftLinkReceiveMode = c64SystemConfig.SwiftLinkReceiveMode,
             ROMs = c64SystemConfig.ROMs,
             ROMDirectory = c64SystemConfig.ROMDirectory,
             RenderProviderType = c64SystemConfig.RenderProviderType ?? DefaultRenderProviderType,
@@ -135,10 +136,16 @@ public class C64SystemConfigurerCore : ISystemConfigurer
         var c64 = (C64)system;
         if (SupportsSwiftLinkTcpTransport && c64.SwiftLink != null && hostSystemConfig is IC64SwiftLinkTcpHostConfig swiftLinkHostConfig)
         {
-            var transport = new TcpTransport(
-                swiftLinkHostConfig.SwiftLinkTcpHost,
-                swiftLinkHostConfig.SwiftLinkTcpPort,
-                LoggerFactory.CreateLogger(nameof(TcpTransport)));
+            ISwiftLinkTransport transport = swiftLinkHostConfig.SwiftLinkTransportMode switch
+            {
+                C64SwiftLinkTransportMode.HayesModem => new HayesModemTransport(
+                    (host, port) => new TcpTransport(host, port, LoggerFactory.CreateLogger(nameof(TcpTransport))),
+                    LoggerFactory.CreateLogger(nameof(HayesModemTransport))),
+                _ => new TcpTransport(
+                    swiftLinkHostConfig.SwiftLinkTcpHost,
+                    swiftLinkHostConfig.SwiftLinkTcpPort,
+                    LoggerFactory.CreateLogger(nameof(TcpTransport)))
+            };
             c64.SwiftLink.Transport = transport;
             if (swiftLinkHostConfig.SwiftLinkConnectOnBoot)
                 await transport.ConnectAsync();

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64SystemConfigurerCore.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64SystemConfigurerCore.cs
@@ -1,4 +1,5 @@
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Systems.Commodore64.Transport;
 using Highbyte.DotNet6502.Systems.Commodore64.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -111,6 +112,8 @@ public class C64SystemConfigurerCore : ISystemConfigurer
             AudioEnabled = c64SystemConfig.AudioEnabled,
             KeyboardJoystickEnabled = c64SystemConfig.KeyboardJoystickEnabled,
             KeyboardJoystick = c64SystemConfig.KeyboardJoystick,
+            SwiftLinkEnabled = c64SystemConfig.SwiftLinkEnabled,
+            SwiftLinkCartridgeIOAddress = c64SystemConfig.SwiftLinkCartridgeIOAddress,
             ROMs = c64SystemConfig.ROMs,
             ROMDirectory = c64SystemConfig.ROMDirectory,
             RenderProviderType = c64SystemConfig.RenderProviderType ?? DefaultRenderProviderType,
@@ -126,12 +129,29 @@ public class C64SystemConfigurerCore : ISystemConfigurer
     /// Builds a <see cref="SystemRunner"/> with no input consumer wired — the base behaviour for a
     /// host with no input (the Headless host). Tech hosts override to attach a C64 input handler.
     /// </summary>
-    public virtual Task<SystemRunner> BuildSystemRunner(ISystem system, IHostSystemConfig hostSystemConfig)
-        => Task.FromResult(new SystemRunner((C64)system));
+    public virtual async Task<SystemRunner> BuildSystemRunner(ISystem system, IHostSystemConfig hostSystemConfig)
+    {
+        var c64 = (C64)system;
+        if (SupportsSwiftLinkTcpTransport && c64.SwiftLink != null && hostSystemConfig is IC64SwiftLinkTcpHostConfig swiftLinkHostConfig)
+        {
+            var transport = new TcpTransport(swiftLinkHostConfig.SwiftLinkTcpHost, swiftLinkHostConfig.SwiftLinkTcpPort);
+            c64.SwiftLink.Transport = transport;
+            if (swiftLinkHostConfig.SwiftLinkConnectOnBoot)
+                await transport.ConnectAsync();
+        }
+
+        return new SystemRunner(c64);
+    }
 
     /// <summary>
     /// Fallback render-provider type used when <see cref="C64SystemConfig.RenderProviderType"/> is
     /// not set. Null by default (the host decides); the browser host overrides it.
     /// </summary>
     protected virtual Type? DefaultRenderProviderType => null;
+
+    /// <summary>
+    /// Browser hosts cannot use raw TCP, so they override this to defer SwiftLink transport
+    /// hookup until a WebSocket-backed transport exists.
+    /// </summary>
+    protected virtual bool SupportsSwiftLinkTcpTransport => true;
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64CartridgeDevice.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64CartridgeDevice.cs
@@ -1,0 +1,9 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+
+public interface IC64CartridgeDevice
+{
+    string Name { get; }
+    void MapIOLocations(Memory mem);
+    void Tick();
+    void Reset();
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLink/C64CartridgeIOAddress.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLink/C64CartridgeIOAddress.cs
@@ -1,0 +1,7 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
+
+public enum C64CartridgeIOAddress
+{
+    DE00 = 0,
+    DF00 = 1,
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLink/C64SwiftLinkConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLink/C64SwiftLinkConfig.cs
@@ -63,6 +63,20 @@ public class C64SwiftLinkConfig
 
     public void SetDirtyCallback(Action? markDirty) => _markDirty = markDirty;
 
+    public bool IsValid(out List<string> validationErrors, string configPath = nameof(C64SwiftLinkConfig))
+    {
+        validationErrors = new List<string>();
+
+        if (!Enum.IsDefined(CartridgeIOAddress))
+            validationErrors.Add($"{configPath}.{nameof(CartridgeIOAddress)} has an invalid value.");
+        if (!Enum.IsDefined(InterruptMode))
+            validationErrors.Add($"{configPath}.{nameof(InterruptMode)} has an invalid value.");
+        if (!Enum.IsDefined(ReceiveMode))
+            validationErrors.Add($"{configPath}.{nameof(ReceiveMode)} has an invalid value.");
+
+        return validationErrors.Count == 0;
+    }
+
     public C64SwiftLinkConfig Clone()
     {
         var clone = (C64SwiftLinkConfig)MemberwiseClone();

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLink/C64SwiftLinkConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLink/C64SwiftLinkConfig.cs
@@ -1,0 +1,72 @@
+using System.Text.Json.Serialization;
+
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
+
+public class C64SwiftLinkConfig
+{
+    [JsonIgnore]
+    private Action? _markDirty;
+
+    private bool _enabled;
+    public bool Enabled
+    {
+        get => _enabled;
+        set
+        {
+            _enabled = value;
+            _markDirty?.Invoke();
+        }
+    }
+
+    private C64CartridgeIOAddress _cartridgeIOAddress;
+    public C64CartridgeIOAddress CartridgeIOAddress
+    {
+        get => _cartridgeIOAddress;
+        set
+        {
+            _cartridgeIOAddress = value;
+            _markDirty?.Invoke();
+        }
+    }
+
+    private C64SwiftLinkInterruptMode _interruptMode;
+    [JsonConverter(typeof(JsonStringEnumConverter<C64SwiftLinkInterruptMode>))]
+    public C64SwiftLinkInterruptMode InterruptMode
+    {
+        get => _interruptMode;
+        set
+        {
+            _interruptMode = value;
+            _markDirty?.Invoke();
+        }
+    }
+
+    private C64SwiftLinkReceiveMode _receiveMode;
+    [JsonConverter(typeof(JsonStringEnumConverter<C64SwiftLinkReceiveMode>))]
+    public C64SwiftLinkReceiveMode ReceiveMode
+    {
+        get => _receiveMode;
+        set
+        {
+            _receiveMode = value;
+            _markDirty?.Invoke();
+        }
+    }
+
+    public C64SwiftLinkConfig()
+    {
+        _interruptMode = C64SwiftLinkInterruptMode.IRQ;
+        _receiveMode = C64SwiftLinkReceiveMode.Compatible;
+        _cartridgeIOAddress = C64CartridgeIOAddress.DE00;
+        _enabled = false;
+    }
+
+    public void SetDirtyCallback(Action? markDirty) => _markDirty = markDirty;
+
+    public C64SwiftLinkConfig Clone()
+    {
+        var clone = (C64SwiftLinkConfig)MemberwiseClone();
+        clone._markDirty = null;
+        return clone;
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLink/C64SwiftLinkHostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLink/C64SwiftLinkHostConfig.cs
@@ -1,0 +1,68 @@
+using System.Text.Json.Serialization;
+
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
+
+public class C64SwiftLinkHostConfig
+{
+    [JsonIgnore]
+    private Action? _markDirty;
+
+    private C64SwiftLinkTransportMode _transportMode;
+    [JsonConverter(typeof(JsonStringEnumConverter<C64SwiftLinkTransportMode>))]
+    public C64SwiftLinkTransportMode TransportMode
+    {
+        get => _transportMode;
+        set
+        {
+            _transportMode = value;
+            _markDirty?.Invoke();
+        }
+    }
+
+    private string _tcpHost = "127.0.0.1";
+    public string TcpHost
+    {
+        get => _tcpHost;
+        set
+        {
+            _tcpHost = value;
+            _markDirty?.Invoke();
+        }
+    }
+
+    private int _tcpPort = 5000;
+    public int TcpPort
+    {
+        get => _tcpPort;
+        set
+        {
+            _tcpPort = value;
+            _markDirty?.Invoke();
+        }
+    }
+
+    private bool _connectOnBoot;
+    public bool ConnectOnBoot
+    {
+        get => _connectOnBoot;
+        set
+        {
+            _connectOnBoot = value;
+            _markDirty?.Invoke();
+        }
+    }
+
+    public C64SwiftLinkHostConfig()
+    {
+        _transportMode = C64SwiftLinkTransportMode.RawTcp;
+    }
+
+    public void SetDirtyCallback(Action? markDirty) => _markDirty = markDirty;
+
+    public C64SwiftLinkHostConfig Clone()
+    {
+        var clone = (C64SwiftLinkHostConfig)MemberwiseClone();
+        clone._markDirty = null;
+        return clone;
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLink/C64SwiftLinkHostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLink/C64SwiftLinkHostConfig.cs
@@ -59,6 +59,35 @@ public class C64SwiftLinkHostConfig
 
     public void SetDirtyCallback(Action? markDirty) => _markDirty = markDirty;
 
+    public bool IsValid(out List<string> validationErrors, string configPath = nameof(C64SwiftLinkHostConfig))
+    {
+        validationErrors = new List<string>();
+
+        if (!Enum.IsDefined(TransportMode))
+            validationErrors.Add($"{configPath}.{nameof(TransportMode)} has an invalid value.");
+
+        if (TransportMode == C64SwiftLinkTransportMode.RawTcp)
+        {
+            if (string.IsNullOrWhiteSpace(TcpHost))
+            {
+                validationErrors.Add($"{configPath}.{nameof(TcpHost)} must be set for RawTcp mode.");
+            }
+            else if (Uri.CheckHostName(TcpHost.Trim()) == UriHostNameType.Unknown)
+            {
+                validationErrors.Add($"{configPath}.{nameof(TcpHost)} must be a valid host name or IP address.");
+            }
+        }
+        else if (TransportMode == C64SwiftLinkTransportMode.HayesModem && ConnectOnBoot)
+        {
+            validationErrors.Add($"{configPath}.{nameof(ConnectOnBoot)} can only be enabled in RawTcp mode.");
+        }
+
+        if (TcpPort is < 1 or > 65535)
+            validationErrors.Add($"{configPath}.{nameof(TcpPort)} must be between 1 and 65535.");
+
+        return validationErrors.Count == 0;
+    }
+
     public C64SwiftLinkHostConfig Clone()
     {
         var clone = (C64SwiftLinkHostConfig)MemberwiseClone();

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLink/C64SwiftLinkInterruptMode.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLink/C64SwiftLinkInterruptMode.cs
@@ -1,0 +1,7 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
+
+public enum C64SwiftLinkInterruptMode
+{
+    IRQ = 0,
+    NMI = 1,
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLink/C64SwiftLinkReceiveMode.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLink/C64SwiftLinkReceiveMode.cs
@@ -1,4 +1,4 @@
-namespace Highbyte.DotNet6502.Systems.Commodore64.Config;
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 
 public enum C64SwiftLinkReceiveMode
 {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLink/C64SwiftLinkTransportMode.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLink/C64SwiftLinkTransportMode.cs
@@ -1,0 +1,7 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
+
+public enum C64SwiftLinkTransportMode
+{
+    RawTcp,
+    HayesModem
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLink/IC64SwiftLinkTcpHostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLink/IC64SwiftLinkTcpHostConfig.cs
@@ -1,4 +1,4 @@
-namespace Highbyte.DotNet6502.Systems.Commodore64.Config;
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 
 public interface IC64SwiftLinkTcpHostConfig
 {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
@@ -1,6 +1,7 @@
 using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 using Highbyte.DotNet6502.Systems.Commodore64.Transport;
 using Microsoft.Extensions.Logging;
+using System.Text;
 
 namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
 
@@ -16,6 +17,7 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     private const byte CommandTransmitterControlMask = 0b0000_1100;
     private const byte CommandTransmitterIrqControl = 0b0000_0100;
     private const string IrqSourceName = "SwiftLink";
+    private const int DiagnosticHistorySize = 24;
 
     private readonly ILogger _logger;
     private readonly ushort _baseAddress;
@@ -31,6 +33,9 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     private byte? _lastLoggedStatusValue;
     private int _statusReadCount;
     private ulong _nextReceiveCycleAvailable;
+    private readonly string?[] _diagnosticHistory = new string?[DiagnosticHistorySize];
+    private int _diagnosticHistoryNextIndex;
+    private int _diagnosticHistoryCount;
 
     public SwiftLinkDevice(C64CartridgeIOAddress baseAddress, ILogger logger)
     {
@@ -44,6 +49,10 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     public C64SwiftLinkInterruptMode InterruptMode { get; set; } = C64SwiftLinkInterruptMode.IRQ;
     public C64SwiftLinkReceiveMode ReceiveMode { get; set; } = C64SwiftLinkReceiveMode.Compatible;
     public Func<ulong>? GetCurrentCycleCount { get; set; }
+    // Optional device-specific compatibility hook. When unset, NMI is asserted as soon as
+    // SwiftLink marks its receive interrupt pending. C64 currently uses this for software
+    // that temporarily banks out the mapped NMI vector area.
+    public Func<bool>? CanDeliverNmi { get; set; }
     public ulong ReceivePacingCycles { get; set; }
     public ushort BaseAddress => _baseAddress;
 
@@ -68,17 +77,12 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
             CompletePendingSend();
         }
 
+        TryAssertDeferredNmi();
+
         if (_rxFull)
             return;
 
-        if (ReceivePacingCycles > 0)
-        {
-            var currentCycles = GetCurrentCycleCount?.Invoke() ?? 0;
-            if (currentCycles < _nextReceiveCycleAvailable)
-                return;
-        }
-
-        TryLatchReceivedByte();
+        TryLatchReceivedByteIfReady();
     }
 
     public void Reset()
@@ -94,6 +98,9 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
         _lastLoggedStatusValue = null;
         _statusReadCount = 0;
         _nextReceiveCycleAvailable = 0;
+        Array.Clear(_diagnosticHistory);
+        _diagnosticHistoryNextIndex = 0;
+        _diagnosticHistoryCount = 0;
         ClearIrqPending();
         Transport?.Reset();
     }
@@ -103,6 +110,7 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
         var value = _rxData;
         _rxFull = false;
         _logger.LogDebug("SwiftLink DATA read returned 0x{Value:X2}.", value);
+        RecordDiagnosticEvent($"DATA read 0x{value:X2}");
         return value;
     }
 
@@ -115,6 +123,7 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
         }
 
         _logger.LogDebug("SwiftLink DATA write sent 0x{Value:X2}.", value);
+        RecordDiagnosticEvent($"DATA write 0x{value:X2}");
         _txEmpty = false;
         var transport = Transport;
         if (transport == null)
@@ -204,6 +213,7 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     {
         _commandRegister = value;
         _logger.LogDebug("SwiftLink command register set to 0x{Value:X2}.", value);
+        RecordDiagnosticEvent($"COMMAND=0x{value:X2}");
 
         if (!InterruptsEnabled || !ReceiveInterruptEnabled)
             ClearIrqPending();
@@ -218,6 +228,7 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     {
         _controlRegister = value;
         _logger.LogDebug("SwiftLink control register set to 0x{Value:X2}.", value);
+        RecordDiagnosticEvent($"CONTROL=0x{value:X2}");
     }
 
     private void CompletePendingSend()
@@ -266,8 +277,9 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
             InterruptMode,
             _rxFull,
             _txEmpty);
+        RecordDiagnosticEvent($"IRQ set mode={InterruptMode} rx={_rxFull} tx={_txEmpty}");
         if (InterruptMode == C64SwiftLinkInterruptMode.NMI)
-            CpuInterrupts?.SetNMISourceActive(IrqSourceName);
+            TryAssertDeferredNmi();
         else
             CpuInterrupts?.SetIRQSourceActive(IrqSourceName, autoAcknowledge: false);
     }
@@ -276,6 +288,7 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     {
         _irqPending = false;
         _logger.LogDebug("SwiftLink {InterruptMode} pending cleared.", InterruptMode);
+        RecordDiagnosticEvent($"IRQ clear mode={InterruptMode}");
         if (InterruptMode == C64SwiftLinkInterruptMode.NMI)
             CpuInterrupts?.SetNMISourceInactive(IrqSourceName);
         else
@@ -285,6 +298,26 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     private bool IsCarrierDetected => Transport?.IsCarrierDetected == true;
 
     private bool IsDataSetReady => Transport?.IsDataSetReady == true;
+
+    private void TryAssertDeferredNmi()
+    {
+        if (!_irqPending || InterruptMode != C64SwiftLinkInterruptMode.NMI)
+            return;
+
+        if (CpuInterrupts?.IsNMISourceActive(IrqSourceName) == true)
+            return;
+
+        if (CanDeliverNmi?.Invoke() == false)
+        {
+            // SwiftLink-specific compatibility behavior: keep the pending receive state but
+            // avoid asserting the NMI source until the mapped NMI vector is usable again.
+            RecordDiagnosticEvent("NMI deferred");
+            return;
+        }
+
+        CpuInterrupts?.SetNMISourceActive(IrqSourceName);
+        RecordDiagnosticEvent("NMI asserted");
+    }
 
     private void TryLatchReceivedByte()
     {
@@ -299,7 +332,20 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
             _nextReceiveCycleAvailable = currentCycles + ReceivePacingCycles;
         }
         _logger.LogDebug("SwiftLink RX latched byte 0x{Value:X2}.", value);
+        RecordDiagnosticEvent($"RX latch 0x{value:X2}");
         RaiseReceiveIrqIfEnabled();
+    }
+
+    private void TryLatchReceivedByteIfReady()
+    {
+        if (ReceivePacingCycles > 0)
+        {
+            var currentCycles = GetCurrentCycleCount?.Invoke() ?? 0;
+            if (currentCycles < _nextReceiveCycleAvailable)
+                return;
+        }
+
+        TryLatchReceivedByte();
     }
 
     private void UpdateConnectionState()
@@ -314,8 +360,53 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
             _logger.LogInformation("SwiftLink TCP transport {State}.", isConnected ? "connected" : "disconnected");
         else
             _logger.LogDebug("SwiftLink TCP transport initial state is {State}.", isConnected ? "connected" : "disconnected");
+        RecordDiagnosticEvent($"Transport {(isConnected ? "connected" : "disconnected")}");
 
         if (hadPreviousState && ReceiveInterruptEnabled)
             SetIrqPending();
+    }
+
+    private void RecordDiagnosticEvent(string message)
+    {
+        var cycle = GetCurrentCycleCount?.Invoke() ?? 0;
+        _diagnosticHistory[_diagnosticHistoryNextIndex] = $"{cycle}:{message}";
+        _diagnosticHistoryNextIndex = (_diagnosticHistoryNextIndex + 1) % DiagnosticHistorySize;
+        if (_diagnosticHistoryCount < DiagnosticHistorySize)
+            _diagnosticHistoryCount++;
+    }
+
+    private string GetDiagnosticHistory()
+    {
+        if (_diagnosticHistoryCount == 0)
+            return "-";
+
+        var sb = new StringBuilder();
+        var startIndex = (_diagnosticHistoryNextIndex - _diagnosticHistoryCount + DiagnosticHistorySize) % DiagnosticHistorySize;
+        for (var i = 0; i < _diagnosticHistoryCount; i++)
+        {
+            if (i > 0)
+                sb.Append(" | ");
+            var entryIndex = (startIndex + i) % DiagnosticHistorySize;
+            sb.Append(_diagnosticHistory[entryIndex]);
+        }
+        return sb.ToString();
+    }
+
+    // Targeted troubleshooting helpers: keep the capture local to SwiftLink so future
+    // investigations can log GetDiagnosticState() from a caller without adding ad hoc
+    // logging back into the broader C64 execution path.
+    public string GetDiagnosticState()
+    {
+        var transport = Transport;
+        return
+            $"Base=0x{_baseAddress:X4}, " +
+            $"InterruptMode={InterruptMode}, ReceiveMode={ReceiveMode}, " +
+            $"RX_FULL={_rxFull}, RX_DATA=0x{_rxData:X2}, TX_EMPTY={_txEmpty}, IRQ_PENDING={_irqPending}, " +
+            $"CMD=0x{_commandRegister:X2}, CTRL=0x{_controlRegister:X2}, " +
+            $"IRQ_ENABLED={InterruptsEnabled}, RX_IRQ_ENABLED={ReceiveInterruptEnabled}, TX_IRQ_ENABLED={TransmitInterruptEnabled}, " +
+            $"CARRIER={IsCarrierDetected}, DSR_READY={IsDataSetReady}, " +
+            $"TRANSPORT_CONNECTED={transport?.IsConnected == true}, NMI_DELIVERABLE={CanDeliverNmi?.Invoke()}, " +
+            $"NEXT_RX_CYCLE={_nextReceiveCycleAvailable}, STATUS_READS={_statusReadCount}, " +
+            $"HISTORY=[{GetDiagnosticHistory()}]";
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
@@ -1,4 +1,4 @@
-using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 using Highbyte.DotNet6502.Systems.Commodore64.Transport;
 using Microsoft.Extensions.Logging;
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
@@ -30,7 +30,7 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     private bool? _lastConnectedState;
     private byte? _lastLoggedStatusValue;
     private int _statusReadCount;
-    private bool _receivePollRequested = true;
+    private ulong _nextReceiveCycleAvailable;
 
     public SwiftLinkDevice(C64CartridgeIOAddress baseAddress, ILogger logger)
     {
@@ -43,6 +43,8 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     public CPUInterrupts? CpuInterrupts { get; set; }
     public C64SwiftLinkInterruptMode InterruptMode { get; set; } = C64SwiftLinkInterruptMode.IRQ;
     public C64SwiftLinkReceiveMode ReceiveMode { get; set; } = C64SwiftLinkReceiveMode.Compatible;
+    public Func<ulong>? GetCurrentCycleCount { get; set; }
+    public ulong ReceivePacingCycles { get; set; }
     public ushort BaseAddress => _baseAddress;
 
     public void MapIOLocations(Memory mem)
@@ -69,16 +71,13 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
         if (_rxFull)
             return;
 
-        if (ReceiveMode == C64SwiftLinkReceiveMode.FastBuffered)
+        if (ReceivePacingCycles > 0)
         {
-            TryLatchReceivedByte();
-            return;
+            var currentCycles = GetCurrentCycleCount?.Invoke() ?? 0;
+            if (currentCycles < _nextReceiveCycleAvailable)
+                return;
         }
 
-        if (!_receivePollRequested)
-            return;
-
-        _receivePollRequested = false;
         TryLatchReceivedByte();
     }
 
@@ -94,14 +93,13 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
         _lastConnectedState = null;
         _lastLoggedStatusValue = null;
         _statusReadCount = 0;
-        _receivePollRequested = true;
+        _nextReceiveCycleAvailable = 0;
         ClearIrqPending();
         Transport?.Reset();
     }
 
     private byte DataLoad(ushort _)
     {
-        RequestReceivePoll();
         var value = _rxData;
         _rxFull = false;
         _logger.LogDebug("SwiftLink DATA read returned 0x{Value:X2}.", value);
@@ -110,14 +108,18 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
 
     private void DataStore(ushort _, byte value)
     {
-        RequestReceivePoll();
         if (!_txEmpty)
+        {
+            _logger.LogDebug("SwiftLink DATA write dropped while TX not empty: 0x{Value:X2}.", value);
             return;
+        }
 
+        _logger.LogDebug("SwiftLink DATA write sent 0x{Value:X2}.", value);
         _txEmpty = false;
         var transport = Transport;
         if (transport == null)
         {
+            _logger.LogDebug("SwiftLink DATA write had no transport attached.");
             _txEmpty = true;
             return;
         }
@@ -145,7 +147,6 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
 
     private byte StatusLoad(ushort _)
     {
-        RequestReceivePoll();
         byte value = 0;
         // Match the C64-specific behavior used by VICE's ACIA emulation more closely:
         // software tends to observe carrier readiness through the DSR bit, while DCD is
@@ -191,19 +192,16 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
 
     private void StatusStore(ushort _, byte __)
     {
-        RequestReceivePoll();
         Reset();
     }
 
     private byte CommandLoad(ushort _)
     {
-        RequestReceivePoll();
         return _commandRegister;
     }
 
     private void CommandStore(ushort _, byte value)
     {
-        RequestReceivePoll();
         _commandRegister = value;
         _logger.LogDebug("SwiftLink command register set to 0x{Value:X2}.", value);
 
@@ -213,13 +211,11 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
 
     private byte ControlLoad(ushort _)
     {
-        RequestReceivePoll();
         return _controlRegister;
     }
 
     private void ControlStore(ushort _, byte value)
     {
-        RequestReceivePoll();
         _controlRegister = value;
         _logger.LogDebug("SwiftLink control register set to 0x{Value:X2}.", value);
     }
@@ -290,12 +286,6 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
 
     private bool IsDataSetReady => Transport?.IsDataSetReady == true;
 
-    private void RequestReceivePoll()
-    {
-        if (ReceiveMode == C64SwiftLinkReceiveMode.Compatible)
-            _receivePollRequested = true;
-    }
-
     private void TryLatchReceivedByte()
     {
         if (Transport?.TryDequeueReceivedByte(out var value) != true)
@@ -303,6 +293,11 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
 
         _rxData = value;
         _rxFull = true;
+        if (ReceivePacingCycles > 0)
+        {
+            var currentCycles = GetCurrentCycleCount?.Invoke() ?? 0;
+            _nextReceiveCycleAvailable = currentCycles + ReceivePacingCycles;
+        }
         _logger.LogDebug("SwiftLink RX latched byte 0x{Value:X2}.", value);
         RaiseReceiveIrqIfEnabled();
     }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
@@ -9,6 +9,11 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     private const byte StatusRxFullBit = 1 << 3;
     private const byte StatusTxEmptyBit = 1 << 4;
     private const byte StatusIrqBit = 1 << 7;
+    private const byte CommandDtrBit = 1 << 0;
+    private const byte CommandReceiverIrqDisableBit = 1 << 1;
+    private const byte CommandTransmitterControlMask = 0b0000_1100;
+    private const byte CommandTransmitterIrqControl = 0b0000_0100;
+    private const string IrqSourceName = "SwiftLink";
 
     private readonly ILogger _logger;
     private readonly ushort _baseAddress;
@@ -29,6 +34,7 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
 
     public string Name => "SwiftLink";
     public ISwiftLinkTransport? Transport { get; set; }
+    public CPUInterrupts? CpuInterrupts { get; set; }
     public ushort BaseAddress => _baseAddress;
 
     public void MapIOLocations(Memory mem)
@@ -54,6 +60,7 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
         {
             _rxData = value;
             _rxFull = true;
+            RaiseReceiveIrqIfEnabled();
         }
     }
 
@@ -66,6 +73,7 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
         _commandRegister = 0;
         _controlRegister = 0;
         _pendingSendTask = null;
+        ClearIrqPending();
         Transport?.Reset();
     }
 
@@ -119,6 +127,11 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
             value |= StatusTxEmptyBit;
         if (_irqPending)
             value |= StatusIrqBit;
+
+        // The 6551 IRQ status flag is cleared by reading the status register.
+        if (_irqPending)
+            ClearIrqPending();
+
         return value;
     }
 
@@ -130,6 +143,9 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     private void CommandStore(ushort _, byte value)
     {
         _commandRegister = value;
+
+        if (!InterruptsEnabled)
+            ClearIrqPending();
     }
 
     private void ControlStore(ushort _, byte value)
@@ -152,5 +168,38 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
             _logger.LogDebug(pendingSendTask.Exception, "SwiftLink send task faulted.");
 
         _txEmpty = true;
+        RaiseTransmitIrqIfEnabled();
+    }
+
+    private bool InterruptsEnabled => (_commandRegister & CommandDtrBit) != 0;
+
+    private bool ReceiveInterruptEnabled
+        => InterruptsEnabled && (_commandRegister & CommandReceiverIrqDisableBit) == 0;
+
+    private bool TransmitInterruptEnabled
+        => InterruptsEnabled && (_commandRegister & CommandTransmitterControlMask) == CommandTransmitterIrqControl;
+
+    private void RaiseReceiveIrqIfEnabled()
+    {
+        if (_rxFull && ReceiveInterruptEnabled)
+            SetIrqPending();
+    }
+
+    private void RaiseTransmitIrqIfEnabled()
+    {
+        if (_txEmpty && TransmitInterruptEnabled)
+            SetIrqPending();
+    }
+
+    private void SetIrqPending()
+    {
+        _irqPending = true;
+        CpuInterrupts?.SetIRQSourceActive(IrqSourceName, autoAcknowledge: false);
+    }
+
+    private void ClearIrqPending()
+    {
+        _irqPending = false;
+        CpuInterrupts?.SetIRQSourceInactive(IrqSourceName);
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
@@ -1,0 +1,156 @@
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Systems.Commodore64.Transport;
+using Microsoft.Extensions.Logging;
+
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+
+public sealed class SwiftLinkDevice : IC64CartridgeDevice
+{
+    private const byte StatusRxFullBit = 1 << 3;
+    private const byte StatusTxEmptyBit = 1 << 4;
+    private const byte StatusIrqBit = 1 << 7;
+
+    private readonly ILogger _logger;
+    private readonly ushort _baseAddress;
+
+    private byte _rxData;
+    private bool _rxFull;
+    private bool _txEmpty = true;
+    private bool _irqPending;
+    private byte _commandRegister;
+    private byte _controlRegister;
+    private Task? _pendingSendTask;
+
+    public SwiftLinkDevice(C64CartridgeIOAddress baseAddress, ILogger logger)
+    {
+        _baseAddress = baseAddress == C64CartridgeIOAddress.DF00 ? (ushort)0xDF00 : (ushort)0xDE00;
+        _logger = logger;
+    }
+
+    public string Name => "SwiftLink";
+    public ISwiftLinkTransport? Transport { get; set; }
+    public ushort BaseAddress => _baseAddress;
+
+    public void MapIOLocations(Memory mem)
+    {
+        mem.MapReader((ushort)(_baseAddress + 0x00), DataLoad);
+        mem.MapWriter((ushort)(_baseAddress + 0x00), DataStore);
+        mem.MapReader((ushort)(_baseAddress + 0x01), StatusLoad);
+        mem.MapWriter((ushort)(_baseAddress + 0x01), StatusStore);
+        mem.MapReader((ushort)(_baseAddress + 0x02), (_) => _commandRegister);
+        mem.MapWriter((ushort)(_baseAddress + 0x02), CommandStore);
+        mem.MapReader((ushort)(_baseAddress + 0x03), (_) => _controlRegister);
+        mem.MapWriter((ushort)(_baseAddress + 0x03), ControlStore);
+    }
+
+    public void Tick()
+    {
+        if (_pendingSendTask != null && _pendingSendTask.IsCompleted)
+        {
+            CompletePendingSend();
+        }
+
+        if (!_rxFull && Transport?.TryDequeueReceivedByte(out var value) == true)
+        {
+            _rxData = value;
+            _rxFull = true;
+        }
+    }
+
+    public void Reset()
+    {
+        _rxData = 0;
+        _rxFull = false;
+        _txEmpty = true;
+        _irqPending = false;
+        _commandRegister = 0;
+        _controlRegister = 0;
+        _pendingSendTask = null;
+        Transport?.Reset();
+    }
+
+    private byte DataLoad(ushort _)
+    {
+        var value = _rxData;
+        _rxFull = false;
+        return value;
+    }
+
+    private void DataStore(ushort _, byte value)
+    {
+        if (!_txEmpty)
+            return;
+
+        _txEmpty = false;
+        var transport = Transport;
+        if (transport == null)
+        {
+            _txEmpty = true;
+            return;
+        }
+
+        try
+        {
+            var sendTask = transport.SendAsync(value).AsTask();
+            if (sendTask.IsCompleted)
+            {
+                _pendingSendTask = sendTask;
+                CompletePendingSend();
+            }
+            else
+            {
+                _pendingSendTask = sendTask;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "SwiftLink send failed.");
+            _pendingSendTask = null;
+            _txEmpty = true;
+        }
+    }
+
+    private byte StatusLoad(ushort _)
+    {
+        byte value = 0;
+        if (_rxFull)
+            value |= StatusRxFullBit;
+        if (_txEmpty)
+            value |= StatusTxEmptyBit;
+        if (_irqPending)
+            value |= StatusIrqBit;
+        return value;
+    }
+
+    private void StatusStore(ushort _, byte __)
+    {
+        Reset();
+    }
+
+    private void CommandStore(ushort _, byte value)
+    {
+        _commandRegister = value;
+    }
+
+    private void ControlStore(ushort _, byte value)
+    {
+        _controlRegister = value;
+    }
+
+    private void CompletePendingSend()
+    {
+        var pendingSendTask = _pendingSendTask;
+        _pendingSendTask = null;
+
+        if (pendingSendTask == null)
+        {
+            _txEmpty = true;
+            return;
+        }
+
+        if (pendingSendTask.IsFaulted)
+            _logger.LogDebug(pendingSendTask.Exception, "SwiftLink send task faulted.");
+
+        _txEmpty = true;
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
@@ -8,6 +8,8 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
 {
     private const byte StatusRxFullBit = 1 << 3;
     private const byte StatusTxEmptyBit = 1 << 4;
+    private const byte StatusDcdBit = 1 << 5;
+    private const byte StatusDsrBit = 1 << 6;
     private const byte StatusIrqBit = 1 << 7;
     private const byte CommandDtrBit = 1 << 0;
     private const byte CommandReceiverIrqDisableBit = 1 << 1;
@@ -25,6 +27,7 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     private byte _commandRegister;
     private byte _controlRegister;
     private Task? _pendingSendTask;
+    private bool? _lastConnectedState;
 
     public SwiftLinkDevice(C64CartridgeIOAddress baseAddress, ILogger logger)
     {
@@ -35,6 +38,7 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     public string Name => "SwiftLink";
     public ISwiftLinkTransport? Transport { get; set; }
     public CPUInterrupts? CpuInterrupts { get; set; }
+    public C64SwiftLinkInterruptMode InterruptMode { get; set; } = C64SwiftLinkInterruptMode.IRQ;
     public ushort BaseAddress => _baseAddress;
 
     public void MapIOLocations(Memory mem)
@@ -51,6 +55,8 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
 
     public void Tick()
     {
+        UpdateConnectionState();
+
         if (_pendingSendTask != null && _pendingSendTask.IsCompleted)
         {
             CompletePendingSend();
@@ -73,6 +79,7 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
         _commandRegister = 0;
         _controlRegister = 0;
         _pendingSendTask = null;
+        _lastConnectedState = null;
         ClearIrqPending();
         Transport?.Reset();
     }
@@ -121,6 +128,10 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     private byte StatusLoad(ushort _)
     {
         byte value = 0;
+        if (!IsCarrierDetected)
+            value |= StatusDcdBit;
+        if (!IsDataSetReady)
+            value |= StatusDsrBit;
         if (_rxFull)
             value |= StatusRxFullBit;
         if (_txEmpty)
@@ -143,14 +154,16 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     private void CommandStore(ushort _, byte value)
     {
         _commandRegister = value;
+        _logger.LogDebug("SwiftLink command register set to 0x{Value:X2}.", value);
 
-        if (!InterruptsEnabled)
+        if (!InterruptsEnabled || !ReceiveInterruptEnabled)
             ClearIrqPending();
     }
 
     private void ControlStore(ushort _, byte value)
     {
         _controlRegister = value;
+        _logger.LogDebug("SwiftLink control register set to 0x{Value:X2}.", value);
     }
 
     private void CompletePendingSend()
@@ -194,12 +207,39 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     private void SetIrqPending()
     {
         _irqPending = true;
-        CpuInterrupts?.SetIRQSourceActive(IrqSourceName, autoAcknowledge: false);
+        if (InterruptMode == C64SwiftLinkInterruptMode.NMI)
+            CpuInterrupts?.SetNMISourceActive(IrqSourceName);
+        else
+            CpuInterrupts?.SetIRQSourceActive(IrqSourceName, autoAcknowledge: false);
     }
 
     private void ClearIrqPending()
     {
         _irqPending = false;
-        CpuInterrupts?.SetIRQSourceInactive(IrqSourceName);
+        if (InterruptMode == C64SwiftLinkInterruptMode.NMI)
+            CpuInterrupts?.SetNMISourceInactive(IrqSourceName);
+        else
+            CpuInterrupts?.SetIRQSourceInactive(IrqSourceName);
+    }
+
+    private bool IsCarrierDetected => Transport?.IsConnected == true;
+
+    private bool IsDataSetReady => Transport?.IsConnected == true;
+
+    private void UpdateConnectionState()
+    {
+        var isConnected = Transport?.IsConnected == true;
+        if (_lastConnectedState == isConnected)
+            return;
+
+        var hadPreviousState = _lastConnectedState.HasValue;
+        _lastConnectedState = isConnected;
+        if (hadPreviousState)
+            _logger.LogInformation("SwiftLink TCP transport {State}.", isConnected ? "connected" : "disconnected");
+        else
+            _logger.LogDebug("SwiftLink TCP transport initial state is {State}.", isConnected ? "connected" : "disconnected");
+
+        if (hadPreviousState && ReceiveInterruptEnabled)
+            SetIrqPending();
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
@@ -28,6 +28,9 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     private byte _controlRegister;
     private Task? _pendingSendTask;
     private bool? _lastConnectedState;
+    private byte? _lastLoggedStatusValue;
+    private int _statusReadCount;
+    private bool _receivePollRequested = true;
 
     public SwiftLinkDevice(C64CartridgeIOAddress baseAddress, ILogger logger)
     {
@@ -39,6 +42,7 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     public ISwiftLinkTransport? Transport { get; set; }
     public CPUInterrupts? CpuInterrupts { get; set; }
     public C64SwiftLinkInterruptMode InterruptMode { get; set; } = C64SwiftLinkInterruptMode.IRQ;
+    public C64SwiftLinkReceiveMode ReceiveMode { get; set; } = C64SwiftLinkReceiveMode.Compatible;
     public ushort BaseAddress => _baseAddress;
 
     public void MapIOLocations(Memory mem)
@@ -47,9 +51,9 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
         mem.MapWriter((ushort)(_baseAddress + 0x00), DataStore);
         mem.MapReader((ushort)(_baseAddress + 0x01), StatusLoad);
         mem.MapWriter((ushort)(_baseAddress + 0x01), StatusStore);
-        mem.MapReader((ushort)(_baseAddress + 0x02), (_) => _commandRegister);
+        mem.MapReader((ushort)(_baseAddress + 0x02), CommandLoad);
         mem.MapWriter((ushort)(_baseAddress + 0x02), CommandStore);
-        mem.MapReader((ushort)(_baseAddress + 0x03), (_) => _controlRegister);
+        mem.MapReader((ushort)(_baseAddress + 0x03), ControlLoad);
         mem.MapWriter((ushort)(_baseAddress + 0x03), ControlStore);
     }
 
@@ -62,12 +66,20 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
             CompletePendingSend();
         }
 
-        if (!_rxFull && Transport?.TryDequeueReceivedByte(out var value) == true)
+        if (_rxFull)
+            return;
+
+        if (ReceiveMode == C64SwiftLinkReceiveMode.FastBuffered)
         {
-            _rxData = value;
-            _rxFull = true;
-            RaiseReceiveIrqIfEnabled();
+            TryLatchReceivedByte();
+            return;
         }
+
+        if (!_receivePollRequested)
+            return;
+
+        _receivePollRequested = false;
+        TryLatchReceivedByte();
     }
 
     public void Reset()
@@ -80,19 +92,25 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
         _controlRegister = 0;
         _pendingSendTask = null;
         _lastConnectedState = null;
+        _lastLoggedStatusValue = null;
+        _statusReadCount = 0;
+        _receivePollRequested = true;
         ClearIrqPending();
         Transport?.Reset();
     }
 
     private byte DataLoad(ushort _)
     {
+        RequestReceivePoll();
         var value = _rxData;
         _rxFull = false;
+        _logger.LogDebug("SwiftLink DATA read returned 0x{Value:X2}.", value);
         return value;
     }
 
     private void DataStore(ushort _, byte value)
     {
+        RequestReceivePoll();
         if (!_txEmpty)
             return;
 
@@ -127,9 +145,11 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
 
     private byte StatusLoad(ushort _)
     {
+        RequestReceivePoll();
         byte value = 0;
-        if (!IsCarrierDetected)
-            value |= StatusDcdBit;
+        // Match the C64-specific behavior used by VICE's ACIA emulation more closely:
+        // software tends to observe carrier readiness through the DSR bit, while DCD is
+        // not surfaced in a useful way on C64-class machines.
         if (!IsDataSetReady)
             value |= StatusDsrBit;
         if (_rxFull)
@@ -138,6 +158,29 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
             value |= StatusTxEmptyBit;
         if (_irqPending)
             value |= StatusIrqBit;
+
+        _statusReadCount++;
+        if (_statusReadCount <= 200)
+        {
+            _logger.LogDebug(
+                "SwiftLink STATUS read #{Count}: 0x{Value:X2} (RX_FULL={RxFull}, TX_EMPTY={TxEmpty}, IRQ={IrqPending}, DSR_READY={DsrReady}, CARRIER={Carrier}).",
+                _statusReadCount,
+                value,
+                _rxFull,
+                _txEmpty,
+                _irqPending,
+                IsDataSetReady,
+                IsCarrierDetected);
+        }
+        else if (_lastLoggedStatusValue != value)
+        {
+            _logger.LogDebug("SwiftLink STATUS read returned 0x{Value:X2}.", value);
+            _lastLoggedStatusValue = value;
+        }
+        else
+        {
+            _lastLoggedStatusValue = value;
+        }
 
         // The 6551 IRQ status flag is cleared by reading the status register.
         if (_irqPending)
@@ -148,11 +191,19 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
 
     private void StatusStore(ushort _, byte __)
     {
+        RequestReceivePoll();
         Reset();
+    }
+
+    private byte CommandLoad(ushort _)
+    {
+        RequestReceivePoll();
+        return _commandRegister;
     }
 
     private void CommandStore(ushort _, byte value)
     {
+        RequestReceivePoll();
         _commandRegister = value;
         _logger.LogDebug("SwiftLink command register set to 0x{Value:X2}.", value);
 
@@ -160,8 +211,15 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
             ClearIrqPending();
     }
 
+    private byte ControlLoad(ushort _)
+    {
+        RequestReceivePoll();
+        return _controlRegister;
+    }
+
     private void ControlStore(ushort _, byte value)
     {
+        RequestReceivePoll();
         _controlRegister = value;
         _logger.LogDebug("SwiftLink control register set to 0x{Value:X2}.", value);
     }
@@ -207,6 +265,11 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     private void SetIrqPending()
     {
         _irqPending = true;
+        _logger.LogDebug(
+            "SwiftLink {InterruptMode} pending set (RX_FULL={RxFull}, TX_EMPTY={TxEmpty}).",
+            InterruptMode,
+            _rxFull,
+            _txEmpty);
         if (InterruptMode == C64SwiftLinkInterruptMode.NMI)
             CpuInterrupts?.SetNMISourceActive(IrqSourceName);
         else
@@ -216,15 +279,33 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
     private void ClearIrqPending()
     {
         _irqPending = false;
+        _logger.LogDebug("SwiftLink {InterruptMode} pending cleared.", InterruptMode);
         if (InterruptMode == C64SwiftLinkInterruptMode.NMI)
             CpuInterrupts?.SetNMISourceInactive(IrqSourceName);
         else
             CpuInterrupts?.SetIRQSourceInactive(IrqSourceName);
     }
 
-    private bool IsCarrierDetected => Transport?.IsConnected == true;
+    private bool IsCarrierDetected => Transport?.IsCarrierDetected == true;
 
-    private bool IsDataSetReady => Transport?.IsConnected == true;
+    private bool IsDataSetReady => Transport?.IsDataSetReady == true;
+
+    private void RequestReceivePoll()
+    {
+        if (ReceiveMode == C64SwiftLinkReceiveMode.Compatible)
+            _receivePollRequested = true;
+    }
+
+    private void TryLatchReceivedByte()
+    {
+        if (Transport?.TryDequeueReceivedByte(out var value) != true)
+            return;
+
+        _rxData = value;
+        _rxFull = true;
+        _logger.LogDebug("SwiftLink RX latched byte 0x{Value:X2}.", value);
+        RaiseReceiveIrqIfEnabled();
+    }
 
     private void UpdateConnectionState()
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64CartridgeIOAddress.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64CartridgeIOAddress.cs
@@ -1,0 +1,7 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Config;
+
+public enum C64CartridgeIOAddress
+{
+    DE00 = 0,
+    DF00 = 1,
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64CartridgeIOAddress.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64CartridgeIOAddress.cs
@@ -1,7 +1,0 @@
-namespace Highbyte.DotNet6502.Systems.Commodore64.Config;
-
-public enum C64CartridgeIOAddress
-{
-    DE00 = 0,
-    DF00 = 1,
-}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64Config.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64Config.cs
@@ -28,6 +28,7 @@ public class C64Config
     public bool SwiftLinkEnabled { get; set; }
     public C64CartridgeIOAddress SwiftLinkCartridgeIOAddress { get; set; }
     public C64SwiftLinkInterruptMode SwiftLinkInterruptMode { get; set; }
+    public C64SwiftLinkReceiveMode SwiftLinkReceiveMode { get; set; }
     public Type? RenderProviderType { get; set; }
     public Type? AudioProviderType { get; set; }
     public SidEmulationMode SidEmulationMode { get; set; } = SidEmulationMode.Auto;
@@ -50,6 +51,7 @@ public class C64Config
         SwiftLinkEnabled = false;
         SwiftLinkCartridgeIOAddress = C64CartridgeIOAddress.DE00;
         SwiftLinkInterruptMode = C64SwiftLinkInterruptMode.IRQ;
+        SwiftLinkReceiveMode = C64SwiftLinkReceiveMode.Compatible;
 
         // Settings not currently changeable by user
         TimerMode = TimerMode.UpdateEachRasterLine;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64Config.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64Config.cs
@@ -25,6 +25,8 @@ public class C64Config
     public bool KeyboardJoystickEnabled { get; set; }
     public int KeyboardJoystick { get; set; }
     public C64KeyboardJoystickMap KeyboardJoystickMap { get; set; }
+    public bool SwiftLinkEnabled { get; set; }
+    public C64CartridgeIOAddress SwiftLinkCartridgeIOAddress { get; set; }
     public Type? RenderProviderType { get; set; }
     public Type? AudioProviderType { get; set; }
     public SidEmulationMode SidEmulationMode { get; set; } = SidEmulationMode.Auto;
@@ -44,6 +46,8 @@ public class C64Config
         AudioEnabled = false;
         KeyboardJoystickEnabled = false;
         KeyboardJoystick = 2;
+        SwiftLinkEnabled = false;
+        SwiftLinkCartridgeIOAddress = C64CartridgeIOAddress.DE00;
 
         // Settings not currently changeable by user
         TimerMode = TimerMode.UpdateEachRasterLine;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64Config.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64Config.cs
@@ -1,4 +1,5 @@
 using Highbyte.DotNet6502.Systems.Commodore64.Audio.Sample;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 using Highbyte.DotNet6502.Systems.Commodore64.Video;
 
 namespace Highbyte.DotNet6502.Systems.Commodore64.Config;
@@ -25,10 +26,7 @@ public class C64Config
     public bool KeyboardJoystickEnabled { get; set; }
     public int KeyboardJoystick { get; set; }
     public C64KeyboardJoystickMap KeyboardJoystickMap { get; set; }
-    public bool SwiftLinkEnabled { get; set; }
-    public C64CartridgeIOAddress SwiftLinkCartridgeIOAddress { get; set; }
-    public C64SwiftLinkInterruptMode SwiftLinkInterruptMode { get; set; }
-    public C64SwiftLinkReceiveMode SwiftLinkReceiveMode { get; set; }
+    public C64SwiftLinkConfig SwiftLink { get; set; }
     public Type? RenderProviderType { get; set; }
     public Type? AudioProviderType { get; set; }
     public SidEmulationMode SidEmulationMode { get; set; } = SidEmulationMode.Auto;
@@ -48,10 +46,7 @@ public class C64Config
         AudioEnabled = false;
         KeyboardJoystickEnabled = false;
         KeyboardJoystick = 2;
-        SwiftLinkEnabled = false;
-        SwiftLinkCartridgeIOAddress = C64CartridgeIOAddress.DE00;
-        SwiftLinkInterruptMode = C64SwiftLinkInterruptMode.IRQ;
-        SwiftLinkReceiveMode = C64SwiftLinkReceiveMode.Compatible;
+        SwiftLink = new C64SwiftLinkConfig();
 
         // Settings not currently changeable by user
         TimerMode = TimerMode.UpdateEachRasterLine;
@@ -65,6 +60,7 @@ public class C64Config
     {
         var clone = (C64Config)this.MemberwiseClone();
         clone.ROMs = ROM.Clone(ROMs);
+        clone.SwiftLink = SwiftLink.Clone();
         return clone;
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64Config.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64Config.cs
@@ -27,6 +27,7 @@ public class C64Config
     public C64KeyboardJoystickMap KeyboardJoystickMap { get; set; }
     public bool SwiftLinkEnabled { get; set; }
     public C64CartridgeIOAddress SwiftLinkCartridgeIOAddress { get; set; }
+    public C64SwiftLinkInterruptMode SwiftLinkInterruptMode { get; set; }
     public Type? RenderProviderType { get; set; }
     public Type? AudioProviderType { get; set; }
     public SidEmulationMode SidEmulationMode { get; set; } = SidEmulationMode.Auto;
@@ -48,6 +49,7 @@ public class C64Config
         KeyboardJoystick = 2;
         SwiftLinkEnabled = false;
         SwiftLinkCartridgeIOAddress = C64CartridgeIOAddress.DE00;
+        SwiftLinkInterruptMode = C64SwiftLinkInterruptMode.IRQ;
 
         // Settings not currently changeable by user
         TimerMode = TimerMode.UpdateEachRasterLine;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SwiftLinkInterruptMode.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SwiftLinkInterruptMode.cs
@@ -1,0 +1,7 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Config;
+
+public enum C64SwiftLinkInterruptMode
+{
+    IRQ = 0,
+    NMI = 1,
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SwiftLinkInterruptMode.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SwiftLinkInterruptMode.cs
@@ -1,7 +1,0 @@
-namespace Highbyte.DotNet6502.Systems.Commodore64.Config;
-
-public enum C64SwiftLinkInterruptMode
-{
-    IRQ = 0,
-    NMI = 1,
-}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SwiftLinkReceiveMode.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SwiftLinkReceiveMode.cs
@@ -1,0 +1,7 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Config;
+
+public enum C64SwiftLinkReceiveMode
+{
+    Compatible = 0,
+    FastBuffered = 1,
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SwiftLinkTransportMode.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SwiftLinkTransportMode.cs
@@ -1,0 +1,7 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Config;
+
+public enum C64SwiftLinkTransportMode
+{
+    RawTcp,
+    HayesModem
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SwiftLinkTransportMode.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SwiftLinkTransportMode.cs
@@ -1,7 +1,0 @@
-namespace Highbyte.DotNet6502.Systems.Commodore64.Config;
-
-public enum C64SwiftLinkTransportMode
-{
-    RawTcp,
-    HayesModem
-}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SystemConfig.cs
@@ -298,6 +298,28 @@ public class C64SystemConfig : ISystemConfig
         }
     }
 
+    private bool _swiftLinkEnabled;
+    public bool SwiftLinkEnabled
+    {
+        get => _swiftLinkEnabled;
+        set
+        {
+            _swiftLinkEnabled = value;
+            _isDirty = true;
+        }
+    }
+
+    private C64CartridgeIOAddress _swiftLinkCartridgeIOAddress;
+    public C64CartridgeIOAddress SwiftLinkCartridgeIOAddress
+    {
+        get => _swiftLinkCartridgeIOAddress;
+        set
+        {
+            _swiftLinkCartridgeIOAddress = value;
+            _isDirty = true;
+        }
+    }
+
     [JsonIgnore]
     public C64KeyboardJoystickMap KeyboardJoystickMap { get; private set; }
 
@@ -322,6 +344,8 @@ public class C64SystemConfig : ISystemConfig
         _audioEnabled = true;
         _keyboardJoystickEnabled = false;
         _keyboardJoystick = 2;
+        _swiftLinkEnabled = false;
+        _swiftLinkCartridgeIOAddress = C64CartridgeIOAddress.DE00;
 
         KeyboardJoystickMap = new C64KeyboardJoystickMap();
 
@@ -429,6 +453,9 @@ public class C64SystemConfig : ISystemConfig
                     validationErrors.AddRange(romValidationErrors);
             }
         }
+
+        if (!Enum.IsDefined(SwiftLinkCartridgeIOAddress))
+            validationErrors.Add($"{nameof(SwiftLinkCartridgeIOAddress)} has an invalid value.");
 
         return validationErrors.Count == 0;
     }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SystemConfig.cs
@@ -2,6 +2,7 @@ using System.Runtime.InteropServices;
 using System.Text.Json.Serialization;
 using Highbyte.DotNet6502.Systems.Commodore64.Audio;
 using Highbyte.DotNet6502.Systems.Commodore64.Audio.Sample;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 using Highbyte.DotNet6502.Systems.Commodore64.Render.CustomGeneral;
 using Highbyte.DotNet6502.Systems.Commodore64.Render.CustomPayload;
 using Highbyte.DotNet6502.Systems.Commodore64.Render.Rasterizer;
@@ -14,6 +15,8 @@ namespace Highbyte.DotNet6502.Systems.Commodore64.Config;
 public class C64SystemConfig : ISystemConfig
 {
     private bool _isDirty = false;
+    private void MarkDirty() => _isDirty = true;
+
     [JsonIgnore]
     public bool IsDirty => _isDirty;
 
@@ -298,48 +301,14 @@ public class C64SystemConfig : ISystemConfig
         }
     }
 
-    private bool _swiftLinkEnabled;
-    public bool SwiftLinkEnabled
+    private C64SwiftLinkConfig _swiftLink = new();
+    public C64SwiftLinkConfig SwiftLink
     {
-        get => _swiftLinkEnabled;
+        get => _swiftLink;
         set
         {
-            _swiftLinkEnabled = value;
-            _isDirty = true;
-        }
-    }
-
-    private C64CartridgeIOAddress _swiftLinkCartridgeIOAddress;
-    public C64CartridgeIOAddress SwiftLinkCartridgeIOAddress
-    {
-        get => _swiftLinkCartridgeIOAddress;
-        set
-        {
-            _swiftLinkCartridgeIOAddress = value;
-            _isDirty = true;
-        }
-    }
-
-    private C64SwiftLinkInterruptMode _swiftLinkInterruptMode;
-    [JsonConverter(typeof(JsonStringEnumConverter<C64SwiftLinkInterruptMode>))]
-    public C64SwiftLinkInterruptMode SwiftLinkInterruptMode
-    {
-        get => _swiftLinkInterruptMode;
-        set
-        {
-            _swiftLinkInterruptMode = value;
-            _isDirty = true;
-        }
-    }
-
-    private C64SwiftLinkReceiveMode _swiftLinkReceiveMode;
-    [JsonConverter(typeof(JsonStringEnumConverter<C64SwiftLinkReceiveMode>))]
-    public C64SwiftLinkReceiveMode SwiftLinkReceiveMode
-    {
-        get => _swiftLinkReceiveMode;
-        set
-        {
-            _swiftLinkReceiveMode = value;
+            _swiftLink = value ?? new C64SwiftLinkConfig();
+            _swiftLink.SetDirtyCallback(MarkDirty);
             _isDirty = true;
         }
     }
@@ -363,16 +332,13 @@ public class C64SystemConfig : ISystemConfig
             _romDirectory = "%USERPROFILE%/Documents/C64/VICE/C64";
         }
 
-        _swiftLinkInterruptMode = C64SwiftLinkInterruptMode.IRQ;
-        _swiftLinkReceiveMode = C64SwiftLinkReceiveMode.Compatible;
-
         _colorMapName = ColorMaps.DEFAULT_COLOR_MAP_NAME;
 
         _audioEnabled = true;
         _keyboardJoystickEnabled = false;
         _keyboardJoystick = 2;
-        _swiftLinkEnabled = false;
-        _swiftLinkCartridgeIOAddress = C64CartridgeIOAddress.DE00;
+        _swiftLink = new C64SwiftLinkConfig();
+        _swiftLink.SetDirtyCallback(MarkDirty);
 
         KeyboardJoystickMap = new C64KeyboardJoystickMap();
 
@@ -439,6 +405,8 @@ public class C64SystemConfig : ISystemConfig
     {
         var clone = (C64SystemConfig)this.MemberwiseClone();
         clone.ROMs = ROM.Clone(ROMs);
+        clone._swiftLink = SwiftLink.Clone();
+        clone._swiftLink.SetDirtyCallback(clone.MarkDirty);
         return clone;
     }
 
@@ -481,12 +449,12 @@ public class C64SystemConfig : ISystemConfig
             }
         }
 
-        if (!Enum.IsDefined(SwiftLinkCartridgeIOAddress))
-            validationErrors.Add($"{nameof(SwiftLinkCartridgeIOAddress)} has an invalid value.");
-        if (!Enum.IsDefined(SwiftLinkInterruptMode))
-            validationErrors.Add($"{nameof(SwiftLinkInterruptMode)} has an invalid value.");
-        if (!Enum.IsDefined(SwiftLinkReceiveMode))
-            validationErrors.Add($"{nameof(SwiftLinkReceiveMode)} has an invalid value.");
+        if (!Enum.IsDefined(SwiftLink.CartridgeIOAddress))
+            validationErrors.Add($"{nameof(SwiftLink)}.{nameof(SwiftLink.CartridgeIOAddress)} has an invalid value.");
+        if (!Enum.IsDefined(SwiftLink.InterruptMode))
+            validationErrors.Add($"{nameof(SwiftLink)}.{nameof(SwiftLink.InterruptMode)} has an invalid value.");
+        if (!Enum.IsDefined(SwiftLink.ReceiveMode))
+            validationErrors.Add($"{nameof(SwiftLink)}.{nameof(SwiftLink.ReceiveMode)} has an invalid value.");
 
         return validationErrors.Count == 0;
     }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SystemConfig.cs
@@ -320,6 +320,18 @@ public class C64SystemConfig : ISystemConfig
         }
     }
 
+    private C64SwiftLinkInterruptMode _swiftLinkInterruptMode;
+    [JsonConverter(typeof(JsonStringEnumConverter<C64SwiftLinkInterruptMode>))]
+    public C64SwiftLinkInterruptMode SwiftLinkInterruptMode
+    {
+        get => _swiftLinkInterruptMode;
+        set
+        {
+            _swiftLinkInterruptMode = value;
+            _isDirty = true;
+        }
+    }
+
     [JsonIgnore]
     public C64KeyboardJoystickMap KeyboardJoystickMap { get; private set; }
 
@@ -338,6 +350,8 @@ public class C64SystemConfig : ISystemConfig
         {
             _romDirectory = "%USERPROFILE%/Documents/C64/VICE/C64";
         }
+
+        _swiftLinkInterruptMode = C64SwiftLinkInterruptMode.IRQ;
 
         _colorMapName = ColorMaps.DEFAULT_COLOR_MAP_NAME;
 
@@ -456,6 +470,8 @@ public class C64SystemConfig : ISystemConfig
 
         if (!Enum.IsDefined(SwiftLinkCartridgeIOAddress))
             validationErrors.Add($"{nameof(SwiftLinkCartridgeIOAddress)} has an invalid value.");
+        if (!Enum.IsDefined(SwiftLinkInterruptMode))
+            validationErrors.Add($"{nameof(SwiftLinkInterruptMode)} has an invalid value.");
 
         return validationErrors.Count == 0;
     }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SystemConfig.cs
@@ -332,6 +332,18 @@ public class C64SystemConfig : ISystemConfig
         }
     }
 
+    private C64SwiftLinkReceiveMode _swiftLinkReceiveMode;
+    [JsonConverter(typeof(JsonStringEnumConverter<C64SwiftLinkReceiveMode>))]
+    public C64SwiftLinkReceiveMode SwiftLinkReceiveMode
+    {
+        get => _swiftLinkReceiveMode;
+        set
+        {
+            _swiftLinkReceiveMode = value;
+            _isDirty = true;
+        }
+    }
+
     [JsonIgnore]
     public C64KeyboardJoystickMap KeyboardJoystickMap { get; private set; }
 
@@ -352,6 +364,7 @@ public class C64SystemConfig : ISystemConfig
         }
 
         _swiftLinkInterruptMode = C64SwiftLinkInterruptMode.IRQ;
+        _swiftLinkReceiveMode = C64SwiftLinkReceiveMode.Compatible;
 
         _colorMapName = ColorMaps.DEFAULT_COLOR_MAP_NAME;
 
@@ -472,6 +485,8 @@ public class C64SystemConfig : ISystemConfig
             validationErrors.Add($"{nameof(SwiftLinkCartridgeIOAddress)} has an invalid value.");
         if (!Enum.IsDefined(SwiftLinkInterruptMode))
             validationErrors.Add($"{nameof(SwiftLinkInterruptMode)} has an invalid value.");
+        if (!Enum.IsDefined(SwiftLinkReceiveMode))
+            validationErrors.Add($"{nameof(SwiftLinkReceiveMode)} has an invalid value.");
 
         return validationErrors.Count == 0;
     }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SystemConfig.cs
@@ -449,12 +449,16 @@ public class C64SystemConfig : ISystemConfig
             }
         }
 
-        if (!Enum.IsDefined(SwiftLink.CartridgeIOAddress))
-            validationErrors.Add($"{nameof(SwiftLink)}.{nameof(SwiftLink.CartridgeIOAddress)} has an invalid value.");
-        if (!Enum.IsDefined(SwiftLink.InterruptMode))
-            validationErrors.Add($"{nameof(SwiftLink)}.{nameof(SwiftLink.InterruptMode)} has an invalid value.");
-        if (!Enum.IsDefined(SwiftLink.ReceiveMode))
-            validationErrors.Add($"{nameof(SwiftLink)}.{nameof(SwiftLink.ReceiveMode)} has an invalid value.");
+        if (SwiftLink == null)
+        {
+            validationErrors.Add($"{nameof(SwiftLink)} must be set.");
+        }
+        else
+        {
+            var swiftLinkValidationErrors = new List<string>();
+            if (!SwiftLink.IsValid(out swiftLinkValidationErrors, nameof(SwiftLink)))
+                validationErrors.AddRange(swiftLinkValidationErrors);
+        }
 
         return validationErrors.Count == 0;
     }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/IC64SwiftLinkTcpHostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/IC64SwiftLinkTcpHostConfig.cs
@@ -1,0 +1,8 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Config;
+
+public interface IC64SwiftLinkTcpHostConfig
+{
+    string SwiftLinkTcpHost { get; }
+    int SwiftLinkTcpPort { get; }
+    bool SwiftLinkConnectOnBoot { get; }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/IC64SwiftLinkTcpHostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/IC64SwiftLinkTcpHostConfig.cs
@@ -2,6 +2,7 @@ namespace Highbyte.DotNet6502.Systems.Commodore64.Config;
 
 public interface IC64SwiftLinkTcpHostConfig
 {
+    C64SwiftLinkTransportMode SwiftLinkTransportMode { get; }
     string SwiftLinkTcpHost { get; }
     int SwiftLinkTcpPort { get; }
     bool SwiftLinkConnectOnBoot { get; }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Highbyte.DotNet6502.Systems.Commodore64.csproj
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Highbyte.DotNet6502.Systems.Commodore64.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Highbyte.DotNet6502.AI\Highbyte.DotNet6502.AI.csproj" />
+    <ProjectReference Include="..\Highbyte.DotNet6502.Systems.Commodore64.Transport\Highbyte.DotNet6502.Systems.Commodore64.Transport.csproj" />
     <ProjectReference Include="..\Highbyte.DotNet6502.Systems\Highbyte.DotNet6502.Systems.csproj" />
     <ProjectReference Include="..\Highbyte.DotNet6502.Monitor\Highbyte.DotNet6502.Monitor.csproj" />
     <ProjectReference Include="..\Highbyte.DotNet6502\Highbyte.DotNet6502.csproj" />

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Input/C64InputConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Input/C64InputConfig.cs
@@ -5,6 +5,7 @@ using Highbyte.DotNet6502.Systems.Input;
 namespace Highbyte.DotNet6502.Systems.Commodore64.Input;
 
 /// <summary>
+/// 
 /// Host-agnostic C64 gamepad/joystick configuration: which C64 joystick port a host gamepad
 /// drives, and the gamepad-button to C64-joystick-action mapping.
 ///

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/DiskDrive/D64/Download/D64Downloader.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/DiskDrive/D64/Download/D64Downloader.cs
@@ -106,8 +106,9 @@ public class D64DownloadDiskInfo
     public bool AudioEnabled { get; set; }
     public string? DirectLoadPRGName { get; set; }
     public string C64Variant { get; set; }
+    public bool AvailableInBrowser { get; set; }
 
-    public D64DownloadDiskInfo(string displayName, string downloadUrl, List<string>? runCommands = null, DownloadType downloadType = DownloadType.D64, bool keyboardJoystickEnabled = false, int keyboardJoystickNumber = 2, bool requiresBitmap = false, bool audioEnabled = false, string? directLoadPRGName = null, string c64Variant = "C64NTSC")
+    public D64DownloadDiskInfo(string displayName, string downloadUrl, List<string>? runCommands = null, DownloadType downloadType = DownloadType.D64, bool keyboardJoystickEnabled = false, int keyboardJoystickNumber = 2, bool requiresBitmap = false, bool audioEnabled = false, string? directLoadPRGName = null, string c64Variant = "C64NTSC", bool availableInBrowser = true)
     {
         DisplayName = displayName;
         DownloadUrl = downloadUrl;
@@ -117,6 +118,7 @@ public class D64DownloadDiskInfo
         RequiresBitmap = requiresBitmap;
         AudioEnabled = audioEnabled;
         C64Variant = c64Variant;
+        AvailableInBrowser = availableInBrowser;
 
         DirectLoadPRGName = directLoadPRGName;
 

--- a/src/libraries/Highbyte.DotNet6502.Systems/ISystemCleanup.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/ISystemCleanup.cs
@@ -1,0 +1,6 @@
+namespace Highbyte.DotNet6502.Systems;
+
+public interface ISystemCleanup
+{
+    void Cleanup();
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems/SystemRunner.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/SystemRunner.cs
@@ -55,5 +55,6 @@ public class SystemRunner
     public void Cleanup()
     {
         _system.InputConsumer?.Cleanup();
+        (_system as ISystemCleanup)?.Cleanup();
     }
 }

--- a/src/libraries/Highbyte.DotNet6502/CPU.cs
+++ b/src/libraries/Highbyte.DotNet6502/CPU.cs
@@ -179,6 +179,16 @@ public class CPU
     }
 
     /// <summary>
+    /// Services any pending hardware interrupts at the current instruction boundary.
+    /// Intended for system-level device ticking that occurs after instruction execution.
+    /// </summary>
+    /// <param name="mem"></param>
+    public void ProcessPendingInterrupts(Memory mem)
+    {
+        ProcessInterrupts(mem);
+    }
+
+    /// <summary>
     /// Executes one instruction, and will fire events and collect statistics.
     /// </summary>
     /// <param name="mem"></param>

--- a/src/libraries/Highbyte.DotNet6502/CPU.cs
+++ b/src/libraries/Highbyte.DotNet6502/CPU.cs
@@ -92,7 +92,7 @@ public class CPU
     /// </summary>
     /// <value></value>
 
-    public bool NMI => CPUInterrupts.NMILineEnabled;
+    public bool NMI => CPUInterrupts.NMIPending;
 
     /// <summary>
     /// Aggregated stats and info for all invocations of Execute()
@@ -273,14 +273,9 @@ public class CPU
 
     private void ProcessInterrupts(Memory mem)
     {
-        if (CPUInterrupts.NMILineEnabled)
+        if (CPUInterrupts.NMIPending)
         {
-            // TODO: Should all NMI sources be cleared here?
-            for (int i = CPUInterrupts.ActiveNMISources.Count - 1; i >= 0; i--)
-            {
-                var source = CPUInterrupts.ActiveNMISources.ElementAt(i);
-                CPUInterrupts.SetNMISourceInactive(source);
-            }
+            CPUInterrupts.ClearPendingNMI();
             ProcessHardwareNMI(mem);
         }
         else if (CPUInterrupts.IRQLineEnabled && !ProcessorStatus.InterruptDisable)

--- a/src/libraries/Highbyte.DotNet6502/CPUInterrupts.cs
+++ b/src/libraries/Highbyte.DotNet6502/CPUInterrupts.cs
@@ -3,8 +3,12 @@ namespace Highbyte.DotNet6502;
 public class CPUInterrupts
 {
     public bool IRQLineEnabled => ActiveIRQSources.Count > 0;
-
     public bool NMILineEnabled => ActiveNMISources.Count > 0;
+
+    // 6502 NMI is edge-triggered: once a source transitions active we latch a pending
+    // NMI until the CPU services it. Keeping a source active does not retrigger NMI
+    // until it has been cleared and asserted again.
+    public bool NMIPending { get; private set; }
 
     public Dictionary<string, bool> ActiveIRQSources { get; private set; } = new();
     public HashSet<string> ActiveNMISources { get; private set; } = new();
@@ -45,7 +49,8 @@ public class CPUInterrupts
     /// <param name="source">Unique name of source</param>
     public void SetNMISourceActive(string source)
     {
-        ActiveNMISources.Add(source);
+        if (ActiveNMISources.Add(source))
+            NMIPending = true;
     }
 
     /// <summary>
@@ -65,5 +70,10 @@ public class CPUInterrupts
     public bool IsNMISourceActive(string source)
     {
         return ActiveNMISources.Contains(source);
+    }
+
+    public void ClearPendingNMI()
+    {
+        NMIPending = false;
     }
 }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64CpuPortTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64CpuPortTests.cs
@@ -1,0 +1,75 @@
+using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64;
+
+public class C64CpuPortTests
+{
+    private const ushort KernalProbeAddress = 0xFF84;
+    private const ushort TestProgramAddress = 0xC000;
+
+    [Fact]
+    public void Startup_6510_Port_Uses_C64_Defaults()
+    {
+        var c64 = BuildC64();
+
+        Assert.Equal(0x2F, c64.Mem.Read(0x0000));
+        Assert.Equal(0x37, c64.Mem.Read(0x0001));
+        Assert.Equal(31, c64.CurrentBank);
+    }
+
+    [Fact]
+    public void Kernal_Rom_Stays_Visible_When_Bank_Lines_Are_Configured_As_Inputs()
+    {
+        var c64 = BuildC64();
+        SeedKernalAndRamProbe(c64, kernalValue: 0x42, ramValue: 0x00);
+
+        c64.Mem.Write(0x0000, 0x00);
+        c64.Mem.Write(0x0001, 0x00);
+
+        Assert.Equal(0x17, c64.Mem.Read(0x0001));
+        Assert.Equal(0x07, c64.CurrentBank & 0x07);
+        Assert.Equal(0x42, c64.Mem.Read(KernalProbeAddress));
+    }
+
+    [Fact]
+    public void Dec_And_Inc_Zero_Page_01_Use_The_Real_Port_Value()
+    {
+        var c64 = BuildC64();
+        SeedKernalAndRamProbe(c64, kernalValue: 0x42, ramValue: 0x00);
+
+        c64.Mem.Write((ushort)(TestProgramAddress + 0), 0xC6); // DEC $01
+        c64.Mem.Write((ushort)(TestProgramAddress + 1), 0x01);
+        c64.Mem.Write((ushort)(TestProgramAddress + 2), 0xE6); // INC $01
+        c64.Mem.Write((ushort)(TestProgramAddress + 3), 0x01);
+
+        c64.CPU.PC = TestProgramAddress;
+
+        c64.CPU.ExecuteOneInstructionMinimal(c64.Mem);
+        Assert.Equal(0x36, c64.Mem.Read(0x0001));
+        Assert.Equal(0x06, c64.CurrentBank & 0x07);
+        Assert.Equal(0x42, c64.Mem.Read(KernalProbeAddress));
+
+        c64.CPU.ExecuteOneInstructionMinimal(c64.Mem);
+        Assert.Equal(0x37, c64.Mem.Read(0x0001));
+        Assert.Equal(0x07, c64.CurrentBank & 0x07);
+        Assert.Equal(0x42, c64.Mem.Read(KernalProbeAddress));
+    }
+
+    private static C64 BuildC64()
+    {
+        return C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            C64Model = "C64PAL",
+            Vic2Model = "PAL"
+        }, NullLoggerFactory.Instance);
+    }
+
+    private static void SeedKernalAndRamProbe(C64 c64, byte kernalValue, byte ramValue)
+    {
+        c64.ROMData[C64SystemConfig.KERNAL_ROM_NAME][KernalProbeAddress - 0xE000] = kernalValue;
+        c64.RAM[KernalProbeAddress] = ramValue;
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64SwiftLinkHostConfigTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64SwiftLinkHostConfigTests.cs
@@ -1,0 +1,55 @@
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64;
+
+public class C64SwiftLinkHostConfigTests
+{
+    [Fact]
+    public void IsValid_Rejects_Blank_Host_In_RawTcp_Mode()
+    {
+        var config = new C64SwiftLinkHostConfig
+        {
+            TransportMode = C64SwiftLinkTransportMode.RawTcp,
+            TcpHost = "",
+            TcpPort = 6400
+        };
+
+        var isValid = config.IsValid(out var validationErrors, "SwiftLinkHost");
+
+        Assert.False(isValid);
+        Assert.Contains("SwiftLinkHost.TcpHost must be set for RawTcp mode.", validationErrors);
+    }
+
+    [Fact]
+    public void IsValid_Rejects_ConnectOnBoot_In_Hayes_Mode()
+    {
+        var config = new C64SwiftLinkHostConfig
+        {
+            TransportMode = C64SwiftLinkTransportMode.HayesModem,
+            ConnectOnBoot = true,
+            TcpPort = 6400
+        };
+
+        var isValid = config.IsValid(out var validationErrors, "SwiftLinkHost");
+
+        Assert.False(isValid);
+        Assert.Contains("SwiftLinkHost.ConnectOnBoot can only be enabled in RawTcp mode.", validationErrors);
+    }
+
+    [Fact]
+    public void IsValid_Accepts_Valid_RawTcp_Config()
+    {
+        var config = new C64SwiftLinkHostConfig
+        {
+            TransportMode = C64SwiftLinkTransportMode.RawTcp,
+            TcpHost = "127.0.0.1",
+            TcpPort = 5000,
+            ConnectOnBoot = true
+        };
+
+        var isValid = config.IsValid(out var validationErrors, "SwiftLinkHost");
+
+        Assert.True(isValid);
+        Assert.Empty(validationErrors);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64SystemConfigTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64SystemConfigTests.cs
@@ -1,0 +1,21 @@
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64;
+
+public class C64SystemConfigTests
+{
+    [Fact]
+    public void IsValid_Includes_SwiftLink_Validation_Errors()
+    {
+        var config = new C64SystemConfig();
+        config.SwiftLink.InterruptMode = (C64SwiftLinkInterruptMode)999;
+
+        var isValid = config.IsValid(out var validationErrors);
+
+        Assert.False(isValid);
+        Assert.Contains(
+            $"{nameof(C64SystemConfig.SwiftLink)}.{nameof(C64SwiftLinkConfig.InterruptMode)} has an invalid value.",
+            validationErrors);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
@@ -199,11 +199,14 @@ public class SwiftLinkDeviceTests
     }
 
     [Fact]
-    public async Task Compatible_Receive_Mode_Waits_For_New_Acia_Access_After_Empty_Poll()
+    public async Task Compatible_Receive_Mode_Paces_Queued_Bytes_By_Cpu_Cycles()
     {
+        ulong currentCycles = 0;
         var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance)
         {
-            ReceiveMode = C64SwiftLinkReceiveMode.Compatible
+            ReceiveMode = C64SwiftLinkReceiveMode.Compatible,
+            ReceivePacingCycles = 10,
+            GetCurrentCycleCount = () => currentCycles,
         };
         var transport = new LoopbackTransport();
         await transport.ConnectAsync();
@@ -212,19 +215,23 @@ public class SwiftLinkDeviceTests
         var mem = new Memory();
         device.MapIOLocations(mem);
 
-        mem.Read(0xDE01);
-        device.Tick();
-
         await transport.SendAsync(0x41);
+        await transport.SendAsync(0x42);
+
         device.Tick();
+        Assert.True(IsRxFull(mem.Read(0xDE01)));
+        Assert.Equal(0x41, mem.Read(0xDE00));
 
         Assert.False(IsRxFull(mem.Read(0xDE01)));
 
-        mem.Read(0xDE01);
+        currentCycles = 9;
         device.Tick();
+        Assert.False(IsRxFull(mem.Read(0xDE01)));
 
+        currentCycles = 10;
+        device.Tick();
         Assert.True(IsRxFull(mem.Read(0xDE01)));
-        Assert.Equal(0x41, mem.Read(0xDE00));
+        Assert.Equal(0x42, mem.Read(0xDE00));
     }
 
     [Fact]

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
@@ -2,12 +2,16 @@ using Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
 using Highbyte.DotNet6502.Systems.Commodore64.Transport;
 using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Highbyte.DotNet6502.Systems.Tests.Commodore64.Cartridge;
 
 public class SwiftLinkDeviceTests
 {
+    private const byte ReceiveIrqEnabledCommand = 0x09;
+    private const byte TransmitIrqEnabledCommand = 0x05;
+
     [Fact]
     public async Task Rx_Full_Is_Set_When_Transport_Has_Data_And_Cleared_On_Read()
     {
@@ -88,6 +92,109 @@ public class SwiftLinkDeviceTests
     }
 
     [Fact]
+    public async Task Receive_Irq_Is_Raised_When_Rx_Full_Transitions_And_Cleared_On_Status_Read()
+    {
+        var interrupts = new CPUInterrupts();
+        var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance)
+        {
+            CpuInterrupts = interrupts
+        };
+        var transport = new LoopbackTransport();
+        await transport.ConnectAsync();
+        device.Transport = transport;
+
+        var mem = new Memory();
+        device.MapIOLocations(mem);
+        mem.Write(0xDE02, ReceiveIrqEnabledCommand);
+
+        await transport.SendAsync(0x41);
+        device.Tick();
+
+        Assert.True(interrupts.IRQLineEnabled);
+        var status = mem.Read(0xDE01);
+        Assert.True(IsRxFull(status));
+        Assert.True(IsIrqPending(status));
+        Assert.False(interrupts.IRQLineEnabled);
+
+        Assert.Equal(0x41, mem.Read(0xDE00));
+        Assert.False(IsIrqPending(mem.Read(0xDE01)));
+    }
+
+    [Fact]
+    public void Transmit_Irq_Is_Raised_When_Send_Completes_And_Cleared_On_Status_Read()
+    {
+        var interrupts = new CPUInterrupts();
+        var transport = new PendingSendTransport();
+        var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance)
+        {
+            Transport = transport,
+            CpuInterrupts = interrupts
+        };
+
+        var mem = new Memory();
+        device.MapIOLocations(mem);
+        mem.Write(0xDE02, TransmitIrqEnabledCommand);
+
+        mem.Write(0xDE00, 0x42);
+        Assert.False(interrupts.IRQLineEnabled);
+
+        transport.CompletePendingSend();
+        device.Tick();
+
+        Assert.True(interrupts.IRQLineEnabled);
+        var status = mem.Read(0xDE01);
+        Assert.True(IsTxEmpty(status));
+        Assert.True(IsIrqPending(status));
+        Assert.False(interrupts.IRQLineEnabled);
+    }
+
+    [Fact]
+    public async Task Rx_Queue_Behaves_As_Network_Side_Fifo_While_C64_Side_Stays_One_Byte()
+    {
+        var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance);
+        var transport = new LoopbackTransport();
+        await transport.ConnectAsync();
+        device.Transport = transport;
+
+        var mem = new Memory();
+        device.MapIOLocations(mem);
+
+        await transport.SendAsync(0x41);
+        await transport.SendAsync(0x42);
+
+        device.Tick();
+        Assert.True(IsRxFull(mem.Read(0xDE01)));
+        Assert.Equal(0x41, mem.Read(0xDE00));
+
+        device.Tick();
+        Assert.True(IsRxFull(mem.Read(0xDE01)));
+        Assert.Equal(0x42, mem.Read(0xDE00));
+    }
+
+    [Fact]
+    public async Task Receive_Irq_Is_Not_Raised_When_Disabled()
+    {
+        var interrupts = new CPUInterrupts();
+        var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance)
+        {
+            CpuInterrupts = interrupts
+        };
+        var transport = new LoopbackTransport();
+        await transport.ConnectAsync();
+        device.Transport = transport;
+
+        var mem = new Memory();
+        device.MapIOLocations(mem);
+
+        await transport.SendAsync(0x41);
+        device.Tick();
+
+        Assert.False(interrupts.IRQLineEnabled);
+        Assert.True(IsRxFull(mem.Read(0xDE01)));
+        Assert.False(IsIrqPending(mem.Read(0xDE01)));
+    }
+
+    [Fact]
     public void BuildC64_Creates_SwiftLink_Device_When_Enabled()
     {
         var c64 = C64.BuildC64(new C64Config
@@ -99,6 +206,7 @@ public class SwiftLinkDeviceTests
 
         Assert.NotNull(c64.SwiftLink);
         Assert.Equal((ushort)0xDF00, c64.SwiftLink!.BaseAddress);
+        Assert.Same(c64.CPU.CPUInterrupts, c64.SwiftLink.CpuInterrupts);
     }
 
     [Fact]
@@ -118,6 +226,9 @@ public class SwiftLinkDeviceTests
 
     private static bool IsTxEmpty(byte status)
         => (status & (1 << 4)) != 0;
+
+    private static bool IsIrqPending(byte status)
+        => (status & (1 << 7)) != 0;
 
     private sealed class PendingSendTransport : ISwiftLinkTransport
     {

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
@@ -1,0 +1,160 @@
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Systems.Commodore64.Transport;
+using Highbyte.DotNet6502.Systems.Commodore64;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64.Cartridge;
+
+public class SwiftLinkDeviceTests
+{
+    [Fact]
+    public async Task Rx_Full_Is_Set_When_Transport_Has_Data_And_Cleared_On_Read()
+    {
+        var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance);
+        var transport = new LoopbackTransport();
+        await transport.ConnectAsync();
+        device.Transport = transport;
+
+        var mem = new Memory();
+        device.MapIOLocations(mem);
+
+        await transport.SendAsync(0x41);
+        device.Tick();
+
+        Assert.True(IsRxFull(mem.Read(0xDE01)));
+        Assert.Equal(0x41, mem.Read(0xDE00));
+        Assert.False(IsRxFull(mem.Read(0xDE01)));
+    }
+
+    [Fact]
+    public void Tx_Empty_Clears_On_Write_And_Sets_After_Send_Completes()
+    {
+        var transport = new PendingSendTransport();
+        var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance)
+        {
+            Transport = transport
+        };
+
+        var mem = new Memory();
+        device.MapIOLocations(mem);
+
+        mem.Write(0xDE00, 0x42);
+        Assert.False(IsTxEmpty(mem.Read(0xDE01)));
+
+        transport.CompletePendingSend();
+        device.Tick();
+
+        Assert.True(IsTxEmpty(mem.Read(0xDE01)));
+    }
+
+    [Theory]
+    [InlineData(C64CartridgeIOAddress.DE00, (ushort)0xDE00)]
+    [InlineData(C64CartridgeIOAddress.DF00, (ushort)0xDF00)]
+    public void Device_Maps_At_Configured_Base_Address(C64CartridgeIOAddress cartridgeIOAddress, ushort expectedBaseAddress)
+    {
+        var device = new SwiftLinkDevice(cartridgeIOAddress, NullLogger<SwiftLinkDevice>.Instance);
+        var mem = new Memory();
+        device.MapIOLocations(mem);
+
+        mem.Write((ushort)(expectedBaseAddress + 0x02), 0x77);
+
+        Assert.Equal(0x77, mem.Read((ushort)(expectedBaseAddress + 0x02)));
+    }
+
+    [Fact]
+    public async Task Status_Write_Resets_Register_State()
+    {
+        var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance);
+        var transport = new LoopbackTransport();
+        await transport.ConnectAsync();
+        device.Transport = transport;
+
+        var mem = new Memory();
+        device.MapIOLocations(mem);
+
+        mem.Write(0xDE02, 0x12);
+        mem.Write(0xDE03, 0x34);
+        await transport.SendAsync(0x55);
+        device.Tick();
+
+        Assert.True(IsRxFull(mem.Read(0xDE01)));
+        mem.Write(0xDE01, 0x00);
+
+        Assert.Equal(0x00, mem.Read(0xDE02));
+        Assert.Equal(0x00, mem.Read(0xDE03));
+        Assert.False(IsRxFull(mem.Read(0xDE01)));
+        Assert.True(IsTxEmpty(mem.Read(0xDE01)));
+    }
+
+    [Fact]
+    public void BuildC64_Creates_SwiftLink_Device_When_Enabled()
+    {
+        var c64 = C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            SwiftLinkEnabled = true,
+            SwiftLinkCartridgeIOAddress = C64CartridgeIOAddress.DF00,
+        }, new NullLoggerFactory());
+
+        Assert.NotNull(c64.SwiftLink);
+        Assert.Equal((ushort)0xDF00, c64.SwiftLink!.BaseAddress);
+    }
+
+    [Fact]
+    public void BuildC64_Does_Not_Create_SwiftLink_Device_When_Disabled()
+    {
+        var c64 = C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            SwiftLinkEnabled = false,
+        }, new NullLoggerFactory());
+
+        Assert.Null(c64.SwiftLink);
+    }
+
+    private static bool IsRxFull(byte status)
+        => (status & (1 << 3)) != 0;
+
+    private static bool IsTxEmpty(byte status)
+        => (status & (1 << 4)) != 0;
+
+    private sealed class PendingSendTransport : ISwiftLinkTransport
+    {
+        private TaskCompletionSource _sendCompletionSource = NewCompletionSource();
+
+        public bool IsConnected => true;
+
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask DisconnectAsync(CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
+
+        public bool TryDequeueReceivedByte(out byte value)
+        {
+            value = 0;
+            return false;
+        }
+
+        public ValueTask SendAsync(byte value, CancellationToken cancellationToken = default)
+            => new(_sendCompletionSource.Task);
+
+        public void Reset()
+        {
+            _sendCompletionSource = NewCompletionSource();
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public void CompletePendingSend()
+        {
+            _sendCompletionSource.TrySetResult();
+        }
+
+        private static TaskCompletionSource NewCompletionSource()
+            => new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
@@ -199,6 +199,59 @@ public class SwiftLinkDeviceTests
     }
 
     [Fact]
+    public async Task Compatible_Receive_Mode_Waits_For_New_Acia_Access_After_Empty_Poll()
+    {
+        var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance)
+        {
+            ReceiveMode = C64SwiftLinkReceiveMode.Compatible
+        };
+        var transport = new LoopbackTransport();
+        await transport.ConnectAsync();
+        device.Transport = transport;
+
+        var mem = new Memory();
+        device.MapIOLocations(mem);
+
+        mem.Read(0xDE01);
+        device.Tick();
+
+        await transport.SendAsync(0x41);
+        device.Tick();
+
+        Assert.False(IsRxFull(mem.Read(0xDE01)));
+
+        mem.Read(0xDE01);
+        device.Tick();
+
+        Assert.True(IsRxFull(mem.Read(0xDE01)));
+        Assert.Equal(0x41, mem.Read(0xDE00));
+    }
+
+    [Fact]
+    public async Task FastBuffered_Receive_Mode_Latches_Queued_Byte_Without_New_Acia_Access()
+    {
+        var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance)
+        {
+            ReceiveMode = C64SwiftLinkReceiveMode.FastBuffered
+        };
+        var transport = new LoopbackTransport();
+        await transport.ConnectAsync();
+        device.Transport = transport;
+
+        var mem = new Memory();
+        device.MapIOLocations(mem);
+
+        mem.Read(0xDE01);
+        device.Tick();
+
+        await transport.SendAsync(0x41);
+        device.Tick();
+
+        Assert.True(IsRxFull(mem.Read(0xDE01)));
+        Assert.Equal(0x41, mem.Read(0xDE00));
+    }
+
+    [Fact]
     public async Task Receive_Irq_Is_Not_Raised_When_Disabled()
     {
         var interrupts = new CPUInterrupts();
@@ -231,7 +284,7 @@ public class SwiftLinkDeviceTests
         var mem = new Memory();
         device.MapIOLocations(mem);
 
-        Assert.True(IsDcdHigh(mem.Read(0xDE01)));
+        Assert.False(IsDcdHigh(mem.Read(0xDE01)));
         Assert.True(IsDsrHigh(mem.Read(0xDE01)));
 
         await transport.ConnectAsync();
@@ -255,6 +308,7 @@ public class SwiftLinkDeviceTests
         Assert.Equal((ushort)0xDF00, c64.SwiftLink!.BaseAddress);
         Assert.Same(c64.CPU.CPUInterrupts, c64.SwiftLink.CpuInterrupts);
         Assert.Equal(C64SwiftLinkInterruptMode.IRQ, c64.SwiftLink.InterruptMode);
+        Assert.Equal(C64SwiftLinkReceiveMode.Compatible, c64.SwiftLink.ReceiveMode);
     }
 
     [Fact]
@@ -289,6 +343,8 @@ public class SwiftLinkDeviceTests
         private TaskCompletionSource _sendCompletionSource = NewCompletionSource();
 
         public bool IsConnected => true;
+        public bool IsCarrierDetected => true;
+        public bool IsDataSetReady => true;
 
         public ValueTask ConnectAsync(CancellationToken cancellationToken = default)
             => ValueTask.CompletedTask;

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
@@ -121,6 +121,33 @@ public class SwiftLinkDeviceTests
     }
 
     [Fact]
+    public async Task Receive_Nmi_Is_Raised_When_Configured_And_Cleared_On_Status_Read()
+    {
+        var interrupts = new CPUInterrupts();
+        var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance)
+        {
+            CpuInterrupts = interrupts,
+            InterruptMode = C64SwiftLinkInterruptMode.NMI
+        };
+        var transport = new LoopbackTransport();
+        await transport.ConnectAsync();
+        device.Transport = transport;
+
+        var mem = new Memory();
+        device.MapIOLocations(mem);
+        mem.Write(0xDE02, ReceiveIrqEnabledCommand);
+
+        await transport.SendAsync(0x41);
+        device.Tick();
+
+        Assert.True(interrupts.NMILineEnabled);
+        var status = mem.Read(0xDE01);
+        Assert.True(IsRxFull(status));
+        Assert.True(IsIrqPending(status));
+        Assert.False(interrupts.NMILineEnabled);
+    }
+
+    [Fact]
     public void Transmit_Irq_Is_Raised_When_Send_Completes_And_Cleared_On_Status_Read()
     {
         var interrupts = new CPUInterrupts();
@@ -195,6 +222,26 @@ public class SwiftLinkDeviceTests
     }
 
     [Fact]
+    public async Task Status_Reflects_Carrier_And_Dsr_State_From_Transport_Connection()
+    {
+        var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance);
+        var transport = new LoopbackTransport();
+        device.Transport = transport;
+
+        var mem = new Memory();
+        device.MapIOLocations(mem);
+
+        Assert.True(IsDcdHigh(mem.Read(0xDE01)));
+        Assert.True(IsDsrHigh(mem.Read(0xDE01)));
+
+        await transport.ConnectAsync();
+        device.Tick();
+
+        Assert.False(IsDcdHigh(mem.Read(0xDE01)));
+        Assert.False(IsDsrHigh(mem.Read(0xDE01)));
+    }
+
+    [Fact]
     public void BuildC64_Creates_SwiftLink_Device_When_Enabled()
     {
         var c64 = C64.BuildC64(new C64Config
@@ -207,6 +254,7 @@ public class SwiftLinkDeviceTests
         Assert.NotNull(c64.SwiftLink);
         Assert.Equal((ushort)0xDF00, c64.SwiftLink!.BaseAddress);
         Assert.Same(c64.CPU.CPUInterrupts, c64.SwiftLink.CpuInterrupts);
+        Assert.Equal(C64SwiftLinkInterruptMode.IRQ, c64.SwiftLink.InterruptMode);
     }
 
     [Fact]
@@ -229,6 +277,12 @@ public class SwiftLinkDeviceTests
 
     private static bool IsIrqPending(byte status)
         => (status & (1 << 7)) != 0;
+
+    private static bool IsDcdHigh(byte status)
+        => (status & (1 << 5)) != 0;
+
+    private static bool IsDsrHigh(byte status)
+        => (status & (1 << 6)) != 0;
 
     private sealed class PendingSendTransport : ISwiftLinkTransport
     {

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
@@ -1,4 +1,5 @@
 using Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
 using Highbyte.DotNet6502.Systems.Commodore64.Transport;
 using Highbyte.DotNet6502.Systems.Commodore64;
@@ -307,8 +308,11 @@ public class SwiftLinkDeviceTests
         var c64 = C64.BuildC64(new C64Config
         {
             LoadROMs = false,
-            SwiftLinkEnabled = true,
-            SwiftLinkCartridgeIOAddress = C64CartridgeIOAddress.DF00,
+            SwiftLink =
+            {
+                Enabled = true,
+                CartridgeIOAddress = C64CartridgeIOAddress.DF00,
+            },
         }, new NullLoggerFactory());
 
         Assert.NotNull(c64.SwiftLink);
@@ -324,7 +328,10 @@ public class SwiftLinkDeviceTests
         var c64 = C64.BuildC64(new C64Config
         {
             LoadROMs = false,
-            SwiftLinkEnabled = false,
+            SwiftLink =
+            {
+                Enabled = false,
+            },
         }, new NullLoggerFactory());
 
         Assert.Null(c64.SwiftLink);

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/HayesModemTransportTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/HayesModemTransportTests.cs
@@ -1,0 +1,155 @@
+using System.Collections.Concurrent;
+using Highbyte.DotNet6502.Systems.Commodore64.Transport;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64;
+
+public class HayesModemTransportTests
+{
+    [Fact]
+    public async Task At_Command_Returns_Ok()
+    {
+        var transport = CreateTransport();
+
+        await SendAsciiAsync(transport, "AT\r");
+
+        Assert.Equal("\r\nOK\r\n", DrainAscii(transport));
+    }
+
+    [Fact]
+    public async Task Atdt_Connects_Using_Dial_Target_And_Enters_Data_Mode()
+    {
+        FakeDataTransport? connectedTransport = null;
+        var transport = CreateTransport((host, port) =>
+        {
+            connectedTransport = new FakeDataTransport(host, port);
+            return connectedTransport;
+        });
+
+        await SendAsciiAsync(transport, "ATDTexample.com:6400\r");
+
+        Assert.NotNull(connectedTransport);
+        Assert.Equal("example.com", connectedTransport!.Host);
+        Assert.Equal(6400, connectedTransport.Port);
+        Assert.Equal("\r\nCONNECT 1200\r\n", DrainAscii(transport));
+        Assert.True(transport.IsCarrierDetected);
+        Assert.True(transport.IsDataSetReady);
+
+        await transport.SendAsync((byte)'X');
+
+        Assert.Equal((byte)'X', Assert.Single(connectedTransport.SentBytes));
+    }
+
+    [Fact]
+    public async Task Lost_Carrier_Queues_No_Carrier_And_Returns_To_Command_Mode()
+    {
+        FakeDataTransport? connectedTransport = null;
+        var transport = CreateTransport((host, port) =>
+        {
+            connectedTransport = new FakeDataTransport(host, port);
+            return connectedTransport;
+        });
+
+        await SendAsciiAsync(transport, "ATDTexample.com:6400\r");
+        Assert.Equal("\r\nCONNECT 1200\r\n", DrainAscii(transport));
+
+        connectedTransport!.IsConnectedValue = false;
+
+        Assert.True(transport.TryDequeueReceivedByte(out var firstByte));
+        Assert.Equal("\r\nNO CARRIER\r\n", DrainAsciiIncludingFirstByte(transport, firstByte));
+        Assert.False(transport.IsCarrierDetected);
+        Assert.False(transport.IsDataSetReady);
+    }
+
+    [Fact]
+    public async Task Invalid_Dial_Target_Returns_Error()
+    {
+        var transport = CreateTransport();
+
+        await SendAsciiAsync(transport, "ATDTnot-a-target\r");
+
+        Assert.Equal("\r\nERROR\r\n", DrainAscii(transport));
+    }
+
+    private static HayesModemTransport CreateTransport(Func<string, int, ISwiftLinkTransport>? dialTransportFactory = null)
+    {
+        dialTransportFactory ??= (host, port) => new FakeDataTransport(host, port);
+        return new HayesModemTransport(dialTransportFactory, NullLogger<HayesModemTransport>.Instance);
+    }
+
+    private static async Task SendAsciiAsync(ISwiftLinkTransport transport, string text)
+    {
+        foreach (var ch in text)
+            await transport.SendAsync((byte)ch);
+    }
+
+    private static string DrainAscii(ISwiftLinkTransport transport)
+    {
+        var chars = new List<char>();
+        while (transport.TryDequeueReceivedByte(out var value))
+            chars.Add((char)value);
+        return new string(chars.ToArray());
+    }
+
+    private static string DrainAsciiIncludingFirstByte(ISwiftLinkTransport transport, byte firstByte)
+    {
+        var chars = new List<char> { (char)firstByte };
+        while (transport.TryDequeueReceivedByte(out var value))
+            chars.Add((char)value);
+        return new string(chars.ToArray());
+    }
+
+    private sealed class FakeDataTransport : ISwiftLinkTransport
+    {
+        public FakeDataTransport(string host, int port)
+        {
+            Host = host;
+            Port = port;
+            IsConnectedValue = true;
+        }
+
+        public string Host { get; }
+        public int Port { get; }
+        public bool IsConnectedValue { get; set; }
+        public List<byte> SentBytes { get; } = new();
+        public ConcurrentQueue<byte> ReceivedBytes { get; } = new();
+
+        public bool IsConnected => IsConnectedValue;
+        public bool IsCarrierDetected => IsConnectedValue;
+        public bool IsDataSetReady => IsConnectedValue;
+
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default)
+        {
+            IsConnectedValue = true;
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask DisconnectAsync(CancellationToken cancellationToken = default)
+        {
+            IsConnectedValue = false;
+            return ValueTask.CompletedTask;
+        }
+
+        public bool TryDequeueReceivedByte(out byte value)
+            => ReceivedBytes.TryDequeue(out value);
+
+        public ValueTask SendAsync(byte value, CancellationToken cancellationToken = default)
+        {
+            SentBytes.Add(value);
+            return ValueTask.CompletedTask;
+        }
+
+        public void Reset()
+        {
+            SentBytes.Clear();
+            while (ReceivedBytes.TryDequeue(out _))
+            {
+            }
+        }
+
+        public void Dispose()
+        {
+            IsConnectedValue = false;
+        }
+    }
+}

--- a/tests/Highbyte.DotNet6502.Tests/CPUTest.cs
+++ b/tests/Highbyte.DotNet6502.Tests/CPUTest.cs
@@ -132,6 +132,36 @@ public class CPUTest
     }
 
     [Fact]
+    public void CPU_Can_Service_Pending_NMI_Between_Instructions()
+    {
+        var cpu = new CPU();
+        var mem = new Memory();
+
+        mem[0x1000] = (byte)OpCodeId.NOP;
+        mem.WriteWord(CPU.NonMaskableIRQHandlerVector, 0x3456);
+        cpu.PC = 0x1000;
+        cpu.SP = 0xFF;
+        cpu.ProcessorStatus.InterruptDisable = false;
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+        Assert.Equal(0x1001, cpu.PC);
+
+        cpu.CPUInterrupts.SetNMISourceActive("dummy");
+
+        cpu.ProcessPendingInterrupts(mem);
+
+        Assert.Equal((ushort)0x3456, cpu.PC);
+        Assert.False(cpu.NMI);
+
+        var pcOnStackAddress = (ushort)(CPU.StackBaseAddress + (byte)(cpu.SP + 2));
+        var addrFromStack = new byte[2];
+        addrFromStack[0] = mem[pcOnStackAddress];
+        addrFromStack[1] = mem[(ushort)(pcOnStackAddress + 1)];
+        var pcOnStack = ByteHelpers.ToLittleEndianWord(addrFromStack);
+        Assert.Equal((ushort)0x1001, pcOnStack);
+    }
+
+    [Fact]
     public void CPU_Can_Detect_Unknown_OpCode()
     {
         // Arrange

--- a/tests/swiftlink-smoke/README.md
+++ b/tests/swiftlink-smoke/README.md
@@ -1,0 +1,31 @@
+## SwiftLink smoke
+
+Local end-to-end smoke test for C64 SwiftLink Phase 1 through the real Headless app.
+
+What it checks:
+
+- Headless host config enables SwiftLink and connects to a local TCP endpoint.
+- The smoke runner waits until the SwiftLink TCP connection is established.
+- A tiny C64 machine-code program writes one byte to `$DE00`.
+- A local echo server returns that byte.
+- The C64 program reads the echoed byte back and stores it at `$C100`.
+- The smoke runner loads the PRG and starts it through the existing remote-control TCP API, then verifies `$C100 == $41`.
+
+Run locally:
+
+```sh
+./tests/swiftlink-smoke/run-local.sh
+```
+
+```powershell
+./tests/swiftlink-smoke/run-local.ps1
+```
+
+Requirements:
+
+- Python 3 available as `python3`, `python`, or `py -3`.
+- Working C64 ROM configuration for the Headless app.
+
+This smoke is intentionally separate from the xUnit suites. It starts a real TCP server and a real Headless app process, so it is better treated like `tests/wasm-smoke` than a unit or integration test.
+
+If the smoke fails, the runner keeps its temporary logs and artifacts and prints the temp directory path.

--- a/tests/swiftlink-smoke/README.md
+++ b/tests/swiftlink-smoke/README.md
@@ -21,6 +21,12 @@ Run locally:
 ./tests/swiftlink-smoke/run-local.ps1
 ```
 
+Interrupt-driven burst smoke:
+
+```sh
+./tests/swiftlink-smoke/run-irq-local.sh
+```
+
 Requirements:
 
 - Python 3 available as `python3`, `python`, or `py -3`.

--- a/tests/swiftlink-smoke/run-irq-local.sh
+++ b/tests/swiftlink-smoke/run-irq-local.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+HEADLESS_PROJECT="src/apps/Highbyte.DotNet6502.App.Headless/Highbyte.DotNet6502.App.Headless.csproj"
+REMOTE_PROJECT="src/apps/Highbyte.DotNet6502.App.RemoteClient/Highbyte.DotNet6502.App.RemoteClient.csproj"
+HEADLESS_OUT="$REPO_ROOT/src/apps/Highbyte.DotNet6502.App.Headless/bin/Debug/net10.0"
+REMOTE_OUT="$REPO_ROOT/src/apps/Highbyte.DotNet6502.App.RemoteClient/bin/Debug/net10.0"
+HEADLESS_DLL="$HEADLESS_OUT/Highbyte.DotNet6502.App.Headless.dll"
+REMOTE_DLL="$REMOTE_OUT/Highbyte.DotNet6502.App.RemoteClient.dll"
+APPSETTINGS_PATH="$HEADLESS_OUT/appsettings.Development.json"
+
+PAYLOAD_START=0x30
+PAYLOAD_COUNT=16
+
+find_python() {
+  if command -v python3 >/dev/null 2>&1; then
+    echo "python3"
+    return
+  fi
+  if command -v python >/dev/null 2>&1; then
+    echo "python"
+    return
+  fi
+  echo "Python 3 is required." >&2
+  exit 1
+}
+
+PYTHON_BIN="$(find_python)"
+REMOTE_PORT="$("$PYTHON_BIN" - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+)"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/swiftlink-irq-smoke.XXXXXX")"
+PRG_PATH="$TMP_DIR/swiftlink-irq-smoke.prg"
+SERVER_PORT_FILE="$TMP_DIR/server.port"
+SERVER_LOG="$TMP_DIR/server.log"
+SERVER_STDOUT="$TMP_DIR/server.stdout.log"
+SERVER_TRIGGER="$TMP_DIR/server.trigger"
+HEADLESS_LOG="$TMP_DIR/headless.log"
+APPSETTINGS_BACKUP="$TMP_DIR/appsettings.Development.backup.json"
+
+SERVER_PID=""
+HEADLESS_PID=""
+HAD_APPSETTINGS=0
+SUCCESS=0
+
+cleanup() {
+  set +e
+  if [[ -f "$REMOTE_DLL" ]]; then
+    dotnet "$REMOTE_DLL" --port "$REMOTE_PORT" emu.quit >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$HEADLESS_PID" ]] && kill -0 "$HEADLESS_PID" >/dev/null 2>&1; then
+    kill "$HEADLESS_PID" >/dev/null 2>&1 || true
+    wait "$HEADLESS_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ "$HAD_APPSETTINGS" -eq 1 ]]; then
+    cp "$APPSETTINGS_BACKUP" "$APPSETTINGS_PATH"
+  else
+    rm -f "$APPSETTINGS_PATH"
+  fi
+  if [[ "$SUCCESS" -eq 1 ]]; then
+    rm -rf "$TMP_DIR"
+  else
+    echo "IRQ smoke artifacts kept at $TMP_DIR" >&2
+  fi
+}
+trap cleanup EXIT
+
+if [[ -f "$APPSETTINGS_PATH" ]]; then
+  cp "$APPSETTINGS_PATH" "$APPSETTINGS_BACKUP"
+  HAD_APPSETTINGS=1
+fi
+
+echo "==> Building Headless app and remote client"
+dotnet build "$REPO_ROOT/$HEADLESS_PROJECT" >/dev/null
+dotnet build "$REPO_ROOT/$REMOTE_PROJECT" >/dev/null
+
+echo "==> Starting local TCP burst server"
+"$PYTHON_BIN" "$SCRIPT_DIR/tcp_burst_server.py" \
+  --host 127.0.0.1 \
+  --port 0 \
+  --port-file "$SERVER_PORT_FILE" \
+  --log-file "$SERVER_LOG" \
+  --trigger-file "$SERVER_TRIGGER" \
+  --start-byte "$PAYLOAD_START" \
+  --count "$PAYLOAD_COUNT" \
+  >"$SERVER_STDOUT" 2>&1 &
+SERVER_PID=$!
+
+for _ in {1..40}; do
+  [[ -f "$SERVER_PORT_FILE" ]] && break
+  sleep 0.25
+done
+
+if [[ ! -f "$SERVER_PORT_FILE" ]]; then
+  echo "Burst server did not publish a port." >&2
+  exit 1
+fi
+SERVER_PORT="$(tr -d '[:space:]' <"$SERVER_PORT_FILE")"
+
+echo "==> Generating SwiftLink IRQ smoke PRG"
+"$PYTHON_BIN" "$SCRIPT_DIR/write_irq_smoke_prg.py" "$PRG_PATH"
+
+cat >"$APPSETTINGS_PATH" <<JSON
+{
+  "Highbyte.DotNet6502.C64.Headless": {
+    "SwiftLinkTcpHost": "127.0.0.1",
+    "SwiftLinkTcpPort": $SERVER_PORT,
+    "SwiftLinkConnectOnBoot": true,
+    "SystemConfig": {
+      "SwiftLinkEnabled": true,
+      "SwiftLinkCartridgeIOAddress": "DE00"
+    }
+  }
+}
+JSON
+
+echo "==> Starting Headless app"
+DOTNET_ENVIRONMENT=Development \
+dotnet "$HEADLESS_DLL" \
+  --system C64 \
+  --start \
+  --waitForSystemReady \
+  --remote-port "$REMOTE_PORT" \
+  --allow-remote-quit \
+  -l Warning \
+  >"$HEADLESS_LOG" 2>&1 &
+HEADLESS_PID=$!
+
+remote_cmd() {
+  dotnet "$REMOTE_DLL" --port "$REMOTE_PORT" "$@"
+}
+
+echo "==> Waiting for remote control endpoint"
+for _ in {1..80}; do
+  if remote_cmd emu.state >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.25
+done
+
+if ! remote_cmd emu.state >/dev/null 2>&1; then
+  echo "Remote control endpoint did not become ready." >&2
+  echo "Headless log: $HEADLESS_LOG" >&2
+  exit 1
+fi
+
+echo "==> Waiting for SwiftLink TCP connection"
+for _ in {1..80}; do
+  if [[ -f "$SERVER_STDOUT" ]] && grep -q "connected " "$SERVER_STDOUT"; then
+    break
+  fi
+  sleep 0.25
+done
+
+if ! [[ -f "$SERVER_STDOUT" ]] || ! grep -q "connected " "$SERVER_STDOUT"; then
+  echo "SwiftLink transport did not connect to the burst server." >&2
+  echo "Headless log: $HEADLESS_LOG" >&2
+  echo "Server log: $SERVER_STDOUT" >&2
+  exit 1
+fi
+
+echo "==> Loading IRQ-driven PRG and starting it through remote control"
+remote_cmd c64.loadprg --file "$PRG_PATH" >/dev/null
+remote_cmd cpu.set --pc C000 >/dev/null
+
+echo "==> Triggering burst send"
+touch "$SERVER_TRIGGER"
+
+echo "==> Waiting for interrupt handler to capture burst"
+DONE_VALUE=""
+COUNT_VALUE=""
+for _ in {1..120}; do
+  if DONE_JSON="$(remote_cmd mem.read --addr C101 --len 1 2>/dev/null)"; then
+    DONE_VALUE="$(printf '%s' "$DONE_JSON" | "$PYTHON_BIN" -c 'import json,sys; data=json.load(sys.stdin).get("data", []); print(data[0] if data else "")' 2>/dev/null || true)"
+  fi
+  if COUNT_JSON="$(remote_cmd mem.read --addr C100 --len 1 2>/dev/null)"; then
+    COUNT_VALUE="$(printf '%s' "$COUNT_JSON" | "$PYTHON_BIN" -c 'import json,sys; data=json.load(sys.stdin).get("data", []); print(data[0] if data else "")' 2>/dev/null || true)"
+  fi
+  if [[ "$DONE_VALUE" == "170" && "$COUNT_VALUE" == "$PAYLOAD_COUNT" ]]; then
+    break
+  fi
+  sleep 0.25
+done
+
+if [[ "$DONE_VALUE" != "170" || "$COUNT_VALUE" != "$PAYLOAD_COUNT" ]]; then
+  echo "IRQ smoke did not finish as expected. done=${DONE_VALUE:-<empty>} count=${COUNT_VALUE:-<empty>}." >&2
+  echo "Headless log: $HEADLESS_LOG" >&2
+  exit 1
+fi
+
+BUFFER_JSON="$(remote_cmd mem.read --addr C200 --len "$PAYLOAD_COUNT")"
+ACTUAL_HEX="$(printf '%s' "$BUFFER_JSON" | "$PYTHON_BIN" -c 'import json,sys; data=json.load(sys.stdin).get("data", []); print("".join(f"{b:02X}" for b in data))')"
+EXPECTED_HEX="$("$PYTHON_BIN" - <<PY
+start = $PAYLOAD_START
+count = $PAYLOAD_COUNT
+print("".join(f"{(start + i) & 0xFF:02X}" for i in range(count)))
+PY
+)"
+
+if [[ "$ACTUAL_HEX" != "$EXPECTED_HEX" ]]; then
+  echo "Captured IRQ buffer mismatch." >&2
+  echo "Expected: $EXPECTED_HEX" >&2
+  echo "Actual:   $ACTUAL_HEX" >&2
+  exit 1
+fi
+
+if ! grep -q "$EXPECTED_HEX" "$SERVER_LOG"; then
+  echo "Burst server did not log the expected payload." >&2
+  echo "Server log: $SERVER_LOG" >&2
+  exit 1
+fi
+
+SUCCESS=1
+echo "==> SwiftLink IRQ smoke test passed"

--- a/tests/swiftlink-smoke/run-irq-local.sh
+++ b/tests/swiftlink-smoke/run-irq-local.sh
@@ -119,9 +119,10 @@ cat >"$APPSETTINGS_PATH" <<JSON
     "SwiftLinkTcpHost": "127.0.0.1",
     "SwiftLinkTcpPort": $SERVER_PORT,
     "SwiftLinkConnectOnBoot": true,
-    "SystemConfig": {
+      "SystemConfig": {
       "SwiftLinkEnabled": true,
-      "SwiftLinkCartridgeIOAddress": "DE00"
+      "SwiftLinkCartridgeIOAddress": "DE00",
+      "SwiftLinkReceiveMode": "FastBuffered"
     }
   }
 }

--- a/tests/swiftlink-smoke/run-irq-local.sh
+++ b/tests/swiftlink-smoke/run-irq-local.sh
@@ -116,13 +116,17 @@ echo "==> Generating SwiftLink IRQ smoke PRG"
 cat >"$APPSETTINGS_PATH" <<JSON
 {
   "Highbyte.DotNet6502.C64.Headless": {
-    "SwiftLinkTcpHost": "127.0.0.1",
-    "SwiftLinkTcpPort": $SERVER_PORT,
-    "SwiftLinkConnectOnBoot": true,
-      "SystemConfig": {
-      "SwiftLinkEnabled": true,
-      "SwiftLinkCartridgeIOAddress": "DE00",
-      "SwiftLinkReceiveMode": "FastBuffered"
+    "SwiftLinkHost": {
+      "TcpHost": "127.0.0.1",
+      "TcpPort": $SERVER_PORT,
+      "ConnectOnBoot": true
+    },
+    "SystemConfig": {
+      "SwiftLink": {
+        "Enabled": true,
+        "CartridgeIOAddress": "DE00",
+        "ReceiveMode": "FastBuffered"
+      }
     }
   }
 }

--- a/tests/swiftlink-smoke/run-local.ps1
+++ b/tests/swiftlink-smoke/run-local.ps1
@@ -112,9 +112,10 @@ try {
     "SwiftLinkTcpHost": "127.0.0.1",
     "SwiftLinkTcpPort": $EchoPort,
     "SwiftLinkConnectOnBoot": true,
-    "SystemConfig": {
+      "SystemConfig": {
       "SwiftLinkEnabled": true,
-      "SwiftLinkCartridgeIOAddress": "DE00"
+      "SwiftLinkCartridgeIOAddress": "DE00",
+      "SwiftLinkReceiveMode": "FastBuffered"
     }
   }
 }

--- a/tests/swiftlink-smoke/run-local.ps1
+++ b/tests/swiftlink-smoke/run-local.ps1
@@ -1,0 +1,220 @@
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = Resolve-Path (Join-Path $ScriptDir '..\..')
+
+$HeadlessProject = Join-Path $RepoRoot 'src/apps/Highbyte.DotNet6502.App.Headless/Highbyte.DotNet6502.App.Headless.csproj'
+$RemoteProject = Join-Path $RepoRoot 'src/apps/Highbyte.DotNet6502.App.RemoteClient/Highbyte.DotNet6502.App.RemoteClient.csproj'
+$HeadlessOut = Join-Path $RepoRoot 'src/apps/Highbyte.DotNet6502.App.Headless/bin/Debug/net10.0'
+$RemoteOut = Join-Path $RepoRoot 'src/apps/Highbyte.DotNet6502.App.RemoteClient/bin/Debug/net10.0'
+$HeadlessDll = Join-Path $HeadlessOut 'Highbyte.DotNet6502.App.Headless.dll'
+$RemoteDll = Join-Path $RemoteOut 'Highbyte.DotNet6502.App.RemoteClient.dll'
+$AppSettingsPath = Join-Path $HeadlessOut 'appsettings.Development.json'
+
+function Get-PythonCommand {
+    if (Get-Command py -ErrorAction SilentlyContinue) {
+        return @('py', '-3')
+    }
+    if (Get-Command python -ErrorAction SilentlyContinue) {
+        return @('python')
+    }
+    throw 'Python 3 is required.'
+}
+
+function Invoke-Python {
+    param([string[]]$Arguments)
+    $prefix = @()
+    if ($PythonCommand.Count -gt 1) {
+        $prefix = $PythonCommand[1..($PythonCommand.Count - 1)]
+    }
+    & $PythonCommand[0] @($prefix + $Arguments)
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Python command failed.'
+    }
+}
+
+function Get-FreePort {
+    $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+    $listener.Start()
+    try {
+        return ([System.Net.IPEndPoint]$listener.LocalEndpoint).Port
+    }
+    finally {
+        $listener.Stop()
+    }
+}
+
+function Invoke-RemoteCommand {
+    param([string[]]$Arguments)
+    $output = & dotnet $RemoteDll --port $RemotePort @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw ($output | Out-String)
+    }
+    return ($output | Out-String)
+}
+
+$PythonCommand = Get-PythonCommand
+$RemotePort = Get-FreePort
+$TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("swiftlink-smoke-" + [System.Guid]::NewGuid().ToString('N'))
+$PrgPath = Join-Path $TempDir 'swiftlink-smoke.prg'
+$EchoPortFile = Join-Path $TempDir 'echo.port'
+$EchoLog = Join-Path $TempDir 'echo.log'
+$EchoStdout = Join-Path $TempDir 'echo.stdout.log'
+$EchoStderr = Join-Path $TempDir 'echo.stderr.log'
+$HeadlessStdout = Join-Path $TempDir 'headless.stdout.log'
+$HeadlessStderr = Join-Path $TempDir 'headless.stderr.log'
+$AppSettingsBackup = Join-Path $TempDir 'appsettings.Development.backup.json'
+
+$EchoProcess = $null
+$HeadlessProcess = $null
+$HadAppSettings = Test-Path $AppSettingsPath
+$Success = $false
+
+New-Item -ItemType Directory -Path $TempDir | Out-Null
+
+try {
+    if ($HadAppSettings) {
+        Copy-Item $AppSettingsPath $AppSettingsBackup
+    }
+
+    Write-Host '==> Building Headless app and remote client'
+    dotnet build $HeadlessProject | Out-Null
+    dotnet build $RemoteProject | Out-Null
+
+    Write-Host '==> Starting local TCP echo server'
+    $echoArgs = @()
+    if ($PythonCommand.Count -gt 1) {
+        $echoArgs += $PythonCommand[1..($PythonCommand.Count - 1)]
+    }
+    $echoArgs += @(
+        (Join-Path $ScriptDir 'tcp_echo_server.py'),
+        '--host', '127.0.0.1',
+        '--port', '0',
+        '--port-file', $EchoPortFile,
+        '--log-file', $EchoLog
+    )
+    $EchoProcess = Start-Process -FilePath $PythonCommand[0] -ArgumentList $echoArgs -PassThru -RedirectStandardOutput $EchoStdout -RedirectStandardError $EchoStderr -NoNewWindow
+
+    for ($i = 0; $i -lt 40 -and -not (Test-Path $EchoPortFile); $i++) {
+        Start-Sleep -Milliseconds 250
+    }
+    if (-not (Test-Path $EchoPortFile)) {
+        throw 'Echo server did not publish a port.'
+    }
+    $EchoPort = (Get-Content $EchoPortFile -Raw).Trim()
+
+    Write-Host '==> Generating SwiftLink smoke PRG'
+    Invoke-Python @((Join-Path $ScriptDir 'write_smoke_prg.py'), $PrgPath)
+
+    @"
+{
+  "Highbyte.DotNet6502.C64.Headless": {
+    "SwiftLinkTcpHost": "127.0.0.1",
+    "SwiftLinkTcpPort": $EchoPort,
+    "SwiftLinkConnectOnBoot": true,
+    "SystemConfig": {
+      "SwiftLinkEnabled": true,
+      "SwiftLinkCartridgeIOAddress": "DE00"
+    }
+  }
+}
+"@ | Set-Content -Path $AppSettingsPath -Encoding utf8
+
+    Write-Host '==> Starting Headless app'
+    $headlessArgs = @(
+        $HeadlessDll,
+        '--system', 'C64',
+        '--start',
+        '--waitForSystemReady',
+        '--remote-port', $RemotePort,
+        '--allow-remote-quit',
+        '-l', 'Warning'
+    )
+    $HeadlessProcess = Start-Process -FilePath 'dotnet' -ArgumentList $headlessArgs -PassThru -RedirectStandardOutput $HeadlessStdout -RedirectStandardError $HeadlessStderr -NoNewWindow
+
+    Write-Host '==> Waiting for remote control endpoint'
+    $ready = $false
+    for ($i = 0; $i -lt 80; $i++) {
+        try {
+            Invoke-RemoteCommand @('emu.state') | Out-Null
+            $ready = $true
+            break
+        }
+        catch {
+            Start-Sleep -Milliseconds 250
+        }
+    }
+    if (-not $ready) {
+        throw "Remote control endpoint did not become ready. Headless stdout: $HeadlessStdout"
+    }
+
+    Write-Host '==> Waiting for SwiftLink TCP connection'
+    $connected = $false
+    for ($i = 0; $i -lt 80; $i++) {
+        if ((Test-Path $EchoStdout) -and (Select-String -Path $EchoStdout -Pattern 'connected ' -Quiet)) {
+            $connected = $true
+            break
+        }
+        Start-Sleep -Milliseconds 250
+    }
+    if (-not $connected) {
+        throw "SwiftLink transport did not connect to the local echo server. Headless stdout: $HeadlessStdout"
+    }
+
+    Write-Host '==> Loading PRG and starting it through remote control'
+    Invoke-RemoteCommand @('c64.loadprg', '--file', $PrgPath) | Out-Null
+    Invoke-RemoteCommand @('cpu.set', '--pc', 'C000') | Out-Null
+
+    Write-Host '==> Waiting for echoed byte to reach C64 memory'
+    $value = $null
+    for ($i = 0; $i -lt 80; $i++) {
+        try {
+            $memJson = Invoke-RemoteCommand @('mem.read', '--addr', 'C100', '--len', '1')
+            $value = (($memJson | ConvertFrom-Json).data | Select-Object -First 1)
+            if ($value -eq 65) {
+                break
+            }
+        }
+        catch {
+        }
+        Start-Sleep -Milliseconds 250
+    }
+
+    if ($value -ne 65) {
+        throw "Expected C64 memory `$C100 to contain 65, got '$value'. Headless stdout: $HeadlessStdout"
+    }
+
+    if (-not (Select-String -Path $EchoLog -Pattern '\b41\b' -Quiet)) {
+        throw "Echo server did not record the transmitted 41 byte. Echo log: $EchoLog"
+    }
+
+    $Success = $true
+    Write-Host '==> SwiftLink smoke test passed'
+}
+finally {
+    if (Test-Path $RemoteDll) {
+        try {
+            Invoke-RemoteCommand @('emu.quit') | Out-Null
+        }
+        catch {
+        }
+    }
+    if ($HeadlessProcess -and -not $HeadlessProcess.HasExited) {
+        Stop-Process -Id $HeadlessProcess.Id -Force
+    }
+    if ($EchoProcess -and -not $EchoProcess.HasExited) {
+        Stop-Process -Id $EchoProcess.Id -Force
+    }
+    if ($HadAppSettings) {
+        Copy-Item $AppSettingsBackup $AppSettingsPath -Force
+    }
+    else {
+        Remove-Item $AppSettingsPath -ErrorAction SilentlyContinue
+    }
+    if ($Success) {
+        Remove-Item $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    else {
+        Write-Warning "Smoke artifacts kept at $TempDir"
+    }
+}

--- a/tests/swiftlink-smoke/run-local.ps1
+++ b/tests/swiftlink-smoke/run-local.ps1
@@ -109,13 +109,17 @@ try {
     @"
 {
   "Highbyte.DotNet6502.C64.Headless": {
-    "SwiftLinkTcpHost": "127.0.0.1",
-    "SwiftLinkTcpPort": $EchoPort,
-    "SwiftLinkConnectOnBoot": true,
-      "SystemConfig": {
-      "SwiftLinkEnabled": true,
-      "SwiftLinkCartridgeIOAddress": "DE00",
-      "SwiftLinkReceiveMode": "FastBuffered"
+    "SwiftLinkHost": {
+      "TcpHost": "127.0.0.1",
+      "TcpPort": $EchoPort,
+      "ConnectOnBoot": true
+    },
+    "SystemConfig": {
+      "SwiftLink": {
+        "Enabled": true,
+        "CartridgeIOAddress": "DE00",
+        "ReceiveMode": "FastBuffered"
+      }
     }
   }
 }

--- a/tests/swiftlink-smoke/run-local.sh
+++ b/tests/swiftlink-smoke/run-local.sh
@@ -109,13 +109,17 @@ echo "==> Generating SwiftLink smoke PRG"
 cat >"$APPSETTINGS_PATH" <<JSON
 {
   "Highbyte.DotNet6502.C64.Headless": {
-    "SwiftLinkTcpHost": "127.0.0.1",
-    "SwiftLinkTcpPort": $ECHO_PORT,
-    "SwiftLinkConnectOnBoot": true,
-      "SystemConfig": {
-      "SwiftLinkEnabled": true,
-      "SwiftLinkCartridgeIOAddress": "DE00",
-      "SwiftLinkReceiveMode": "FastBuffered"
+    "SwiftLinkHost": {
+      "TcpHost": "127.0.0.1",
+      "TcpPort": $ECHO_PORT,
+      "ConnectOnBoot": true
+    },
+    "SystemConfig": {
+      "SwiftLink": {
+        "Enabled": true,
+        "CartridgeIOAddress": "DE00",
+        "ReceiveMode": "FastBuffered"
+      }
     }
   }
 }

--- a/tests/swiftlink-smoke/run-local.sh
+++ b/tests/swiftlink-smoke/run-local.sh
@@ -112,9 +112,10 @@ cat >"$APPSETTINGS_PATH" <<JSON
     "SwiftLinkTcpHost": "127.0.0.1",
     "SwiftLinkTcpPort": $ECHO_PORT,
     "SwiftLinkConnectOnBoot": true,
-    "SystemConfig": {
+      "SystemConfig": {
       "SwiftLinkEnabled": true,
-      "SwiftLinkCartridgeIOAddress": "DE00"
+      "SwiftLinkCartridgeIOAddress": "DE00",
+      "SwiftLinkReceiveMode": "FastBuffered"
     }
   }
 }

--- a/tests/swiftlink-smoke/run-local.sh
+++ b/tests/swiftlink-smoke/run-local.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+HEADLESS_PROJECT="src/apps/Highbyte.DotNet6502.App.Headless/Highbyte.DotNet6502.App.Headless.csproj"
+REMOTE_PROJECT="src/apps/Highbyte.DotNet6502.App.RemoteClient/Highbyte.DotNet6502.App.RemoteClient.csproj"
+HEADLESS_OUT="$REPO_ROOT/src/apps/Highbyte.DotNet6502.App.Headless/bin/Debug/net10.0"
+REMOTE_OUT="$REPO_ROOT/src/apps/Highbyte.DotNet6502.App.RemoteClient/bin/Debug/net10.0"
+HEADLESS_DLL="$HEADLESS_OUT/Highbyte.DotNet6502.App.Headless.dll"
+REMOTE_DLL="$REMOTE_OUT/Highbyte.DotNet6502.App.RemoteClient.dll"
+APPSETTINGS_PATH="$HEADLESS_OUT/appsettings.Development.json"
+
+find_python() {
+  if command -v python3 >/dev/null 2>&1; then
+    echo "python3"
+    return
+  fi
+  if command -v python >/dev/null 2>&1; then
+    echo "python"
+    return
+  fi
+  echo "Python 3 is required." >&2
+  exit 1
+}
+
+PYTHON_BIN="$(find_python)"
+REMOTE_PORT="$("$PYTHON_BIN" - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+)"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/swiftlink-smoke.XXXXXX")"
+PRG_PATH="$TMP_DIR/swiftlink-smoke.prg"
+ECHO_PORT_FILE="$TMP_DIR/echo.port"
+ECHO_LOG="$TMP_DIR/echo.log"
+ECHO_STDOUT="$TMP_DIR/echo.stdout.log"
+HEADLESS_LOG="$TMP_DIR/headless.log"
+APPSETTINGS_BACKUP="$TMP_DIR/appsettings.Development.backup.json"
+
+ECHO_PID=""
+HEADLESS_PID=""
+HAD_APPSETTINGS=0
+SUCCESS=0
+
+cleanup() {
+  set +e
+  if [[ -f "$REMOTE_DLL" ]]; then
+    dotnet "$REMOTE_DLL" --port "$REMOTE_PORT" emu.quit >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$HEADLESS_PID" ]] && kill -0 "$HEADLESS_PID" >/dev/null 2>&1; then
+    kill "$HEADLESS_PID" >/dev/null 2>&1 || true
+    wait "$HEADLESS_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$ECHO_PID" ]] && kill -0 "$ECHO_PID" >/dev/null 2>&1; then
+    kill "$ECHO_PID" >/dev/null 2>&1 || true
+    wait "$ECHO_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ "$HAD_APPSETTINGS" -eq 1 ]]; then
+    cp "$APPSETTINGS_BACKUP" "$APPSETTINGS_PATH"
+  else
+    rm -f "$APPSETTINGS_PATH"
+  fi
+  if [[ "$SUCCESS" -eq 1 ]]; then
+    rm -rf "$TMP_DIR"
+  else
+    echo "Smoke artifacts kept at $TMP_DIR" >&2
+  fi
+}
+trap cleanup EXIT
+
+if [[ -f "$APPSETTINGS_PATH" ]]; then
+  cp "$APPSETTINGS_PATH" "$APPSETTINGS_BACKUP"
+  HAD_APPSETTINGS=1
+fi
+
+echo "==> Building Headless app and remote client"
+dotnet build "$REPO_ROOT/$HEADLESS_PROJECT" >/dev/null
+dotnet build "$REPO_ROOT/$REMOTE_PROJECT" >/dev/null
+
+echo "==> Starting local TCP echo server"
+"$PYTHON_BIN" "$SCRIPT_DIR/tcp_echo_server.py" \
+  --host 127.0.0.1 \
+  --port 0 \
+  --port-file "$ECHO_PORT_FILE" \
+  --log-file "$ECHO_LOG" \
+  >"$ECHO_STDOUT" 2>&1 &
+ECHO_PID=$!
+
+for _ in {1..40}; do
+  [[ -f "$ECHO_PORT_FILE" ]] && break
+  sleep 0.25
+done
+
+if [[ ! -f "$ECHO_PORT_FILE" ]]; then
+  echo "Echo server did not publish a port." >&2
+  exit 1
+fi
+ECHO_PORT="$(tr -d '[:space:]' <"$ECHO_PORT_FILE")"
+
+echo "==> Generating SwiftLink smoke PRG"
+"$PYTHON_BIN" "$SCRIPT_DIR/write_smoke_prg.py" "$PRG_PATH"
+
+cat >"$APPSETTINGS_PATH" <<JSON
+{
+  "Highbyte.DotNet6502.C64.Headless": {
+    "SwiftLinkTcpHost": "127.0.0.1",
+    "SwiftLinkTcpPort": $ECHO_PORT,
+    "SwiftLinkConnectOnBoot": true,
+    "SystemConfig": {
+      "SwiftLinkEnabled": true,
+      "SwiftLinkCartridgeIOAddress": "DE00"
+    }
+  }
+}
+JSON
+
+echo "==> Starting Headless app"
+DOTNET_ENVIRONMENT=Development \
+dotnet "$HEADLESS_DLL" \
+  --system C64 \
+  --start \
+  --waitForSystemReady \
+  --remote-port "$REMOTE_PORT" \
+  --allow-remote-quit \
+  -l Warning \
+  >"$HEADLESS_LOG" 2>&1 &
+HEADLESS_PID=$!
+
+remote_cmd() {
+  dotnet "$REMOTE_DLL" --port "$REMOTE_PORT" "$@"
+}
+
+echo "==> Waiting for remote control endpoint"
+for _ in {1..80}; do
+  if remote_cmd emu.state >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.25
+done
+
+if ! remote_cmd emu.state >/dev/null 2>&1; then
+  echo "Remote control endpoint did not become ready." >&2
+  echo "Headless log: $HEADLESS_LOG" >&2
+  exit 1
+fi
+
+echo "==> Waiting for SwiftLink TCP connection"
+for _ in {1..80}; do
+  if [[ -f "$ECHO_STDOUT" ]] && grep -q "connected " "$ECHO_STDOUT"; then
+    break
+  fi
+  sleep 0.25
+done
+
+if ! [[ -f "$ECHO_STDOUT" ]] || ! grep -q "connected " "$ECHO_STDOUT"; then
+  echo "SwiftLink transport did not connect to the local echo server." >&2
+  echo "Headless log: $HEADLESS_LOG" >&2
+  echo "Echo server log: $ECHO_STDOUT" >&2
+  exit 1
+fi
+
+echo "==> Loading PRG and starting it through remote control"
+remote_cmd c64.loadprg --file "$PRG_PATH" >/dev/null
+remote_cmd cpu.set --pc C000 >/dev/null
+
+echo "==> Waiting for echoed byte to reach C64 memory"
+VALUE=""
+for _ in {1..80}; do
+  if MEM_JSON="$(remote_cmd mem.read --addr C100 --len 1 2>/dev/null)"; then
+    VALUE="$(printf '%s' "$MEM_JSON" | "$PYTHON_BIN" -c 'import json,sys; data=json.load(sys.stdin).get("data", []); print(data[0] if data else "")' 2>/dev/null || true)"
+    if [[ "$VALUE" == "65" ]]; then
+      break
+    fi
+  fi
+  sleep 0.25
+done
+
+if [[ "$VALUE" != "65" ]]; then
+  echo "Expected C64 memory \$C100 to contain 65, got '${VALUE:-<empty>}'." >&2
+  echo "Headless log: $HEADLESS_LOG" >&2
+  exit 1
+fi
+
+if ! grep -q '\b41\b' "$ECHO_LOG"; then
+  echo "Echo server did not record the transmitted 41 byte." >&2
+  echo "Echo log: $ECHO_LOG" >&2
+  exit 1
+fi
+
+SUCCESS=1
+echo "==> SwiftLink smoke test passed"

--- a/tests/swiftlink-smoke/tcp_burst_server.py
+++ b/tests/swiftlink-smoke/tcp_burst_server.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+import argparse
+import pathlib
+import socket
+import sys
+import time
+from typing import Optional
+
+
+def wait_for_trigger(trigger_file: Optional[str]) -> None:
+    if not trigger_file:
+        return
+
+    trigger_path = pathlib.Path(trigger_file)
+    while not trigger_path.exists():
+        time.sleep(0.05)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=0)
+    parser.add_argument("--port-file")
+    parser.add_argument("--log-file")
+    parser.add_argument("--trigger-file")
+    parser.add_argument("--start-byte", type=lambda value: int(value, 0), default=0x30)
+    parser.add_argument("--count", type=int, default=16)
+    args = parser.parse_args()
+
+    payload = bytes((args.start_byte + i) & 0xFF for i in range(args.count))
+    log_path = pathlib.Path(args.log_file) if args.log_file else None
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind((args.host, args.port))
+        server.listen()
+
+        actual_port = server.getsockname()[1]
+        if args.port_file:
+            pathlib.Path(args.port_file).write_text(f"{actual_port}\n", encoding="utf-8")
+
+        print(f"listening {args.host}:{actual_port}", flush=True)
+
+        client, address = server.accept()
+        print(f"connected {address[0]}:{address[1]}", flush=True)
+        with client:
+            wait_for_trigger(args.trigger_file)
+            client.sendall(payload)
+            hex_bytes = payload.hex().upper()
+            print(f"sent {hex_bytes}", flush=True)
+            if log_path:
+                log_path.write_text(f"{hex_bytes}\n", encoding="utf-8")
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/tests/swiftlink-smoke/tcp_echo_server.py
+++ b/tests/swiftlink-smoke/tcp_echo_server.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import argparse
+import pathlib
+import socket
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=0)
+    parser.add_argument("--port-file")
+    parser.add_argument("--log-file")
+    args = parser.parse_args()
+
+    log_path = pathlib.Path(args.log_file) if args.log_file else None
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind((args.host, args.port))
+        server.listen()
+
+        actual_port = server.getsockname()[1]
+        if args.port_file:
+            pathlib.Path(args.port_file).write_text(f"{actual_port}\n", encoding="utf-8")
+
+        print(f"listening {args.host}:{actual_port}", flush=True)
+
+        while True:
+            client, address = server.accept()
+            print(f"connected {address[0]}:{address[1]}", flush=True)
+            with client:
+                while True:
+                    data = client.recv(4096)
+                    if not data:
+                        break
+                    hex_bytes = data.hex().upper()
+                    print(f"recv {hex_bytes}", flush=True)
+                    if log_path:
+                        with log_path.open("a", encoding="utf-8") as log_file:
+                            log_file.write(f"{hex_bytes}\n")
+                    client.sendall(data)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/tests/swiftlink-smoke/write_irq_smoke_prg.py
+++ b/tests/swiftlink-smoke/write_irq_smoke_prg.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+import pathlib
+import sys
+
+
+LOAD_ADDRESS = 0xC000
+COUNT_ADDR = 0xC100
+DONE_ADDR = 0xC101
+BUFFER_ADDR = 0xC200
+EXPECTED_COUNT = 16
+COMMAND_RECEIVE_IRQ_ENABLED = 0x09
+
+
+class ProgramBuilder:
+    def __init__(self, load_address: int):
+        self.load_address = load_address
+        self.code = bytearray()
+        self.labels: dict[str, int] = {}
+        self.absolute_patches: list[tuple[int, str]] = []
+        self.relative_patches: list[tuple[int, str]] = []
+
+    @property
+    def current_address(self) -> int:
+        return self.load_address + len(self.code)
+
+    def label(self, name: str) -> None:
+        self.labels[name] = self.current_address
+
+    def byte(self, value: int) -> None:
+        self.code.append(value & 0xFF)
+
+    def bytes(self, *values: int) -> None:
+        self.code.extend(value & 0xFF for value in values)
+
+    def lda_imm(self, value: int) -> None:
+        self.bytes(0xA9, value)
+
+    def lda_abs(self, address: int) -> None:
+        self.bytes(0xAD, address & 0xFF, (address >> 8) & 0xFF)
+
+    def ldx_abs(self, address: int) -> None:
+        self.bytes(0xAE, address & 0xFF, (address >> 8) & 0xFF)
+
+    def sta_abs(self, address: int) -> None:
+        self.bytes(0x8D, address & 0xFF, (address >> 8) & 0xFF)
+
+    def stx_abs(self, address: int) -> None:
+        self.bytes(0x8E, address & 0xFF, (address >> 8) & 0xFF)
+
+    def cmp_imm(self, value: int) -> None:
+        self.bytes(0xC9, value)
+
+    def cpx_imm(self, value: int) -> None:
+        self.bytes(0xE0, value)
+
+    def and_imm(self, value: int) -> None:
+        self.bytes(0x29, value)
+
+    def branch(self, opcode: int, label: str) -> None:
+        self.byte(opcode)
+        self.relative_patches.append((len(self.code), label))
+        self.byte(0x00)
+
+    def bne(self, label: str) -> None:
+        self.branch(0xD0, label)
+
+    def beq(self, label: str) -> None:
+        self.branch(0xF0, label)
+
+    def bcs(self, label: str) -> None:
+        self.branch(0xB0, label)
+
+    def jmp(self, label: str) -> None:
+        self.byte(0x4C)
+        self.absolute_patches.append((len(self.code), label))
+        self.bytes(0x00, 0x00)
+
+    def patch_absolute(self, label: str) -> None:
+        self.absolute_patches.append((len(self.code), label))
+        self.bytes(0x00, 0x00)
+
+    def build(self) -> bytes:
+        for offset, label in self.absolute_patches:
+            address = self.labels[label]
+            self.code[offset] = address & 0xFF
+            self.code[offset + 1] = (address >> 8) & 0xFF
+
+        for offset, label in self.relative_patches:
+            target = self.labels[label]
+            branch_address = self.load_address + offset + 1
+            delta = target - branch_address
+            if delta < -128 or delta > 127:
+                raise ValueError(f"Branch to {label} out of range: {delta}")
+            self.code[offset] = delta & 0xFF
+
+        return bytes(self.code)
+
+
+def build_program() -> bytes:
+    b = ProgramBuilder(LOAD_ADDRESS)
+
+    b.bytes(0x78)  # sei
+    b.lda_imm(0x35)
+    b.bytes(0x85, 0x01)  # sta $01
+
+    b.lda_imm(0x00)
+    b.sta_abs(COUNT_ADDR)
+    b.sta_abs(DONE_ADDR)
+
+    b.lda_imm(COMMAND_RECEIVE_IRQ_ENABLED)
+    b.sta_abs(0xDE02)
+    b.lda_imm(0x00)
+    b.sta_abs(0xDE03)
+
+    irq_vector_low_immediate_offset = len(b.code) + 1
+    b.lda_imm(0x00)
+    b.sta_abs(0xFFFE)
+    irq_vector_high_immediate_offset = len(b.code) + 1
+    b.lda_imm(0x00)
+    b.sta_abs(0xFFFF)
+
+    b.bytes(0x58)  # cli
+
+    b.label("main_loop")
+    b.lda_abs(COUNT_ADDR)
+    b.cmp_imm(EXPECTED_COUNT)
+    b.bne("main_loop")
+    b.lda_imm(0xAA)
+    b.sta_abs(DONE_ADDR)
+    b.jmp("done_loop")
+
+    b.label("done_loop")
+    b.jmp("done_loop")
+
+    b.label("irq_handler")
+    b.bytes(0x48)       # pha
+    b.bytes(0x8A)       # txa
+    b.bytes(0x48)       # pha
+    b.bytes(0x98)       # tya
+    b.bytes(0x48)       # pha
+    b.lda_abs(0xDE01)   # ack status / inspect RX_FULL
+    b.and_imm(0x08)
+    b.beq("irq_restore")
+    b.ldx_abs(COUNT_ADDR)
+    b.cpx_imm(EXPECTED_COUNT)
+    b.bcs("irq_drain_only")
+    b.lda_abs(0xDE00)
+    b.bytes(0x9D, BUFFER_ADDR & 0xFF, (BUFFER_ADDR >> 8) & 0xFF)  # sta buffer,x
+    b.bytes(0xE8)       # inx
+    b.stx_abs(COUNT_ADDR)
+    b.jmp("irq_restore")
+
+    b.label("irq_drain_only")
+    b.lda_abs(0xDE00)
+
+    b.label("irq_restore")
+    b.bytes(0x68)  # pla
+    b.bytes(0xA8)  # tay
+    b.bytes(0x68)  # pla
+    b.bytes(0xAA)  # tax
+    b.bytes(0x68)  # pla
+    b.bytes(0x40)  # rti
+
+    program = bytearray(b.build())
+    irq_handler_address = b.labels["irq_handler"]
+
+    # Patch the IRQ vector immediates now that the handler address is known.
+    program[irq_vector_low_immediate_offset] = irq_handler_address & 0xFF
+    program[irq_vector_high_immediate_offset] = (irq_handler_address >> 8) & 0xFF
+
+    return bytes([LOAD_ADDRESS & 0xFF, (LOAD_ADDRESS >> 8) & 0xFF]) + bytes(program)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: write_irq_smoke_prg.py <output.prg>", file=sys.stderr)
+        return 2
+
+    output_path = pathlib.Path(sys.argv[1])
+    output_path.write_bytes(build_program())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/swiftlink-smoke/write_smoke_prg.py
+++ b/tests/swiftlink-smoke/write_smoke_prg.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import pathlib
+import sys
+
+
+PROGRAM_BYTES = bytes(
+    [
+        0x00,
+        0xC0,
+        0xA9,
+        0x41,
+        0x8D,
+        0x00,
+        0xDE,
+        0xAD,
+        0x01,
+        0xDE,
+        0x29,
+        0x08,
+        0xF0,
+        0xF9,
+        0xAD,
+        0x00,
+        0xDE,
+        0x8D,
+        0x00,
+        0xC1,
+        0x4C,
+        0x12,
+        0xC0,
+    ]
+)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: write_smoke_prg.py <output.prg>", file=sys.stderr)
+        return 2
+
+    output_path = pathlib.Path(sys.argv[1])
+    output_path.write_bytes(PROGRAM_BYTES)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
This PR adds SwiftLink support for the C64 emulator, including both raw TCP transport and a Hayes-compatible modem mode for modem-driven software such as Compunet Reborn.

On the C64 side, it adds a SwiftLink-compatible ACIA device with configurable base address, interrupt mode, and receive mode. On the host side, it adds transport support for direct TCP connections and a modem layer that handles AT/ATDT-style dialing before bridging to TCP.

The work also includes a few foundational emulator fixes that are not SwiftLink-specific:

- 6502 NMI handling was improved to behave more like real hardware, including correct edge-triggered semantics.
- The C64 execution loop now services newly raised hardware interrupts after post-instruction device ticks, so device-generated IRQ/NMI signals are visible at the correct instruction boundary instead of one instruction late.
- This timing fix is generally beneficial for other emulated hardware devices, not only SwiftLink, because it improves how post-instruction peripherals integrate with the CPU interrupt pipeline.

A SwiftLink-specific compatibility hook was also added for NMI delivery in cases where software temporarily banks out the mapped NMI vector area. That part is intentionally scoped to SwiftLink behavior and is separate from the more general CPU/C64 interrupt timing fix.

## Included

SwiftLink cartridge device for C64
Raw TCP transport mode
Hayes modem transport mode
Avalonia config/UI support for SwiftLink
SwiftLink config restructuring into SystemConfig.SwiftLink and HostConfig.SwiftLinkHost
Validation for SwiftLink system and host config
Browser availability metadata for downloadable .d64 entries
Compunet Reborn .d64 download entry
Focused CPU and SwiftLink tests

## Validation

Manual testing with Compunet Reborn
Manual testing reaching and interacting beyond the login flow
Focused CPU interrupt tests
SwiftLink device tests
