### PR TITLE
Add unofficial 6502 opcode compatibility profiles

### DIFF
--- a/docs/home/limitations.md
+++ b/docs/home/limitations.md
@@ -12,7 +12,7 @@
 
 ## Missing 6502 features
 
-- Support for unofficial / undocumented opcodes is not implemented.
+- Coverage of unofficial / undocumented **NMOS** opcodes is partial. Official 6502 opcodes are implemented, and the currently supported unofficial opcodes are exposed through compatibility profiles in [`Highbyte.DotNet6502`](../libraries/core/dotnet6502.md).
 
 ## Missing or incomplete C64 features
 

--- a/docs/libraries/core/dotnet6502.md
+++ b/docs/libraries/core/dotnet6502.md
@@ -8,8 +8,40 @@ Library: `Highbyte.DotNet6502`
 - Has no UI, meant to be integrated into other applications.
 - Emulation of a 6502 processor.
 - Supports all official 6502 opcodes.
+- Supports a compatibility-profile based subset of undocumented NMOS 6502 opcodes.
 - Can load an assembled 6502 program binary and execute it.
 - Passes this [Functional 6502 test program](https://github.com/Klaus2m5/6502_65C02_functional_tests).
+
+## Opcode compatibility profiles
+
+The core CPU library exposes undocumented opcodes through `CpuCompatibilityProfile`.
+Higher profiles include everything from lower profiles.
+
+| Profile | Meaning |
+| ------- | ------- |
+| `OfficialOnly` | Only documented MOS 6502 opcodes are available. |
+| `StableUnofficial` | Also enables the more predictable undocumented NMOS opcodes commonly used on real 6502/6510 hardware. |
+| `ExperimentalUnofficial` | Also enables the currently implemented but less reliable undocumented opcodes used for targeted compatibility testing. |
+| `FullUnofficial` | Also enables halt-style unofficial opcodes such as `JAM` / `KIL` that can intentionally jam the CPU until reset. |
+
+Notes:
+
+- `new CPU()` and `InstructionList.GetAllInstructions()` currently use `ExperimentalUnofficial`.
+- `GenericComputer` defaults to `ExperimentalUnofficial`.
+- `C64` and `Vic20` default to `StableUnofficial`.
+- These profiles describe the currently implemented undocumented **NMOS** opcode set. They are not a claim of complete coverage for every unofficial opcode found on every 6502-family variant.
+- `JAM` / `KIL` behavior is modeled as the CPU entering a halted/jammed state until `Reset(...)` is called.
+
+Example:
+
+```c#
+using Highbyte.DotNet6502;
+
+var defaultCpu = new CPU();
+var officialCpu = new CPU(CpuCompatibilityProfile.OfficialOnly);
+var stableCpu = new CPU(CpuCompatibilityProfile.StableUnofficial);
+var fullCpu = new CPU(CpuCompatibilityProfile.FullUnofficial);
+```
 
 ## Requirements
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/CpuCompatibilityProfileOption.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/CpuCompatibilityProfileOption.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+using Highbyte.DotNet6502;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
+
+public record CpuCompatibilityProfileOption(CpuCompatibilityProfile Profile, string DisplayName, string HelpText)
+{
+    public static IReadOnlyList<CpuCompatibilityProfileOption> All { get; } = new[]
+    {
+        new CpuCompatibilityProfileOption(
+            CpuCompatibilityProfile.OfficialOnly,
+            "Official only",
+            "Only documented MOS 6502 opcodes are available."),
+        new CpuCompatibilityProfileOption(
+            CpuCompatibilityProfile.StableUnofficial,
+            "Stable unofficial",
+            "Also enables the predictable NMOS unofficial opcodes commonly used on real 6502/6510 hardware."),
+        new CpuCompatibilityProfileOption(
+            CpuCompatibilityProfile.ExperimentalUnofficial,
+            "Experimental unofficial",
+            "Also enables the remaining executable undocumented opcodes such as ARR and LAS for targeted compatibility testing."),
+        new CpuCompatibilityProfileOption(
+            CpuCompatibilityProfile.FullUnofficial,
+            "Full unofficial",
+            "Also enables halt-style unofficial opcodes such as JAM/KIL that can intentionally stop the CPU."),
+    };
+
+    public static CpuCompatibilityProfileOption FromProfile(CpuCompatibilityProfile profile)
+        => All.Single(option => option.Profile == profile);
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64ConfigDialogViewModel.cs
@@ -70,6 +70,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
     private AudioProviderOption? _selectedAudioProvider;
     private AudioTargetOption? _selectedAudioTarget;
     private bool _suppressAudioTargetUpdate;
+    private CpuCompatibilityProfileOption? _selectedCpuCompatibilityProfile;
     private SidEmulationModeOption? _selectedSidEmulationMode;
 
     private string _corsProxyOverrideURL = string.Empty;
@@ -121,6 +122,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
         SwiftLinkConnectOnBoot = _workingConfig.SwiftLinkHost.ConnectOnBoot;
 
         AudioEnabled = _workingConfig.SystemConfig.AudioEnabled;
+        _selectedCpuCompatibilityProfile = CpuCompatibilityProfileOption.FromProfile(_workingConfig.SystemConfig.CpuCompatibilityProfile);
 
         RomDirectory = _workingConfig.SystemConfig.ROMDirectory;
         CorsProxyOverrideURL = _workingConfig.CorsProxyOverrideURL ?? string.Empty;
@@ -191,6 +193,8 @@ public class C64ConfigDialogViewModel : ViewModelBase
     public ObservableCollection<RenderTargetOption> RenderTargets { get; } = new();
     public ObservableCollection<AudioProviderOption> AudioProviders { get; } = new();
     public ObservableCollection<AudioTargetOption> AudioTargets { get; } = new();
+    public ObservableCollection<CpuCompatibilityProfileOption> CpuCompatibilityProfiles { get; } =
+        new(CpuCompatibilityProfileOption.All);
     public ObservableCollection<SidEmulationModeOption> SidEmulationModes { get; } = new();
     public ObservableCollection<int> AvailableJoysticks { get; }
     public ObservableCollection<KeyMappingEntry> KeyboardMappings { get; } = new();
@@ -594,6 +598,25 @@ public class C64ConfigDialogViewModel : ViewModelBase
     public string SelectedAudioProviderHelpText => SelectedAudioProvider?.HelpText ?? string.Empty;
 
     public string SelectedAudioTargetHelpText => SelectedAudioTarget?.HelpText ?? string.Empty;
+
+    public CpuCompatibilityProfileOption? SelectedCpuCompatibilityProfile
+    {
+        get => _selectedCpuCompatibilityProfile;
+        set
+        {
+            if (ReferenceEquals(_selectedCpuCompatibilityProfile, value))
+                return;
+
+            this.RaiseAndSetIfChanged(ref _selectedCpuCompatibilityProfile, value);
+
+            if (value != null)
+                _workingConfig.SystemConfig.CpuCompatibilityProfile = value.Profile;
+
+            this.RaisePropertyChanged(nameof(SelectedCpuCompatibilityProfileHelpText));
+        }
+    }
+
+    public string SelectedCpuCompatibilityProfileHelpText => SelectedCpuCompatibilityProfile?.HelpText ?? string.Empty;
 
     public SidEmulationModeOption? SelectedSidEmulationMode
     {
@@ -1466,6 +1489,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
         if (_workingConfig.SystemConfig.AudioTargetType != null)
             _originalConfig.SystemConfig.SetAudioTargetType(_workingConfig.SystemConfig.AudioTargetType);
 
+        _originalConfig.SystemConfig.CpuCompatibilityProfile = _workingConfig.SystemConfig.CpuCompatibilityProfile;
         _originalConfig.SystemConfig.SidEmulationMode = _workingConfig.SystemConfig.SidEmulationMode;
 
         _originalConfig.SystemConfig.ROMs = ROM.Clone(_workingConfig.SystemConfig.ROMs);

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64ConfigUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64ConfigUserControl.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64.ViewModels"
+        xmlns:corevm="using:Highbyte.DotNet6502.App.Avalonia.Core.ViewModels"
         x:Class="Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64.Views.C64ConfigUserControl"
         x:DataType="vm:C64ConfigDialogViewModel">
   
@@ -117,6 +118,37 @@
         </Border>
         </StackPanel>
           
+        <!-- CPU Section -->
+        <StackPanel Width="460" Classes="wrap-item">
+            <Border Classes="content-section">
+                <StackPanel Classes="spacing-tight">
+                <TextBlock Text="CPU"
+                            Classes=""/>
+
+                <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto" Classes="spacing-tight">
+                    <TextBlock Grid.Row="0" Grid.Column="0"
+                                Text="Profile:"
+                                Classes="secondary-text"/>
+                    <ComboBox Grid.Row="0" Grid.Column="1"
+                            AutomationProperties.AutomationId="CpuCompatibilityProfileComboBox"
+                            AutomationProperties.Name="CPU opcode compatibility profile"
+                            ItemsSource="{Binding CpuCompatibilityProfiles}"
+                            SelectedItem="{Binding SelectedCpuCompatibilityProfile}"
+                            ToolTip.Tip="{Binding SelectedCpuCompatibilityProfileHelpText}"
+                            Classes="h-stretch"
+                            MaxDropDownHeight="200">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate x:DataType="corevm:CpuCompatibilityProfileOption">
+                            <TextBlock Text="{Binding DisplayName}"/>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                </Grid>
+
+                </StackPanel>
+            </Border>
+        </StackPanel>
+
         <!-- Render Section -->
         <StackPanel Width="460" Classes="wrap-item">
             <Border Classes="content-section">

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/ViewModels/Vic20ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/ViewModels/Vic20ConfigDialogViewModel.cs
@@ -37,6 +37,7 @@ public class Vic20ConfigDialogViewModel : ViewModelBase
     private RenderProviderOption? _selectedRenderProvider;
     private RenderTargetOption? _selectedRenderTarget;
     private bool _suppressRenderTargetUpdate;
+    private CpuCompatibilityProfileOption? _selectedCpuCompatibilityProfile;
 
     public ReactiveCommand<Unit, Unit> DownloadRomsToByteArrayCommand { get; }
     public ReactiveCommand<Unit, Unit> DownloadRomsToFilesCommand { get; }
@@ -56,6 +57,7 @@ public class Vic20ConfigDialogViewModel : ViewModelBase
 
         RomDirectory = _workingConfig.SystemConfig.ROMDirectory;
         CorsProxyOverrideURL = _workingConfig.CorsProxyOverrideURL ?? string.Empty;
+        _selectedCpuCompatibilityProfile = CpuCompatibilityProfileOption.FromProfile(_workingConfig.SystemConfig.CpuCompatibilityProfile);
 
         InitializeRenderOptions();
         UpdateRomStatuses();
@@ -108,6 +110,8 @@ public class Vic20ConfigDialogViewModel : ViewModelBase
     public ObservableCollection<Vic20RomStatusViewModel> RomStatuses { get; } = new();
     public ObservableCollection<RenderProviderOption> RenderProviders { get; } = new();
     public ObservableCollection<RenderTargetOption> RenderTargets { get; } = new();
+    public ObservableCollection<CpuCompatibilityProfileOption> CpuCompatibilityProfiles { get; } =
+        new(CpuCompatibilityProfileOption.All);
 
     public bool IsRunningInWebAssembly { get; } = PlatformDetection.IsRunningInWebAssembly();
 
@@ -232,6 +236,25 @@ public class Vic20ConfigDialogViewModel : ViewModelBase
     public string SelectedRenderProviderHelpText => SelectedRenderProvider?.HelpText ?? string.Empty;
 
     public string SelectedRenderTargetHelpText => SelectedRenderTarget?.HelpText ?? string.Empty;
+
+    public CpuCompatibilityProfileOption? SelectedCpuCompatibilityProfile
+    {
+        get => _selectedCpuCompatibilityProfile;
+        set
+        {
+            if (ReferenceEquals(_selectedCpuCompatibilityProfile, value))
+                return;
+
+            this.RaiseAndSetIfChanged(ref _selectedCpuCompatibilityProfile, value);
+
+            if (value != null)
+                _workingConfig.SystemConfig.CpuCompatibilityProfile = value.Profile;
+
+            this.RaisePropertyChanged(nameof(SelectedCpuCompatibilityProfileHelpText));
+        }
+    }
+
+    public string SelectedCpuCompatibilityProfileHelpText => SelectedCpuCompatibilityProfile?.HelpText ?? string.Empty;
 
     public string OkButtonText => IsRunningInWebAssembly ? "Save" : "Ok";
 
@@ -413,6 +436,7 @@ public class Vic20ConfigDialogViewModel : ViewModelBase
             _originalConfig.SystemConfig.ROMDirectory = _workingConfig.SystemConfig.ROMDirectory;
             _originalConfig.CorsProxyOverrideURL = _workingConfig.CorsProxyOverrideURL;
             _originalConfig.SystemConfig.ROMs = ROM.Clone(_workingConfig.SystemConfig.ROMs);
+            _originalConfig.SystemConfig.CpuCompatibilityProfile = _workingConfig.SystemConfig.CpuCompatibilityProfile;
 
             if (_workingConfig.SystemConfig.RenderProviderType != null)
                 _originalConfig.SystemConfig.SetRenderProviderType(_workingConfig.SystemConfig.RenderProviderType);

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20ConfigDialogView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20ConfigDialogView.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.ViewModels"
+             xmlns:corevm="using:Highbyte.DotNet6502.App.Avalonia.Core.ViewModels"
              x:Class="Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.Views.Vic20ConfigDialogView"
              x:DataType="vm:Vic20ConfigDialogViewModel"
              AutomationProperties.AutomationId="Vic20ConfigDialogView"
@@ -100,6 +101,34 @@
                                         IsVisible="{Binding !IsRunningInWebAssembly}"
                                         IsEnabled="{Binding IsNotBusy}"/>
                             </StackPanel>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <StackPanel Width="460" Classes="wrap-item">
+                    <Border Classes="content-section">
+                        <StackPanel Classes="spacing-tight">
+                            <TextBlock Text="CPU"/>
+
+                            <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto" Classes="spacing-tight">
+                                <TextBlock Grid.Row="0" Grid.Column="0"
+                                           Text="Profile:"
+                                           Classes="secondary-text"/>
+                                <ComboBox Grid.Row="0" Grid.Column="1"
+                                          AutomationProperties.AutomationId="Vic20CpuCompatibilityProfileComboBox"
+                                          AutomationProperties.Name="VIC-20 CPU opcode compatibility profile"
+                                          ItemsSource="{Binding CpuCompatibilityProfiles}"
+                                          SelectedItem="{Binding SelectedCpuCompatibilityProfile}"
+                                          ToolTip.Tip="{Binding SelectedCpuCompatibilityProfileHelpText}"
+                                          Classes="h-stretch"
+                                          MaxDropDownHeight="200">
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate x:DataType="corevm:CpuCompatibilityProfileOption">
+                                            <TextBlock Text="{Binding DisplayName}"/>
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
+                                </ComboBox>
+                            </Grid>
                         </StackPanel>
                     </Border>
                 </StackPanel>

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -281,7 +281,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             InstrumentationEnabled = c64Config.InstrumentationEnabled
         };
 
-        var cpu = CreateC64CPU(loggerFactory);
+        var cpu = CreateC64CPU(loggerFactory, c64Config.CpuCompatibilityProfile);
         var vic2 = Vic2.BuildVic2(vic2Model, c64);
         var sid = Sid.BuildSid(c64);
 
@@ -425,9 +425,9 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
         c64.ApplyCpuPortMemoryConfiguration();
     }
 
-    private static CPU CreateC64CPU(ILoggerFactory loggerFactory)
+    private static CPU CreateC64CPU(ILoggerFactory loggerFactory, CpuCompatibilityProfile compatibilityProfile)
     {
-        var cpu = new CPU(loggerFactory);
+        var cpu = new CPU(loggerFactory, compatibilityProfile);
         // The CPU execute method uses will not raise any events (like after instruction executed). Therefore advance VIC2 raster line etc needs to be manually called instead (see ExecuteOneFrame)
         //cpu.InstructionExecuted += (s, e) => vic2.AdvanceRaster(e.InstructionExecState.CyclesConsumed);
         return cpu;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64SystemConfigurerCore.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64SystemConfigurerCore.cs
@@ -119,6 +119,7 @@ public class C64SystemConfigurerCore : ISystemConfigurer
             RenderProviderType = c64SystemConfig.RenderProviderType ?? DefaultRenderProviderType,
             AudioProviderType = c64SystemConfig.AudioProviderType,
             SidEmulationMode = c64SystemConfig.SidEmulationMode,
+            CpuCompatibilityProfile = c64SystemConfig.CpuCompatibilityProfile,
         };
 
         var c64 = C64.BuildC64(c64Config, LoggerFactory);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64Config.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64Config.cs
@@ -30,6 +30,7 @@ public class C64Config
     public Type? RenderProviderType { get; set; }
     public Type? AudioProviderType { get; set; }
     public SidEmulationMode SidEmulationMode { get; set; } = SidEmulationMode.Auto;
+    public CpuCompatibilityProfile CpuCompatibilityProfile { get; set; } = CpuCompatibilityProfile.StableUnofficial;
 
     public C64Config()
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SystemConfig.cs
@@ -243,6 +243,7 @@ public class C64SystemConfig : ISystemConfig
     }
 
     private SidEmulationMode _sidEmulationMode = SidEmulationMode.Auto;
+    private CpuCompatibilityProfile _cpuCompatibilityProfile = CpuCompatibilityProfile.StableUnofficial;
 
     /// <summary>
     /// Accuracy / performance trade-off for the sample-based SID emulation provider
@@ -254,6 +255,16 @@ public class C64SystemConfig : ISystemConfig
         set
         {
             _sidEmulationMode = value;
+            _isDirty = true;
+        }
+    }
+
+    public CpuCompatibilityProfile CpuCompatibilityProfile
+    {
+        get => _cpuCompatibilityProfile;
+        set
+        {
+            _cpuCompatibilityProfile = value;
             _isDirty = true;
         }
     }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Generic/Config/GenericComputerConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Generic/Config/GenericComputerConfig.cs
@@ -9,6 +9,7 @@ public class GenericComputerConfig
     private float _screenRefreshFrequencyHz;
     private bool _waitForHostToAcknowledgeFrame;
     private EmulatorMemoryConfig _memory = default!;
+    private CpuCompatibilityProfile _cpuCompatibilityProfile = CpuCompatibilityProfile.ExperimentalUnofficial;
     public Type? RenderProviderType { get; set; }
 
     public string ProgramBinaryFile
@@ -68,6 +69,15 @@ public class GenericComputerConfig
         set
         {
             _memory = value;
+        }
+    }
+
+    public CpuCompatibilityProfile CpuCompatibilityProfile
+    {
+        get { return _cpuCompatibilityProfile; }
+        set
+        {
+            _cpuCompatibilityProfile = value;
         }
     }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Generic/Config/GenericComputerExampleConfigs.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Generic/Config/GenericComputerExampleConfigs.cs
@@ -12,6 +12,7 @@ public static class GenericComputerExampleConfigs
             throw new ArgumentException($"No example program with name '{exampleName}' exists in system config.");
         exampleConfig.ProgramBinaryFile = systemConfig.ExamplePrograms[exampleName] ?? string.Empty;
         exampleConfig.RenderProviderType = systemConfig.RenderProviderType;
+        exampleConfig.CpuCompatibilityProfile = systemConfig.CpuCompatibilityProfile;
         return exampleConfig;
     }
 
@@ -20,6 +21,7 @@ public static class GenericComputerExampleConfigs
         var exampleConfig = GetExampleConfigClone(exampleName);
         exampleConfig.ProgramBinary = prgBytes;
         exampleConfig.RenderProviderType = systemConfig.RenderProviderType;
+        exampleConfig.CpuCompatibilityProfile = systemConfig.CpuCompatibilityProfile;
         return exampleConfig;
     }
 
@@ -176,4 +178,3 @@ public static class GenericComputerExampleConfigs
 
     }
 }
-

--- a/src/libraries/Highbyte.DotNet6502.Systems.Generic/Config/GenericComputerSystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Generic/Config/GenericComputerSystemConfig.cs
@@ -37,6 +37,17 @@ public class GenericComputerSystemConfig : ISystemConfig
 
     public bool AudioEnabled { get; set; }
 
+    private CpuCompatibilityProfile _cpuCompatibilityProfile = CpuCompatibilityProfile.ExperimentalUnofficial;
+    public CpuCompatibilityProfile CpuCompatibilityProfile
+    {
+        get => _cpuCompatibilityProfile;
+        set
+        {
+            _cpuCompatibilityProfile = value;
+            _isDirty = true;
+        }
+    }
+
     public Dictionary<string, string?> ExamplePrograms
     {
         get

--- a/src/libraries/Highbyte.DotNet6502.Systems.Generic/GenericComputer.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Generic/GenericComputer.cs
@@ -75,7 +75,7 @@ public class GenericComputer : ISystem, ITextMode, IScreen
 
         _genericComputerConfig = genericComputerConfig;
         Mem = new Memory();
-        CPU = new CPU(loggerFactory);
+        CPU = new CPU(loggerFactory, genericComputerConfig.CpuCompatibilityProfile);
         DefaultExecOptions = new ExecOptions();
 
         _oneFrameExecEvaluator = new LegacyExecEvaluator(new ExecOptions { CyclesRequested = CPUCyclesPerFrame });

--- a/src/libraries/Highbyte.DotNet6502.Systems.Generic/GenericComputerBuilder.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Generic/GenericComputerBuilder.cs
@@ -24,7 +24,7 @@ public class GenericComputerBuilder
 
     public GenericComputerBuilder WithCPU()
     {
-        _genericComputer.CPU = new CPU(_loggerFactory);
+        _genericComputer.CPU = new CPU(_loggerFactory, _genericComputer.GenericComputerConfig.CpuCompatibilityProfile);
         return this;
     }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20Config.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20Config.cs
@@ -56,6 +56,7 @@ public class Vic20Config
 
     // CPU cycles per frame: VIC-20 NTSC runs at ~14318 cycles/frame at 60 Hz
     public ulong CpuCyclesPerFrame { get; set; } = 14318;
+    public CpuCompatibilityProfile CpuCompatibilityProfile { get; set; } = CpuCompatibilityProfile.StableUnofficial;
 
     public float ScreenRefreshFrequencyHz => TvModel.RefreshFrequencyHz;
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20SystemConfig.cs
@@ -57,6 +57,17 @@ public class Vic20SystemConfig : ISystemConfig
 
     public bool AudioEnabled { get; set; } = false;
 
+    private CpuCompatibilityProfile _cpuCompatibilityProfile = CpuCompatibilityProfile.StableUnofficial;
+    public CpuCompatibilityProfile CpuCompatibilityProfile
+    {
+        get => _cpuCompatibilityProfile;
+        set
+        {
+            _cpuCompatibilityProfile = value;
+            _isDirty = true;
+        }
+    }
+
     private string _romDirectory = string.Empty;
     public string ROMDirectory
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Vic20.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Vic20.cs
@@ -92,7 +92,7 @@ public class Vic20 : ISystem, ITextMode, IScreen, ISystemState
     {
         _vic20Config = config;
         Mem = CreateUnexpandedMemory();
-        CPU = new CPU(loggerFactory);
+        CPU = new CPU(loggerFactory, config.CpuCompatibilityProfile);
         DefaultExecOptions = new ExecOptions();
 
         // Create VIA chips before ROM mapping so they can register memory callbacks.

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Vic20SystemConfigurerCore.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Vic20SystemConfigurerCore.cs
@@ -55,6 +55,7 @@ public class Vic20SystemConfigurerCore : ISystemConfigurer
     {
         var vic20SystemConfig = (Vic20SystemConfig)systemConfig;
         var vic20Config = BuildVic20ConfigForVariant(configurationVariant);
+        vic20Config.CpuCompatibilityProfile = vic20SystemConfig.CpuCompatibilityProfile;
 
         Dictionary<string, byte[]>? romData = null;
         if (vic20SystemConfig.ROMs.Count > 0)

--- a/src/libraries/Highbyte.DotNet6502/CPU.cs
+++ b/src/libraries/Highbyte.DotNet6502/CPU.cs
@@ -99,8 +99,10 @@ public class CPU
     /// </summary>
     /// <value></value>
     public ExecState ExecState { get; private set; }
+    public bool IsHalted { get; private set; }
 
     public InstructionList InstructionList { get; private set; }
+    public CpuCompatibilityProfile CompatibilityProfile { get; private set; }
 
     public event EventHandler<CPUInstructionExecutedEventArgs>? InstructionExecuted;
     protected virtual void OnInstructionExecuted(CPUInstructionExecutedEventArgs e)
@@ -126,18 +128,25 @@ public class CPU
 
     private ILogger _logger;
 
-    public CPU() : this(new ExecState(), new NullLoggerFactory()) { }
-    public CPU(ExecState execState) : this(execState, new NullLoggerFactory()) { }
-    public CPU(ILoggerFactory loggerFactory) : this(new ExecState(), loggerFactory) { }
+    public CPU() : this(new ExecState(), new NullLoggerFactory(), CpuCompatibilityProfile.ExperimentalUnofficial) { }
+    public CPU(ExecState execState) : this(execState, new NullLoggerFactory(), CpuCompatibilityProfile.ExperimentalUnofficial) { }
+    public CPU(ILoggerFactory loggerFactory) : this(new ExecState(), loggerFactory, CpuCompatibilityProfile.ExperimentalUnofficial) { }
+    public CPU(CpuCompatibilityProfile compatibilityProfile) : this(new ExecState(), new NullLoggerFactory(), compatibilityProfile) { }
+    public CPU(ILoggerFactory loggerFactory, CpuCompatibilityProfile compatibilityProfile)
+        : this(new ExecState(), loggerFactory, compatibilityProfile) { }
 
     public CPU(ExecState execState, ILoggerFactory loggerFactory)
+        : this(execState, loggerFactory, CpuCompatibilityProfile.ExperimentalUnofficial) { }
+
+    public CPU(ExecState execState, ILoggerFactory loggerFactory, CpuCompatibilityProfile compatibilityProfile)
     {
         _logger = loggerFactory.CreateLogger(typeof(CPU).Name);
 
         ProcessorStatus = new ProcessorStatus();
         ExecState = execState;
+        CompatibilityProfile = compatibilityProfile;
         // TODO: Inject instruction list?
-        InstructionList = InstructionList.GetAllInstructions();
+        InstructionList = InstructionList.GetAllInstructions(compatibilityProfile);
         // TODO: Inject InstructionExecutor?
         _instructionExecutor = new InstructionExecutor(loggerFactory);
     }
@@ -153,6 +162,8 @@ public class CPU
             Y = this.Y,
             ProcessorStatus = this.ProcessorStatus,
             ExecState = this.ExecState.Clone(),
+            IsHalted = this.IsHalted,
+            CompatibilityProfile = this.CompatibilityProfile,
             InstructionList = this.InstructionList.Clone(),
             _logger = this._logger
         };
@@ -169,11 +180,15 @@ public class CPU
     public InstructionExecResult ExecuteOneInstructionMinimal(
         Memory mem)
     {
+        if (IsHalted)
+            return InstructionExecResult.CpuAlreadyHaltedResult(PC);
+
         var instructionExecutionResult = _instructionExecutor.Execute(this, mem);
 
         ExecState.UpdateTotal(instructionExecutionResult);
 
-        ProcessInterrupts(mem);
+        if (!instructionExecutionResult.HaltedCpu)
+            ProcessInterrupts(mem);
 
         return instructionExecutionResult;
     }
@@ -229,6 +244,9 @@ public class CPU
 
         while (true)
         {
+            if (IsHalted)
+                break;
+
             // Evaluate BEFORE executing the next instruction.
             // Checking pre-execution means breakpoints trigger at the correct address
             // (before the instruction at that address runs), and evaluators that count
@@ -268,6 +286,11 @@ public class CPU
                 OnUnknownOpCodeDetected(new CPUUnknownOpCodeDetectedEventArgs(this, mem, instructionExecutionResult.OpCodeByte));
                 Debug.WriteLine($"Unknown opcode: {instructionExecutionResult.OpCodeByte.ToHex()}");
             }
+            else if (instructionExecutionResult.HaltedCpu)
+            {
+                OnUnknownOpCodeDetected(new CPUUnknownOpCodeDetectedEventArgs(this, mem, instructionExecutionResult.OpCodeByte));
+                break;
+            }
             else
             {
                 // Fire event for instruction recognized and executed
@@ -283,6 +306,9 @@ public class CPU
 
     private void ProcessInterrupts(Memory mem)
     {
+        if (IsHalted)
+            return;
+
         if (CPUInterrupts.NMIPending)
         {
             ushort nmiVector = FetchWord(mem, CPU.NonMaskableIRQHandlerVector);
@@ -359,6 +385,12 @@ public class CPU
     {
         // Change PC to address found at BRK/IRQ handler vector
         PC = FetchWord(mem, CPU.ResetVector);
+        IsHalted = false;
+    }
+
+    internal void Halt()
+    {
+        IsHalted = true;
     }
 
     /// <summary>

--- a/src/libraries/Highbyte.DotNet6502/CpuCompatibilityProfile.cs
+++ b/src/libraries/Highbyte.DotNet6502/CpuCompatibilityProfile.cs
@@ -1,0 +1,13 @@
+namespace Highbyte.DotNet6502;
+
+/// <summary>
+/// Controls which undocumented NMOS 6502 opcodes are exposed through a CPU's instruction list.
+/// Higher values include all opcodes from lower values.
+/// </summary>
+public enum CpuCompatibilityProfile
+{
+    OfficialOnly = 0,
+    StableUnofficial = 1,
+    ExperimentalUnofficial = 2,
+    FullUnofficial = 3,
+}

--- a/src/libraries/Highbyte.DotNet6502/InstructionExecResult.cs
+++ b/src/libraries/Highbyte.DotNet6502/InstructionExecResult.cs
@@ -4,6 +4,7 @@ public struct InstructionExecResult
 {
     public byte OpCodeByte { get; private set; }
     public bool UnknownInstruction { get; private set; }
+    public bool HaltedCpu { get; private set; }
     /// <summary>
     /// True when this result was produced by an actual instruction execution or a
     /// deliberate pre-execution peek (i.e. not a default zero-initialised instance).
@@ -13,6 +14,7 @@ public struct InstructionExecResult
     /// </summary>
     public bool IsValid { get; private set; }
     public bool IsBRKInstruction => IsValid && OpCodeByte == (byte)OpCodeId.BRK;
+    public bool IsHaltInstruction => IsValid && HaltedCpu;
     public ulong CyclesConsumed { get; private set; }
     public ushort AtPC { get; private set; }
 
@@ -28,6 +30,7 @@ public struct InstructionExecResult
         return new InstructionExecResult(opCodeByte)
         {
             UnknownInstruction = true,
+            HaltedCpu = false,
             IsValid = true,
             CyclesConsumed = 1,
             AtPC = atPC
@@ -39,8 +42,33 @@ public struct InstructionExecResult
         return new InstructionExecResult(opCodeByte)
         {
             UnknownInstruction = false,
+            HaltedCpu = false,
             IsValid = true,
             CyclesConsumed = cyclesConsumed,
+            AtPC = atPC,
+        };
+    }
+
+    public static InstructionExecResult HaltInstructionResult(byte opCodeByte, ushort atPC, ulong cyclesConsumed)
+    {
+        return new InstructionExecResult(opCodeByte)
+        {
+            UnknownInstruction = false,
+            HaltedCpu = true,
+            IsValid = true,
+            CyclesConsumed = cyclesConsumed,
+            AtPC = atPC,
+        };
+    }
+
+    public static InstructionExecResult CpuAlreadyHaltedResult(ushort atPC)
+    {
+        return new InstructionExecResult(0)
+        {
+            UnknownInstruction = false,
+            HaltedCpu = true,
+            IsValid = false,
+            CyclesConsumed = 0,
             AtPC = atPC,
         };
     }

--- a/src/libraries/Highbyte.DotNet6502/InstructionExecutor.cs
+++ b/src/libraries/Highbyte.DotNet6502/InstructionExecutor.cs
@@ -129,36 +129,7 @@ public class InstructionExecutor
         }
 
         // Execute the instruction-specific logic, with final value calculated in addrModeCalcResult.
-        ulong extraCyclesConsumed;
-        if (instruction is IInstructionUsesByte instructionUsesByte)
-        {
-            // Instruction expects a byte directly or via a relative or absolute (word) address
-            byte instructionValue;
-            if (addrModeCalcResult.InsAddress.HasValue)
-                instructionValue = cpu.FetchByte(mem, addrModeCalcResult.InsAddress.Value);
-            else
-                instructionValue = addrModeCalcResult.InsValue!.Value;
-
-            extraCyclesConsumed = instructionUsesByte.ExecuteWithByte(cpu, mem, instructionValue, addrModeCalcResult);
-        }
-        else if (instruction is IInstructionUsesAddress instructionUseAddress && addrModeCalcResult.InsAddress.HasValue)
-        {
-            // Instruction expects a an address (to write to, or use to change program counter)
-            extraCyclesConsumed = instructionUseAddress.ExecuteWithWord(cpu, mem, addrModeCalcResult.InsAddress.Value, addrModeCalcResult);
-        }
-        else if (instruction is IInstructionUsesStack instructionUsesStack)
-        {
-            // Instruction is expected to push or pop stack
-            extraCyclesConsumed = instructionUsesStack.ExecuteWithStack(cpu, mem, addrModeCalcResult);
-        }
-        else if (instruction is IInstructionUsesOnlyRegOrStatus instructionUseNone)
-        {
-            extraCyclesConsumed = instructionUseNone.Execute(cpu, addrModeCalcResult);
-        }
-        else
-        {
-            throw new DotNet6502Exception($"Bug detected. Did not find a way to execute instruction: {instruction.Name} opcode: {opCode.ToHex()}");
-        }
+        var extraCyclesConsumed = ExecuteInstruction(cpu, mem, instruction, addrModeCalcResult, opCode);
 
         var cyclesConsumed = opCodeObject.MinimumCycles + extraCyclesConsumed;
         if (cpu.IsHalted)
@@ -169,5 +140,40 @@ public class InstructionExecutor
         }
 
         return InstructionExecResult.KnownInstructionResult(opCode, atPC, cyclesConsumed);
+    }
+
+    private static ulong ExecuteInstruction(CPU cpu, Memory mem, Instruction instruction, AddrModeCalcResult addrModeCalcResult, byte opCode)
+    {
+        if (instruction is IInstructionUsesByte instructionUsesByte)
+        {
+            return instructionUsesByte.ExecuteWithByte(cpu, mem, GetInstructionValue(cpu, mem, addrModeCalcResult), addrModeCalcResult);
+        }
+
+        if (instruction is IInstructionUsesAddress instructionUseAddress && addrModeCalcResult.InsAddress.HasValue)
+        {
+            // Instruction expects an address to write to, or use to change program counter.
+            return instructionUseAddress.ExecuteWithWord(cpu, mem, addrModeCalcResult.InsAddress.Value, addrModeCalcResult);
+        }
+
+        if (instruction is IInstructionUsesStack instructionUsesStack)
+        {
+            return instructionUsesStack.ExecuteWithStack(cpu, mem, addrModeCalcResult);
+        }
+
+        if (instruction is IInstructionUsesOnlyRegOrStatus instructionUseNone)
+        {
+            return instructionUseNone.Execute(cpu, addrModeCalcResult);
+        }
+
+        throw new DotNet6502Exception($"Bug detected. Did not find a way to execute instruction: {instruction.Name} opcode: {opCode.ToHex()}");
+    }
+
+    private static byte GetInstructionValue(CPU cpu, Memory mem, AddrModeCalcResult addrModeCalcResult)
+    {
+        // Instruction expects a byte directly or via a relative or absolute (word) address.
+        if (addrModeCalcResult.InsAddress.HasValue)
+            return cpu.FetchByte(mem, addrModeCalcResult.InsAddress.Value);
+
+        return addrModeCalcResult.InsValue!.Value;
     }
 }

--- a/src/libraries/Highbyte.DotNet6502/InstructionExecutor.cs
+++ b/src/libraries/Highbyte.DotNet6502/InstructionExecutor.cs
@@ -160,6 +160,14 @@ public class InstructionExecutor
             throw new DotNet6502Exception($"Bug detected. Did not find a way to execute instruction: {instruction.Name} opcode: {opCode.ToHex()}");
         }
 
-        return InstructionExecResult.KnownInstructionResult(opCode, atPC, opCodeObject.MinimumCycles + extraCyclesConsumed);
+        var cyclesConsumed = opCodeObject.MinimumCycles + extraCyclesConsumed;
+        if (cpu.IsHalted)
+        {
+            if (_logger.IsEnabled(LogLevel.Warning))
+                _logger.LogWarning("CPU halted by unofficial instruction {OpCode} at {AtPC}", opCode.ToHex(), atPC.ToHex());
+            return InstructionExecResult.HaltInstructionResult(opCode, atPC, cyclesConsumed);
+        }
+
+        return InstructionExecResult.KnownInstructionResult(opCode, atPC, cyclesConsumed);
     }
 }

--- a/src/libraries/Highbyte.DotNet6502/InstructionList.cs
+++ b/src/libraries/Highbyte.DotNet6502/InstructionList.cs
@@ -45,7 +45,7 @@ public class InstructionList
         return new InstructionList(this.OpCodeDictionary, this.InstructionDictionary);
     }
 
-    public static InstructionList GetAllInstructions()
+    public static InstructionList GetAllInstructions(CpuCompatibilityProfile compatibilityProfile = CpuCompatibilityProfile.ExperimentalUnofficial)
     {
         // Manual (AOT & trimming safe) list of all instruction implementations.
         // Add new instruction types here when introduced.
@@ -107,18 +107,165 @@ public class InstructionList
             new TXA(),
             new TXS(),
             new TYA(),
+
+            // Illegal / undocumented opcodes
+            new JAM(),
+            new NOP_Illegal(),
+            new LAX(),
+            new SAX(),
+            new DCP(),
+            new ISC(),
+            new SLO(),
+            new SRE(),
+            new RLA(),
+            new RRA(),
+            new ANC(),
+            new ALR(),
+            new ARR(),
+            new AXS(),
+            new LAS(),
         };
 
-        var instructionList = new InstructionList(insList);
+        var opCodeDictionary = new Dictionary<byte, OpCode>();
+        var instructionDictionary = new Dictionary<byte, Instruction>();
+        foreach (var instruction in insList)
+        {
+            foreach (var opCode in instruction.OpCodes)
+            {
+                if (!ShouldIncludeOpCode(opCode.Code, compatibilityProfile))
+                    continue;
+
+                opCodeDictionary.Add(opCode.Code.ToByte(), opCode);
+                instructionDictionary.Add(opCode.CodeRaw, instruction);
+            }
+        }
+
+        var instructionList = new InstructionList(opCodeDictionary, instructionDictionary);
 
         // Run verification to ensure the manual list above matches dynamically discovered instructions (won't work when published in AOT release mode)
 #if DEBUG
-        var insListVerification = GetAllInstructionDynamcic();
-        VerifyInstructionListsMatch(instructionList, insListVerification);
+        if (compatibilityProfile == CpuCompatibilityProfile.FullUnofficial)
+        {
+            var insListVerification = GetAllInstructionDynamcic();
+            VerifyInstructionListsMatch(instructionList, insListVerification);
+        }
 #endif
 
         return instructionList;
     }
+
+    private static bool ShouldIncludeOpCode(OpCodeId opCodeId, CpuCompatibilityProfile compatibilityProfile)
+        => compatibilityProfile >= GetMinimumCompatibilityProfile(opCodeId);
+
+    private static CpuCompatibilityProfile GetMinimumCompatibilityProfile(OpCodeId opCodeId)
+        => opCodeId switch
+        {
+            // Stable undocumented opcodes commonly used on NMOS 6502/6510 machines.
+            OpCodeId.NOP_ILL_1A or
+            OpCodeId.NOP_ILL_3A or
+            OpCodeId.NOP_ILL_5A or
+            OpCodeId.NOP_ILL_7A or
+            OpCodeId.NOP_ILL_DA or
+            OpCodeId.NOP_ILL_FA or
+            OpCodeId.NOP_ILL_IMM_80 or
+            OpCodeId.NOP_ILL_IMM_82 or
+            OpCodeId.NOP_ILL_IMM_89 or
+            OpCodeId.NOP_ILL_IMM_C2 or
+            OpCodeId.NOP_ILL_IMM_E2 or
+            OpCodeId.NOP_ILL_ZP_04 or
+            OpCodeId.NOP_ILL_ZP_44 or
+            OpCodeId.NOP_ILL_ZP_64 or
+            OpCodeId.NOP_ILL_ZP_X_14 or
+            OpCodeId.NOP_ILL_ZP_X_34 or
+            OpCodeId.NOP_ILL_ZP_X_54 or
+            OpCodeId.NOP_ILL_ZP_X_74 or
+            OpCodeId.NOP_ILL_ZP_X_D4 or
+            OpCodeId.NOP_ILL_ZP_X_F4 or
+            OpCodeId.NOP_ILL_ABS or
+            OpCodeId.NOP_ILL_ABS_X_1C or
+            OpCodeId.NOP_ILL_ABS_X_3C or
+            OpCodeId.NOP_ILL_ABS_X_5C or
+            OpCodeId.NOP_ILL_ABS_X_7C or
+            OpCodeId.NOP_ILL_ABS_X_DC or
+            OpCodeId.NOP_ILL_ABS_X_FC or
+            OpCodeId.LAX_IX_IND or
+            OpCodeId.LAX_ZP or
+            OpCodeId.LAX_ABS or
+            OpCodeId.LAX_IND_IX or
+            OpCodeId.LAX_ZP_Y or
+            OpCodeId.LAX_ABS_Y or
+            OpCodeId.SAX_IX_IND or
+            OpCodeId.SAX_ZP or
+            OpCodeId.SAX_ABS or
+            OpCodeId.SAX_ZP_Y or
+            OpCodeId.DCP_IX_IND or
+            OpCodeId.DCP_ZP or
+            OpCodeId.DCP_ABS or
+            OpCodeId.DCP_IND_IX or
+            OpCodeId.DCP_ZP_X or
+            OpCodeId.DCP_ABS_Y or
+            OpCodeId.DCP_ABS_X or
+            OpCodeId.ISC_IX_IND or
+            OpCodeId.ISC_ZP or
+            OpCodeId.ISC_ABS or
+            OpCodeId.ISC_IND_IX or
+            OpCodeId.ISC_ZP_X or
+            OpCodeId.ISC_ABS_Y or
+            OpCodeId.ISC_ABS_X or
+            OpCodeId.SLO_IX_IND or
+            OpCodeId.SLO_ZP or
+            OpCodeId.SLO_ABS or
+            OpCodeId.SLO_IND_IX or
+            OpCodeId.SLO_ZP_X or
+            OpCodeId.SLO_ABS_Y or
+            OpCodeId.SLO_ABS_X or
+            OpCodeId.SRE_IX_IND or
+            OpCodeId.SRE_ZP or
+            OpCodeId.SRE_ABS or
+            OpCodeId.SRE_IND_IX or
+            OpCodeId.SRE_ZP_X or
+            OpCodeId.SRE_ABS_Y or
+            OpCodeId.SRE_ABS_X or
+            OpCodeId.RLA_IX_IND or
+            OpCodeId.RLA_ZP or
+            OpCodeId.RLA_ABS or
+            OpCodeId.RLA_IND_IX or
+            OpCodeId.RLA_ZP_X or
+            OpCodeId.RLA_ABS_Y or
+            OpCodeId.RLA_ABS_X or
+            OpCodeId.RRA_IX_IND or
+            OpCodeId.RRA_ZP or
+            OpCodeId.RRA_ABS or
+            OpCodeId.RRA_IND_IX or
+            OpCodeId.RRA_ZP_X or
+            OpCodeId.RRA_ABS_Y or
+            OpCodeId.RRA_ABS_X or
+            OpCodeId.ANC_I_0B or
+            OpCodeId.ANC_I_2B or
+            OpCodeId.ALR_I or
+            OpCodeId.AXS_I or
+            OpCodeId.SBC_I_EB => CpuCompatibilityProfile.StableUnofficial,
+
+            // Known less reliable but still executable opcodes that are useful for targeted compatibility/testing.
+            OpCodeId.ARR_I or
+            OpCodeId.LAS_ABS_Y => CpuCompatibilityProfile.ExperimentalUnofficial,
+
+            // Halt-style unofficial opcodes that intentionally jam the CPU until reset.
+            OpCodeId.JAM_02 or
+            OpCodeId.JAM_12 or
+            OpCodeId.JAM_22 or
+            OpCodeId.JAM_32 or
+            OpCodeId.JAM_42 or
+            OpCodeId.JAM_52 or
+            OpCodeId.JAM_62 or
+            OpCodeId.JAM_72 or
+            OpCodeId.JAM_92 or
+            OpCodeId.JAM_B2 or
+            OpCodeId.JAM_D2 or
+            OpCodeId.JAM_F2 => CpuCompatibilityProfile.FullUnofficial,
+
+            _ => CpuCompatibilityProfile.OfficialOnly,
+        };
 
 #if DEBUG
     /// <summary>

--- a/src/libraries/Highbyte.DotNet6502/Instructions/ALR.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/ALR.cs
@@ -1,0 +1,27 @@
+namespace Highbyte.DotNet6502.Instructions;
+
+/// <summary>
+/// ALR (illegal, also ASR) — AND immediate then LSR accumulator.
+/// ANDs A with the immediate byte, then shifts A one bit right
+/// (bit 7 = 0, old bit 0 → C), setting N, Z, and C flags.
+/// </summary>
+public class ALR : Instruction, IInstructionUsesByte
+{
+    private readonly List<OpCode> _opCodes;
+    public override List<OpCode> OpCodes => _opCodes;
+
+    public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
+    {
+        cpu.A &= value;
+        cpu.A = BinaryArithmeticHelpers.PerformLSRAndSetStatusRegisters(cpu.A, ref cpu.ProcessorStatus);
+        return 0;
+    }
+
+    public ALR()
+    {
+        _opCodes = new List<OpCode>
+        {
+            new OpCode { Code = OpCodeId.ALR_I, AddressingMode = AddrMode.I, Size = 2, MinimumCycles = 2 },
+        };
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502/Instructions/ANC.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/ANC.cs
@@ -1,0 +1,30 @@
+using Highbyte.DotNet6502.Utils;
+
+namespace Highbyte.DotNet6502.Instructions;
+
+/// <summary>
+/// ANC (illegal) — AND immediate, then copy bit 7 of result to Carry.
+/// Opcodes 0x0B and 0x2B both perform the same operation.
+/// </summary>
+public class ANC : Instruction, IInstructionUsesByte
+{
+    private readonly List<OpCode> _opCodes;
+    public override List<OpCode> OpCodes => _opCodes;
+
+    public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
+    {
+        cpu.A &= value;
+        BinaryArithmeticHelpers.SetFlagsAfterRegisterLoadIncDec(cpu.A, ref cpu.ProcessorStatus);
+        cpu.ProcessorStatus.Carry = cpu.A.IsBitSet(7);
+        return 0;
+    }
+
+    public ANC()
+    {
+        _opCodes = new List<OpCode>
+        {
+            new OpCode { Code = OpCodeId.ANC_I_0B, AddressingMode = AddrMode.I, Size = 2, MinimumCycles = 2 },
+            new OpCode { Code = OpCodeId.ANC_I_2B, AddressingMode = AddrMode.I, Size = 2, MinimumCycles = 2 },
+        };
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502/Instructions/ARR.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/ARR.cs
@@ -1,0 +1,37 @@
+using Highbyte.DotNet6502.Utils;
+
+namespace Highbyte.DotNet6502.Instructions;
+
+/// <summary>
+/// ARR (illegal) — AND immediate then ROR accumulator with non-standard flags.
+/// ANDs A with the immediate byte, then rotates A one bit right through carry.
+/// Flags differ from a normal ROR: C = bit 6 of result; V = bit 6 XOR bit 5 of result.
+/// N and Z are set normally.
+/// </summary>
+public class ARR : Instruction, IInstructionUsesByte
+{
+    private readonly List<OpCode> _opCodes;
+    public override List<OpCode> OpCodes => _opCodes;
+
+    public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
+    {
+        cpu.A &= value;
+
+        bool oldCarry = cpu.ProcessorStatus.Carry;
+        cpu.A = (byte)((cpu.A >> 1) | (oldCarry ? 0x80 : 0x00));
+
+        // Non-standard flag behaviour
+        cpu.ProcessorStatus.Carry    = cpu.A.IsBitSet(6);
+        cpu.ProcessorStatus.Overflow = cpu.A.IsBitSet(6) ^ cpu.A.IsBitSet(5);
+        BinaryArithmeticHelpers.SetFlagsAfterRegisterLoadIncDec(cpu.A, ref cpu.ProcessorStatus);
+        return 0;
+    }
+
+    public ARR()
+    {
+        _opCodes = new List<OpCode>
+        {
+            new OpCode { Code = OpCodeId.ARR_I, AddressingMode = AddrMode.I, Size = 2, MinimumCycles = 2 },
+        };
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502/Instructions/AXS.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/AXS.cs
@@ -1,0 +1,29 @@
+namespace Highbyte.DotNet6502.Instructions;
+
+/// <summary>
+/// AXS (illegal, also SBX/SAX) — X = (A AND X) − immediate.
+/// Computes the bitwise AND of A and X, subtracts the immediate byte without
+/// borrow (carry is not used as input), stores the result in X, and sets
+/// N, Z, and C flags as CMP does (C = (A&amp;X) >= imm).
+/// </summary>
+public class AXS : Instruction, IInstructionUsesByte
+{
+    private readonly List<OpCode> _opCodes;
+    public override List<OpCode> OpCodes => _opCodes;
+
+    public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
+    {
+        byte andVal = (byte)(cpu.A & cpu.X);
+        BinaryArithmeticHelpers.SetFlagsAfterCompare(andVal, value, ref cpu.ProcessorStatus);
+        cpu.X = (byte)(andVal - value);
+        return 0;
+    }
+
+    public AXS()
+    {
+        _opCodes = new List<OpCode>
+        {
+            new OpCode { Code = OpCodeId.AXS_I, AddressingMode = AddrMode.I, Size = 2, MinimumCycles = 2 },
+        };
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502/Instructions/DCP.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/DCP.cs
@@ -1,0 +1,34 @@
+namespace Highbyte.DotNet6502.Instructions;
+
+/// <summary>
+/// DCP (illegal) — Decrement memory then CMP with A.
+/// Decrements the value at the effective address by 1, then compares the result
+/// with the accumulator setting N, Z, and C flags as CMP does.
+/// </summary>
+public class DCP : Instruction, IInstructionUsesByte
+{
+    private readonly List<OpCode> _opCodes;
+    public override List<OpCode> OpCodes => _opCodes;
+
+    public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
+    {
+        value--;
+        cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
+        BinaryArithmeticHelpers.SetFlagsAfterCompare(cpu.A, value, ref cpu.ProcessorStatus);
+        return 0;
+    }
+
+    public DCP()
+    {
+        _opCodes = new List<OpCode>
+        {
+            new OpCode { Code = OpCodeId.DCP_IX_IND, AddressingMode = AddrMode.IX_IND, Size = 2, MinimumCycles = 8 },
+            new OpCode { Code = OpCodeId.DCP_ZP,     AddressingMode = AddrMode.ZP,     Size = 2, MinimumCycles = 5 },
+            new OpCode { Code = OpCodeId.DCP_ABS,    AddressingMode = AddrMode.ABS,    Size = 3, MinimumCycles = 6 },
+            new OpCode { Code = OpCodeId.DCP_IND_IX, AddressingMode = AddrMode.IND_IX, Size = 2, MinimumCycles = 8 },
+            new OpCode { Code = OpCodeId.DCP_ZP_X,   AddressingMode = AddrMode.ZP_X,   Size = 2, MinimumCycles = 6 },
+            new OpCode { Code = OpCodeId.DCP_ABS_Y,  AddressingMode = AddrMode.ABS_Y,  Size = 3, MinimumCycles = 7 },
+            new OpCode { Code = OpCodeId.DCP_ABS_X,  AddressingMode = AddrMode.ABS_X,  Size = 3, MinimumCycles = 7 },
+        };
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502/Instructions/ISC.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/ISC.cs
@@ -1,0 +1,34 @@
+namespace Highbyte.DotNet6502.Instructions;
+
+/// <summary>
+/// ISC (illegal, also ISB/INS) — Increment memory then SBC from A.
+/// Increments the value at the effective address by 1, then subtracts the
+/// result from A (with borrow), setting N, V, Z, and C flags as SBC does.
+/// </summary>
+public class ISC : Instruction, IInstructionUsesByte
+{
+    private readonly List<OpCode> _opCodes;
+    public override List<OpCode> OpCodes => _opCodes;
+
+    public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
+    {
+        value++;
+        cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
+        cpu.A = BinaryArithmeticHelpers.SubtractWithCarryAndOverflow(cpu.A, value, ref cpu.ProcessorStatus);
+        return 0;
+    }
+
+    public ISC()
+    {
+        _opCodes = new List<OpCode>
+        {
+            new OpCode { Code = OpCodeId.ISC_IX_IND, AddressingMode = AddrMode.IX_IND, Size = 2, MinimumCycles = 8 },
+            new OpCode { Code = OpCodeId.ISC_ZP,     AddressingMode = AddrMode.ZP,     Size = 2, MinimumCycles = 5 },
+            new OpCode { Code = OpCodeId.ISC_ABS,    AddressingMode = AddrMode.ABS,    Size = 3, MinimumCycles = 6 },
+            new OpCode { Code = OpCodeId.ISC_IND_IX, AddressingMode = AddrMode.IND_IX, Size = 2, MinimumCycles = 8 },
+            new OpCode { Code = OpCodeId.ISC_ZP_X,   AddressingMode = AddrMode.ZP_X,   Size = 2, MinimumCycles = 6 },
+            new OpCode { Code = OpCodeId.ISC_ABS_Y,  AddressingMode = AddrMode.ABS_Y,  Size = 3, MinimumCycles = 7 },
+            new OpCode { Code = OpCodeId.ISC_ABS_X,  AddressingMode = AddrMode.ABS_X,  Size = 3, MinimumCycles = 7 },
+        };
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502/Instructions/JAM.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/JAM.cs
@@ -1,0 +1,35 @@
+namespace Highbyte.DotNet6502.Instructions;
+
+/// <summary>
+/// Halt the CPU until reset. Also known as KIL or HLT.
+/// </summary>
+public class JAM : Instruction, IInstructionUsesOnlyRegOrStatus
+{
+    private readonly List<OpCode> _opCodes;
+    public override List<OpCode> OpCodes => _opCodes;
+
+    public ulong Execute(CPU cpu, AddrModeCalcResult addrModeCalcResult)
+    {
+        cpu.Halt();
+        return 0;
+    }
+
+    public JAM()
+    {
+        _opCodes = new List<OpCode>
+        {
+            new OpCode { Code = OpCodeId.JAM_02, AddressingMode = AddrMode.Implied, Size = 1, MinimumCycles = 2 },
+            new OpCode { Code = OpCodeId.JAM_12, AddressingMode = AddrMode.Implied, Size = 1, MinimumCycles = 2 },
+            new OpCode { Code = OpCodeId.JAM_22, AddressingMode = AddrMode.Implied, Size = 1, MinimumCycles = 2 },
+            new OpCode { Code = OpCodeId.JAM_32, AddressingMode = AddrMode.Implied, Size = 1, MinimumCycles = 2 },
+            new OpCode { Code = OpCodeId.JAM_42, AddressingMode = AddrMode.Implied, Size = 1, MinimumCycles = 2 },
+            new OpCode { Code = OpCodeId.JAM_52, AddressingMode = AddrMode.Implied, Size = 1, MinimumCycles = 2 },
+            new OpCode { Code = OpCodeId.JAM_62, AddressingMode = AddrMode.Implied, Size = 1, MinimumCycles = 2 },
+            new OpCode { Code = OpCodeId.JAM_72, AddressingMode = AddrMode.Implied, Size = 1, MinimumCycles = 2 },
+            new OpCode { Code = OpCodeId.JAM_92, AddressingMode = AddrMode.Implied, Size = 1, MinimumCycles = 2 },
+            new OpCode { Code = OpCodeId.JAM_B2, AddressingMode = AddrMode.Implied, Size = 1, MinimumCycles = 2 },
+            new OpCode { Code = OpCodeId.JAM_D2, AddressingMode = AddrMode.Implied, Size = 1, MinimumCycles = 2 },
+            new OpCode { Code = OpCodeId.JAM_F2, AddressingMode = AddrMode.Implied, Size = 1, MinimumCycles = 2 },
+        };
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502/Instructions/LAS.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/LAS.cs
@@ -1,0 +1,33 @@
+namespace Highbyte.DotNet6502.Instructions;
+
+/// <summary>
+/// LAS (illegal, also LAR) — A = X = SP = memory AND SP.
+/// Reads a byte from memory, ANDs it with the stack pointer, and stores
+/// the result in A, X, and SP. Sets N and Z flags.
+/// </summary>
+public class LAS : Instruction, IInstructionUsesByte
+{
+    private readonly List<OpCode> _opCodes;
+    public override List<OpCode> OpCodes => _opCodes;
+
+    public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
+    {
+        byte result = (byte)(value & cpu.SP);
+        cpu.A  = result;
+        cpu.X  = result;
+        cpu.SP = result;
+        BinaryArithmeticHelpers.SetFlagsAfterRegisterLoadIncDec(result, ref cpu.ProcessorStatus);
+
+        return InstructionExtraCyclesCalculator.CalculateExtraCycles(
+            addrModeCalcResult.OpCode.AddressingMode,
+            addrModeCalcResult.AddressCalculationCrossedPageBoundary);
+    }
+
+    public LAS()
+    {
+        _opCodes = new List<OpCode>
+        {
+            new OpCode { Code = OpCodeId.LAS_ABS_Y, AddressingMode = AddrMode.ABS_Y, Size = 3, MinimumCycles = 4 }, // +1 page cross
+        };
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502/Instructions/LAX.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/LAX.cs
@@ -1,0 +1,35 @@
+namespace Highbyte.DotNet6502.Instructions;
+
+/// <summary>
+/// LAX (illegal) — Load Accumulator and X Register.
+/// Loads the same byte into both A and X; sets N and Z flags.
+/// </summary>
+public class LAX : Instruction, IInstructionUsesByte
+{
+    private readonly List<OpCode> _opCodes;
+    public override List<OpCode> OpCodes => _opCodes;
+
+    public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
+    {
+        cpu.A = value;
+        cpu.X = value;
+        BinaryArithmeticHelpers.SetFlagsAfterRegisterLoadIncDec(value, ref cpu.ProcessorStatus);
+
+        return InstructionExtraCyclesCalculator.CalculateExtraCycles(
+            addrModeCalcResult.OpCode.AddressingMode,
+            addrModeCalcResult.AddressCalculationCrossedPageBoundary);
+    }
+
+    public LAX()
+    {
+        _opCodes = new List<OpCode>
+        {
+            new OpCode { Code = OpCodeId.LAX_IX_IND, AddressingMode = AddrMode.IX_IND, Size = 2, MinimumCycles = 6 },
+            new OpCode { Code = OpCodeId.LAX_ZP,     AddressingMode = AddrMode.ZP,     Size = 2, MinimumCycles = 3 },
+            new OpCode { Code = OpCodeId.LAX_ABS,    AddressingMode = AddrMode.ABS,    Size = 3, MinimumCycles = 4 },
+            new OpCode { Code = OpCodeId.LAX_IND_IX, AddressingMode = AddrMode.IND_IX, Size = 2, MinimumCycles = 5 }, // +1 page cross
+            new OpCode { Code = OpCodeId.LAX_ZP_Y,   AddressingMode = AddrMode.ZP_Y,   Size = 2, MinimumCycles = 4 },
+            new OpCode { Code = OpCodeId.LAX_ABS_Y,  AddressingMode = AddrMode.ABS_Y,  Size = 3, MinimumCycles = 4 }, // +1 page cross
+        };
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502/Instructions/NOP.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/NOP.cs
@@ -24,7 +24,13 @@ public class NOP : Instruction, IInstructionUsesOnlyRegOrStatus
                     AddressingMode = AddrMode.Implied,
                     Size = 1,
                     MinimumCycles = 2,
-                }
+                },
+                new OpCode { Code = OpCodeId.NOP_ILL_1A, AddressingMode = AddrMode.Implied, Size = 1, MinimumCycles = 2 },
+                new OpCode { Code = OpCodeId.NOP_ILL_3A, AddressingMode = AddrMode.Implied, Size = 1, MinimumCycles = 2 },
+                new OpCode { Code = OpCodeId.NOP_ILL_5A, AddressingMode = AddrMode.Implied, Size = 1, MinimumCycles = 2 },
+                new OpCode { Code = OpCodeId.NOP_ILL_7A, AddressingMode = AddrMode.Implied, Size = 1, MinimumCycles = 2 },
+                new OpCode { Code = OpCodeId.NOP_ILL_DA, AddressingMode = AddrMode.Implied, Size = 1, MinimumCycles = 2 },
+                new OpCode { Code = OpCodeId.NOP_ILL_FA, AddressingMode = AddrMode.Implied, Size = 1, MinimumCycles = 2 },
         };
     }
 }

--- a/src/libraries/Highbyte.DotNet6502/Instructions/NOP_Illegal.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/NOP_Illegal.cs
@@ -1,0 +1,54 @@
+namespace Highbyte.DotNet6502.Instructions;
+
+/// <summary>
+/// Illegal NOP variants that read (and discard) a byte from memory.
+/// </summary>
+public class NOP_Illegal : Instruction, IInstructionUsesByte
+{
+    private readonly List<OpCode> _opCodes;
+    public override List<OpCode> OpCodes => _opCodes;
+
+    public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
+    {
+        return InstructionExtraCyclesCalculator.CalculateExtraCycles(
+            addrModeCalcResult.OpCode.AddressingMode,
+            addrModeCalcResult.AddressCalculationCrossedPageBoundary);
+    }
+
+    public NOP_Illegal()
+    {
+        _opCodes = new List<OpCode>
+        {
+            // Immediate
+            new OpCode { Code = OpCodeId.NOP_ILL_IMM_80, AddressingMode = AddrMode.I, Size = 2, MinimumCycles = 2 },
+            new OpCode { Code = OpCodeId.NOP_ILL_IMM_82, AddressingMode = AddrMode.I, Size = 2, MinimumCycles = 2 },
+            new OpCode { Code = OpCodeId.NOP_ILL_IMM_89, AddressingMode = AddrMode.I, Size = 2, MinimumCycles = 2 },
+            new OpCode { Code = OpCodeId.NOP_ILL_IMM_C2, AddressingMode = AddrMode.I, Size = 2, MinimumCycles = 2 },
+            new OpCode { Code = OpCodeId.NOP_ILL_IMM_E2, AddressingMode = AddrMode.I, Size = 2, MinimumCycles = 2 },
+
+            // Zero page
+            new OpCode { Code = OpCodeId.NOP_ILL_ZP_04, AddressingMode = AddrMode.ZP, Size = 2, MinimumCycles = 3 },
+            new OpCode { Code = OpCodeId.NOP_ILL_ZP_44, AddressingMode = AddrMode.ZP, Size = 2, MinimumCycles = 3 },
+            new OpCode { Code = OpCodeId.NOP_ILL_ZP_64, AddressingMode = AddrMode.ZP, Size = 2, MinimumCycles = 3 },
+
+            // Zero page, X
+            new OpCode { Code = OpCodeId.NOP_ILL_ZP_X_14, AddressingMode = AddrMode.ZP_X, Size = 2, MinimumCycles = 4 },
+            new OpCode { Code = OpCodeId.NOP_ILL_ZP_X_34, AddressingMode = AddrMode.ZP_X, Size = 2, MinimumCycles = 4 },
+            new OpCode { Code = OpCodeId.NOP_ILL_ZP_X_54, AddressingMode = AddrMode.ZP_X, Size = 2, MinimumCycles = 4 },
+            new OpCode { Code = OpCodeId.NOP_ILL_ZP_X_74, AddressingMode = AddrMode.ZP_X, Size = 2, MinimumCycles = 4 },
+            new OpCode { Code = OpCodeId.NOP_ILL_ZP_X_D4, AddressingMode = AddrMode.ZP_X, Size = 2, MinimumCycles = 4 },
+            new OpCode { Code = OpCodeId.NOP_ILL_ZP_X_F4, AddressingMode = AddrMode.ZP_X, Size = 2, MinimumCycles = 4 },
+
+            // Absolute
+            new OpCode { Code = OpCodeId.NOP_ILL_ABS, AddressingMode = AddrMode.ABS, Size = 3, MinimumCycles = 4 },
+
+            // Absolute, X (+1 cycle on page cross)
+            new OpCode { Code = OpCodeId.NOP_ILL_ABS_X_1C, AddressingMode = AddrMode.ABS_X, Size = 3, MinimumCycles = 4 },
+            new OpCode { Code = OpCodeId.NOP_ILL_ABS_X_3C, AddressingMode = AddrMode.ABS_X, Size = 3, MinimumCycles = 4 },
+            new OpCode { Code = OpCodeId.NOP_ILL_ABS_X_5C, AddressingMode = AddrMode.ABS_X, Size = 3, MinimumCycles = 4 },
+            new OpCode { Code = OpCodeId.NOP_ILL_ABS_X_7C, AddressingMode = AddrMode.ABS_X, Size = 3, MinimumCycles = 4 },
+            new OpCode { Code = OpCodeId.NOP_ILL_ABS_X_DC, AddressingMode = AddrMode.ABS_X, Size = 3, MinimumCycles = 4 },
+            new OpCode { Code = OpCodeId.NOP_ILL_ABS_X_FC, AddressingMode = AddrMode.ABS_X, Size = 3, MinimumCycles = 4 },
+        };
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502/Instructions/RLA.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/RLA.cs
@@ -1,0 +1,35 @@
+namespace Highbyte.DotNet6502.Instructions;
+
+/// <summary>
+/// RLA (illegal) — ROL memory then AND into A.
+/// Rotates the value at the effective address one bit left through carry,
+/// then ANDs the rotated result into A, setting N, Z, and C flags.
+/// </summary>
+public class RLA : Instruction, IInstructionUsesByte
+{
+    private readonly List<OpCode> _opCodes;
+    public override List<OpCode> OpCodes => _opCodes;
+
+    public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
+    {
+        value = BinaryArithmeticHelpers.PerformROLAndSetStatusRegisters(value, ref cpu.ProcessorStatus);
+        cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
+        cpu.A &= value;
+        BinaryArithmeticHelpers.SetFlagsAfterRegisterLoadIncDec(cpu.A, ref cpu.ProcessorStatus);
+        return 0;
+    }
+
+    public RLA()
+    {
+        _opCodes = new List<OpCode>
+        {
+            new OpCode { Code = OpCodeId.RLA_IX_IND, AddressingMode = AddrMode.IX_IND, Size = 2, MinimumCycles = 8 },
+            new OpCode { Code = OpCodeId.RLA_ZP,     AddressingMode = AddrMode.ZP,     Size = 2, MinimumCycles = 5 },
+            new OpCode { Code = OpCodeId.RLA_ABS,    AddressingMode = AddrMode.ABS,    Size = 3, MinimumCycles = 6 },
+            new OpCode { Code = OpCodeId.RLA_IND_IX, AddressingMode = AddrMode.IND_IX, Size = 2, MinimumCycles = 8 },
+            new OpCode { Code = OpCodeId.RLA_ZP_X,   AddressingMode = AddrMode.ZP_X,   Size = 2, MinimumCycles = 6 },
+            new OpCode { Code = OpCodeId.RLA_ABS_Y,  AddressingMode = AddrMode.ABS_Y,  Size = 3, MinimumCycles = 7 },
+            new OpCode { Code = OpCodeId.RLA_ABS_X,  AddressingMode = AddrMode.ABS_X,  Size = 3, MinimumCycles = 7 },
+        };
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502/Instructions/RRA.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/RRA.cs
@@ -1,0 +1,34 @@
+namespace Highbyte.DotNet6502.Instructions;
+
+/// <summary>
+/// RRA (illegal) — ROR memory then ADC into A.
+/// Rotates the value at the effective address one bit right through carry,
+/// then adds the rotated result to A with carry, setting N, V, Z, and C flags.
+/// </summary>
+public class RRA : Instruction, IInstructionUsesByte
+{
+    private readonly List<OpCode> _opCodes;
+    public override List<OpCode> OpCodes => _opCodes;
+
+    public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
+    {
+        value = BinaryArithmeticHelpers.PerformRORAndSetStatusRegisters(value, ref cpu.ProcessorStatus);
+        cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
+        cpu.A = BinaryArithmeticHelpers.AddWithCarryAndOverflow(cpu.A, value, ref cpu.ProcessorStatus);
+        return 0;
+    }
+
+    public RRA()
+    {
+        _opCodes = new List<OpCode>
+        {
+            new OpCode { Code = OpCodeId.RRA_IX_IND, AddressingMode = AddrMode.IX_IND, Size = 2, MinimumCycles = 8 },
+            new OpCode { Code = OpCodeId.RRA_ZP,     AddressingMode = AddrMode.ZP,     Size = 2, MinimumCycles = 5 },
+            new OpCode { Code = OpCodeId.RRA_ABS,    AddressingMode = AddrMode.ABS,    Size = 3, MinimumCycles = 6 },
+            new OpCode { Code = OpCodeId.RRA_IND_IX, AddressingMode = AddrMode.IND_IX, Size = 2, MinimumCycles = 8 },
+            new OpCode { Code = OpCodeId.RRA_ZP_X,   AddressingMode = AddrMode.ZP_X,   Size = 2, MinimumCycles = 6 },
+            new OpCode { Code = OpCodeId.RRA_ABS_Y,  AddressingMode = AddrMode.ABS_Y,  Size = 3, MinimumCycles = 7 },
+            new OpCode { Code = OpCodeId.RRA_ABS_X,  AddressingMode = AddrMode.ABS_X,  Size = 3, MinimumCycles = 7 },
+        };
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502/Instructions/SAX.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/SAX.cs
@@ -1,0 +1,28 @@
+namespace Highbyte.DotNet6502.Instructions;
+
+/// <summary>
+/// SAX (illegal) — Store A AND X.
+/// Stores the bitwise AND of A and X to memory. Flags are not affected.
+/// </summary>
+public class SAX : Instruction, IInstructionUsesAddress
+{
+    private readonly List<OpCode> _opCodes;
+    public override List<OpCode> OpCodes => _opCodes;
+
+    public ulong ExecuteWithWord(CPU cpu, Memory mem, ushort address, AddrModeCalcResult addrModeCalcResult)
+    {
+        cpu.StoreByte((byte)(cpu.A & cpu.X), mem, address);
+        return 0;
+    }
+
+    public SAX()
+    {
+        _opCodes = new List<OpCode>
+        {
+            new OpCode { Code = OpCodeId.SAX_IX_IND, AddressingMode = AddrMode.IX_IND, Size = 2, MinimumCycles = 6 },
+            new OpCode { Code = OpCodeId.SAX_ZP,     AddressingMode = AddrMode.ZP,     Size = 2, MinimumCycles = 3 },
+            new OpCode { Code = OpCodeId.SAX_ABS,    AddressingMode = AddrMode.ABS,    Size = 3, MinimumCycles = 4 },
+            new OpCode { Code = OpCodeId.SAX_ZP_Y,   AddressingMode = AddrMode.ZP_Y,   Size = 2, MinimumCycles = 4 },
+        };
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502/Instructions/SBC.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/SBC.cs
@@ -86,6 +86,13 @@ public class SBC : Instruction, IInstructionUsesByte
                 Size = 2,
                 MinimumCycles = 5, // +1 if page boundary is crossed
             },
+            new OpCode
+            {
+                Code = OpCodeId.SBC_I_EB,
+                AddressingMode = AddrMode.I,
+                Size = 2,
+                MinimumCycles = 2,
+            },
         };
 
     }

--- a/src/libraries/Highbyte.DotNet6502/Instructions/SLO.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/SLO.cs
@@ -1,0 +1,35 @@
+namespace Highbyte.DotNet6502.Instructions;
+
+/// <summary>
+/// SLO (illegal, also ASO) — ASL memory then ORA into A.
+/// Shifts the value at the effective address one bit left (bit 0 = 0, old bit 7 → C),
+/// then ORs the shifted result into A, setting N, Z, and C flags.
+/// </summary>
+public class SLO : Instruction, IInstructionUsesByte
+{
+    private readonly List<OpCode> _opCodes;
+    public override List<OpCode> OpCodes => _opCodes;
+
+    public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
+    {
+        value = BinaryArithmeticHelpers.PerformASLAndSetStatusRegisters(value, ref cpu.ProcessorStatus);
+        cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
+        cpu.A |= value;
+        BinaryArithmeticHelpers.SetFlagsAfterRegisterLoadIncDec(cpu.A, ref cpu.ProcessorStatus);
+        return 0;
+    }
+
+    public SLO()
+    {
+        _opCodes = new List<OpCode>
+        {
+            new OpCode { Code = OpCodeId.SLO_IX_IND, AddressingMode = AddrMode.IX_IND, Size = 2, MinimumCycles = 8 },
+            new OpCode { Code = OpCodeId.SLO_ZP,     AddressingMode = AddrMode.ZP,     Size = 2, MinimumCycles = 5 },
+            new OpCode { Code = OpCodeId.SLO_ABS,    AddressingMode = AddrMode.ABS,    Size = 3, MinimumCycles = 6 },
+            new OpCode { Code = OpCodeId.SLO_IND_IX, AddressingMode = AddrMode.IND_IX, Size = 2, MinimumCycles = 8 },
+            new OpCode { Code = OpCodeId.SLO_ZP_X,   AddressingMode = AddrMode.ZP_X,   Size = 2, MinimumCycles = 6 },
+            new OpCode { Code = OpCodeId.SLO_ABS_Y,  AddressingMode = AddrMode.ABS_Y,  Size = 3, MinimumCycles = 7 },
+            new OpCode { Code = OpCodeId.SLO_ABS_X,  AddressingMode = AddrMode.ABS_X,  Size = 3, MinimumCycles = 7 },
+        };
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502/Instructions/SRE.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/SRE.cs
@@ -1,0 +1,35 @@
+namespace Highbyte.DotNet6502.Instructions;
+
+/// <summary>
+/// SRE (illegal, also LSE) — LSR memory then EOR into A.
+/// Shifts the value at the effective address one bit right (bit 7 = 0, old bit 0 → C),
+/// then XORs the shifted result into A, setting N, Z, and C flags.
+/// </summary>
+public class SRE : Instruction, IInstructionUsesByte
+{
+    private readonly List<OpCode> _opCodes;
+    public override List<OpCode> OpCodes => _opCodes;
+
+    public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
+    {
+        value = BinaryArithmeticHelpers.PerformLSRAndSetStatusRegisters(value, ref cpu.ProcessorStatus);
+        cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
+        cpu.A ^= value;
+        BinaryArithmeticHelpers.SetFlagsAfterRegisterLoadIncDec(cpu.A, ref cpu.ProcessorStatus);
+        return 0;
+    }
+
+    public SRE()
+    {
+        _opCodes = new List<OpCode>
+        {
+            new OpCode { Code = OpCodeId.SRE_IX_IND, AddressingMode = AddrMode.IX_IND, Size = 2, MinimumCycles = 8 },
+            new OpCode { Code = OpCodeId.SRE_ZP,     AddressingMode = AddrMode.ZP,     Size = 2, MinimumCycles = 5 },
+            new OpCode { Code = OpCodeId.SRE_ABS,    AddressingMode = AddrMode.ABS,    Size = 3, MinimumCycles = 6 },
+            new OpCode { Code = OpCodeId.SRE_IND_IX, AddressingMode = AddrMode.IND_IX, Size = 2, MinimumCycles = 8 },
+            new OpCode { Code = OpCodeId.SRE_ZP_X,   AddressingMode = AddrMode.ZP_X,   Size = 2, MinimumCycles = 6 },
+            new OpCode { Code = OpCodeId.SRE_ABS_Y,  AddressingMode = AddrMode.ABS_Y,  Size = 3, MinimumCycles = 7 },
+            new OpCode { Code = OpCodeId.SRE_ABS_X,  AddressingMode = AddrMode.ABS_X,  Size = 3, MinimumCycles = 7 },
+        };
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502/OpCodeId.cs
+++ b/src/libraries/Highbyte.DotNet6502/OpCodeId.cs
@@ -263,4 +263,146 @@ public enum OpCodeId: byte
     BRK = 0x00,
     RTI = 0x40,
     NOP = 0xEA,
+
+    // ── Illegal / undocumented opcodes ──────────────────────────────────────
+
+    // JAM / KIL / HLT — halts the CPU until reset
+    JAM_02 = 0x02,
+    JAM_12 = 0x12,
+    JAM_22 = 0x22,
+    JAM_32 = 0x32,
+    JAM_42 = 0x42,
+    JAM_52 = 0x52,
+    JAM_62 = 0x62,
+    JAM_72 = 0x72,
+    JAM_92 = 0x92,
+    JAM_B2 = 0xB2,
+    JAM_D2 = 0xD2,
+    JAM_F2 = 0xF2,
+
+    // Extra implied NOPs (do nothing, 2 cycles each)
+    NOP_ILL_1A = 0x1A,
+    NOP_ILL_3A = 0x3A,
+    NOP_ILL_5A = 0x5A,
+    NOP_ILL_7A = 0x7A,
+    NOP_ILL_DA = 0xDA,
+    NOP_ILL_FA = 0xFA,
+
+    // NOPs that read (and discard) a byte — immediate
+    NOP_ILL_IMM_80 = 0x80,
+    NOP_ILL_IMM_82 = 0x82,
+    NOP_ILL_IMM_89 = 0x89,
+    NOP_ILL_IMM_C2 = 0xC2,
+    NOP_ILL_IMM_E2 = 0xE2,
+
+    // NOPs that read a zero-page byte
+    NOP_ILL_ZP_04 = 0x04,
+    NOP_ILL_ZP_44 = 0x44,
+    NOP_ILL_ZP_64 = 0x64,
+
+    // NOPs that read a zero-page,X byte
+    NOP_ILL_ZP_X_14 = 0x14,
+    NOP_ILL_ZP_X_34 = 0x34,
+    NOP_ILL_ZP_X_54 = 0x54,
+    NOP_ILL_ZP_X_74 = 0x74,
+    NOP_ILL_ZP_X_D4 = 0xD4,
+    NOP_ILL_ZP_X_F4 = 0xF4,
+
+    // NOP that reads an absolute byte
+    NOP_ILL_ABS = 0x0C,
+
+    // NOPs that read an absolute,X byte (+1 cycle on page cross)
+    NOP_ILL_ABS_X_1C = 0x1C,
+    NOP_ILL_ABS_X_3C = 0x3C,
+    NOP_ILL_ABS_X_5C = 0x5C,
+    NOP_ILL_ABS_X_7C = 0x7C,
+    NOP_ILL_ABS_X_DC = 0xDC,
+    NOP_ILL_ABS_X_FC = 0xFC,
+
+    // LAX — load A and X from same address
+    LAX_IX_IND = 0xA3,
+    LAX_ZP     = 0xA7,
+    LAX_ABS    = 0xAF,
+    LAX_IND_IX = 0xB3,
+    LAX_ZP_Y   = 0xB7,
+    LAX_ABS_Y  = 0xBF,
+
+    // SAX — store A AND X
+    SAX_IX_IND = 0x83,
+    SAX_ZP     = 0x87,
+    SAX_ABS    = 0x8F,
+    SAX_ZP_Y   = 0x97,
+
+    // DCP — decrement memory then CMP with A
+    DCP_IX_IND = 0xC3,
+    DCP_ZP     = 0xC7,
+    DCP_ABS    = 0xCF,
+    DCP_IND_IX = 0xD3,
+    DCP_ZP_X   = 0xD7,
+    DCP_ABS_Y  = 0xDB,
+    DCP_ABS_X  = 0xDF,
+
+    // ISC — increment memory then SBC from A
+    ISC_IX_IND = 0xE3,
+    ISC_ZP     = 0xE7,
+    ISC_ABS    = 0xEF,
+    ISC_IND_IX = 0xF3,
+    ISC_ZP_X   = 0xF7,
+    ISC_ABS_Y  = 0xFB,
+    ISC_ABS_X  = 0xFF,
+
+    // SLO — ASL memory then ORA into A
+    SLO_IX_IND = 0x03,
+    SLO_ZP     = 0x07,
+    SLO_ABS    = 0x0F,
+    SLO_IND_IX = 0x13,
+    SLO_ZP_X   = 0x17,
+    SLO_ABS_Y  = 0x1B,
+    SLO_ABS_X  = 0x1F,
+
+    // SRE — LSR memory then EOR into A
+    SRE_IX_IND = 0x43,
+    SRE_ZP     = 0x47,
+    SRE_ABS    = 0x4F,
+    SRE_IND_IX = 0x53,
+    SRE_ZP_X   = 0x57,
+    SRE_ABS_Y  = 0x5B,
+    SRE_ABS_X  = 0x5F,
+
+    // RLA — ROL memory then AND into A
+    RLA_IX_IND = 0x23,
+    RLA_ZP     = 0x27,
+    RLA_ABS    = 0x2F,
+    RLA_IND_IX = 0x33,
+    RLA_ZP_X   = 0x37,
+    RLA_ABS_Y  = 0x3B,
+    RLA_ABS_X  = 0x3F,
+
+    // RRA — ROR memory then ADC into A
+    RRA_IX_IND = 0x63,
+    RRA_ZP     = 0x67,
+    RRA_ABS    = 0x6F,
+    RRA_IND_IX = 0x73,
+    RRA_ZP_X   = 0x77,
+    RRA_ABS_Y  = 0x7B,
+    RRA_ABS_X  = 0x7F,
+
+    // ANC — AND immediate, bit 7 of result → Carry
+    ANC_I_0B = 0x0B,
+    ANC_I_2B = 0x2B,
+
+    // ALR — AND immediate then LSR accumulator
+    ALR_I = 0x4B,
+
+    // ARR — AND immediate then ROR accumulator (unusual flags)
+    ARR_I = 0x6B,
+
+    // AXS — X = (A & X) − immediate  (CMP-style flags, no borrow input)
+    AXS_I = 0xCB,
+
+    // LAS — A = X = SP = memory & SP
+    LAS_ABS_Y = 0xBB,
+
+    // SBC duplicate (identical to SBC_I 0xE9)
+    SBC_I_EB = 0xEB,
 }

--- a/tests/Highbyte.DotNet6502.Tests/CPUHelperTest.cs
+++ b/tests/Highbyte.DotNet6502.Tests/CPUHelperTest.cs
@@ -49,7 +49,7 @@ public class CPUHelperTest
         var cpu = new CPU();
         var mem = new Memory();
 
-        var opCodeByte = (byte)0xff;    // 0xff (255) is not a known opcode.
+        var opCodeByte = (byte)0x02;    // 0x02 (JAM/KIL) is not a known opcode.
         mem[0x1000] = opCodeByte;
         cpu.PC = 0x1000;
         

--- a/tests/Highbyte.DotNet6502.Tests/CPUTest.cs
+++ b/tests/Highbyte.DotNet6502.Tests/CPUTest.cs
@@ -10,6 +10,15 @@ namespace Highbyte.DotNet6502.Tests;
 public class CPUTest
 {
     [Fact]
+    public void CPU_Without_Profile_Uses_ExperimentalUnofficial_Default()
+    {
+        var cpu = new CPU();
+
+        Assert.Equal(CpuCompatibilityProfile.ExperimentalUnofficial, cpu.CompatibilityProfile);
+        Assert.DoesNotContain((byte)OpCodeId.JAM_02, cpu.InstructionList.OpCodeDictionary.Keys);
+    }
+
+    [Fact]
     public void CPU_Handles_Hardware_IRQ_When_InterruptDisable_Is_Not_Set()
     {
         // Arrange
@@ -165,10 +174,10 @@ public class CPUTest
     public void CPU_Can_Detect_Unknown_OpCode()
     {
         // Arrange
-        var cpu = new CPU();
+        var cpu = new CPU(CpuCompatibilityProfile.ExperimentalUnofficial);
         var mem = new Memory();
 
-        mem[0x1000] = 0x02; // OpCode that does not exist
+        mem[0x1000] = 0x02; // JAM is not available below FullUnofficial
         cpu.PC = 0x1000;
 
         // Act
@@ -190,10 +199,10 @@ public class CPUTest
         // skip branch. This test plugs in a recording logger (IsEnabled=true) so the
         // LogWarning call site is also covered.
         var loggerFactory = new RecordingLoggerFactory();
-        var cpu = new CPU(loggerFactory);
+        var cpu = new CPU(loggerFactory, CpuCompatibilityProfile.ExperimentalUnofficial);
         var mem = new Memory();
 
-        mem[0x1000] = 0x02; // OpCode that does not exist
+        mem[0x1000] = 0x02; // JAM is not available below FullUnofficial
         cpu.PC = 0x1000;
 
         var execState = cpu.Execute(
@@ -273,10 +282,10 @@ public class CPUTest
     public void CPU_Can_Detect_Unknown_OpCode_With_MinimalExecution()
     {
         // Arrange
-        var cpu = new CPU();
+        var cpu = new CPU(CpuCompatibilityProfile.ExperimentalUnofficial);
         var mem = new Memory();
 
-        mem[0x1000] = 0x02; // OpCode that does not exist
+        mem[0x1000] = 0x02; // JAM is not available below FullUnofficial
         cpu.PC = 0x1000;
 
         // Act
@@ -284,6 +293,50 @@ public class CPUTest
 
         // Assert
         Assert.True(execResult.UnknownInstruction);
+    }
+
+    [Fact]
+    public void CPU_Halts_When_FullUnofficial_JAM_Opcode_Is_Executed()
+    {
+        var cpu = new CPU(CpuCompatibilityProfile.FullUnofficial);
+        var mem = new Memory();
+        CPUUnknownOpCodeDetectedEventArgs? detectedEvent = null;
+        cpu.UnknownOpCodeDetected += (_, args) => detectedEvent = args;
+
+        ushort originalPC = 0x1000;
+        mem[originalPC] = (byte)OpCodeId.JAM_02;
+        mem[(ushort)(originalPC + 1)] = (byte)OpCodeId.NOP;
+        cpu.PC = originalPC;
+
+        var execState = cpu.Execute(
+            mem,
+            new LegacyExecEvaluator(new ExecOptions { MaxNumberOfInstructions = 10, UnknownInstructionThrowsException = false }));
+
+        Assert.True(cpu.IsHalted);
+        Assert.True(execState.LastOpCodeWasHandled);
+        Assert.True(execState.LastInstructionExecResult.IsHaltInstruction);
+        Assert.Equal((ulong)0, execState.UnknownOpCodeCount);
+        Assert.Equal((ulong)1, execState.InstructionsExecutionCount);
+        Assert.Equal((ushort)(originalPC + 1), cpu.PC);
+        Assert.NotNull(detectedEvent);
+        Assert.Equal((byte)OpCodeId.JAM_02, detectedEvent!.OpCode);
+    }
+
+    [Fact]
+    public void CPU_Reset_Clears_Halt_State()
+    {
+        var cpu = new CPU(CpuCompatibilityProfile.FullUnofficial);
+        var mem = new Memory();
+
+        mem[0x1000] = (byte)OpCodeId.JAM_02;
+        mem.WriteWord(CPU.ResetVector, 0xC000);
+        cpu.PC = 0x1000;
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+        cpu.Reset(mem);
+
+        Assert.False(cpu.IsHalted);
+        Assert.Equal((ushort)0xC000, cpu.PC);
     }
 
     [Fact]

--- a/tests/Highbyte.DotNet6502.Tests/InstructionListTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/InstructionListTests.cs
@@ -17,9 +17,58 @@ public class InstructionListTests
         Assert.True(list.OpCodeDictionary.Count > 0, "OpCodeDictionary should contain at least one opcode");
         Assert.True(list.InstructionDictionary.Count > 0, "InstructionDictionary should contain at least one instruction");
         
-        // Note: In DEBUG mode, GetAllInstructions() automatically verifies that the manual instruction list
-        // matches the dynamically discovered instructions. If they don't match, it throws an exception.
-        // This test validates that verification passes (by not throwing).
+        // This test ensures the default instruction list can be created successfully.
+    }
+
+    [Fact]
+    public void GetAllInstructions_With_OfficialOnly_Profile_Excludes_Unofficial_OpCodes()
+    {
+        var list = InstructionList.GetAllInstructions(CpuCompatibilityProfile.OfficialOnly);
+
+        Assert.Contains((byte)OpCodeId.NOP, list.OpCodeDictionary.Keys);
+        Assert.DoesNotContain((byte)OpCodeId.NOP_ILL_1A, list.OpCodeDictionary.Keys);
+        Assert.DoesNotContain((byte)OpCodeId.ARR_I, list.OpCodeDictionary.Keys);
+    }
+
+    [Fact]
+    public void GetAllInstructions_With_StableUnofficial_Profile_Includes_Stable_But_Not_Experimental_OpCodes()
+    {
+        var list = InstructionList.GetAllInstructions(CpuCompatibilityProfile.StableUnofficial);
+
+        Assert.Contains((byte)OpCodeId.NOP_ILL_1A, list.OpCodeDictionary.Keys);
+        Assert.Contains((byte)OpCodeId.SBC_I_EB, list.OpCodeDictionary.Keys);
+        Assert.DoesNotContain((byte)OpCodeId.ARR_I, list.OpCodeDictionary.Keys);
+        Assert.DoesNotContain((byte)OpCodeId.LAS_ABS_Y, list.OpCodeDictionary.Keys);
+    }
+
+    [Fact]
+    public void GetAllInstructions_With_ExperimentalUnofficial_Profile_Includes_Experimental_OpCodes()
+    {
+        var list = InstructionList.GetAllInstructions(CpuCompatibilityProfile.ExperimentalUnofficial);
+
+        Assert.Contains((byte)OpCodeId.ARR_I, list.OpCodeDictionary.Keys);
+        Assert.Contains((byte)OpCodeId.LAS_ABS_Y, list.OpCodeDictionary.Keys);
+        Assert.DoesNotContain((byte)OpCodeId.JAM_02, list.OpCodeDictionary.Keys);
+    }
+
+    [Fact]
+    public void GetAllInstructions_Without_Profile_Uses_ExperimentalUnofficial_Default()
+    {
+        var defaultList = InstructionList.GetAllInstructions();
+        var experimentalList = InstructionList.GetAllInstructions(CpuCompatibilityProfile.ExperimentalUnofficial);
+
+        Assert.Equal(experimentalList.OpCodeDictionary.Keys, defaultList.OpCodeDictionary.Keys);
+        Assert.DoesNotContain((byte)OpCodeId.JAM_02, defaultList.OpCodeDictionary.Keys);
+    }
+
+    [Fact]
+    public void GetAllInstructions_With_FullUnofficial_Profile_Includes_Halt_OpCodes()
+    {
+        var fullList = InstructionList.GetAllInstructions(CpuCompatibilityProfile.FullUnofficial);
+
+        Assert.Contains((byte)OpCodeId.ARR_I, fullList.OpCodeDictionary.Keys);
+        Assert.Contains((byte)OpCodeId.LAS_ABS_Y, fullList.OpCodeDictionary.Keys);
+        Assert.Contains((byte)OpCodeId.JAM_02, fullList.OpCodeDictionary.Keys);
     }
 
 #if DEBUG

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/ALR_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/ALR_test.cs
@@ -1,0 +1,82 @@
+namespace Highbyte.DotNet6502.Tests.Instructions;
+
+public class ALR_test
+{
+    [Fact]
+    public void ALR_I_Takes_2_Cycles()
+    {
+        var test = new TestSpec
+        {
+            A = 0xFF,
+            OpCode         = OpCodeId.ALR_I,
+            FinalValue     = 0xAA,
+            ExpectedCycles = 2,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void ALR_I_ANDs_A_With_Immediate_Then_Shifts_Right()
+    {
+        // A=0xFF & imm=0xAA → 0xAA; LSR→ A=0x55, C=0 (bit0 of 0xAA=0)
+        var test = new TestSpec
+        {
+            A = 0xFF,
+            OpCode     = OpCodeId.ALR_I,
+            FinalValue = 0xAA,
+            ExpectedA  = 0x55,
+            ExpectedC  = false,
+            ExpectedN  = false,
+            ExpectedZ  = false,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void ALR_I_Sets_Carry_From_Bit0_Of_AND_Result()
+    {
+        // A=0xFF & imm=0x01 → 0x01; LSR→ A=0x00, C=1
+        var test = new TestSpec
+        {
+            A = 0xFF,
+            OpCode     = OpCodeId.ALR_I,
+            FinalValue = 0x01,
+            ExpectedA  = 0x00,
+            ExpectedC  = true,
+            ExpectedZ  = true,
+            ExpectedN  = false,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void ALR_I_Always_Clears_Negative_Flag()
+    {
+        // LSR always puts 0 in bit7, so N is always 0
+        var test = new TestSpec
+        {
+            A = 0xFF,
+            OpCode     = OpCodeId.ALR_I,
+            FinalValue = 0xFF,
+            ExpectedA  = 0x7F,
+            ExpectedN  = false,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void ALR_I_Sets_Zero_Flag_When_AND_Result_Is_Zero()
+    {
+        // A=0xF0 & imm=0x0F → 0x00; LSR→ A=0x00, Z=1
+        var test = new TestSpec
+        {
+            A = 0xF0,
+            OpCode     = OpCodeId.ALR_I,
+            FinalValue = 0x0F,
+            ExpectedA  = 0x00,
+            ExpectedZ  = true,
+            ExpectedC  = false,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/ANC_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/ANC_test.cs
@@ -1,0 +1,94 @@
+namespace Highbyte.DotNet6502.Tests.Instructions;
+
+public class ANC_test
+{
+    [Fact]
+    public void ANC_0B_Takes_2_Cycles()
+    {
+        var test = new TestSpec
+        {
+            A = 0xFF,
+            OpCode         = OpCodeId.ANC_I_0B,
+            FinalValue     = 0xF0,
+            ExpectedCycles = 2,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void ANC_0B_ANDs_A_With_Immediate()
+    {
+        var test = new TestSpec
+        {
+            A = 0xFF,
+            OpCode     = OpCodeId.ANC_I_0B,
+            FinalValue = 0xF0,
+            ExpectedA  = 0xF0,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void ANC_0B_Sets_Carry_From_Bit7_Of_Result()
+    {
+        // A=0xFF & imm=0xF0 → result=0xF0, bit7=1 → C=1
+        var test = new TestSpec
+        {
+            A = 0xFF,
+            OpCode     = OpCodeId.ANC_I_0B,
+            FinalValue = 0xF0,
+            ExpectedA  = 0xF0,
+            ExpectedC  = true,
+            ExpectedN  = true,
+            ExpectedZ  = false,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void ANC_0B_Clears_Carry_When_Bit7_Of_Result_Is_Clear()
+    {
+        // A=0xFF & imm=0x0F → result=0x0F, bit7=0 → C=0
+        var test = new TestSpec
+        {
+            A = 0xFF,
+            OpCode     = OpCodeId.ANC_I_0B,
+            FinalValue = 0x0F,
+            ExpectedA  = 0x0F,
+            ExpectedC  = false,
+            ExpectedN  = false,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void ANC_0B_Sets_Zero_Flag_When_Result_Is_Zero()
+    {
+        var test = new TestSpec
+        {
+            A = 0xF0,
+            OpCode     = OpCodeId.ANC_I_0B,
+            FinalValue = 0x0F,
+            ExpectedA  = 0x00,
+            ExpectedZ  = true,
+            ExpectedC  = false,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void ANC_2B_Behaves_Identically_To_0B()
+    {
+        // Both opcodes must produce the same result
+        var test = new TestSpec
+        {
+            A = 0xFF,
+            OpCode     = OpCodeId.ANC_I_2B,
+            FinalValue = 0xF0,
+            ExpectedA  = 0xF0,
+            ExpectedC  = true,
+            ExpectedN  = true,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/ARR_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/ARR_test.cs
@@ -1,0 +1,109 @@
+namespace Highbyte.DotNet6502.Tests.Instructions;
+
+public class ARR_test
+{
+    [Fact]
+    public void ARR_I_Takes_2_Cycles()
+    {
+        var test = new TestSpec
+        {
+            A = 0xFF, C = true,
+            OpCode         = OpCodeId.ARR_I,
+            FinalValue     = 0xFF,
+            ExpectedCycles = 2,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void ARR_I_ANDs_A_With_Immediate_Then_Rotates_Right()
+    {
+        // A=0xFF & imm=0xFF → 0xFF; old C=1 → bit7 of result; 0xFF>>1 | 0x80 = 0xFF
+        var test = new TestSpec
+        {
+            A = 0xFF, C = true,
+            OpCode     = OpCodeId.ARR_I,
+            FinalValue = 0xFF,
+            ExpectedA  = 0xFF,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void ARR_I_Sets_Carry_From_Bit6_Of_Result()
+    {
+        // A=0xFF & imm=0xFF → 0xFF; C=1 → result=0xFF; C=bit6(0xFF)=1
+        var test = new TestSpec
+        {
+            A = 0xFF, C = true,
+            OpCode     = OpCodeId.ARR_I,
+            FinalValue = 0xFF,
+            ExpectedA  = 0xFF,
+            ExpectedC  = true,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void ARR_I_Clears_Carry_When_Bit6_Of_Result_Is_Clear()
+    {
+        // A=0x01 & imm=0x01 → 0x01; C=0 → ROR: result=0x00 (0x01>>1=0x00, no carry in); bit6(0x00)=0
+        var test = new TestSpec
+        {
+            A = 0x01, C = false,
+            OpCode     = OpCodeId.ARR_I,
+            FinalValue = 0x01,
+            ExpectedA  = 0x00,
+            ExpectedC  = false,
+            ExpectedZ  = true,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void ARR_I_Sets_Overflow_As_Bit6_XOR_Bit5_Of_Result()
+    {
+        // A=0xFF & imm=0xFF → 0xFF; C=1 → result=0xFF; V=bit6^bit5=1^1=0
+        var test = new TestSpec
+        {
+            A = 0xFF, C = true,
+            OpCode     = OpCodeId.ARR_I,
+            FinalValue = 0xFF,
+            ExpectedV  = false, // bit6(1) XOR bit5(1) = 0
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void ARR_I_Sets_Overflow_When_Bit6_And_Bit5_Differ()
+    {
+        // Need result where bit6=1, bit5=0 (or vice versa)
+        // A=0xFF & imm=0x7F → 0x7F (bit7=0,bit6=1,bit5=1,bit4=1...)
+        // C=1 → ROR(0x7F, C=1): result = (0x7F>>1) | 0x80 = 0x3F | 0x80 = 0xBF
+        // bit6(0xBF)=0, bit5(0xBF)=1 → V=0^1=1
+        var test = new TestSpec
+        {
+            A = 0xFF, C = true,
+            OpCode     = OpCodeId.ARR_I,
+            FinalValue = 0x7F,
+            ExpectedA  = 0xBF,
+            ExpectedV  = true,  // bit6(0)=0 XOR bit5(1)=1 → 1
+            ExpectedC  = false, // bit6(0xBF)=0
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void ARR_I_Sets_Negative_Flag_Based_On_Bit7_Of_Result()
+    {
+        // C=1 puts 1 in bit7 of the result
+        var test = new TestSpec
+        {
+            A = 0xFF, C = true,
+            OpCode     = OpCodeId.ARR_I,
+            FinalValue = 0xFF,
+            ExpectedN  = true,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/AXS_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/AXS_test.cs
@@ -1,0 +1,107 @@
+namespace Highbyte.DotNet6502.Tests.Instructions;
+
+public class AXS_test
+{
+    [Fact]
+    public void AXS_I_Takes_2_Cycles()
+    {
+        var test = new TestSpec
+        {
+            A = 0xFF, X = 0x0F,
+            OpCode         = OpCodeId.AXS_I,
+            FinalValue     = 0x05,
+            ExpectedCycles = 2,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void AXS_I_Stores_A_AND_X_Minus_Immediate_In_X()
+    {
+        // A=0xFF, X=0x0F → A&X=0x0F; X = 0x0F - 0x05 = 0x0A
+        var test = new TestSpec
+        {
+            A = 0xFF, X = 0x0F,
+            OpCode     = OpCodeId.AXS_I,
+            FinalValue = 0x05,
+            ExpectedX  = 0x0A,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void AXS_I_Does_Not_Change_A()
+    {
+        var test = new TestSpec
+        {
+            A = 0xFF, X = 0x0F,
+            OpCode     = OpCodeId.AXS_I,
+            FinalValue = 0x05,
+            ExpectedA  = 0xFF,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void AXS_I_Sets_Carry_When_A_AND_X_Greater_Or_Equal_To_Immediate()
+    {
+        // A&X=0x0F, imm=0x05 → 0x0F >= 0x05 → C=1
+        var test = new TestSpec
+        {
+            A = 0xFF, X = 0x0F,
+            OpCode     = OpCodeId.AXS_I,
+            FinalValue = 0x05,
+            ExpectedX  = 0x0A,
+            ExpectedC  = true,
+            ExpectedZ  = false,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void AXS_I_Clears_Carry_When_A_AND_X_Less_Than_Immediate()
+    {
+        // A=0x07, X=0x03 → A&X=0x03, imm=0x05 → 0x03 < 0x05 → C=0
+        var test = new TestSpec
+        {
+            A = 0x07, X = 0x03,
+            OpCode     = OpCodeId.AXS_I,
+            FinalValue = 0x05,
+            ExpectedC  = false,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void AXS_I_Sets_Zero_Flag_When_Result_Is_Zero()
+    {
+        // A=0x0F, X=0xFF → A&X=0x0F, imm=0x0F → X=0x00, Z=1, C=1 (equal)
+        var test = new TestSpec
+        {
+            A = 0x0F, X = 0xFF,
+            OpCode     = OpCodeId.AXS_I,
+            FinalValue = 0x0F,
+            ExpectedX  = 0x00,
+            ExpectedZ  = true,
+            ExpectedC  = true,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void AXS_I_Sets_Negative_Flag_When_Bit7_Of_Result_Set()
+    {
+        // A=0xFF, X=0xFF → A&X=0xFF, imm=0x80 → X=0x7F; (0xFF-0x80)=0x7F, N=0
+        // Better: A=0xFF, X=0xFF → A&X=0xFF, imm=0x01 → X=0xFE, N=1
+        var test = new TestSpec
+        {
+            A = 0xFF, X = 0xFF,
+            OpCode     = OpCodeId.AXS_I,
+            FinalValue = 0x01,
+            ExpectedX  = 0xFE,
+            ExpectedN  = true,
+            ExpectedC  = true,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/DCP_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/DCP_test.cs
@@ -1,0 +1,196 @@
+namespace Highbyte.DotNet6502.Tests.Instructions;
+
+public class DCP_test
+{
+    [Fact]
+    public void DCP_ZP_Takes_5_Cycles()
+    {
+        var test = new TestSpec
+        {
+            A = 0x05,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.DCP_ZP,
+            FinalValue     = 0x06,
+            ExpectedCycles = 5,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void DCP_ZP_Decrements_Memory_Value()
+    {
+        var test = new TestSpec
+        {
+            A = 0x00,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.DCP_ZP,
+            FinalValue     = 0x06,
+            ExpectedMemVal = 0x05,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void DCP_ZP_Sets_Zero_And_Carry_When_A_Equals_Decremented_Value()
+    {
+        // A = 5, mem = 6 → mem becomes 5, CMP(A=5, mem=5): Z=1, C=1 (A>=mem), N=0
+        var test = new TestSpec
+        {
+            A = 0x05,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.DCP_ZP,
+            FinalValue     = 0x06,
+            ExpectedMemVal = 0x05,
+            ExpectedZ      = true,
+            ExpectedC      = true,
+            ExpectedN      = false,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void DCP_ZP_Sets_Carry_And_Clears_Zero_When_A_Greater_Than_Decremented_Value()
+    {
+        // A = 10, mem = 6 → mem becomes 5, CMP(A=10, mem=5): Z=0, C=1, N=0
+        var test = new TestSpec
+        {
+            A = 0x0A,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.DCP_ZP,
+            FinalValue     = 0x06,
+            ExpectedMemVal = 0x05,
+            ExpectedZ      = false,
+            ExpectedC      = true,
+            ExpectedN      = false,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void DCP_ZP_Clears_Carry_When_A_Less_Than_Decremented_Value()
+    {
+        // A = 3, mem = 6 → mem becomes 5, CMP(A=3, mem=5): C=0 (A<mem)
+        var test = new TestSpec
+        {
+            A = 0x03,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.DCP_ZP,
+            FinalValue     = 0x06,
+            ExpectedMemVal = 0x05,
+            ExpectedC      = false,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void DCP_ZP_Sets_Negative_Flag_When_Result_Has_Bit7_Set()
+    {
+        // A = 0x01, mem = 0x83 → mem becomes 0x82, CMP(1, 0x82): N = bit7(1-0x82) = bit7(0x7F) = 0...
+        // Let's pick: A = 0x80, mem = 0x02 → mem = 0x01, CMP(0x80, 0x01): 0x80-0x01=0x7F, N=0, C=1
+        // Better: A = 0x01, mem = 0x83 → mem=0x82, CMP(0x01,0x82): 0x01-0x82=0x7F... N=0
+        // Even better: A = 0x00, mem = 0x01 → mem = 0x00, CMP(0x00, 0x00): Z=1, but that's Z
+        // Actually: CMP sets N based on bit7 of (register - value)
+        // A=0x10, mem=0x91 → mem=0x90, CMP(0x10, 0x90): 0x10-0x90=0x80, N=1
+        var test = new TestSpec
+        {
+            A = 0x10,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.DCP_ZP,
+            FinalValue     = 0x91,
+            ExpectedMemVal = 0x90,
+            ExpectedN      = true,
+            ExpectedC      = false, // 0x10 < 0x90
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void DCP_ZP_X_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0x05,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.DCP_ZP_X,
+            FinalValue     = 0x06,
+            ExpectedMemVal = 0x05,
+            ExpectedCycles = 6,
+        };
+        test.Execute_And_Verify(AddrMode.ZP_X);
+    }
+
+    [Fact]
+    public void DCP_ABS_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0x05,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.DCP_ABS,
+            FinalValue     = 0x06,
+            ExpectedMemVal = 0x05,
+            ExpectedCycles = 6,
+        };
+        test.Execute_And_Verify(AddrMode.ABS);
+    }
+
+    [Fact]
+    public void DCP_ABS_X_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0x05,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.DCP_ABS_X,
+            FinalValue     = 0x06,
+            ExpectedMemVal = 0x05,
+            ExpectedCycles = 7,
+        };
+        test.Execute_And_Verify(AddrMode.ABS_X);
+    }
+
+    [Fact]
+    public void DCP_ABS_Y_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0x05,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.DCP_ABS_Y,
+            FinalValue     = 0x06,
+            ExpectedMemVal = 0x05,
+            ExpectedCycles = 7,
+        };
+        test.Execute_And_Verify(AddrMode.ABS_Y);
+    }
+
+    [Fact]
+    public void DCP_IX_IND_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0x05,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.DCP_IX_IND,
+            FinalValue     = 0x06,
+            ExpectedMemVal = 0x05,
+            ExpectedCycles = 8,
+        };
+        test.Execute_And_Verify(AddrMode.IX_IND);
+    }
+
+    [Fact]
+    public void DCP_IND_IX_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0x05,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.DCP_IND_IX,
+            FinalValue     = 0x06,
+            ExpectedMemVal = 0x05,
+            ExpectedCycles = 8,
+        };
+        test.Execute_And_Verify(AddrMode.IND_IX);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/ISC_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/ISC_test.cs
@@ -1,0 +1,175 @@
+namespace Highbyte.DotNet6502.Tests.Instructions;
+
+public class ISC_test
+{
+    [Fact]
+    public void ISC_ZP_Takes_5_Cycles()
+    {
+        var test = new TestSpec
+        {
+            A = 0x20, C = true,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.ISC_ZP,
+            FinalValue     = 0x0F,
+            ExpectedCycles = 5,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void ISC_ZP_Increments_Memory_Value()
+    {
+        var test = new TestSpec
+        {
+            A = 0x20, C = true,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.ISC_ZP,
+            FinalValue     = 0x0F,
+            ExpectedMemVal = 0x10,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void ISC_ZP_Subtracts_Incremented_Value_From_A()
+    {
+        // A=0x20, C=1 (no borrow), mem=0x0F → mem=0x10, SBC(0x20, 0x10, C=1): A=0x10
+        var test = new TestSpec
+        {
+            A = 0x20, C = true,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.ISC_ZP,
+            FinalValue     = 0x0F,
+            ExpectedA      = 0x10,
+            ExpectedC      = true,
+            ExpectedZ      = false,
+            ExpectedN      = false,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void ISC_ZP_Sets_Zero_Flag_When_Result_Is_Zero()
+    {
+        // A=0x10, C=1, mem=0x0F → mem=0x10, SBC(0x10, 0x10, C=1): A=0x00, Z=1
+        var test = new TestSpec
+        {
+            A = 0x10, C = true,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.ISC_ZP,
+            FinalValue     = 0x0F,
+            ExpectedA      = 0x00,
+            ExpectedZ      = true,
+            ExpectedC      = true,
+            ExpectedN      = false,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void ISC_ZP_Sets_Negative_Flag_When_Result_Is_Negative()
+    {
+        // A=0x05, C=1, mem=0x0F → mem=0x10, SBC(0x05, 0x10, C=1): 0x05-0x10=-11 (0xF5), N=1, C=0 (borrow)
+        var test = new TestSpec
+        {
+            A = 0x05, C = true,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.ISC_ZP,
+            FinalValue     = 0x0F,
+            ExpectedA      = 0xF5,
+            ExpectedN      = true,
+            ExpectedC      = false,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void ISC_ZP_X_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0x20, C = true,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.ISC_ZP_X,
+            FinalValue     = 0x0F,
+            ExpectedMemVal = 0x10,
+            ExpectedCycles = 6,
+        };
+        test.Execute_And_Verify(AddrMode.ZP_X);
+    }
+
+    [Fact]
+    public void ISC_ABS_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0x20, C = true,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.ISC_ABS,
+            FinalValue     = 0x0F,
+            ExpectedMemVal = 0x10,
+            ExpectedCycles = 6,
+        };
+        test.Execute_And_Verify(AddrMode.ABS);
+    }
+
+    [Fact]
+    public void ISC_ABS_X_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0x20, C = true,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.ISC_ABS_X,
+            FinalValue     = 0x0F,
+            ExpectedMemVal = 0x10,
+            ExpectedCycles = 7,
+        };
+        test.Execute_And_Verify(AddrMode.ABS_X);
+    }
+
+    [Fact]
+    public void ISC_ABS_Y_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0x20, C = true,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.ISC_ABS_Y,
+            FinalValue     = 0x0F,
+            ExpectedMemVal = 0x10,
+            ExpectedCycles = 7,
+        };
+        test.Execute_And_Verify(AddrMode.ABS_Y);
+    }
+
+    [Fact]
+    public void ISC_IX_IND_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0x20, C = true,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.ISC_IX_IND,
+            FinalValue     = 0x0F,
+            ExpectedMemVal = 0x10,
+            ExpectedCycles = 8,
+        };
+        test.Execute_And_Verify(AddrMode.IX_IND);
+    }
+
+    [Fact]
+    public void ISC_IND_IX_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0x20, C = true,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.ISC_IND_IX,
+            FinalValue     = 0x0F,
+            ExpectedMemVal = 0x10,
+            ExpectedCycles = 8,
+        };
+        test.Execute_And_Verify(AddrMode.IND_IX);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/LAS_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/LAS_test.cs
@@ -1,0 +1,89 @@
+namespace Highbyte.DotNet6502.Tests.Instructions;
+
+public class LAS_test
+{
+    [Fact]
+    public void LAS_ABS_Y_Takes_4_Cycles()
+    {
+        var test = new TestSpec
+        {
+            A = 0x00, X = 0x00, SP = 0x30,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.LAS_ABS_Y,
+            FinalValue     = 0xFF,
+            ExpectedCycles = 4,
+        };
+        test.Execute_And_Verify(AddrMode.ABS_Y);
+    }
+
+    [Fact]
+    public void LAS_ABS_Y_Takes_5_Cycles_When_Page_Boundary_Crossed()
+    {
+        var test = new TestSpec
+        {
+            A = 0x00, X = 0x00, SP = 0x30,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.LAS_ABS_Y,
+            FinalValue     = 0xFF,
+            ExpectedCycles = 5,
+        };
+        test.Execute_And_Verify(AddrMode.ABS_Y, fullAddress_Should_Cross_Page_Boundary: true);
+    }
+
+    [Fact]
+    public void LAS_ABS_Y_Stores_Memory_AND_SP_Into_A_X_And_SP()
+    {
+        // SP=0x30, mem=0xFF → result=0xFF&0x30=0x30; A=X=SP=0x30
+        var test = new TestSpec
+        {
+            A = 0x00, X = 0x00, SP = 0x30,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.LAS_ABS_Y,
+            FinalValue     = 0xFF,
+            ExpectedA      = 0x30,
+            ExpectedX      = 0x30,
+            ExpectedSP     = 0x30,
+            ExpectedN      = false,
+            ExpectedZ      = false,
+        };
+        test.Execute_And_Verify(AddrMode.ABS_Y);
+    }
+
+    [Fact]
+    public void LAS_ABS_Y_AND_Masks_Memory_With_SP()
+    {
+        // SP=0xF0, mem=0x0F → result=0xF0&0x0F=0x00; A=X=SP=0x00
+        var test = new TestSpec
+        {
+            A = 0x01, X = 0x01, SP = 0xF0,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.LAS_ABS_Y,
+            FinalValue     = 0x0F,
+            ExpectedA      = 0x00,
+            ExpectedX      = 0x00,
+            ExpectedSP     = 0x00,
+            ExpectedZ      = true,
+            ExpectedN      = false,
+        };
+        test.Execute_And_Verify(AddrMode.ABS_Y);
+    }
+
+    [Fact]
+    public void LAS_ABS_Y_Sets_Negative_Flag_When_Bit7_Set()
+    {
+        // SP=0xFF, mem=0x80 → result=0xFF&0x80=0x80; N=1
+        var test = new TestSpec
+        {
+            A = 0x00, X = 0x00, SP = 0xFF,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.LAS_ABS_Y,
+            FinalValue     = 0x80,
+            ExpectedA      = 0x80,
+            ExpectedX      = 0x80,
+            ExpectedSP     = 0x80,
+            ExpectedN      = true,
+            ExpectedZ      = false,
+        };
+        test.Execute_And_Verify(AddrMode.ABS_Y);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/LAX_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/LAX_test.cs
@@ -1,0 +1,159 @@
+namespace Highbyte.DotNet6502.Tests.Instructions;
+
+public class LAX_test
+{
+    [Fact]
+    public void LAX_ZP_Takes_3_Cycles()
+    {
+        var test = new TestSpec
+        {
+            A = 0, X = 0,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.LAX_ZP,
+            FinalValue     = 0xAB,
+            ExpectedCycles = 3,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void LAX_ZP_Loads_Both_A_And_X_With_Same_Value()
+    {
+        var test = new TestSpec
+        {
+            A = 0x00, X = 0x00,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.LAX_ZP,
+            FinalValue     = 0xAB,
+            ExpectedA      = 0xAB,
+            ExpectedX      = 0xAB,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void LAX_ZP_Sets_Negative_Flag_When_Bit7_Set()
+    {
+        var test = new TestSpec
+        {
+            A = 0x00, X = 0x00,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.LAX_ZP,
+            FinalValue     = 0x80,
+            ExpectedA      = 0x80,
+            ExpectedX      = 0x80,
+            ExpectedN      = true,
+            ExpectedZ      = false,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void LAX_ZP_Sets_Zero_Flag_When_Value_Is_Zero()
+    {
+        var test = new TestSpec
+        {
+            A = 0x01, X = 0x01,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.LAX_ZP,
+            FinalValue     = 0x00,
+            ExpectedA      = 0x00,
+            ExpectedX      = 0x00,
+            ExpectedZ      = true,
+            ExpectedN      = false,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void LAX_ABS_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0x00, X = 0x00,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.LAX_ABS,
+            FinalValue     = 0x42,
+            ExpectedA      = 0x42,
+            ExpectedX      = 0x42,
+            ExpectedCycles = 4,
+        };
+        test.Execute_And_Verify(AddrMode.ABS);
+    }
+
+    [Fact]
+    public void LAX_ABS_Y_Takes_4_Cycles()
+    {
+        var test = new TestSpec
+        {
+            A = 0x00, X = 0x00,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.LAX_ABS_Y,
+            FinalValue     = 0x42,
+            ExpectedCycles = 4,
+        };
+        test.Execute_And_Verify(AddrMode.ABS_Y);
+    }
+
+    [Fact]
+    public void LAX_ABS_Y_Takes_5_Cycles_When_Page_Boundary_Crossed()
+    {
+        var test = new TestSpec
+        {
+            A = 0x00, X = 0x00,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.LAX_ABS_Y,
+            FinalValue     = 0x42,
+            ExpectedCycles = 5,
+        };
+        test.Execute_And_Verify(AddrMode.ABS_Y, fullAddress_Should_Cross_Page_Boundary: true);
+    }
+
+    [Fact]
+    public void LAX_IX_IND_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0x00, X = 0x05,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.LAX_IX_IND,
+            FinalValue     = 0x77,
+            ExpectedA      = 0x77,
+            ExpectedX      = 0x77,
+            ExpectedCycles = 6,
+        };
+        test.Execute_And_Verify(AddrMode.IX_IND);
+    }
+
+    [Fact]
+    public void LAX_IND_IX_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0x00, X = 0x00,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.LAX_IND_IX,
+            FinalValue     = 0x77,
+            ExpectedA      = 0x77,
+            ExpectedX      = 0x77,
+            ExpectedCycles = 5,
+        };
+        test.Execute_And_Verify(AddrMode.IND_IX);
+    }
+
+    [Fact]
+    public void LAX_ZP_Y_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0x00, X = 0x00,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.LAX_ZP_Y,
+            FinalValue     = 0x42,
+            ExpectedA      = 0x42,
+            ExpectedX      = 0x42,
+            ExpectedCycles = 4,
+        };
+        test.Execute_And_Verify(AddrMode.ZP_Y);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/NOP_Illegal_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/NOP_Illegal_test.cs
@@ -1,0 +1,116 @@
+namespace Highbyte.DotNet6502.Tests.Instructions;
+
+public class NOP_Illegal_test
+{
+    [Fact]
+    public void NOP_ILL_1A_Takes_2_Cycles()
+    {
+        var test = new TestSpec { OpCode = OpCodeId.NOP_ILL_1A, ExpectedCycles = 2 };
+        test.Execute_And_Verify(AddrMode.Implied);
+    }
+
+    [Fact]
+    public void NOP_ILL_DA_Takes_2_Cycles()
+    {
+        var test = new TestSpec { OpCode = OpCodeId.NOP_ILL_DA, ExpectedCycles = 2 };
+        test.Execute_And_Verify(AddrMode.Implied);
+    }
+
+    [Fact]
+    public void NOP_ILL_Implied_Has_No_Side_Effects()
+    {
+        var test = new TestSpec
+        {
+            A = 0x12, X = 0x34, Y = 0x56, SP = 0xff,
+            C = false, Z = false, N = false, V = false,
+            OpCode         = OpCodeId.NOP_ILL_3A,
+            ExpectedA      = 0x12,
+            ExpectedX      = 0x34,
+            ExpectedY      = 0x56,
+            ExpectedSP     = 0xff,
+            ExpectedC      = false,
+            ExpectedZ      = false,
+            ExpectedN      = false,
+            ExpectedV      = false,
+        };
+        test.Execute_And_Verify(AddrMode.Implied);
+    }
+
+    [Fact]
+    public void NOP_ILL_IMM_80_Takes_2_Cycles()
+    {
+        var test = new TestSpec
+        {
+            InsEffect      = InstrEffect.None,
+            OpCode         = OpCodeId.NOP_ILL_IMM_80,
+            FinalValue     = 0x42,
+            ExpectedCycles = 2,
+        };
+        test.Execute_And_Verify(AddrMode.I);
+    }
+
+    [Fact]
+    public void NOP_ILL_ZP_04_Takes_3_Cycles()
+    {
+        var test = new TestSpec
+        {
+            InsEffect      = InstrEffect.None,
+            OpCode         = OpCodeId.NOP_ILL_ZP_04,
+            FinalValue     = 0x42,
+            ExpectedCycles = 3,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void NOP_ILL_ZP_X_14_Takes_4_Cycles()
+    {
+        var test = new TestSpec
+        {
+            InsEffect      = InstrEffect.None,
+            OpCode         = OpCodeId.NOP_ILL_ZP_X_14,
+            FinalValue     = 0x42,
+            ExpectedCycles = 4,
+        };
+        test.Execute_And_Verify(AddrMode.ZP_X);
+    }
+
+    [Fact]
+    public void NOP_ILL_ABS_Takes_4_Cycles()
+    {
+        var test = new TestSpec
+        {
+            InsEffect      = InstrEffect.None,
+            OpCode         = OpCodeId.NOP_ILL_ABS,
+            FinalValue     = 0x42,
+            ExpectedCycles = 4,
+        };
+        test.Execute_And_Verify(AddrMode.ABS);
+    }
+
+    [Fact]
+    public void NOP_ILL_ABS_X_1C_Takes_4_Cycles()
+    {
+        var test = new TestSpec
+        {
+            InsEffect      = InstrEffect.None,
+            OpCode         = OpCodeId.NOP_ILL_ABS_X_1C,
+            FinalValue     = 0x42,
+            ExpectedCycles = 4,
+        };
+        test.Execute_And_Verify(AddrMode.ABS_X);
+    }
+
+    [Fact]
+    public void NOP_ILL_ABS_X_1C_Takes_5_Cycles_When_Page_Boundary_Crossed()
+    {
+        var test = new TestSpec
+        {
+            InsEffect      = InstrEffect.None,
+            OpCode         = OpCodeId.NOP_ILL_ABS_X_1C,
+            FinalValue     = 0x42,
+            ExpectedCycles = 5,
+        };
+        test.Execute_And_Verify(AddrMode.ABS_X, fullAddress_Should_Cross_Page_Boundary: true);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/RLA_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/RLA_test.cs
@@ -1,0 +1,107 @@
+namespace Highbyte.DotNet6502.Tests.Instructions;
+
+public class RLA_test
+{
+    [Fact]
+    public void RLA_ZP_Takes_5_Cycles()
+    {
+        var test = new TestSpec
+        {
+            A = 0xFF, C = false,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.RLA_ZP,
+            FinalValue     = 0x40,
+            ExpectedCycles = 5,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void RLA_ZP_Rotates_Memory_Left_Through_Carry()
+    {
+        // C=0, mem=0x40 → ROL: bit7(0x40)=0→C, result=(0x40<<1)|0=0x80
+        var test = new TestSpec
+        {
+            A = 0xFF, C = false,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.RLA_ZP,
+            FinalValue     = 0x40,
+            ExpectedMemVal = 0x80,
+            ExpectedC      = false,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void RLA_ZP_Sets_Carry_From_Old_Bit7_Of_Memory()
+    {
+        // C=0, mem=0x80 → ROL: bit7(0x80)=1→C=1, result=0x00|0=0x00
+        var test = new TestSpec
+        {
+            A = 0xFF, C = false,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.RLA_ZP,
+            FinalValue     = 0x80,
+            ExpectedMemVal = 0x00,
+            ExpectedC      = true,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void RLA_ZP_ANDs_Rotated_Value_Into_A()
+    {
+        // A=0xFF, C=0, mem=0x40 → ROL→0x80, A=0xFF&0x80=0x80, N=1
+        var test = new TestSpec
+        {
+            A = 0xFF, C = false,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.RLA_ZP,
+            FinalValue     = 0x40,
+            ExpectedA      = 0x80,
+            ExpectedN      = true,
+            ExpectedZ      = false,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void RLA_ZP_Sets_Zero_Flag_When_AND_Result_Is_Zero()
+    {
+        // A=0x0F, C=0, mem=0x40 → ROL→0x80, A=0x0F&0x80=0x00, Z=1
+        var test = new TestSpec
+        {
+            A = 0x0F, C = false,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.RLA_ZP,
+            FinalValue     = 0x40,
+            ExpectedA      = 0x00,
+            ExpectedZ      = true,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void RLA_ZP_X_Works() =>
+        new TestSpec { A = 0xFF, C = false, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.RLA_ZP_X,   FinalValue = 0x40, ExpectedMemVal = 0x80, ExpectedCycles = 6 }.Execute_And_Verify(AddrMode.ZP_X);
+
+    [Fact]
+    public void RLA_ABS_Works() =>
+        new TestSpec { A = 0xFF, C = false, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.RLA_ABS,    FinalValue = 0x40, ExpectedMemVal = 0x80, ExpectedCycles = 6 }.Execute_And_Verify(AddrMode.ABS);
+
+    [Fact]
+    public void RLA_ABS_X_Works() =>
+        new TestSpec { A = 0xFF, C = false, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.RLA_ABS_X,  FinalValue = 0x40, ExpectedMemVal = 0x80, ExpectedCycles = 7 }.Execute_And_Verify(AddrMode.ABS_X);
+
+    [Fact]
+    public void RLA_ABS_Y_Works() =>
+        new TestSpec { A = 0xFF, C = false, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.RLA_ABS_Y,  FinalValue = 0x40, ExpectedMemVal = 0x80, ExpectedCycles = 7 }.Execute_And_Verify(AddrMode.ABS_Y);
+
+    [Fact]
+    public void RLA_IX_IND_Works() =>
+        new TestSpec { A = 0xFF, C = false, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.RLA_IX_IND, FinalValue = 0x40, ExpectedMemVal = 0x80, ExpectedCycles = 8 }.Execute_And_Verify(AddrMode.IX_IND);
+
+    [Fact]
+    public void RLA_IND_IX_Works() =>
+        new TestSpec { A = 0xFF, C = false, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.RLA_IND_IX, FinalValue = 0x40, ExpectedMemVal = 0x80, ExpectedCycles = 8 }.Execute_And_Verify(AddrMode.IND_IX);
+}

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/RRA_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/RRA_test.cs
@@ -1,0 +1,110 @@
+namespace Highbyte.DotNet6502.Tests.Instructions;
+
+public class RRA_test
+{
+    [Fact]
+    public void RRA_ZP_Takes_5_Cycles()
+    {
+        var test = new TestSpec
+        {
+            A = 0x10, C = false,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.RRA_ZP,
+            FinalValue     = 0x04,
+            ExpectedCycles = 5,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void RRA_ZP_Rotates_Memory_Right_Through_Carry()
+    {
+        // C=0, mem=0x04 → ROR: bit0(0x04)=0→C, result=(0x04>>1)|0x00=0x02
+        var test = new TestSpec
+        {
+            A = 0x00, C = false,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.RRA_ZP,
+            FinalValue     = 0x04,
+            ExpectedMemVal = 0x02,
+            ExpectedC      = false,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void RRA_ZP_Rotated_Out_Bit_Becomes_Carry_Input_For_ADC()
+    {
+        // C=0, mem=0x01 → ROR: C=1 (old bit0), result=0x00; ADC(A=0x00, 0x00, C=1): A=0x01
+        var test = new TestSpec
+        {
+            A = 0x00, C = false,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.RRA_ZP,
+            FinalValue     = 0x01,
+            ExpectedA      = 0x01, // ADC(0, 0, C=1) = 1
+            ExpectedC      = false,
+            ExpectedZ      = false,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void RRA_ZP_ADCs_Rotated_Value_Into_A()
+    {
+        // A=0x10, C=0, mem=0x04 → ROR→0x02, C=0; ADC(0x10, 0x02, C=0)=0x12
+        var test = new TestSpec
+        {
+            A = 0x10, C = false,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.RRA_ZP,
+            FinalValue     = 0x04,
+            ExpectedA      = 0x12,
+            ExpectedZ      = false,
+            ExpectedN      = false,
+            ExpectedC      = false,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void RRA_ZP_Sets_Carry_When_ADC_Overflows()
+    {
+        // A=0xFF, C=0, mem=0x02 → ROR→0x01, C=0; ADC(0xFF, 0x01, C=0)=0x00, C=1
+        var test = new TestSpec
+        {
+            A = 0xFF, C = false,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.RRA_ZP,
+            FinalValue     = 0x02,
+            ExpectedA      = 0x00,
+            ExpectedC      = true,
+            ExpectedZ      = true,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void RRA_ZP_X_Works() =>
+        new TestSpec { A = 0x00, C = false, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.RRA_ZP_X,   FinalValue = 0x04, ExpectedMemVal = 0x02, ExpectedCycles = 6 }.Execute_And_Verify(AddrMode.ZP_X);
+
+    [Fact]
+    public void RRA_ABS_Works() =>
+        new TestSpec { A = 0x00, C = false, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.RRA_ABS,    FinalValue = 0x04, ExpectedMemVal = 0x02, ExpectedCycles = 6 }.Execute_And_Verify(AddrMode.ABS);
+
+    [Fact]
+    public void RRA_ABS_X_Works() =>
+        new TestSpec { A = 0x00, C = false, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.RRA_ABS_X,  FinalValue = 0x04, ExpectedMemVal = 0x02, ExpectedCycles = 7 }.Execute_And_Verify(AddrMode.ABS_X);
+
+    [Fact]
+    public void RRA_ABS_Y_Works() =>
+        new TestSpec { A = 0x00, C = false, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.RRA_ABS_Y,  FinalValue = 0x04, ExpectedMemVal = 0x02, ExpectedCycles = 7 }.Execute_And_Verify(AddrMode.ABS_Y);
+
+    [Fact]
+    public void RRA_IX_IND_Works() =>
+        new TestSpec { A = 0x00, C = false, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.RRA_IX_IND, FinalValue = 0x04, ExpectedMemVal = 0x02, ExpectedCycles = 8 }.Execute_And_Verify(AddrMode.IX_IND);
+
+    [Fact]
+    public void RRA_IND_IX_Works() =>
+        new TestSpec { A = 0x00, C = false, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.RRA_IND_IX, FinalValue = 0x04, ExpectedMemVal = 0x02, ExpectedCycles = 8 }.Execute_And_Verify(AddrMode.IND_IX);
+}

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/SAX_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/SAX_test.cs
@@ -1,0 +1,106 @@
+namespace Highbyte.DotNet6502.Tests.Instructions;
+
+public class SAX_test
+{
+    [Fact]
+    public void SAX_ZP_Takes_3_Cycles()
+    {
+        var test = new TestSpec
+        {
+            A = 0xFF, X = 0x0F,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.SAX_ZP,
+            FinalValue     = 0x00,
+            ExpectedCycles = 3,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void SAX_ZP_Stores_A_AND_X_To_Memory()
+    {
+        var test = new TestSpec
+        {
+            A = 0xFF, X = 0x0F,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.SAX_ZP,
+            FinalValue     = 0x00,
+            ExpectedMemVal = 0x0F, // 0xFF & 0x0F = 0x0F
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void SAX_ZP_Stores_Zero_When_A_And_X_Have_No_Common_Bits()
+    {
+        var test = new TestSpec
+        {
+            A = 0xF0, X = 0x0F,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.SAX_ZP,
+            FinalValue     = 0xFF,
+            ExpectedMemVal = 0x00, // 0xF0 & 0x0F = 0x00
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void SAX_ZP_Does_Not_Change_A_Or_X()
+    {
+        var test = new TestSpec
+        {
+            A = 0xAB, X = 0xCD,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.SAX_ZP,
+            FinalValue     = 0x00,
+            ExpectedA      = 0xAB,
+            ExpectedX      = 0xCD,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void SAX_ABS_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0xFF, X = 0xF0,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.SAX_ABS,
+            FinalValue     = 0x00,
+            ExpectedMemVal = 0xF0,
+            ExpectedCycles = 4,
+        };
+        test.Execute_And_Verify(AddrMode.ABS);
+    }
+
+    [Fact]
+    public void SAX_IX_IND_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0x3C, X = 0x0F,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.SAX_IX_IND,
+            FinalValue     = 0x00,
+            ExpectedMemVal = 0x0C, // 0x3C & 0x0F = 0x0C
+            ExpectedCycles = 6,
+        };
+        test.Execute_And_Verify(AddrMode.IX_IND);
+    }
+
+    [Fact]
+    public void SAX_ZP_Y_Works()
+    {
+        var test = new TestSpec
+        {
+            A = 0xFF, X = 0xAA,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.SAX_ZP_Y,
+            FinalValue     = 0x00,
+            ExpectedMemVal = 0xAA, // 0xFF & 0xAA = 0xAA
+            ExpectedCycles = 4,
+        };
+        test.Execute_And_Verify(AddrMode.ZP_Y);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/SLO_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/SLO_test.cs
@@ -1,0 +1,105 @@
+namespace Highbyte.DotNet6502.Tests.Instructions;
+
+public class SLO_test
+{
+    [Fact]
+    public void SLO_ZP_Takes_5_Cycles()
+    {
+        var test = new TestSpec
+        {
+            A = 0x01,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.SLO_ZP,
+            FinalValue     = 0x40,
+            ExpectedCycles = 5,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void SLO_ZP_Shifts_Memory_Left_One_Bit()
+    {
+        var test = new TestSpec
+        {
+            A = 0x00,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.SLO_ZP,
+            FinalValue     = 0x40,
+            ExpectedMemVal = 0x80, // 0x40 << 1 = 0x80
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void SLO_ZP_Sets_Carry_From_Old_Bit7_Of_Memory()
+    {
+        // mem = 0x80 (bit7=1) → after ASL: mem=0x00, C=1
+        var test = new TestSpec
+        {
+            A = 0x00,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.SLO_ZP,
+            FinalValue     = 0x80,
+            ExpectedMemVal = 0x00,
+            ExpectedC      = true,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void SLO_ZP_ORs_Shifted_Value_Into_A()
+    {
+        // A=0x01, mem=0x40 → shifted=0x80, A = 0x01|0x80 = 0x81
+        var test = new TestSpec
+        {
+            A = 0x01,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.SLO_ZP,
+            FinalValue     = 0x40,
+            ExpectedA      = 0x81,
+            ExpectedN      = true,
+            ExpectedZ      = false,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void SLO_ZP_Sets_Zero_Flag_When_A_ORA_Result_Is_Zero()
+    {
+        // A=0x00, mem=0x80 → shifted=0x00, A=0x00|0x00=0x00, Z=1
+        var test = new TestSpec
+        {
+            A = 0x00,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.SLO_ZP,
+            FinalValue     = 0x80,
+            ExpectedA      = 0x00,
+            ExpectedZ      = true,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void SLO_ZP_X_Works() =>
+        new TestSpec { A = 0x01, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.SLO_ZP_X,   FinalValue = 0x40, ExpectedMemVal = 0x80, ExpectedCycles = 6 }.Execute_And_Verify(AddrMode.ZP_X);
+
+    [Fact]
+    public void SLO_ABS_Works() =>
+        new TestSpec { A = 0x01, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.SLO_ABS,    FinalValue = 0x40, ExpectedMemVal = 0x80, ExpectedCycles = 6 }.Execute_And_Verify(AddrMode.ABS);
+
+    [Fact]
+    public void SLO_ABS_X_Works() =>
+        new TestSpec { A = 0x01, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.SLO_ABS_X,  FinalValue = 0x40, ExpectedMemVal = 0x80, ExpectedCycles = 7 }.Execute_And_Verify(AddrMode.ABS_X);
+
+    [Fact]
+    public void SLO_ABS_Y_Works() =>
+        new TestSpec { A = 0x01, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.SLO_ABS_Y,  FinalValue = 0x40, ExpectedMemVal = 0x80, ExpectedCycles = 7 }.Execute_And_Verify(AddrMode.ABS_Y);
+
+    [Fact]
+    public void SLO_IX_IND_Works() =>
+        new TestSpec { A = 0x01, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.SLO_IX_IND, FinalValue = 0x40, ExpectedMemVal = 0x80, ExpectedCycles = 8 }.Execute_And_Verify(AddrMode.IX_IND);
+
+    [Fact]
+    public void SLO_IND_IX_Works() =>
+        new TestSpec { A = 0x01, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.SLO_IND_IX, FinalValue = 0x40, ExpectedMemVal = 0x80, ExpectedCycles = 8 }.Execute_And_Verify(AddrMode.IND_IX);
+}

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/SRE_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/SRE_test.cs
@@ -1,0 +1,104 @@
+namespace Highbyte.DotNet6502.Tests.Instructions;
+
+public class SRE_test
+{
+    [Fact]
+    public void SRE_ZP_Takes_5_Cycles()
+    {
+        var test = new TestSpec
+        {
+            A = 0x00,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.SRE_ZP,
+            FinalValue     = 0x02,
+            ExpectedCycles = 5,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void SRE_ZP_Shifts_Memory_Right_One_Bit()
+    {
+        var test = new TestSpec
+        {
+            A = 0x00,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.SRE_ZP,
+            FinalValue     = 0x02,
+            ExpectedMemVal = 0x01, // 0x02 >> 1 = 0x01
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void SRE_ZP_Sets_Carry_From_Old_Bit0_Of_Memory()
+    {
+        // mem=0x01 (bit0=1) → shifted=0x00, C=1
+        var test = new TestSpec
+        {
+            A = 0x00,
+            InsEffect      = InstrEffect.Mem,
+            OpCode         = OpCodeId.SRE_ZP,
+            FinalValue     = 0x01,
+            ExpectedMemVal = 0x00,
+            ExpectedC      = true,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void SRE_ZP_EORs_Shifted_Value_Into_A()
+    {
+        // A=0x80, mem=0x02 → shifted=0x01, A = 0x80^0x01 = 0x81
+        var test = new TestSpec
+        {
+            A = 0x80,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.SRE_ZP,
+            FinalValue     = 0x02,
+            ExpectedA      = 0x81,
+            ExpectedN      = true,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void SRE_ZP_Sets_Zero_Flag_When_Result_Is_Zero()
+    {
+        // A=0x01, mem=0x02 → shifted=0x01, A=0x01^0x01=0x00, Z=1
+        var test = new TestSpec
+        {
+            A = 0x01,
+            InsEffect      = InstrEffect.Reg,
+            OpCode         = OpCodeId.SRE_ZP,
+            FinalValue     = 0x02,
+            ExpectedA      = 0x00,
+            ExpectedZ      = true,
+        };
+        test.Execute_And_Verify(AddrMode.ZP);
+    }
+
+    [Fact]
+    public void SRE_ZP_X_Works() =>
+        new TestSpec { A = 0x00, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.SRE_ZP_X,   FinalValue = 0x02, ExpectedMemVal = 0x01, ExpectedCycles = 6 }.Execute_And_Verify(AddrMode.ZP_X);
+
+    [Fact]
+    public void SRE_ABS_Works() =>
+        new TestSpec { A = 0x00, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.SRE_ABS,    FinalValue = 0x02, ExpectedMemVal = 0x01, ExpectedCycles = 6 }.Execute_And_Verify(AddrMode.ABS);
+
+    [Fact]
+    public void SRE_ABS_X_Works() =>
+        new TestSpec { A = 0x00, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.SRE_ABS_X,  FinalValue = 0x02, ExpectedMemVal = 0x01, ExpectedCycles = 7 }.Execute_And_Verify(AddrMode.ABS_X);
+
+    [Fact]
+    public void SRE_ABS_Y_Works() =>
+        new TestSpec { A = 0x00, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.SRE_ABS_Y,  FinalValue = 0x02, ExpectedMemVal = 0x01, ExpectedCycles = 7 }.Execute_And_Verify(AddrMode.ABS_Y);
+
+    [Fact]
+    public void SRE_IX_IND_Works() =>
+        new TestSpec { A = 0x00, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.SRE_IX_IND, FinalValue = 0x02, ExpectedMemVal = 0x01, ExpectedCycles = 8 }.Execute_And_Verify(AddrMode.IX_IND);
+
+    [Fact]
+    public void SRE_IND_IX_Works() =>
+        new TestSpec { A = 0x00, InsEffect = InstrEffect.Mem, OpCode = OpCodeId.SRE_IND_IX, FinalValue = 0x02, ExpectedMemVal = 0x01, ExpectedCycles = 8 }.Execute_And_Verify(AddrMode.IND_IX);
+}

--- a/tests/Highbyte.DotNet6502.Tests/Utils/OutputGenTest.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Utils/OutputGenTest.cs
@@ -24,15 +24,30 @@ public class OutputGenTest
     public void OutputGen_Returns_Correctly_Formatted_Disassembly_If_OpCode_Is_Unknown()
     {
         // Arrange
-        var cpu = new CPU();
+        var cpu = new CPU(CpuCompatibilityProfile.ExperimentalUnofficial);
         var mem = new Memory();
-        mem[0x1000] = 0xff; // 0xff is not a (official) 6502 opcode
+        mem[0x1000] = 0x02; // 0x02 (JAM/KIL) is only available in FullUnofficial
 
         // Act
         var outputString = OutputGen.GetInstructionDisassembly(cpu, mem, 0x1000);
 
         // Assert
-        Assert.Equal("1000  ff        ???        ", outputString);
+        Assert.Equal("1000  02        ???        ", outputString);
+    }
+
+    [Fact]
+    public void OutputGen_Returns_Correctly_Formatted_Disassembly_For_JAM_In_FullUnofficial()
+    {
+        // Arrange
+        var cpu = new CPU(CpuCompatibilityProfile.FullUnofficial);
+        var mem = new Memory();
+        mem[0x1000] = 0x02;
+
+        // Act
+        var outputString = OutputGen.GetInstructionDisassembly(cpu, mem, 0x1000);
+
+        // Assert
+        Assert.Equal("1000  02        JAM        ", outputString);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add CPU compatibility profiles for official, stable unofficial, experimental unofficial, and full unofficial 6502 opcode support
- implement undocumented NMOS opcode coverage including JAM/KIL halt behavior, and wire profile selection through Generic, C64, and VIC-20 configuration and Avalonia UI
- document the profile meanings/defaults and extend tests for opcode exposure, execution, disassembly, and reset behavior
