### PR TITLE
Persist VIC20 config in Avalonia Browser local storage.

### DIFF
--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Vic20/Vic20AvaloniaEnginePlugin.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Vic20/Vic20AvaloniaEnginePlugin.cs
@@ -1,6 +1,7 @@
 using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Plugins;
 using Highbyte.DotNet6502.Systems.Vic20;
+using Highbyte.DotNet6502.Impl.Avalonia;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -25,7 +26,8 @@ public sealed class Vic20AvaloniaEnginePlugin : ISystemEnginePlugin
         {
             var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
             var config = sp.GetRequiredService<IConfiguration>();
-            return new Vic20Setup(loggerFactory, config);
+            var persistence = sp.GetRequiredService<CustomConfigPersistence>();
+            return new Vic20Setup(loggerFactory, config, persistence.Save);
         });
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Vic20/Vic20HostConfigJsonContext.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Vic20/Vic20HostConfigJsonContext.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace Highbyte.DotNet6502.Impl.Avalonia.Vic20;
+
+/// <summary>
+/// Source-generated JSON context for the VIC-20 host config.
+/// Kept separate from the Avalonia.Core context so this plug-in
+/// can be added/removed without recompiling the core.
+/// </summary>
+[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(Vic20HostConfig))]
+internal partial class Vic20HostConfigJsonContext : JsonSerializerContext
+{
+}

--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Vic20/Vic20Setup.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Vic20/Vic20Setup.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Vic20;
 using Highbyte.DotNet6502.Systems.Vic20.Input;
@@ -15,11 +16,28 @@ namespace Highbyte.DotNet6502.Impl.Avalonia.Vic20;
 public class Vic20Setup : Vic20SystemConfigurerCore
 {
     private readonly ILoggerFactory _loggerFactory;
+    private readonly Func<string, string, string?, Task>? _saveCustomConfigString;
 
-    public Vic20Setup(ILoggerFactory loggerFactory, IConfiguration configuration)
+    public Vic20Setup(
+        ILoggerFactory loggerFactory,
+        IConfiguration configuration,
+        Func<string, string, string?, Task>? saveCustomConfigString = null)
         : base(loggerFactory, configuration, () => new Vic20HostConfig(), Vic20HostConfig.ConfigSectionName)
     {
         _loggerFactory = loggerFactory;
+        _saveCustomConfigString = saveCustomConfigString;
+    }
+
+    public override async Task PersistHostSystemConfig(IHostSystemConfig hostSystemConfig)
+    {
+        if (_saveCustomConfigString == null)
+        {
+            LoggerFactory.CreateLogger(nameof(Vic20Setup))
+                .LogWarning("No method for saving custom config JSON supplied, so not saving Vic20HostConfig.");
+            return;
+        }
+        var json = JsonSerializer.Serialize(hostSystemConfig, Vic20HostConfigJsonContext.Default.Vic20HostConfig);
+        await _saveCustomConfigString(Vic20HostConfig.ConfigSectionName, json, null);
     }
 
     public override Task<SystemRunner> BuildSystemRunner(ISystem system, IHostSystemConfig hostSystemConfig)


### PR DESCRIPTION
  ## Summary
  - Wire VIC-20 Avalonia setup to the host custom config persistence delegate.
  - Persist `Vic20HostConfig` with a source-generated JSON context.
  - Keep desktop behavior aligned with C64 by logging when no save delegate is available.