### PR TITLE
Improve download error feedback

### DIFF
--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/C64AvaloniaStartupParticipant.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/C64AvaloniaStartupParticipant.cs
@@ -52,33 +52,42 @@ public sealed class C64AvaloniaStartupParticipant : IAutomatedStartupParticipant
         // C64ConfigDialogViewModel / C64RomPromptService are registered transient — resolve them
         // on demand rather than capturing them in this singleton.
         var romPromptService = _serviceProvider.GetRequiredService<C64RomPromptService>();
-        if (!await romPromptService.ShowStartupDownloadPromptAsync())
-        {
-            _logger.LogInformation("User cancelled automated C64 ROM download prompt.");
-            return false;
-        }
-
         var configViewModel = _serviceProvider.GetRequiredService<C64ConfigDialogViewModel>();
-        if (!await configViewModel.DownloadRomsToByteArrayAsync(requireAcknowledgement: false))
-        {
-            _logger.LogError("Automatic C64 ROM download failed: {StatusMessage}",
-                configViewModel.StatusMessage ?? "Unknown error.");
-            return false;
-        }
+        if (!await romPromptService.RunStartupDownloadWorkflowAsync(
+            configViewModel,
+            async () =>
+            {
+                if (!await configViewModel.TryApplyChangesAsync())
+                {
+                    var failureMessage = string.Join(
+                        Environment.NewLine,
+                        new[]
+                        {
+                            configViewModel.StatusMessage,
+                            configViewModel.ValidationMessage
+                        }.Where(message => !string.IsNullOrWhiteSpace(message)));
+                    if (string.IsNullOrWhiteSpace(failureMessage))
+                        failureMessage = "The downloaded ROM configuration could not be saved.";
 
-        if (!await configViewModel.TryApplyChangesAsync())
-        {
-            _logger.LogError("Automatic C64 ROM download could not be saved: {StatusMessage} {ValidationMessage}",
-                configViewModel.StatusMessage ?? string.Empty,
-                configViewModel.ValidationMessage ?? string.Empty);
-            return false;
-        }
+                    _logger.LogError("Automatic C64 ROM download could not be saved: {StatusMessage} {ValidationMessage}",
+                        configViewModel.StatusMessage ?? string.Empty,
+                        configViewModel.ValidationMessage ?? string.Empty);
+                    return (false, "C64 ROM Configuration Failed", failureMessage);
+                }
 
-        var (isValidAfterDownload, errorsAfterDownload) = await hostApp.IsCurrentSystemConfigValid();
-        if (!isValidAfterDownload)
+                var (isValidAfterDownload, errorsAfterDownload) = await hostApp.IsCurrentSystemConfigValid();
+                if (!isValidAfterDownload)
+                {
+                    var failureMessage = string.Join(Environment.NewLine, errorsAfterDownload);
+                    _logger.LogError("C64 configuration is still invalid after automatic ROM download: {Errors}",
+                        string.Join(" | ", errorsAfterDownload));
+                    return (false, "C64 Configuration Still Invalid", failureMessage);
+                }
+
+                return (true, null, null);
+            }))
         {
-            _logger.LogError("C64 configuration is still invalid after automatic ROM download: {Errors}",
-                string.Join(" | ", errorsAfterDownload));
+            _logger.LogInformation("Automated C64 ROM download workflow was cancelled or failed.");
             return false;
         }
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/C64RomPromptService.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/C64RomPromptService.cs
@@ -6,6 +6,8 @@ using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Highbyte.DotNet6502.App.Avalonia.Core;
+using Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64.ViewModels;
+using Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64.Views;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
 using Microsoft.Extensions.Logging;
 
@@ -33,14 +35,271 @@ public sealed class C64RomPromptService
             cancelText: "No",
             owner: owner);
 
-    public Task<bool> ShowStartupDownloadPromptAsync()
-        => ShowDownloadPromptAsync(
-            title: "Download C64 ROMs",
-            leadText: "This C64 startup link needs Commodore 64 ROM files before the emulator can start. The app can download them from:",
-            acknowledgeText: "Do you acknowledge these requirements and want the app to download the ROMs now?",
-            confirmText: "Download ROMs",
-            cancelText: "Cancel",
-            owner: null);
+    public async Task<bool> RunStartupDownloadWorkflowAsync(
+        C64ConfigDialogViewModel configViewModel,
+        Func<Task<(bool success, string? errorTitle, string? errorMessage)>> finalizeAfterDownloadAsync)
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        Grid? overlayHost = null;
+        Panel? overlayPanel = null;
+
+        void CloseOverlay(bool result)
+        {
+            if (overlayPanel != null && overlayHost != null)
+                overlayHost.Children.Remove(overlayPanel);
+            tcs.TrySetResult(result);
+        }
+
+        async Task OpenConfigAsync()
+        {
+            if (overlayPanel != null && overlayHost != null)
+                overlayHost.Children.Remove(overlayPanel);
+
+            await ShowStartupConfigOverlayAsync(configViewModel);
+            tcs.TrySetResult(false);
+        }
+
+        var titleText = new TextBlock
+        {
+            Text = "Download C64 ROMs",
+            FontSize = 14,
+            FontWeight = FontWeight.Bold,
+            HorizontalAlignment = HorizontalAlignment.Center
+        };
+
+        var leadTextBlock = new TextBlock
+        {
+            Text = "This C64 startup link needs Commodore 64 ROM files before the emulator can start. The app can download them from:",
+            FontSize = 10,
+            TextWrapping = TextWrapping.Wrap
+        };
+
+        var statusTextBlock = new TextBlock
+        {
+            FontSize = 10,
+            TextWrapping = TextWrapping.Wrap,
+            IsVisible = false
+        };
+
+        var progressBar = new ProgressBar
+        {
+            IsIndeterminate = true,
+            IsVisible = false,
+            Height = 6
+        };
+
+        var errorTextBlock = new TextBlock
+        {
+            Classes = { "small" },
+            TextWrapping = TextWrapping.Wrap
+        };
+
+        var errorBorder = new Border
+        {
+            Classes = { "error-container-small" },
+            IsVisible = false,
+            Child = errorTextBlock
+        };
+
+        var downloadButton = new Button
+        {
+            Content = "Download ROMs",
+            Classes = { "small", "primary" }
+        };
+
+        var openConfigButton = new Button
+        {
+            Content = "Open C64 Config",
+            Classes = { "small", "primary" },
+            IsVisible = false
+        };
+
+        var cancelButton = new Button
+        {
+            Content = "Cancel",
+            Classes = { "small", "cancel" }
+        };
+
+        void SetBusyState(string statusText)
+        {
+            statusTextBlock.Text = statusText;
+            statusTextBlock.IsVisible = true;
+            progressBar.IsVisible = true;
+            errorBorder.IsVisible = false;
+            downloadButton.IsEnabled = false;
+            cancelButton.IsEnabled = false;
+            openConfigButton.IsVisible = false;
+        }
+
+        void SetFailureState(string title, string leadText, string errorMessage)
+        {
+            titleText.Text = title;
+            leadTextBlock.Text = leadText;
+            statusTextBlock.IsVisible = false;
+            progressBar.IsVisible = false;
+            errorTextBlock.Text = errorMessage;
+            errorBorder.IsVisible = true;
+            downloadButton.IsVisible = false;
+            openConfigButton.IsVisible = true;
+            cancelButton.IsEnabled = true;
+            cancelButton.Content = "Cancel";
+        }
+
+        async Task StartDownloadAsync()
+        {
+            SetBusyState("Downloading C64 ROMs...");
+
+            try
+            {
+                if (!await configViewModel.DownloadRomsToByteArrayAsync(requireAcknowledgement: false))
+                {
+                    SetFailureState(
+                        title: "C64 ROM Download Failed",
+                        leadText: "The automated C64 startup was cancelled because the ROM download failed.",
+                        errorMessage: configViewModel.StatusMessage ?? "Unknown error.");
+                    return;
+                }
+
+                SetBusyState("Saving downloaded ROM configuration...");
+
+                var finalizeResult = await finalizeAfterDownloadAsync();
+                if (!finalizeResult.success)
+                {
+                    SetFailureState(
+                        title: finalizeResult.errorTitle ?? "C64 ROM Configuration Failed",
+                        leadText: "The automated C64 startup could not continue. Review the configuration and try again.",
+                        errorMessage: finalizeResult.errorMessage ?? "Unknown error.");
+                    return;
+                }
+
+                CloseOverlay(true);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected failure in startup C64 ROM download workflow.");
+                SetFailureState(
+                    title: "C64 ROM Download Failed",
+                    leadText: "The automated C64 startup was cancelled because the ROM download failed.",
+                    errorMessage: ex.Message);
+            }
+        }
+
+        downloadButton.Click += (_, _) => SafeAsyncHelper.Execute(StartDownloadAsync);
+        openConfigButton.Click += (_, _) => SafeAsyncHelper.Execute(OpenConfigAsync);
+        cancelButton.Click += (_, _) => CloseOverlay(false);
+
+        var urlButton = new Button
+        {
+            Content = C64SystemConfig.DEFAULT_KERNAL_ROM_DOWNLOAD_BASE_URL,
+            Classes = { "link" },
+            FontSize = 10,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Padding = new Thickness(0),
+            Margin = new Thickness(0),
+            Background = Brushes.Transparent,
+            BorderThickness = new Thickness(0),
+            Cursor = new Cursor(StandardCursorType.Hand)
+        };
+        urlButton.Click += (_, _) => SafeAsyncHelper.Execute(() => LaunchUriIfAvailableAsync(null, C64SystemConfig.DEFAULT_KERNAL_ROM_DOWNLOAD_BASE_URL));
+
+        var dialogContent = new Border
+        {
+            Background = new SolidColorBrush(Color.FromRgb(26, 32, 44)),
+            BorderBrush = new SolidColorBrush(Color.FromRgb(74, 85, 104)),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(8),
+            Padding = new Thickness(0),
+            MaxWidth = 560,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+            Child = new StackPanel
+            {
+                Children =
+                {
+                    new Border
+                    {
+                        Background = new SolidColorBrush(Color.FromRgb(45, 55, 72)),
+                        Padding = new Thickness(8, 6),
+                        CornerRadius = new CornerRadius(4, 4, 0, 0),
+                        Child = titleText
+                    },
+                    new StackPanel
+                    {
+                        Margin = new Thickness(12),
+                        Spacing = 8,
+                        Children =
+                        {
+                            leadTextBlock,
+                            urlButton,
+                            new TextBlock
+                            {
+                                Text = "Please be aware that you probably need to:",
+                                FontSize = 10,
+                                TextWrapping = TextWrapping.Wrap,
+                                Margin = new Thickness(0, 8, 0, 0)
+                            },
+                            new TextBlock
+                            {
+                                Text = "• Have a license from Commodore/Cloanto, OR\n• Own a Commodore 64 computer",
+                                FontSize = 10,
+                                TextWrapping = TextWrapping.Wrap,
+                                Margin = new Thickness(8, 0, 0, 0)
+                            },
+                            new TextBlock
+                            {
+                                Text = "to be allowed to download and use these ROM files.",
+                                FontSize = 10,
+                                TextWrapping = TextWrapping.Wrap
+                            },
+                            new TextBlock
+                            {
+                                Text = "Do you acknowledge these requirements and want the app to download the ROMs now?",
+                                FontSize = 10,
+                                TextWrapping = TextWrapping.Wrap,
+                                FontWeight = FontWeight.Bold,
+                                Margin = new Thickness(0, 8, 0, 0)
+                            },
+                            progressBar,
+                            statusTextBlock,
+                            errorBorder,
+                            new StackPanel
+                            {
+                                Orientation = Orientation.Horizontal,
+                                HorizontalAlignment = HorizontalAlignment.Right,
+                                Spacing = 10,
+                                Margin = new Thickness(0, 8, 0, 0),
+                                Children =
+                                {
+                                    downloadButton,
+                                    openConfigButton,
+                                    cancelButton
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        overlayPanel = new Panel
+        {
+            Background = new SolidColorBrush(Color.FromArgb(180, 0, 0, 0)),
+            ZIndex = 1000,
+            Children = { dialogContent }
+        };
+
+        try
+        {
+            overlayHost = _overlayDialogHelper.ShowOverlayDialogOnMainView(overlayPanel);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to show startup C64 ROM workflow overlay.");
+            return false;
+        }
+
+        return await tcs.Task;
+    }
 
     private Task<bool> ShowDownloadPromptAsync(
         string title,
@@ -219,6 +478,29 @@ public sealed class C64RomPromptService
             TopLevel.GetTopLevel(singleView.MainView) is { Launcher: { } launcher })
         {
             await launcher.LaunchUriAsync(new Uri(uri));
+        }
+    }
+
+    private async Task ShowStartupConfigOverlayAsync(C64ConfigDialogViewModel configViewModel)
+    {
+        var configControl = new C64ConfigUserControl
+        {
+            DataContext = configViewModel
+        };
+
+        var overlayPanel = _overlayDialogHelper.BuildOverlayDialogPanel(configControl);
+        var overlayHost = _overlayDialogHelper.ShowOverlayDialogOnMainView(overlayPanel);
+        var tcs = new TaskCompletionSource();
+
+        configControl.ConfigurationChanged += (_, _) => tcs.TrySetResult();
+
+        try
+        {
+            await tcs.Task;
+        }
+        finally
+        {
+            overlayHost.Children.Remove(overlayPanel);
         }
     }
 }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64ConfigDialogViewModel.cs
@@ -47,6 +47,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
 
     private bool _isBusy;
     private string? _statusMessage;
+    private bool _statusMessageIsError;
     private string? _validationMessage;
     private readonly ObservableCollection<string> _validationErrors = new();
     private bool _audioEnabled;
@@ -243,6 +244,20 @@ public class C64ConfigDialogViewModel : ViewModelBase
         }
     }
 
+    public bool StatusMessageIsError
+    {
+        get => _statusMessageIsError;
+        private set
+        {
+            if (_statusMessageIsError == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _statusMessageIsError, value);
+            this.RaisePropertyChanged(nameof(HasNonErrorStatusMessage));
+            this.RaisePropertyChanged(nameof(HasErrorStatusMessage));
+        }
+    }
+
     public string? ValidationMessage
     {
         get => _validationMessage;
@@ -257,6 +272,10 @@ public class C64ConfigDialogViewModel : ViewModelBase
     }
 
     public bool HasStatusMessage => !string.IsNullOrEmpty(StatusMessage);
+
+    public bool HasNonErrorStatusMessage => HasStatusMessage && !StatusMessageIsError;
+
+    public bool HasErrorStatusMessage => HasStatusMessage && StatusMessageIsError;
 
     public bool HasValidationMessage => !string.IsNullOrEmpty(ValidationMessage);
 
@@ -642,37 +661,79 @@ public class C64ConfigDialogViewModel : ViewModelBase
     public Task AutoDownloadRomsToByteArrayAsync()
         => DownloadRomsToByteArrayAsync(requireAcknowledgement: true);
 
+    private void SetStatusMessage(string? message, bool isError = false)
+    {
+        StatusMessage = message;
+        StatusMessageIsError = !string.IsNullOrEmpty(message) && isError;
+    }
+
     public async Task<bool> DownloadRomsToByteArrayAsync(bool requireAcknowledgement)
     {
         if (requireAcknowledgement && !await RequestRomLicenseAcknowledgementAsync())
         {
-            StatusMessage = "ROM download cancelled.";
+            _logger.LogInformation("C64 ROM download to memory cancelled by user.");
+            SetStatusMessage("ROM download cancelled.");
             return false;
         }
 
         try
         {
+            _logger.LogInformation("Starting C64 ROM download to in-memory byte arrays.");
             IsBusy = true;
-            StatusMessage = "Downloading ROMs...";
+            SetStatusMessage("Downloading ROMs...");
             ValidationMessage = string.Empty;
 
             foreach (var romDownload in _workingConfig.SystemConfig.ROMDownloadUrls)
             {
+                var romName = romDownload.Key;
+                var romUrl = romDownload.Value;
                 var proxyUrl = _workingConfig.GetCorsProxyURL();
                 var fullROMUrl = !string.IsNullOrEmpty(proxyUrl)
-                    ? $"{proxyUrl}{Uri.EscapeDataString(romDownload.Value)}"
-                    : romDownload.Value;
+                    ? $"{proxyUrl}{Uri.EscapeDataString(romUrl)}"
+                    : romUrl;
 
-                var romBytes = await _httpClient.GetByteArrayAsync(fullROMUrl);
-                _workingConfig.SystemConfig.SetROM(romDownload.Key, data: romBytes);
+                try
+                {
+                    _logger.LogInformation(
+                        "Downloading ROM {RomName} from {SourceUrl} using request URL {RequestUrl}",
+                        romName,
+                        romUrl,
+                        fullROMUrl);
+
+                    var romBytes = await _httpClient.GetByteArrayAsync(fullROMUrl);
+                    _workingConfig.SystemConfig.SetROM(romName, data: romBytes);
+                    _logger.LogInformation("Downloaded ROM {RomName}: {ByteCount} bytes", romName, romBytes.Length);
+                }
+                catch (Exception ex)
+                {
+                    var userMessage = DownloadErrorHelper.BuildDownloadFailureMessage(
+                        $"ROM '{romName}'",
+                        romUrl,
+                        fullROMUrl,
+                        ex);
+
+                    _logger.LogError(
+                        ex,
+                        "Failed to download ROM {RomName}. Source URL: {SourceUrl}. Request URL: {RequestUrl}. Details: {ErrorSummary}",
+                        romName,
+                        romUrl,
+                        fullROMUrl,
+                        DownloadErrorHelper.FlattenExceptionMessages(ex));
+
+                    throw new InvalidOperationException(userMessage, ex);
+                }
             }
 
-            StatusMessage = "ROMs downloaded successfully.";
+            SetStatusMessage("ROMs downloaded successfully.");
             return true;
         }
         catch (Exception ex)
         {
-            StatusMessage = $"Error downloading ROMs: {ex.Message}";
+            _logger.LogError(
+                ex,
+                "C64 ROM download to memory failed. Details: {ErrorSummary}",
+                DownloadErrorHelper.FlattenExceptionMessages(ex));
+            SetStatusMessage(ex.Message, isError: true);
             return false;
         }
         finally
@@ -689,14 +750,16 @@ public class C64ConfigDialogViewModel : ViewModelBase
         // Request acknowledgement before downloading
         if (!await RequestRomLicenseAcknowledgementAsync())
         {
-            StatusMessage = "";
+            _logger.LogInformation("C64 ROM download to files cancelled by user.");
+            SetStatusMessage(string.Empty);
             return;
         }
 
         try
         {
+            _logger.LogInformation("Starting C64 ROM download to files.");
             IsBusy = true;
-            StatusMessage = "Downloading ROMs...";
+            SetStatusMessage("Downloading ROMs...");
             ValidationMessage = string.Empty;
 
             var romFolder = PathHelper.ExpandOSEnvironmentVariables(_workingConfig.SystemConfig.ROMDirectory);
@@ -717,6 +780,12 @@ public class C64ConfigDialogViewModel : ViewModelBase
                 var dest = Path.Combine(romFolder, filename);
                 try
                 {
+                    _logger.LogInformation(
+                        "Downloading ROM {RomName} from {SourceUrl} to {Destination}",
+                        romName,
+                        romUrl,
+                        dest);
+
                     using var response = await _httpClient.GetAsync(romUrl);
                     if (!response.IsSuccessStatusCode)
                         throw new Exception($"Failed to get '{romUrl}' ({(int)response.StatusCode})");
@@ -731,16 +800,35 @@ public class C64ConfigDialogViewModel : ViewModelBase
                 {
                     if (File.Exists(dest))
                         File.Delete(dest);
-                    throw new Exception($"Error downloading {romUrl}: {ex.Message}", ex);
+
+                    var userMessage = DownloadErrorHelper.BuildDownloadFailureMessage(
+                        $"ROM '{romName}'",
+                        romUrl,
+                        romUrl,
+                        ex);
+
+                    _logger.LogError(
+                        ex,
+                        "Failed to download ROM {RomName}. Source URL: {SourceUrl}. Destination: {Destination}. Details: {ErrorSummary}",
+                        romName,
+                        romUrl,
+                        dest,
+                        DownloadErrorHelper.FlattenExceptionMessages(ex));
+
+                    throw new InvalidOperationException(userMessage, ex);
                 }
             }
 
-            StatusMessage = "ROMs downloaded successfully.";
+            SetStatusMessage("ROMs downloaded successfully.");
 
         }
         catch (System.Exception ex)
         {
-            StatusMessage = $"Error downloading ROMs: {ex.Message}";
+            _logger.LogError(
+                ex,
+                "C64 ROM download to files failed. Details: {ErrorSummary}",
+                DownloadErrorHelper.FlattenExceptionMessages(ex));
+            SetStatusMessage(ex.Message, isError: true);
         }
         finally
         {
@@ -787,12 +875,12 @@ public class C64ConfigDialogViewModel : ViewModelBase
 
         if (errors.Count == 0)
         {
-            StatusMessage = "ROM files loaded.";
+            SetStatusMessage("ROM files loaded.");
             ValidationMessage = string.Empty;
         }
         else
         {
-            StatusMessage = errors.Count < romDataList.Count() ? "Some ROMs loaded with warnings." : null;
+            SetStatusMessage(errors.Count < romDataList.Count() ? "Some ROMs loaded with warnings." : null);
             ValidationMessage = string.Join(Environment.NewLine, errors);
         }
 
@@ -843,12 +931,12 @@ public class C64ConfigDialogViewModel : ViewModelBase
 
         if (errors.Count == 0)
         {
-            StatusMessage = "ROM files loaded.";
+            SetStatusMessage("ROM files loaded.");
             ValidationMessage = string.Empty;
         }
         else
         {
-            StatusMessage = errors.Count < filePaths.Count() ? "Some ROMs loaded with warnings." : null;
+            SetStatusMessage(errors.Count < filePaths.Count() ? "Some ROMs loaded with warnings." : null);
             ValidationMessage = string.Join(Environment.NewLine, errors);
         }
     }
@@ -858,7 +946,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
         _workingConfig.SystemConfig.ROMs = new List<ROM>();
         UpdateRomStatuses();
         UpdateValidationMessageFromConfig();
-        StatusMessage = "All ROMs cleared.";
+        SetStatusMessage("All ROMs cleared.");
     }
 
     public async Task<bool> TryApplyChangesAsync()
@@ -866,12 +954,12 @@ public class C64ConfigDialogViewModel : ViewModelBase
         try
         {
             IsBusy = true;
-            StatusMessage = "Saving...";
+            SetStatusMessage("Saving...");
             ValidationMessage = string.Empty;
 
             if (!_workingConfig.IsValid(out var validationErrors))
             {
-                StatusMessage = null;
+                SetStatusMessage(null);
                 ValidationMessage = string.Join(Environment.NewLine, validationErrors); ;
                 return false;
             }
@@ -888,13 +976,14 @@ public class C64ConfigDialogViewModel : ViewModelBase
             await _hostApp.PersistConfigSectionAsync(ApiConfig.CONFIG_SECTION_SELF_HOSTED, openAISelfhostedConfigSection);
             await _hostApp.PersistConfigSectionAsync(CustomAIEndpointConfig.CONFIG_SECTION, customEndpointConfigSection);
 
-            StatusMessage = "Configuration saved.";
+            SetStatusMessage("Configuration saved.");
             return true;
 
         }
         catch (Exception ex)
         {
-            StatusMessage = $"Error saving config: {ex.Message}"; ;
+            _logger.LogError(ex, "Error while saving C64 configuration.");
+            SetStatusMessage($"Error saving config: {ex.Message}", isError: true);
             return false;
         }
         finally

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
@@ -50,8 +50,8 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
         {"montezuma", new D64DownloadDiskInfo("Montezuma's Revenge", "https://csdb.dk/release/download.php?id=128101", downloadType: DownloadType.ZIP, keyboardJoystickEnabled: true, keyboardJoystickNumber: 2, audioEnabled: true, directLoadPRGName: "*")},
         {"rallyspeedway", new D64DownloadDiskInfo("Rally Speedway", "https://csdb.dk/release/download.php?id=219614", keyboardJoystickEnabled: true, keyboardJoystickNumber: 1, audioEnabled: true, directLoadPRGName: "*")}
     };
-    private string _latestPreloadedDiskError = "";
-    private bool _isLoadingPreloadedDisk = false;
+    private string _latestPreloadedDiskError = string.Empty;
+    private bool _isLoadingPreloadedDisk;
     private D64AutoDownloadAndRun? _d64AutoDownloadAndRun;
 
     // --- ReactiveUI Commands ---
@@ -120,7 +120,7 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
 
         LoadPreloadedDiskCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () => await LoadPreloadedDiskImageAsync(),
-            Observable.Return(true),
+            this.WhenAnyValue(x => x.IsLoadingPreloadedDisk).Select(isLoading => !isLoading),
             RxSchedulers.MainThreadScheduler);
 
         LoadAssemblyExampleCommand = ReactiveCommandHelper.CreateSafeCommand(
@@ -251,9 +251,32 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
     public string SelectedPreloadedDisk
     {
         get => _selectedPreloadedDisk;
-        set => this.RaiseAndSetIfChanged(ref _selectedPreloadedDisk, value);
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _selectedPreloadedDisk, value);
+            LatestPreloadedDiskError = string.Empty;
+        }
     }
-    public bool IsLoadingPreloadedDisk { get; private set; }
+    public bool IsLoadingPreloadedDisk
+    {
+        get => _isLoadingPreloadedDisk;
+        private set => this.RaiseAndSetIfChanged(ref _isLoadingPreloadedDisk, value);
+    }
+
+    public string LatestPreloadedDiskError
+    {
+        get => _latestPreloadedDiskError;
+        private set
+        {
+            if (_latestPreloadedDiskError == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _latestPreloadedDiskError, value);
+            this.RaisePropertyChanged(nameof(HasLatestPreloadedDiskError));
+        }
+    }
+
+    public bool HasLatestPreloadedDiskError => !string.IsNullOrEmpty(LatestPreloadedDiskError);
 
     // Assembly examples
     public ObservableCollection<KeyValuePair<string, string>> AssemblyExamples { get; } = new();
@@ -745,10 +768,10 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
             return;
 
         var diskInfo = _preloadedD64Images[selectedPreloadedDisk];
-        _isLoadingPreloadedDisk = true;
-        _latestPreloadedDiskError = "";
+        IsLoadingPreloadedDisk = true;
+        LatestPreloadedDiskError = string.Empty;
 
-        _logger.LogInformation($"Starting to load preloaded disk: {diskInfo.DisplayName}");
+        _logger.LogInformation("Starting to load preloaded disk: {DisplayName}", diskInfo.DisplayName);
 
         try
         {
@@ -807,19 +830,25 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
         }
         catch (Exception ex)
         {
-            _latestPreloadedDiskError = $"Error downloading or running disk image: {ex.Message}";
-            _logger.LogError($"LoadPreloadedDisk_Click error: {_latestPreloadedDiskError}");
+            LatestPreloadedDiskError = string.IsNullOrWhiteSpace(ex.Message)
+                ? $"Failed to download and run {diskInfo.DisplayName}."
+                : ex.Message;
+            _logger.LogError(
+                ex,
+                "LoadPreloadedDisk_Click error while loading {DisplayName}: {ErrorMessage}",
+                diskInfo.DisplayName,
+                LatestPreloadedDiskError);
         }
         finally
         {
             // Force binding refresh for all properties, config settings for keyboard/joystick may have changed
             RefreshAllBindings();
 
-            _isLoadingPreloadedDisk = false;
-            _logger.LogInformation($"Finished loading preloaded disk. Loading state: {_isLoadingPreloadedDisk}");
-            if (!string.IsNullOrEmpty(_latestPreloadedDiskError))
+            IsLoadingPreloadedDisk = false;
+            _logger.LogInformation("Finished loading preloaded disk. Loading state: {IsLoadingPreloadedDisk}", IsLoadingPreloadedDisk);
+            if (!string.IsNullOrEmpty(LatestPreloadedDiskError))
             {
-                _logger.LogInformation($"Final error state: {_latestPreloadedDiskError}");
+                _logger.LogInformation("Final error state: {LatestPreloadedDiskError}", LatestPreloadedDiskError);
             }
         }
     }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64ConfigUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64ConfigUserControl.axaml
@@ -618,7 +618,14 @@
         <TextBlock Text="{Binding StatusMessage}"
                     Foreground="{DynamicResource SuccessColor}"
                     TextWrapping="Wrap"
-                    IsVisible="{Binding HasStatusMessage}"/>
+                    IsVisible="{Binding HasNonErrorStatusMessage}"/>
+
+        <Border Classes="error-container-small"
+                IsVisible="{Binding HasErrorStatusMessage}">
+          <TextBlock Text="{Binding StatusMessage}"
+                     Classes="small"
+                     TextWrapping="Wrap"/>
+        </Border>
         
         <!-- Validation Error Messages with Border (similar to MainView) -->
         <Border Classes="error-container-small"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml
@@ -136,10 +136,22 @@
                             Command="{Binding LoadPreloadedDiskCommand}"
                             IsVisible="{Binding SelectedPreloadedDisk, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
 
+                    <TextBlock Text="Downloading and starting disk image..."
+                               Classes="small secondary-text"
+                               TextWrapping="Wrap"
+                               IsVisible="{Binding IsLoadingPreloadedDisk}"/>
+
                     <TextBlock Text="Download D64 disk image and auto-run the program on it."
                                Classes="small secondary-text"
                                TextWrapping="Wrap"
                                IsVisible="{Binding SelectedPreloadedDisk, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+
+                    <Border Classes="error-container-small"
+                            IsVisible="{Binding HasLatestPreloadedDiskError}">
+                        <TextBlock Text="{Binding LatestPreloadedDiskError}"
+                                   Classes="small"
+                                   TextWrapping="Wrap"/>
+                    </Border>
                 </StackPanel>
             </Border>
         </StackPanel>

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/DiskDrive/D64/Download/D64AutoDownloadAndRun.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/DiskDrive/D64/Download/D64AutoDownloadAndRun.cs
@@ -25,6 +25,8 @@ public class D64AutoDownloadAndRun
         D64DownloadDiskInfo diskInfo,
         Func<D64DownloadDiskInfo, Task> setConfigCallback)
     {
+        var shouldResumeEmulator = false;
+
         try
         {
             // First reset the C64 emulator
@@ -65,6 +67,7 @@ public class D64AutoDownloadAndRun
             // Pause before proceeding with disk operations
             _logger.LogInformation($"Pausing C64 emulator before disk operations. State before pause: {_hostApp.EmulatorState}");
             _hostApp.Pause();
+            shouldResumeEmulator = true;
 
             // Download and process the disk image (supports both .d64 and .zip files)
             var d64Bytes = await _d64Downloader.DownloadAndProcessDiskImage(diskInfo);
@@ -137,10 +140,28 @@ public class D64AutoDownloadAndRun
             }
 
             await _hostApp.Start();
+            shouldResumeEmulator = false;
         }
         catch (Exception ex)
         {
-            _logger.LogError($"Load error: {ex.Message}");
+            if (shouldResumeEmulator)
+            {
+                try
+                {
+                    _logger.LogInformation("Resuming C64 emulator after disk auto-download failure. State before resume: {EmulatorState}", _hostApp.EmulatorState);
+                    await _hostApp.Start();
+                }
+                catch (Exception resumeEx)
+                {
+                    _logger.LogError(resumeEx, "Failed to resume C64 emulator after disk auto-download failure.");
+                }
+            }
+
+            _logger.LogError(
+                ex,
+                "Failed to download and run disk image {DisplayName}. Details: {ErrorSummary}",
+                diskInfo.DisplayName,
+                DownloadErrorHelper.FlattenExceptionMessages(ex));
             throw;
         }
     }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/DiskDrive/D64/Download/D64Downloader.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/DiskDrive/D64/Download/D64Downloader.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using System.IO.Compression;
+using Highbyte.DotNet6502.Utils;
 
 
 namespace Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.DiskDrive.D64.Download;
@@ -28,29 +29,54 @@ public class D64Downloader
     /// <returns>The .d64 file content as byte array</returns>
     public async Task<byte[]> DownloadAndProcessDiskImage(D64DownloadDiskInfo diskInfo)
     {
-        _logger.LogInformation($"Downloading disk image: {diskInfo.DisplayName} from {diskInfo.DownloadUrl}");
+        _logger.LogInformation(
+            "Downloading disk image {DisplayName} from source URL {SourceUrl}",
+            diskInfo.DisplayName,
+            diskInfo.DownloadUrl);
 
         // Use CORS proxy to bypass browser CORS restrictions
         var downloadUrl = _corsProxyUrl != null ?
             _corsProxyUrl + Uri.EscapeDataString(diskInfo.DownloadUrl)
             : diskInfo.DownloadUrl;
 
-        _logger.LogInformation($"Using download URL: {downloadUrl}");
+        _logger.LogInformation(
+            "Using request URL {RequestUrl} for disk image {DisplayName}",
+            downloadUrl,
+            diskInfo.DisplayName);
 
-        // Check the download type to determine download strategy
-        if (diskInfo.DownloadType == DownloadType.ZIP)
+        try
         {
-            _logger.LogInformation("Processing ZIP file to extract .d64");
-            return await DownloadAndExtractZipD64(downloadUrl);
-        }
-        else
-        {
+            // Check the download type to determine download strategy
+            if (diskInfo.DownloadType == DownloadType.ZIP)
+            {
+                _logger.LogInformation("Processing ZIP file to extract .d64");
+                return await DownloadAndExtractZipD64(downloadUrl);
+            }
+
             // Download direct .d64 file
             using var response = await _httpClient.GetAsync(downloadUrl);
             response.EnsureSuccessStatusCode();
             var d64Bytes = await response.Content.ReadAsByteArrayAsync();
-            _logger.LogInformation($"Downloaded .d64 file: {d64Bytes.Length} bytes");
+            _logger.LogInformation("Downloaded .d64 file: {ByteCount} bytes", d64Bytes.Length);
             return d64Bytes;
+        }
+        catch (Exception ex)
+        {
+            var userMessage = DownloadErrorHelper.BuildDownloadFailureMessage(
+                $"disk image '{diskInfo.DisplayName}'",
+                diskInfo.DownloadUrl,
+                downloadUrl,
+                ex);
+
+            _logger.LogError(
+                ex,
+                "Failed to download disk image {DisplayName}. Source URL: {SourceUrl}. Request URL: {RequestUrl}. Details: {ErrorSummary}",
+                diskInfo.DisplayName,
+                diskInfo.DownloadUrl,
+                downloadUrl,
+                DownloadErrorHelper.FlattenExceptionMessages(ex));
+
+            throw new InvalidOperationException(userMessage, ex);
         }
     }
 
@@ -72,7 +98,7 @@ public class D64Downloader
         var d64Entry = archive.Entries.FirstOrDefault(entry => entry.Name.EndsWith(".d64", StringComparison.OrdinalIgnoreCase))
                 ?? throw new InvalidOperationException("No .d64 file found in the ZIP archive");
 
-        _logger.LogInformation($"Found .d64 file in ZIP: {d64Entry.Name}, size: {d64Entry.Length} bytes");
+        _logger.LogInformation("Found .d64 file in ZIP: {EntryName}, size: {ByteCount} bytes", d64Entry.Name, d64Entry.Length);
 
         // Pre-allocate array with the exact size
         var d64Bytes = new byte[d64Entry.Length];
@@ -89,7 +115,7 @@ public class D64Downloader
             totalBytesRead += bytesRead;
         }
 
-        _logger.LogInformation($"Extracted .d64 file: {d64Bytes.Length} bytes");
+        _logger.LogInformation("Extracted .d64 file: {ByteCount} bytes", d64Bytes.Length);
         return d64Bytes;
     }
 }

--- a/src/libraries/Highbyte.DotNet6502/Utils/DownloadErrorHelper.cs
+++ b/src/libraries/Highbyte.DotNet6502/Utils/DownloadErrorHelper.cs
@@ -1,0 +1,79 @@
+using System.Net;
+
+namespace Highbyte.DotNet6502.Utils;
+
+public static class DownloadErrorHelper
+{
+    public static string BuildDownloadFailureMessage(
+        string resourceName,
+        string? sourceUrl,
+        string? requestUrl,
+        Exception exception)
+    {
+        var rootException = exception.GetBaseException();
+        var sourceDisplay = GetEndpointDisplay(sourceUrl);
+        var requestDisplay = GetEndpointDisplay(requestUrl);
+
+        if (IsBrowserFetchFailure(rootException))
+        {
+            if (!string.IsNullOrEmpty(requestDisplay) &&
+                !string.Equals(sourceDisplay, requestDisplay, StringComparison.OrdinalIgnoreCase))
+            {
+                return $"Failed to download {resourceName} from {sourceDisplay}. The browser could not fetch it via {requestDisplay}. The source site or CORS proxy may be unavailable. Try again later or change the CORS proxy setting.";
+            }
+
+            return $"Failed to download {resourceName} from {sourceDisplay}. The browser could not fetch it. The site may be unavailable, blocked by CORS, or the network request was interrupted.";
+        }
+
+        if (rootException is TaskCanceledException)
+        {
+            return $"Timed out while downloading {resourceName} from {sourceDisplay}. Try again later.";
+        }
+
+        if (rootException is HttpRequestException httpRequestException && httpRequestException.StatusCode is HttpStatusCode statusCode)
+        {
+            return $"Failed to download {resourceName} from {sourceDisplay}. The server returned HTTP {(int)statusCode} ({statusCode}).";
+        }
+
+        var detail = rootException.Message;
+        if (string.IsNullOrWhiteSpace(detail))
+        {
+            return $"Failed to download {resourceName} from {sourceDisplay}.";
+        }
+
+        return $"Failed to download {resourceName} from {sourceDisplay}. {detail}";
+    }
+
+    public static string FlattenExceptionMessages(Exception exception)
+    {
+        var messages = new List<string>();
+        var seenMessages = new HashSet<string>(StringComparer.Ordinal);
+
+        for (var current = exception; current != null; current = current.InnerException)
+        {
+            if (string.IsNullOrWhiteSpace(current.Message))
+                continue;
+
+            if (seenMessages.Add(current.Message))
+            {
+                messages.Add(current.Message);
+            }
+        }
+
+        return messages.Count == 0 ? exception.GetType().Name : string.Join(" --> ", messages);
+    }
+
+    private static bool IsBrowserFetchFailure(Exception exception)
+        => exception.Message.Contains("Failed to fetch", StringComparison.OrdinalIgnoreCase);
+
+    private static string GetEndpointDisplay(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return "the configured source";
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var uri) && !string.IsNullOrWhiteSpace(uri.Host))
+            return uri.Host;
+
+        return url;
+    }
+}

--- a/tests/Highbyte.DotNet6502.Tests/Utils/DownloadErrorHelperTest.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Utils/DownloadErrorHelperTest.cs
@@ -1,0 +1,51 @@
+using System.Net;
+using Highbyte.DotNet6502.Utils;
+
+namespace Highbyte.DotNet6502.Tests.Utils;
+
+public class DownloadErrorHelperTest
+{
+    [Fact]
+    public void BuildDownloadFailureMessage_ExplainsBrowserFetchFailuresWithProxyContext()
+    {
+        var ex = new HttpRequestException("TypeError: Failed to fetch");
+
+        var message = DownloadErrorHelper.BuildDownloadFailureMessage(
+            "disk image 'Giana Sisters'",
+            "https://csdb.dk/release/download.php?id=161456",
+            "https://api.codetabs.com/v1/proxy?quest=https%3A%2F%2Fcsdb.dk%2Frelease%2Fdownload.php%3Fid%3D161456",
+            ex);
+
+        Assert.Contains("disk image 'Giana Sisters'", message);
+        Assert.Contains("csdb.dk", message);
+        Assert.Contains("api.codetabs.com", message);
+        Assert.Contains("CORS proxy", message);
+    }
+
+    [Fact]
+    public void BuildDownloadFailureMessage_ReportsHttpStatusCodes()
+    {
+        var ex = new HttpRequestException("Not found", null, HttpStatusCode.NotFound);
+
+        var message = DownloadErrorHelper.BuildDownloadFailureMessage(
+            "ROM 'kernal'",
+            "https://example.com/kernal.rom",
+            "https://example.com/kernal.rom",
+            ex);
+
+        Assert.Contains("HTTP 404", message);
+        Assert.Contains("NotFound", message);
+    }
+
+    [Fact]
+    public void FlattenExceptionMessages_DeduplicatesRepeatedMessages()
+    {
+        var ex = new InvalidOperationException(
+            "Outer failure",
+            new Exception("TypeError: Failed to fetch", new Exception("TypeError: Failed to fetch")));
+
+        var message = DownloadErrorHelper.FlattenExceptionMessages(ex);
+
+        Assert.Equal("Outer failure --> TypeError: Failed to fetch", message);
+    }
+}


### PR DESCRIPTION
## Summary
Improve logging and UI feedback when C64 ROM or `.d64` auto-download fails in the Avalonia desktop/browser apps.

## What changed
- Added clearer download error formatting, including source/proxy context for browser fetch failures.
- Improved `.d64` auto-download/run logging and restored the emulator if the flow fails after pausing.
- Added inline failure feedback for preloaded `.d64` downloads in the C64 menu.
- Improved C64 config ROM download status/error handling and logging.
- Refactored automated browser startup ROM download into a single overlay workflow that keeps the dialog open during download, shows activity, and surfaces errors in the same dialog with a path into C64 Config.
