### PR TITLE
Add C64 .d64 startup parameters and runtime-config knobs to Avalonia apps

### DIFF
--- a/docs/desktop-apps/avalonia-desktop.md
+++ b/docs/desktop-apps/avalonia-desktop.md
@@ -83,6 +83,12 @@ The desktop app can be launched from the command line with arguments to control 
 # Start C64 and load a .prg file via CLI (no script)
 ./Highbyte.DotNet6502.App.Avalonia.Desktop --system C64 --start --loadPrg game.prg --runLoadedProgram
 
+# Start C64 PAL, mount a .d64, paste LOAD"*",8,1 + RUN, set keyboard-joystick to port 2
+./Highbyte.DotNet6502.App.Avalonia.Desktop --system C64 --systemVariant C64PAL --start --waitForSystemReady --loadD64 "/path/to/SomeGame.d64" --diskMount --runLoadedProgram --keyboardJoystickEnabled --keyboardJoystickNumber 2
+
+# Start C64, direct-load the first PRG from a .d64 image (no disk mount) and RUN it
+./Highbyte.DotNet6502.App.Avalonia.Desktop --system C64 --start --waitForSystemReady --loadD64 "/path/to/SomeGame.d64" --d64Program "*" --runLoadedProgram
+
 # Start with debug adapter for VS Code, waiting for client
 ./Highbyte.DotNet6502.App.Avalonia.Desktop --system C64 --start --enableExternalDebug --debug-port 6502 --debug-wait
 

--- a/docs/desktop-apps/headless.md
+++ b/docs/desktop-apps/headless.md
@@ -59,6 +59,9 @@ The headless app is driven entirely from the command line.
 
 --8<-- "cli-arguments-reference.md"
 
+!!! note
+    The **C64 `.d64` startup parameters** (`--loadD64` / `--d64Program` / `--diskMount` / `--keyboardJoystick*` / `--audioEnabled`) are currently wired only in the Avalonia Desktop app. They are not parsed by the headless app — the headless app has no C64 shell plugin to apply C64-runtime config or run the disk-mount / direct-load flow. The shared `D64AutoDownloadAndRun.MountOrDirectLoadAndRunAsync` helper is host-agnostic, so adding equivalent flags to the headless app is possible but is out of scope for the initial release.
+
 ### Examples
 
 Examples below use `dotnet-6502-headless` as installed via Homebrew or Scoop.

--- a/docs/web-apps/avalonia-browser.md
+++ b/docs/web-apps/avalonia-browser.md
@@ -69,6 +69,13 @@ Query parameter names are case-insensitive. Boolean flags treat an empty value, 
 | `basicText` | Paste inline C64 BASIC source text into the running C64. | Base64url-encoded UTF-8 text. Requires `system=C64`, `start`, and `waitForSystemReady`. Mutually exclusive with `loadPrgUrl` and `runLoadedProgram`. |
 | `basicUrl` | Fetch C64 BASIC source text over HTTP and paste it into the running C64. | Same semantics as `basicText`, but uses a text file URL instead of embedding the source in the query string. |
 | `runBasic` | Queue `RUN` after BASIC source has been pasted. | Requires `basicText` or `basicUrl`. |
+| `loadD64Url` | Fetch a C64 `.d64` disk image over HTTP. | Requires `system=C64`, `start`, `waitForSystemReady`, and exactly one of `d64Program` or `diskMount`. Mutually exclusive with `loadPrgUrl` / `basicText` / `basicUrl`. Browser equivalent of desktop `--loadD64`. Bytes are fetched **after** the C64 has booted to BASIC ready, so the user sees the live BASIC prompt during the download (no blank page). |
+| `d64Program` | Extract a PRG from the `.d64` image and direct-load it into memory (no disk mount). | `*` selects the first directory entry. URL-encode names with spaces. Requires `loadD64Url`. Mutually exclusive with `diskMount`. Mirrors desktop `--d64Program`. |
+| `diskMount` | Mount the `.d64` image in drive 8 and prepare to issue `LOAD"*",8,1` + `RUN`. | Requires `loadD64Url`. Mutually exclusive with `d64Program`. Mirrors desktop `--diskMount`. |
+| `runLoadedProgram` (with `loadD64Url`) | Paste the disk's `RunCommands` after load / mount. | `LOAD"*",8,1` + `RUN` for `diskMount`; just `RUN` for `d64Program`. |
+| `keyboardJoystickEnabled` | Force-enable the C64 keyboard-emulated joystick before the system starts. | Requires `system=C64`. Independent of `loadD64Url` — applies for any C64 start path (plain `start`, `loadPrgUrl`, BASIC paste, `loadD64Url`). |
+| `keyboardJoystickNumber` | C64 joystick port the keyboard emulates (and which gamepad port drives). | Must be `1` or `2`; implies `keyboardJoystickEnabled`. Requires `system=C64`. Independent of `loadD64Url`. |
+| `audioEnabled` | Override C64 audio enable before the system starts. | `true` / `false`. Requires `system=C64`. Independent of `loadD64Url`. |
 | `script` | Run an inline Lua script supplied as base64url-encoded UTF-8 text. | Browser only. Mutually exclusive with all system-driven parameters below. Disabled by default; gated by `Scripting.AllowUrlScripts`. |
 | `scriptUrl` | Fetch a Lua script from a relative or absolute URL and run it. | Same behavior as `script`, but avoids URL-length limits. Disabled by default; gated by `Scripting.AllowUrlScripts`. |
 
@@ -80,13 +87,18 @@ When a URL starts `system=C64` and the app does not yet have the required C64 RO
 2. `start` and `waitForSystemReady` require `system`.
 3. `waitForSystemReady` requires `start`.
 4. `loadPrgUrl` requires `system` and `start`.
-5. `runLoadedProgram` requires `loadPrgUrl`.
+5. `runLoadedProgram` requires `loadPrgUrl` **or** `loadD64Url`.
 6. `basicText` and `basicUrl` are mutually exclusive.
 7. `basicText` and `basicUrl` require `system=C64`, `start`, and `waitForSystemReady`.
 8. `basicText` and `basicUrl` are mutually exclusive with `loadPrgUrl` and `runLoadedProgram`.
 9. `runBasic` requires `basicText` or `basicUrl`.
-10. `script` and `scriptUrl` are mutually exclusive.
-11. `script` and `scriptUrl` are also mutually exclusive with `system`, `start`, `waitForSystemReady`, `loadPrgUrl`, `runLoadedProgram`, `basicText`, `basicUrl`, and `runBasic`.
+10. `loadD64Url` requires `system=C64`, `start`, `waitForSystemReady`, and exactly one of `d64Program` or `diskMount`.
+11. `loadD64Url` is mutually exclusive with `loadPrgUrl`, `basicText`, and `basicUrl`.
+12. `d64Program` and `diskMount` have no effect without `loadD64Url`.
+13. `keyboardJoystickEnabled`, `keyboardJoystickNumber`, and `audioEnabled` require `system=C64` but are independent of `loadD64Url` — they apply for any C64 start path.
+14. `keyboardJoystickNumber` must be `1` or `2`; `audioEnabled` must be `true` or `false`.
+15. `script` and `scriptUrl` are mutually exclusive.
+16. `script` and `scriptUrl` are also mutually exclusive with `system`, `start`, `waitForSystemReady`, `loadPrgUrl`, `runLoadedProgram`, `basicText`, `basicUrl`, `runBasic`, and `loadD64Url`.
 
 Examples:
 
@@ -102,6 +114,15 @@ Examples:
 
 # Paste the same BASIC source inline and run it
 ?system=C64&start=1&waitForSystemReady=1&basicText=MTAgYzE9NzpjMj0xNAoyMCBjPWMxCjMwIGlmIGM9YzEgdGhlbiBjPWMyIDogZ290byA1MAo0MCBpZiBjPWMyIHRoZW4gYz1jMQo1MCBwb2tlIDUzMjgwLGMKNjAgcHJpbnQgImhlbGxvIHdvcmxkISIKNzAgZm9yIGk9MSB0byAxNTA6bmV4dAo4MCBnb3RvIDMwCg&runBasic=1
+
+# Mount a .d64 in drive 8, paste LOAD"*",8,1 + RUN, keyboard-joystick on port 2
+?system=C64&systemVariant=C64PAL&start=1&waitForSystemReady=1&loadD64Url=d64%2Fgiana-sisters.d64&diskMount=1&runLoadedProgram=1&keyboardJoystickEnabled=1&keyboardJoystickNumber=2
+
+# Direct-load the first PRG from a .d64 (no disk mount) and RUN it
+?system=C64&start=1&waitForSystemReady=1&loadD64Url=d64%2Fgiana-sisters.d64&d64Program=*&runLoadedProgram=1
+
+# Start C64 with keyboard-joystick on port 2 and audio disabled (no .d64, no PRG)
+?system=C64&start=1&waitForSystemReady=1&keyboardJoystickEnabled=1&keyboardJoystickNumber=2&audioEnabled=false
 
 # Run an inline Lua script (base64url for: log.info('hello'))
 ?script=bG9nLmluZm8oJ2hlbGxvJyk
@@ -125,8 +146,9 @@ The browser app ships the `basicUrl` sample above as `basic/c64/hello-world.bas`
 
 Important differences from desktop automation:
 
-- `loadPrgUrl`, `basicUrl`, and `scriptUrl` use browser HTTP fetch semantics, so normal browser origin and CORS rules apply.
+- `loadPrgUrl`, `basicUrl`, `loadD64Url`, and `scriptUrl` use browser HTTP fetch semantics, so normal browser origin and CORS rules apply.
 - `basicText` and `basicUrl` are C64-only and use the normal keyboard paste path after BASIC is ready; `runBasic=1` simply appends `RUN` and Return after the pasted source.
+- `loadD64Url` is fetched **after** the C64 has booted to BASIC ready, so a slow remote `.d64` shows progress as a visible BASIC prompt rather than a blank Avalonia page. The desktop equivalent (`--loadD64 <path>`) reads from the local filesystem and is effectively instant.
 - URL-driven Lua is **disabled by default**. Enable **Allow URL-driven scripts (script / scriptUrl query params)** in the browser app's general settings, save, then reload the page.
 - URL-driven scripts do not behave exactly like desktop `--script`: the browser app still selects the configured default system first, then enables the injected script. The script can still take over by calling APIs such as `emu.select(...)` and `emu.start()`.
 

--- a/includes/cli-arguments-reference.md
+++ b/includes/cli-arguments-reference.md
@@ -22,7 +22,38 @@ There are two **mutually exclusive** modes:
 | `--start` | Auto-start the emulator after selection. |
 | `--waitForSystemReady` | Wait until the system reports ready before continuing. Requires `--start`. |
 | `--loadPrg <path>` | Load a `.prg` file into memory. Requires `--start`. |
-| `--runLoadedProgram` | Run the loaded `.prg` file after loading. Requires `--start` and `--loadPrg`. |
+| `--runLoadedProgram` | Run the loaded program after loading. Requires `--start` and one of `--loadPrg` / `--loadD64`. |
+
+### C64 runtime config *(Avalonia Desktop only)*
+
+These flags override the C64 host config before the system starts. They apply for **any** C64
+start path — plain `--start`, `--loadPrg`, BASIC paste, or `--loadD64`. They are parsed by the
+Avalonia Desktop entry point and applied by the C64 Avalonia shell plugin, so they are not
+available in the Headless app today.
+
+| Argument | Description |
+|---|---|
+| `--keyboardJoystickEnabled` | Force-enable the C64 keyboard-emulated joystick. Requires `--system C64`. |
+| `--keyboardJoystickNumber <1\|2>` | C64 joystick port the keyboard emulates (and which gamepad port drives). Implies `--keyboardJoystickEnabled`. Requires `--system C64`. |
+| `--audioEnabled <true\|false>` | Override the C64 audio-enable config before the system starts. Omit to keep the existing value. Requires `--system C64`. |
+
+### C64 `.d64` startup parameters *(Avalonia Desktop only)*
+
+These flags load a `.d64` disk image at startup. Like the runtime-config flags above, they are
+parsed by the Avalonia Desktop entry point and applied by the C64 Avalonia shell plugin, so they
+are **not available in the Headless app today**. (Other hosts can adopt them by adding the
+equivalent CLI parsing in their own entry point and registering an `IAutomatedStartupParticipant`
+that uses the shared `D64AutoDownloadAndRun.MountOrDirectLoadAndRunAsync` helper.)
+
+| Argument | Description |
+|---|---|
+| `--loadD64 <path>` | Local `.d64` path to use at startup. Requires `--system C64`, `--start`, `--waitForSystemReady`, and exactly one of `--d64Program` or `--diskMount`. Mutually exclusive with `--loadPrg`. |
+| `--d64Program <name\|*>` | Extract the named PRG from the disk image and direct-load it into memory (no disk mount). `*` selects the first directory entry. Mutually exclusive with `--diskMount`. |
+| `--diskMount` | Mount the disk image in drive 8 and prepare to issue `LOAD"*",8,1` + `RUN` via the keyboard buffer. Mutually exclusive with `--d64Program`. |
+
+`--runLoadedProgram` in the `--loadD64` flow controls whether the disk's `RunCommands`
+(`LOAD"*",8,1` + `RUN` for `--diskMount`, just `RUN` for `--d64Program`) are pasted after the
+load / mount.
 
 ### Logging
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/Program.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/Program.cs
@@ -126,6 +126,50 @@ internal sealed partial class Program
     ///     </description>
     ///   </item>
     ///   <item>
+    ///     <term><c>loadD64Url</c></term>
+    ///     <description>
+    ///       URL (relative or absolute) to fetch a C64 <c>.d64</c> disk image from. Requires
+    ///       <c>system=C64</c>, <c>start</c>, <c>waitForSystemReady</c>, and exactly one of
+    ///       <c>d64Program</c> or <c>diskMount</c>. Mutually exclusive with <c>loadPrgUrl</c> /
+    ///       <c>basicText</c> / <c>basicUrl</c>. Bytes are pre-fetched on the main thread (mirrors
+    ///       <c>loadPrgUrl</c>).
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <term><c>d64Program</c></term>
+    ///     <description>
+    ///       PRG name to extract from the <c>.d64</c> image and load directly into memory; <c>*</c>
+    ///       selects the first directory entry. URL-encode names with spaces. Mutually exclusive
+    ///       with <c>diskMount</c>; requires <c>loadD64Url</c>.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <term><c>diskMount</c></term>
+    ///     <description>
+    ///       Mount the <c>.d64</c> image in drive 8 and prepare to issue <c>LOAD"*",8,1</c> +
+    ///       <c>RUN</c>. Mutually exclusive with <c>d64Program</c>; requires <c>loadD64Url</c>.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <term><c>keyboardJoystickEnabled</c></term>
+    ///     <description>
+    ///       Force-enable the C64 keyboard-emulated joystick. Requires <c>system=C64</c>; applies
+    ///       for any C64 start path (plain <c>start</c>, <c>loadPrgUrl</c>, BASIC paste,
+    ///       <c>loadD64Url</c>).
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <term><c>keyboardJoystickNumber</c></term>
+    ///     <description>
+    ///       Which C64 joystick port the keyboard emulates (and which gamepad port drives). Must
+    ///       be 1 or 2; implies <c>keyboardJoystickEnabled</c>. Requires <c>system=C64</c>.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <term><c>audioEnabled</c></term>
+    ///     <description>Override C64 audio enable. Requires <c>system=C64</c>.</description>
+    ///   </item>
+    ///   <item>
     ///     <term><c>script</c></term>
     ///     <description>
     ///       Base64url-encoded inline Lua script to load and auto-enable at startup. The script
@@ -164,6 +208,12 @@ internal sealed partial class Program
     ///
     /// # Paste inline BASIC source and run it
     /// ?system=C64&amp;start=1&amp;waitForSystemReady=1&amp;basicText=MTAgYzE9NzpjMj0xNAoyMCBjPWMxCjMwIGlmIGM9YzEgdGhlbiBjPWMyIDogZ290byA1MAo0MCBpZiBjPWMyIHRoZW4gYz1jMQo1MCBwb2tlIDUzMjgwLGMKNjAgcHJpbnQgImhlbGxvIHdvcmxkISIKNzAgZm9yIGk9MSB0byAxNTA6bmV4dAo4MCBnb3RvIDMwCg&amp;runBasic=1
+    ///
+    /// # Mount a .d64 in drive 8 and paste LOAD"*",8,1 + RUN, with keyboard-joystick on port 2
+    /// ?system=C64&amp;start=1&amp;waitForSystemReady=1&amp;loadD64Url=https%3A%2F%2Fexample.com%2Fgame.d64&amp;diskMount=1&amp;runLoadedProgram=1&amp;keyboardJoystickEnabled=1&amp;keyboardJoystickNumber=2
+    ///
+    /// # Direct-load the first PRG from a .d64 (no disk mount) and RUN it
+    /// ?system=C64&amp;start=1&amp;waitForSystemReady=1&amp;loadD64Url=https%3A%2F%2Fexample.com%2Fgame.d64&amp;d64Program=*&amp;runLoadedProgram=1
     ///
     /// # Run an inline Lua script (requires Scripting.AllowUrlScripts=true in browser localStorage config)
     /// ?script=bG9nLmluZm8oJ2hlbGxvJyk        # base64url of: log.info('hello')
@@ -214,6 +264,7 @@ internal sealed partial class Program
                 $"systemVariant={automation.SystemVariant ?? "(none)"}, start={automation.AutoStart}, " +
                 $"waitForSystemReady={automation.WaitForSystemReady}, " +
                 $"loadPrgUrl={automation.LoadPrgUrl ?? "(none)"}, runLoadedProgram={automation.RunLoadedProgram}, " +
+                $"loadD64Url={automation.LoadD64Url ?? "(none)"}, " +
                 $"extraParameters={automation.ExtraParameters.Count}");
         }
         else if (automation.ScriptContent != null || automation.ScriptUrl != null)
@@ -454,6 +505,17 @@ internal sealed partial class Program
         }
         else if (automation.SystemName != null)
         {
+            // .d64 bytes are deliberately NOT pre-fetched here. The participant downloads them via
+            // AutomatedStartupContext.FetchBinaryResource after the C64 reports BASIC ready, so the
+            // user sees the live BASIC prompt during the .d64 download (a pre-fetch here would
+            // block the Avalonia app from starting and leave the page blank).
+            var startupExtras = automation.LoadD64Url != null
+                ? (IReadOnlyDictionary<string, string>)new Dictionary<string, string>(automation.ExtraParameters, StringComparer.OrdinalIgnoreCase)
+                {
+                    ["loadD64Url"] = automation.LoadD64Url,
+                }
+                : automation.ExtraParameters;
+
             automatedStartupRunner = async hostApp =>
             {
                 var startupLogger = loggerFactory.CreateLogger(nameof(Program));
@@ -482,14 +544,24 @@ internal sealed partial class Program
                     };
                 }
 
-                // Host capability for the participant's post-ready automation: fetch a text
-                // resource (e.g. C64 'basicUrl') over HTTP from the current app origin.
+                // Host capabilities for the participant's post-ready automation:
+                //  - text fetch: used by C64 'basicUrl'.
+                //  - binary fetch: used by C64 'loadD64Url' (deferred until BASIC is ready, so the
+                //    user sees the boot rather than a blank page while a remote .d64 downloads).
                 var startupContext = new AutomatedStartupContext
                 {
                     FetchTextResource = async url =>
                     {
                         using var http = GetAppUrlHttpClient();
                         return await GetUtf8TextAsync(http, url);
+                    },
+                    FetchBinaryResource = async url =>
+                    {
+                        using var http = GetAppUrlHttpClient();
+                        startupLogger.LogInformation($"Fetching binary resource from '{url}'...");
+                        var bytes = await http.GetByteArrayAsync(url);
+                        startupLogger.LogInformation($"Fetched {bytes.Length} bytes from '{url}'.");
+                        return bytes;
                     },
                 };
 
@@ -504,7 +576,7 @@ internal sealed partial class Program
                         RunLoadedProgram: automation.RunLoadedProgram,
                         EnableExternalDebug: false)
                     {
-                        ExtraParameters = automation.ExtraParameters,
+                        ExtraParameters = startupExtras,
                     };
                     await AutomatedStartupHandler.ExecuteAsync(
                         hostApp,
@@ -617,6 +689,7 @@ internal sealed partial class Program
         bool RunLoadedProgram,
         string? ScriptContent,
         string? ScriptUrl,
+        string? LoadD64Url,
         IReadOnlyDictionary<string, string> ExtraParameters);
 
     /// <summary>
@@ -625,7 +698,7 @@ internal sealed partial class Program
     /// </summary>
     private static BrowserAutomationParams ParseAutomationQuery(string? url)
     {
-        var empty = new BrowserAutomationParams(null, null, false, false, null, false, null, null, new Dictionary<string, string>());
+        var empty = new BrowserAutomationParams(null, null, false, false, null, false, null, null, null, new Dictionary<string, string>());
         if (string.IsNullOrWhiteSpace(url))
             return empty;
 
@@ -667,6 +740,12 @@ internal sealed partial class Program
         bool runLoaded = map.TryGetValue("runLoadedProgram", out var rl) && IsTruthy(rl);
         string? scriptB64 = map.TryGetValue("script", out var sc) && !string.IsNullOrWhiteSpace(sc) ? sc : null;
         string? scriptUrl = map.TryGetValue("scriptUrl", out var su) && !string.IsNullOrWhiteSpace(su) ? su : null;
+        string? loadD64Url = map.TryGetValue("loadD64Url", out var ld64) && !string.IsNullOrWhiteSpace(ld64) ? ld64 : null;
+        string? d64Program = map.TryGetValue("d64Program", out var d64p) && !string.IsNullOrWhiteSpace(d64p) ? d64p : null;
+        bool diskMount = map.TryGetValue("diskMount", out var dm) && IsTruthy(dm);
+        bool keyboardJoystickEnabled = map.TryGetValue("keyboardJoystickEnabled", out var kje) && IsTruthy(kje);
+        string? keyboardJoystickNumberRaw = map.TryGetValue("keyboardJoystickNumber", out var kjn) && !string.IsNullOrWhiteSpace(kjn) ? kjn : null;
+        string? audioEnabledRaw = map.TryGetValue("audioEnabled", out var ae) && !string.IsNullOrWhiteSpace(ae) ? ae : null;
 
         // Decode base64url-encoded inline script (RFC 4648 §5: '-' and '_' substitute '+' '/'; padding optional).
         string? scriptContent = DecodeBase64UrlUtf8QueryValue("script", scriptB64, logRawValue: true);
@@ -693,11 +772,73 @@ internal sealed partial class Program
             WriteBootstrapLog("Query parameter 'loadPrgUrl' requires 'system' and 'start'; ignoring 'loadPrgUrl'.", LogLevel.Warning);
             loadPrgUrl = null;
         }
-        if (runLoaded && loadPrgUrl == null)
+        // ── .d64 automation validation ───────────────────────────────────────────────────
+        // Runs before the 'runLoadedProgram requires loadPrgUrl' check below so a
+        // loadD64Url + runLoadedProgram URL is accepted (loadD64 is also a valid load source).
+        if (loadD64Url != null)
         {
-            WriteBootstrapLog("Query parameter 'runLoadedProgram' requires 'loadPrgUrl'; ignoring 'runLoadedProgram'.", LogLevel.Warning);
+            if (!string.Equals(systemName, "C64", StringComparison.OrdinalIgnoreCase))
+            {
+                WriteBootstrapLog("Query parameter 'loadD64Url' requires 'system=C64'; ignoring 'loadD64Url' and related .d64 params.", LogLevel.Warning);
+                loadD64Url = null;
+            }
+            else if (!autoStart || !waitForReady)
+            {
+                WriteBootstrapLog("Query parameter 'loadD64Url' requires 'start' and 'waitForSystemReady'; ignoring.", LogLevel.Warning);
+                loadD64Url = null;
+            }
+            else if (loadPrgUrl != null)
+            {
+                WriteBootstrapLog("Query parameter 'loadD64Url' is mutually exclusive with 'loadPrgUrl'; ignoring 'loadD64Url'.", LogLevel.Warning);
+                loadD64Url = null;
+            }
+            else if (d64Program == null && !diskMount)
+            {
+                WriteBootstrapLog("Query parameter 'loadD64Url' requires exactly one of 'd64Program' or 'diskMount'; ignoring.", LogLevel.Warning);
+                loadD64Url = null;
+            }
+            else if (d64Program != null && diskMount)
+            {
+                WriteBootstrapLog("Query parameters 'd64Program' and 'diskMount' are mutually exclusive; ignoring 'loadD64Url'.", LogLevel.Warning);
+                loadD64Url = null;
+            }
+        }
+        // 'd64Program' / 'diskMount' only make sense with 'loadD64Url'.
+        if (loadD64Url == null && (d64Program != null || diskMount))
+        {
+            WriteBootstrapLog("Query parameters 'd64Program' / 'diskMount' have no effect without 'loadD64Url'; ignoring.", LogLevel.Warning);
+            d64Program = null;
+            diskMount = false;
+        }
+        // 'keyboardJoystick*' / 'audioEnabled' are general C64 runtime knobs — they apply
+        // whenever 'system=C64', regardless of how the C64 was started.
+        if (!string.Equals(systemName, "C64", StringComparison.OrdinalIgnoreCase)
+            && (keyboardJoystickEnabled || keyboardJoystickNumberRaw != null || audioEnabledRaw != null))
+        {
+            WriteBootstrapLog("Query parameters 'keyboardJoystick*' / 'audioEnabled' require 'system=C64'; ignoring.", LogLevel.Warning);
+            keyboardJoystickEnabled = false;
+            keyboardJoystickNumberRaw = null;
+            audioEnabledRaw = null;
+        }
+        if (keyboardJoystickNumberRaw != null
+            && !(keyboardJoystickNumberRaw == "1" || keyboardJoystickNumberRaw == "2"))
+        {
+            WriteBootstrapLog("Query parameter 'keyboardJoystickNumber' must be 1 or 2; ignoring.", LogLevel.Warning);
+            keyboardJoystickNumberRaw = null;
+        }
+        if (audioEnabledRaw != null
+            && !bool.TryParse(audioEnabledRaw, out _))
+        {
+            WriteBootstrapLog("Query parameter 'audioEnabled' must be 'true' or 'false'; ignoring.", LogLevel.Warning);
+            audioEnabledRaw = null;
+        }
+        // 'runLoadedProgram' needs a load source — either a PRG URL or a .d64 image.
+        if (runLoaded && loadPrgUrl == null && loadD64Url == null)
+        {
+            WriteBootstrapLog("Query parameter 'runLoadedProgram' requires 'loadPrgUrl' or 'loadD64Url'; ignoring 'runLoadedProgram'.", LogLevel.Warning);
             runLoaded = false;
         }
+
         // ── script-driven automation validation ──────────────────────────────────────────
         // 'script' and 'scriptUrl' are mutually exclusive.
         if (scriptContent != null && scriptUrl != null)
@@ -725,6 +866,11 @@ internal sealed partial class Program
         {
             "system", "systemVariant", "start", "waitForSystemReady",
             "loadPrgUrl", "runLoadedProgram", "script", "scriptUrl",
+            // .d64 startup keys: 'loadD64Url' is consumed by Program.cs (bytes are pre-fetched
+            // into ExtraParameters as 'd64BytesB64'); the others are forwarded into extras after
+            // validation has filtered out invalid combinations.
+            "loadD64Url", "d64Program", "diskMount",
+            "keyboardJoystickEnabled", "keyboardJoystickNumber", "audioEnabled",
         };
         var extraParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var kvp in map)
@@ -733,8 +879,30 @@ internal sealed partial class Program
                 extraParameters[kvp.Key] = kvp.Value;
         }
 
+        // Forward validated params into extras (raw query values were stripped above so the
+        // participant only sees parameters that survived validation). 'loadD64Url' itself is not
+        // added here — the binary fetch is deferred to the participant via
+        // AutomatedStartupContext.FetchBinaryResource and injected as 'loadD64Url' separately in
+        // RunAppAsync.
+        // .d64 keys only when loadD64Url is set.
+        if (loadD64Url != null)
+        {
+            if (d64Program != null)
+                extraParameters["d64Program"] = d64Program;
+            if (diskMount)
+                extraParameters["diskMount"] = "true";
+        }
+        // C64 runtime knobs apply to any C64 start path — emit whenever the user supplied them
+        // and 'system=C64' (the validator already enforced the latter).
+        if (keyboardJoystickEnabled)
+            extraParameters["keyboardJoystickEnabled"] = "true";
+        if (keyboardJoystickNumberRaw != null)
+            extraParameters["keyboardJoystickNumber"] = keyboardJoystickNumberRaw;
+        if (audioEnabledRaw != null)
+            extraParameters["audioEnabled"] = audioEnabledRaw;
+
         return new BrowserAutomationParams(systemName, systemVariant, autoStart, waitForReady,
-            loadPrgUrl, runLoaded, scriptContent, scriptUrl, extraParameters);
+            loadPrgUrl, runLoaded, scriptContent, scriptUrl, loadD64Url, extraParameters);
     }
 
     private static string? DecodeBase64UrlUtf8QueryValue(string parameterName, string? base64UrlValue, bool logRawValue = false)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Program.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Program.cs
@@ -131,8 +131,56 @@ internal sealed partial class Program
     ///   <item>
     ///     <term><c>--runLoadedProgram</c></term>
     ///     <description>
-    ///       Run the loaded program after loading. Requires <c>--start</c> and <c>--loadPrg</c>.
-    ///       For C64 BASIC-style programs, pair with <c>--waitForSystemReady</c>.
+    ///       Run the loaded program after loading. Requires <c>--start</c> and <c>--loadPrg</c>
+    ///       (or <c>--loadD64</c>). For C64 BASIC-style programs, pair with <c>--waitForSystemReady</c>.
+    ///       In the <c>--loadD64</c> flow, controls whether the disk-info <c>RunCommands</c>
+    ///       (e.g. <c>LOAD"*",8,1</c> + <c>RUN</c>) are pasted after the load / mount.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <term><c>--loadD64 &lt;path&gt;</c></term>
+    ///     <description>
+    ///       Load a C64 <c>.d64</c> disk image. Requires <c>--system C64</c>, <c>--start</c>,
+    ///       <c>--waitForSystemReady</c>, and exactly one of <c>--d64Program</c> or <c>--diskMount</c>.
+    ///       Mutually exclusive with <c>--loadPrg</c>.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <term><c>--d64Program &lt;name|*&gt;</c></term>
+    ///     <description>
+    ///       Extract the named PRG file from the <c>.d64</c> image and load it directly into memory
+    ///       (no disk mount). <c>*</c> selects the first directory entry. Mutually exclusive with
+    ///       <c>--diskMount</c>; requires <c>--loadD64</c>.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <term><c>--diskMount</c></term>
+    ///     <description>
+    ///       Mount the <c>.d64</c> image in drive 8 and prepare to issue <c>LOAD"*",8,1</c> +
+    ///       <c>RUN</c> via the keyboard buffer. Mutually exclusive with <c>--d64Program</c>;
+    ///       requires <c>--loadD64</c>.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <term><c>--keyboardJoystickEnabled</c></term>
+    ///     <description>
+    ///       Force-enable the C64 keyboard-emulated joystick before starting. Requires
+    ///       <c>--system C64</c>; applies for any C64 start path (plain <c>--start</c>,
+    ///       <c>--loadPrg</c>, <c>--loadD64</c>).
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <term><c>--keyboardJoystickNumber &lt;1|2&gt;</c></term>
+    ///     <description>
+    ///       Which C64 joystick port the keyboard emulates (and also drives via the active gamepad
+    ///       port). Implies <c>--keyboardJoystickEnabled</c>. Requires <c>--system C64</c>.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <term><c>--audioEnabled &lt;true|false&gt;</c></term>
+    ///     <description>
+    ///       Override the C64 audio-enable config before starting. Omit to keep the existing
+    ///       value. Requires <c>--system C64</c>.
     ///     </description>
     ///   </item>
     ///   <item>
@@ -184,7 +232,19 @@ internal sealed partial class Program
     ///
     /// # Start C64, wait for BASIC, run a .prg, log stats every 5 seconds, and exit after 60 seconds
     /// ./Highbyte.DotNet6502.App.Avalonia.Desktop --system C64 --start --waitForSystemReady --loadPrg game.prg --runLoadedProgram --stats-interval 5 --exit-after 60
+    ///
+    /// # Start C64 (PAL), mount a .d64 in drive 8, paste LOAD"*",8,1 + RUN, set keyboard-joystick to port 2
+    /// ./Highbyte.DotNet6502.App.Avalonia.Desktop --system C64 --systemVariant C64PAL --start --waitForSystemReady --loadD64 ~/Downloads/SomeGame.d64 --diskMount --runLoadedProgram --keyboardJoystickEnabled --keyboardJoystickNumber 2
+    ///
+    /// # Start C64, direct-load the first PRG from a .d64 image (no disk mount) and RUN it
+    /// ./Highbyte.DotNet6502.App.Avalonia.Desktop --system C64 --start --waitForSystemReady --loadD64 ~/Downloads/SomeGame.d64 --d64Program "*" --runLoadedProgram
     /// </code>
+    /// <para>
+    /// For multi-step workflows not covered by the discrete flags (e.g. mounting a disk and
+    /// issuing custom BASIC commands), use <c>--script</c> / <c>--scriptDir</c> with the
+    /// <c>c64.load_d64()</c> / <c>c64.print_text()</c> Lua API
+    /// (see <c>resources/scripts/shared/example_c64_load_d64.lua</c>).
+    /// </para>
     /// </remarks>
     /// <param name="args">Command line arguments.</param>
     [STAThread]
@@ -277,15 +337,37 @@ internal sealed partial class Program
         List<string> scriptFilePaths = ParseMultipleStringArgument(args, "--script");
         string? scriptDirectoryOverride = AutomatedStartupHandler.ParseStringArgument(args, "--scriptDir");
 
-        // Validate automated startup arguments
+        // Parse C64 .d64 startup arguments (handled by C64AvaloniaStartupParticipant via ExtraParameters)
+        string? loadD64Path = AutomatedStartupHandler.ParseStringArgument(args, "--loadD64");
+        string? d64Program = AutomatedStartupHandler.ParseStringArgument(args, "--d64Program");
+        bool diskMount = args.Contains("--diskMount");
+        string? keyboardJoystickNumberRaw = AutomatedStartupHandler.ParseStringArgument(args, "--keyboardJoystickNumber");
+        bool keyboardJoystickEnabledFlag = args.Contains("--keyboardJoystickEnabled");
+        string? audioEnabledRaw = AutomatedStartupHandler.ParseStringArgument(args, "--audioEnabled");
+
+        // Validate automated startup arguments.
+        // The handler validator predates --loadD64 and rejects --runLoadedProgram unless --loadPrg
+        // is set. When --loadD64 is supplied, suppress that one check by feeding the validator a
+        // sentinel path; the real request carries the original (null) loadPrgPath unchanged.
         bool hasScripts = scriptFilePaths.Count > 0 || scriptDirectoryOverride != null;
-        if (!AutomatedStartupHandler.ValidateArguments(systemName, systemVariant, autoStart, waitForSystemReady, loadPrgPath, runLoadedProgram, hasScripts))
+        var validatorLoadPrgPath = loadPrgPath ?? (loadD64Path != null ? "<loadD64>" : null);
+        if (!AutomatedStartupHandler.ValidateArguments(systemName, systemVariant, autoStart, waitForSystemReady, validatorLoadPrgPath, runLoadedProgram, hasScripts))
         {
             return 1; // Exit with error code
         }
         if ((statsInterval.HasValue || exitAfter.HasValue) && !autoStart)
         {
             Console.Error.WriteLine("Error: --stats-interval and --exit-after require --start to be specified.");
+            return 1;
+        }
+
+        // Validate .d64 startup arguments locally (handler stays system-agnostic).
+        if (!ValidateD64Arguments(
+                loadD64Path, d64Program, diskMount,
+                keyboardJoystickEnabledFlag, keyboardJoystickNumberRaw, audioEnabledRaw,
+                systemName, autoStart, waitForSystemReady, loadPrgPath,
+                out int parsedKeyboardJoystickNumber, out bool? parsedAudioEnabled))
+        {
             return 1;
         }
 
@@ -467,9 +549,19 @@ internal sealed partial class Program
                 var startupParticipant = Core.App.Current?.GetServiceProvider()
                     ?.GetKeyedService<IAutomatedStartupParticipant>(systemName);
 
+                var d64Extras = BuildD64Extras(
+                    loadD64Path,
+                    d64Program,
+                    diskMount,
+                    keyboardJoystickEnabledFlag,
+                    keyboardJoystickNumberRaw != null ? (int?)parsedKeyboardJoystickNumber : null,
+                    parsedAudioEnabled);
                 var startupRequest = new AutomatedStartupRequest(
                     systemName, systemVariant, autoStart, waitForSystemReady,
-                    loadPrgPath, runLoadedProgram, enableExternalDebug);
+                    loadPrgPath, runLoadedProgram, enableExternalDebug)
+                {
+                    ExtraParameters = d64Extras,
+                };
                 await AutomatedStartupHandler.ExecuteAsync(
                     hostApp,
                     startupRequest,
@@ -634,6 +726,142 @@ internal sealed partial class Program
             }
         }
         return null;
+    }
+
+    /// <summary>
+    /// Validates the .d64 startup CLI flags (Desktop). Returns false on hard errors (prints to
+    /// stderr and the caller exits 1). C64-only knobs supplied without <c>--loadD64</c> are
+    /// downgraded to a warning so users can keep them while iterating on a partial command line.
+    /// </summary>
+    private static bool ValidateD64Arguments(
+        string? loadD64Path,
+        string? d64Program,
+        bool diskMount,
+        bool keyboardJoystickEnabled,
+        string? keyboardJoystickNumberRaw,
+        string? audioEnabledRaw,
+        string? systemName,
+        bool autoStart,
+        bool waitForSystemReady,
+        string? loadPrgPath,
+        out int keyboardJoystickNumber,
+        out bool? audioEnabled)
+    {
+        keyboardJoystickNumber = 2;
+        audioEnabled = null;
+
+        if (keyboardJoystickNumberRaw != null)
+        {
+            if (!int.TryParse(keyboardJoystickNumberRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+                || (parsed != 1 && parsed != 2))
+            {
+                Console.Error.WriteLine("Error: --keyboardJoystickNumber must be 1 or 2.");
+                return false;
+            }
+            keyboardJoystickNumber = parsed;
+        }
+
+        if (audioEnabledRaw != null)
+        {
+            if (bool.TryParse(audioEnabledRaw, out var parsedAudio))
+            {
+                audioEnabled = parsedAudio;
+            }
+            else
+            {
+                Console.Error.WriteLine("Error: --audioEnabled must be 'true' or 'false'.");
+                return false;
+            }
+        }
+
+        // --d64Program / --diskMount only make sense with --loadD64.
+        if (loadD64Path == null && (d64Program != null || diskMount))
+        {
+            Console.Error.WriteLine("Warning: --d64Program / --diskMount have no effect without --loadD64; ignoring.");
+        }
+
+        // --keyboardJoystick* / --audioEnabled are general C64 runtime knobs. They only need
+        // --system C64 to apply (they take effect when the C64 starts, regardless of how it was
+        // started — plain --start, --loadPrg, --basicText, or --loadD64).
+        var hasRuntimeConfigKnobs = keyboardJoystickEnabled || keyboardJoystickNumberRaw != null || audioEnabledRaw != null;
+        if (hasRuntimeConfigKnobs
+            && !string.Equals(systemName, "C64", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.Error.WriteLine("Warning: --keyboardJoystick* / --audioEnabled require --system C64; ignoring.");
+        }
+
+        if (loadD64Path == null)
+            return true;
+
+        // --loadD64 is C64-only. Match string-literal style used elsewhere in this file for
+        // system selection — Desktop doesn't reference the C64 library directly.
+        if (!string.Equals(systemName, "C64", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.Error.WriteLine("Error: --loadD64 requires --system C64.");
+            return false;
+        }
+        if (!autoStart || !waitForSystemReady)
+        {
+            Console.Error.WriteLine("Error: --loadD64 requires --start and --waitForSystemReady.");
+            return false;
+        }
+        if (loadPrgPath != null)
+        {
+            Console.Error.WriteLine("Error: --loadD64 is mutually exclusive with --loadPrg.");
+            return false;
+        }
+        if (d64Program == null && !diskMount)
+        {
+            Console.Error.WriteLine("Error: --loadD64 requires exactly one of --d64Program or --diskMount.");
+            return false;
+        }
+        if (d64Program != null && diskMount)
+        {
+            Console.Error.WriteLine("Error: --d64Program and --diskMount are mutually exclusive.");
+            return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Build the <see cref="AutomatedStartupRequest.ExtraParameters"/> dictionary the
+    /// C64 Avalonia startup participant reads. Empty / null entries are skipped so the
+    /// participant sees only what the user actually supplied.
+    /// </summary>
+    /// <summary>
+    /// Build the <see cref="AutomatedStartupRequest.ExtraParameters"/> dictionary the C64 Avalonia
+    /// startup participant reads. <c>.d64</c> keys (<c>loadD64Path</c>/<c>d64Program</c>/<c>diskMount</c>)
+    /// are only emitted when <c>--loadD64</c> is supplied; the C64 runtime knobs
+    /// (<c>keyboardJoystickEnabled</c>/<c>keyboardJoystickNumber</c>/<c>audioEnabled</c>) are
+    /// emitted whenever the user supplied them, since they apply for any C64 start path.
+    /// </summary>
+    private static IReadOnlyDictionary<string, string> BuildD64Extras(
+        string? loadD64Path,
+        string? d64Program,
+        bool diskMount,
+        bool keyboardJoystickEnabled,
+        int? keyboardJoystickNumber,
+        bool? audioEnabled)
+    {
+        var extras = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        if (loadD64Path != null)
+        {
+            extras["loadD64Path"] = loadD64Path;
+            if (d64Program != null)
+                extras["d64Program"] = d64Program;
+            if (diskMount)
+                extras["diskMount"] = "true";
+        }
+
+        if (keyboardJoystickEnabled)
+            extras["keyboardJoystickEnabled"] = "true";
+        if (keyboardJoystickNumber.HasValue)
+            extras["keyboardJoystickNumber"] = keyboardJoystickNumber.Value.ToString(CultureInfo.InvariantCulture);
+        if (audioEnabled.HasValue)
+            extras["audioEnabled"] = audioEnabled.Value ? "true" : "false";
+
+        return extras;
     }
 
     private static TimeSpan? ParseDurationSecondsArgument(string[] args, string argumentName)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/C64AvaloniaStartupParticipant.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/C64AvaloniaStartupParticipant.cs
@@ -1,11 +1,16 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64.ViewModels;
+using Highbyte.DotNet6502.Impl.Avalonia.Commodore64;
 using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.DiskDrive.D64.Download;
+using Highbyte.DotNet6502.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -25,6 +30,18 @@ namespace Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64;
 public sealed class C64AvaloniaStartupParticipant : IAutomatedStartupParticipant
 {
     private const ushort C64BasicProgramLoadAddress = 0x0801;
+
+    // Extra-parameter keys shared by Desktop and Browser (Desktop: --loadD64 etc.; Browser: query
+    // params loadD64Url etc. pre-fetched into d64BytesB64). The participant never sees raw HTTP /
+    // CLI parsing — only these typed extras.
+    internal const string ExtraKeyLoadD64Path = "loadD64Path";
+    internal const string ExtraKeyLoadD64Url = "loadD64Url";
+    internal const string ExtraKeyD64Program = "d64Program";
+    internal const string ExtraKeyDiskMount = "diskMount";
+    internal const string ExtraKeyKeyboardJoystickEnabled = "keyboardJoystickEnabled";
+    internal const string ExtraKeyKeyboardJoystickNumber = "keyboardJoystickNumber";
+    internal const string ExtraKeyAudioEnabled = "audioEnabled";
+
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger _logger;
 
@@ -38,6 +55,11 @@ public sealed class C64AvaloniaStartupParticipant : IAutomatedStartupParticipant
 
     public async Task<bool> EnsureReadyForStartAsync(IHostApp hostApp, AutomatedStartupRequest request)
     {
+        // Apply any C64-runtime config supplied via extras (joystick / audio) onto the live
+        // host config before the system starts. Done first so the ROM-download branch below sees
+        // the same config the user requested.
+        ApplyRuntimeConfigFromExtras(hostApp, request);
+
         // ROM auto-download applies only to the browser host. On desktop the ROMs are expected to
         // already be on disk; a missing-ROM case is handled by the normal config UI (unchanged).
         if (!OperatingSystem.IsBrowser())
@@ -90,15 +112,25 @@ public sealed class C64AvaloniaStartupParticipant : IAutomatedStartupParticipant
         => errors.Count > 0 && errors.All(error => error.StartsWith("Missing ROMs:", StringComparison.Ordinal));
 
     /// <summary>
-    /// Post-ready automation: if the request carries the C64 BASIC parameters (<c>basicText</c> /
-    /// <c>basicUrl</c> / <c>runBasic</c>), paste the BASIC source into the running C64 once the
-    /// BASIC prompt is ready. Invalid combinations are logged and skipped — the emulator keeps
-    /// running. See <c>docs/automated-startup-seam2.md</c>.
+    /// Post-ready automation: paste C64 BASIC source (<c>basicText</c> / <c>basicUrl</c>), or run
+    /// the .d64 startup flow (<c>loadD64Path</c> / <c>d64BytesB64</c>) — mount the disk or
+    /// direct-load a PRG and optionally paste the run commands. Invalid combinations are logged
+    /// and skipped; the emulator keeps running. See <c>docs/automated-startup-seam2.md</c>.
     /// </summary>
     public async Task OnSystemReadyAsync(
         IHostApp hostApp, AutomatedStartupRequest request, AutomatedStartupContext context)
     {
         var extras = request.ExtraParameters;
+        await TryHandleBasicAutomationAsync(hostApp, request, context, extras);
+        await TryHandleD64AutomationAsync(hostApp, request, context, extras);
+    }
+
+    private async Task TryHandleBasicAutomationAsync(
+        IHostApp hostApp,
+        AutomatedStartupRequest request,
+        AutomatedStartupContext context,
+        IReadOnlyDictionary<string, string> extras)
+    {
         var basicText = GetExtra(extras, "basicText");
         var basicUrl = GetExtra(extras, "basicUrl");
         var runBasic = extras.TryGetValue("runBasic", out var rb) && IsTruthy(rb);
@@ -167,6 +199,222 @@ public sealed class C64AvaloniaStartupParticipant : IAutomatedStartupParticipant
         _logger.LogInformation("Queueing C64 BASIC source ({LineCount} line(s), runBasic={RunBasic}).",
             CountNonEmptyLines(basicSource), runBasic);
         c64.TextPaste.Paste(pasteText);
+    }
+
+    private async Task TryHandleD64AutomationAsync(
+        IHostApp hostApp,
+        AutomatedStartupRequest request,
+        AutomatedStartupContext context,
+        IReadOnlyDictionary<string, string> extras)
+    {
+        var loadD64Path = GetExtra(extras, ExtraKeyLoadD64Path);
+        var loadD64Url = GetExtra(extras, ExtraKeyLoadD64Url);
+        if (loadD64Path is null && loadD64Url is null)
+            return;
+
+        if (!request.AutoStart || !request.WaitForSystemReady)
+        {
+            _logger.LogWarning("Automation 'loadD64Path'/'loadD64Url' require start + waitForSystemReady; skipping .d64 startup.");
+            return;
+        }
+        if (request.LoadPrgPath is not null)
+        {
+            _logger.LogWarning("Automation .d64 load is mutually exclusive with loading a PRG; skipping .d64 startup.");
+            return;
+        }
+        if (hostApp.CurrentRunningSystem is not C64 c64)
+        {
+            _logger.LogError(".d64 startup requires the running system to be C64.");
+            return;
+        }
+
+        var d64Program = GetExtra(extras, ExtraKeyD64Program);
+        var diskMount = extras.TryGetValue(ExtraKeyDiskMount, out var dm) && IsTruthy(dm);
+        if (d64Program is null && !diskMount)
+        {
+            _logger.LogWarning("Automation .d64 load requires exactly one of 'd64Program' or 'diskMount'; skipping.");
+            return;
+        }
+        if (d64Program is not null && diskMount)
+        {
+            _logger.LogWarning("Automation 'd64Program' and 'diskMount' are mutually exclusive; skipping .d64 startup.");
+            return;
+        }
+        if (loadD64Url is not null && context.FetchBinaryResource is null)
+        {
+            _logger.LogWarning("Automation 'loadD64Url' supplied but host provides no binary-resource fetcher; skipping .d64 startup.");
+            return;
+        }
+
+        // Resolve the .d64 bytes: local file (Desktop) or fetched via the host's binary-resource
+        // fetcher (Browser HTTP). The fetch runs here — after the C64 is started and BASIC reports
+        // ready — so the user sees the live BASIC prompt while a remote .d64 downloads, rather than
+        // a blank Avalonia window during a pre-Avalonia download.
+        byte[] d64Bytes;
+        try
+        {
+            d64Bytes = loadD64Url is not null
+                ? await context.FetchBinaryResource!(loadD64Url)
+                : await ResolveD64BytesFromFileAsync(loadD64Path!);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to read .d64 bytes; skipping .d64 startup.");
+            return;
+        }
+        if (d64Bytes.Length == 0)
+        {
+            _logger.LogWarning(".d64 bytes resolved to an empty buffer; skipping .d64 startup.");
+            return;
+        }
+
+        // Match the existing menu's download flow: an extra second after BASIC reports ready
+        // before mutating disk state, so keystrokes and direct loads land reliably.
+        _logger.LogInformation("Waiting 1 second for C64 BASIC to settle before .d64 startup.");
+        await Task.Delay(1000);
+
+        // The menu's wrapper pauses the C64 around the inner mount/direct-load + paste so the
+        // RAM/disk-drive mutations happen against a quiescent CPU. Mirror that here, then
+        // resume so the queued keystrokes (LOAD"*",8,1 / RUN) get processed.
+        var pausedForD64 = false;
+        if (hostApp.EmulatorState == EmulatorState.Running)
+        {
+            _logger.LogInformation("Pausing C64 before .d64 mount / direct-load.");
+            hostApp.Pause();
+            pausedForD64 = hostApp.EmulatorState == EmulatorState.Paused;
+        }
+
+        try
+        {
+            var diskInfo = BuildDiskInfo(extras, d64Program, loadD64Path);
+            await D64AutoDownloadAndRun.MountOrDirectLoadAndRunAsync(
+                c64,
+                d64Bytes,
+                diskInfo,
+                issueRunCommands: request.RunLoadedProgram,
+                _logger);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during .d64 mount / direct-load; emulator left running.");
+        }
+        finally
+        {
+            if (pausedForD64 && hostApp.EmulatorState == EmulatorState.Paused)
+            {
+                _logger.LogInformation("Resuming C64 after .d64 mount / direct-load.");
+                await hostApp.Start();
+            }
+        }
+    }
+
+    private static async Task<byte[]> ResolveD64BytesFromFileAsync(string loadD64Path)
+    {
+        var expanded = PathHelper.ExpandOSEnvironmentVariables(loadD64Path);
+        if (!File.Exists(expanded))
+            throw new FileNotFoundException($".d64 file not found: {expanded}", expanded);
+        return await File.ReadAllBytesAsync(expanded);
+    }
+
+    private static D64DownloadDiskInfo BuildDiskInfo(
+        IReadOnlyDictionary<string, string> extras,
+        string? d64Program,
+        string? loadD64Path)
+    {
+        // displayName: just for logging — use the file basename when present, else a generic label.
+        var displayName = !string.IsNullOrEmpty(loadD64Path)
+            ? Path.GetFileNameWithoutExtension(loadD64Path)
+            : "Startup .d64";
+
+        int keyboardJoystickNumber = 2;
+        if (extras.TryGetValue(ExtraKeyKeyboardJoystickNumber, out var kjnRaw)
+            && int.TryParse(kjnRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var kjn))
+        {
+            keyboardJoystickNumber = kjn;
+        }
+        var keyboardJoystickEnabled =
+            extras.TryGetValue(ExtraKeyKeyboardJoystickEnabled, out var kjeRaw) && IsTruthy(kjeRaw);
+
+        var audioEnabled =
+            extras.TryGetValue(ExtraKeyAudioEnabled, out var aeRaw) && IsTruthy(aeRaw);
+
+        // Direct-load when --d64Program supplied (incl. "*"); otherwise mount the disk.
+        // DownloadUrl is unused on the startup path (bytes are already in hand) but the DTO
+        // requires a non-null string.
+        return new D64DownloadDiskInfo(
+            displayName: displayName,
+            downloadUrl: loadD64Path ?? string.Empty,
+            keyboardJoystickEnabled: keyboardJoystickEnabled,
+            keyboardJoystickNumber: keyboardJoystickNumber,
+            audioEnabled: audioEnabled,
+            directLoadPRGName: d64Program);
+    }
+
+    /// <summary>
+    /// Apply any of the C64-runtime extras (joystick on/off, joystick port, audio enable) onto the
+    /// resolved <see cref="C64HostConfig"/> so they take effect when the system starts. Only fields
+    /// the user actually supplied are touched. These knobs are independent of the <c>.d64</c>
+    /// startup flow — they apply whenever the selected system is C64 (e.g. plain
+    /// <c>--system C64 --start</c>, <c>--loadPrg</c>, BASIC paste, or <c>--loadD64</c>).
+    /// </summary>
+    private void ApplyRuntimeConfigFromExtras(IHostApp hostApp, AutomatedStartupRequest request)
+    {
+        var extras = request.ExtraParameters;
+        var hasKeyboardJoystickEnabled = extras.ContainsKey(ExtraKeyKeyboardJoystickEnabled);
+        var hasKeyboardJoystickNumber = extras.ContainsKey(ExtraKeyKeyboardJoystickNumber);
+        var hasAudioEnabled = extras.ContainsKey(ExtraKeyAudioEnabled);
+        if (!hasKeyboardJoystickEnabled && !hasKeyboardJoystickNumber && !hasAudioEnabled)
+            return;
+
+        if (hostApp.CurrentHostSystemConfig is not C64HostConfig c64HostConfig)
+        {
+            _logger.LogWarning("Current host config is not C64HostConfig; cannot apply C64 runtime-config extras.");
+            return;
+        }
+
+        var systemConfig = c64HostConfig.SystemConfig;
+        var inputConfig = c64HostConfig.InputConfig;
+        var changed = false;
+
+        if (hasKeyboardJoystickNumber)
+        {
+            if (int.TryParse(extras[ExtraKeyKeyboardJoystickNumber], NumberStyles.Integer, CultureInfo.InvariantCulture, out var port)
+                && (port == 1 || port == 2))
+            {
+                systemConfig.KeyboardJoystick = port;
+                // Match the menu's "Download and Run" flow: keep the active gamepad/joystick port
+                // in sync with the keyboard-joystick port so both input sources drive the same C64 port.
+                inputConfig.CurrentJoystick = port;
+                // The number alone implies enable, mirroring the design ("Implies
+                // --keyboardJoystickEnabled if not also given").
+                systemConfig.KeyboardJoystickEnabled = true;
+                changed = true;
+            }
+            else
+            {
+                _logger.LogWarning("Automation '{Key}' must be 1 or 2; ignoring.", ExtraKeyKeyboardJoystickNumber);
+            }
+        }
+
+        if (hasKeyboardJoystickEnabled)
+        {
+            systemConfig.KeyboardJoystickEnabled = IsTruthy(extras[ExtraKeyKeyboardJoystickEnabled]);
+            changed = true;
+        }
+
+        if (hasAudioEnabled)
+        {
+            systemConfig.AudioEnabled = IsTruthy(extras[ExtraKeyAudioEnabled]);
+            changed = true;
+        }
+
+        if (changed)
+        {
+            hostApp.UpdateHostSystemConfig(c64HostConfig);
+            _logger.LogInformation(
+                "Applied C64 runtime config from automation extras (KeyboardJoystickEnabled={Kje}, KeyboardJoystick={Kj}, AudioEnabled={Ae}).",
+                systemConfig.KeyboardJoystickEnabled, systemConfig.KeyboardJoystick, systemConfig.AudioEnabled);
+        }
     }
 
     public async Task BeforePrgLoadAsync(

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/DiskDrive/D64/Download/D64AutoDownloadAndRun.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/DiskDrive/D64/Download/D64AutoDownloadAndRun.cs
@@ -69,72 +69,7 @@ public class D64AutoDownloadAndRun
             // Download and process the disk image (supports both .d64 and .zip files)
             var d64Bytes = await _d64Downloader.DownloadAndProcessDiskImage(diskInfo);
 
-            // Parse the D64 disk image
-            var d64DiskImage = D64Parser.ParseD64File(d64Bytes);
-            _logger.LogInformation($"Parsed D64 disk image: {d64DiskImage.DiskName}");
-
-            // Check if direct PRG loading is requested (will bypass the disk drive emulation, and extract a PRG file from the .D64 image and load it directly into emulator memory)
-            if (!string.IsNullOrEmpty(diskInfo.DirectLoadPRGName))
-            {
-                _logger.LogInformation($"Direct loading PRG file: {diskInfo.DirectLoadPRGName}");
-
-                // Extract the specified file data directly from the D64 image
-                try
-                {
-                    string directLoadFileName = diskInfo.DirectLoadPRGName == "*" ? d64DiskImage.Files.First().FileName : diskInfo.DirectLoadPRGName;
-                    var prgData = d64DiskImage.ReadFileContent(directLoadFileName);
-                    _logger.LogInformation($"Successfully extracted file {diskInfo.DirectLoadPRGName}, size: {prgData.Length} bytes");
-
-                    // Load the file data directly into memory using BinaryLoader
-                    BinaryLoader.Load(
-                        c64.Mem,
-                        prgData,
-                        out ushort loadedAtAddress,
-                        out ushort fileLength);
-
-                    _logger.LogInformation($"Direct loaded {diskInfo.DirectLoadPRGName} at address {loadedAtAddress:X4}, length {fileLength} bytes");
-
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError($"Failed to direct load PRG file {diskInfo.DirectLoadPRGName}: {ex.Message}");
-                    throw new InvalidOperationException($"Failed to direct load PRG file {diskInfo.DirectLoadPRGName}: {ex.Message}", ex);
-                }
-            }
-            else
-            {
-                // Set the disk image on the running C64's DiskDrive1541. Let the files be loaded from the disk image via BASIC commands (below).
-                var diskDrive = c64.IECBus?.Devices?.OfType<DiskDrive1541>().FirstOrDefault();
-                if (diskDrive != null)
-                {
-                    diskDrive.SetD64DiskImage(d64DiskImage);
-                    _logger.LogInformation($"Disk image loaded and set: {d64DiskImage.DiskName}");
-                }
-                else
-                {
-                    throw new InvalidOperationException("No DiskDrive1541 found in the running C64 system.");
-                }
-            }
-
-            // Run the the specified Basic commands.
-            // Note: If DirectLoadPRGName was specified, RunCommands must not include a LOAD command, only typically a RUN command.
-            if (diskInfo.RunCommands != null && diskInfo.RunCommands.Count > 0)
-            {
-                _logger.LogInformation($"Auto-loading and running program with {diskInfo.RunCommands.Count} commands");
-
-                // Execute each command in sequence
-                foreach (var command in diskInfo.RunCommands)
-                {
-                    _logger.LogInformation($"Executing command: {command}");
-                    c64.TextPaste.Paste($"{command}\n");
-
-                    // Wait a moment between commands (except for the last one)
-                    if (command != diskInfo.RunCommands.Last())
-                    {
-                        await Task.Delay(1000);
-                    }
-                }
-            }
+            await MountOrDirectLoadAndRunAsync(c64, d64Bytes, diskInfo, issueRunCommands: true, _logger);
 
             await _hostApp.Start();
         }
@@ -142,6 +77,94 @@ public class D64AutoDownloadAndRun
         {
             _logger.LogError($"Load error: {ex.Message}");
             throw;
+        }
+    }
+
+    /// <summary>
+    /// Post-BASIC-ready inner work shared between the menu's download-and-run flow and the
+    /// Avalonia automated-startup participant: parse the .d64 bytes, then either mount the
+    /// disk image in drive 8 or extract a single PRG and load it directly into RAM (based on
+    /// <see cref="D64DownloadDiskInfo.DirectLoadPRGName"/>), and optionally paste
+    /// <see cref="D64DownloadDiskInfo.RunCommands"/> into the keyboard buffer with a
+    /// 1-second delay between commands.
+    /// </summary>
+    /// <param name="c64">The running C64. Must be paused (or otherwise quiescent) by the caller.</param>
+    /// <param name="d64Bytes">Raw .d64 image bytes (already downloaded / read).</param>
+    /// <param name="diskInfo">DTO describing direct-load name and run commands.</param>
+    /// <param name="issueRunCommands">When false, skip pasting <see cref="D64DownloadDiskInfo.RunCommands"/>.</param>
+    /// <param name="logger">Logger for progress / errors.</param>
+    public static async Task MountOrDirectLoadAndRunAsync(
+        C64 c64,
+        byte[] d64Bytes,
+        D64DownloadDiskInfo diskInfo,
+        bool issueRunCommands,
+        ILogger logger)
+    {
+        // Parse the D64 disk image
+        var d64DiskImage = D64Parser.ParseD64File(d64Bytes);
+        logger.LogInformation($"Parsed D64 disk image: {d64DiskImage.DiskName}");
+
+        // Check if direct PRG loading is requested (will bypass the disk drive emulation, and extract a PRG file from the .D64 image and load it directly into emulator memory)
+        if (!string.IsNullOrEmpty(diskInfo.DirectLoadPRGName))
+        {
+            logger.LogInformation($"Direct loading PRG file: {diskInfo.DirectLoadPRGName}");
+
+            // Extract the specified file data directly from the D64 image
+            try
+            {
+                string directLoadFileName = diskInfo.DirectLoadPRGName == "*" ? d64DiskImage.Files.First().FileName : diskInfo.DirectLoadPRGName;
+                var prgData = d64DiskImage.ReadFileContent(directLoadFileName);
+                logger.LogInformation($"Successfully extracted file {diskInfo.DirectLoadPRGName}, size: {prgData.Length} bytes");
+
+                // Load the file data directly into memory using BinaryLoader
+                BinaryLoader.Load(
+                    c64.Mem,
+                    prgData,
+                    out ushort loadedAtAddress,
+                    out ushort fileLength);
+
+                logger.LogInformation($"Direct loaded {diskInfo.DirectLoadPRGName} at address {loadedAtAddress:X4}, length {fileLength} bytes");
+
+            }
+            catch (Exception ex)
+            {
+                logger.LogError($"Failed to direct load PRG file {diskInfo.DirectLoadPRGName}: {ex.Message}");
+                throw new InvalidOperationException($"Failed to direct load PRG file {diskInfo.DirectLoadPRGName}: {ex.Message}", ex);
+            }
+        }
+        else
+        {
+            // Set the disk image on the running C64's DiskDrive1541. Let the files be loaded from the disk image via BASIC commands (below).
+            var diskDrive = c64.IECBus?.Devices?.OfType<DiskDrive1541>().FirstOrDefault();
+            if (diskDrive != null)
+            {
+                diskDrive.SetD64DiskImage(d64DiskImage);
+                logger.LogInformation($"Disk image loaded and set: {d64DiskImage.DiskName}");
+            }
+            else
+            {
+                throw new InvalidOperationException("No DiskDrive1541 found in the running C64 system.");
+            }
+        }
+
+        // Run the the specified Basic commands.
+        // Note: If DirectLoadPRGName was specified, RunCommands must not include a LOAD command, only typically a RUN command.
+        if (issueRunCommands && diskInfo.RunCommands != null && diskInfo.RunCommands.Count > 0)
+        {
+            logger.LogInformation($"Auto-loading and running program with {diskInfo.RunCommands.Count} commands");
+
+            // Execute each command in sequence
+            foreach (var command in diskInfo.RunCommands)
+            {
+                logger.LogInformation($"Executing command: {command}");
+                c64.TextPaste.Paste($"{command}\n");
+
+                // Wait a moment between commands (except for the last one)
+                if (command != diskInfo.RunCommands.Last())
+                {
+                    await Task.Delay(1000);
+                }
+            }
         }
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems/AutomatedStartupContext.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/AutomatedStartupContext.cs
@@ -13,4 +13,13 @@ public sealed class AutomatedStartupContext
     /// any parameter that needs it.
     /// </summary>
     public Func<string, Task<string>>? FetchTextResource { get; init; }
+
+    /// <summary>
+    /// Fetches a binary resource by URL or path. Host-supplied (e.g. browser: HTTP from the app
+    /// origin). <see langword="null"/> when the host offers none — a participant must then skip
+    /// any parameter that needs it. Used by participants that defer a binary download until the
+    /// system is actually visible (e.g. the C64 participant fetching a <c>.d64</c> after the
+    /// BASIC prompt is shown, so the user sees the boot instead of a blank page).
+    /// </summary>
+    public Func<string, Task<byte[]>>? FetchBinaryResource { get; init; }
 }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/TimerAndPeripheral/DiskDrive/D64/Download/D64AutoDownloadAndRunTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/TimerAndPeripheral/DiskDrive/D64/Download/D64AutoDownloadAndRunTests.cs
@@ -1,0 +1,160 @@
+using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.DiskDrive;
+using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.DiskDrive.D64.Download;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64.TimerAndPeripheral.DiskDrive.D64.Download;
+
+/// <summary>
+/// Tests for the refactored <see cref="D64AutoDownloadAndRun.MountOrDirectLoadAndRunAsync"/>
+/// helper that is shared by the menu's download-and-run flow and the Avalonia automated-startup
+/// participant. Verifies both branches (mount + direct-load) using a synthetic minimal D64 image.
+/// </summary>
+public class D64AutoDownloadAndRunTests
+{
+    // PRG payload (load address 0x0800 + NOP/NOP/RTS body). The first two bytes are the standard
+    // PRG load-address header consumed by BinaryLoader.Load; the rest is the program body that
+    // lands in C64 RAM starting at the load address.
+    private const ushort PrgLoadAddress = 0x0800;
+    private static readonly byte[] PrgFileBytes = new byte[]
+    {
+        0x00, 0x08,           // load address (little-endian) = 0x0800
+        0xEA, 0xEA, 0x60,     // NOP, NOP, RTS — sentinel body
+    };
+
+    private const string TestFileName = "TEST";
+
+    [Fact]
+    public async Task MountOrDirectLoadAndRunAsync_DirectLoad_LoadsPrgBodyIntoMemory()
+    {
+        var c64 = BuildC64();
+        var d64Bytes = BuildSyntheticD64();
+        var diskInfo = new D64DownloadDiskInfo(
+            displayName: "synthetic",
+            downloadUrl: string.Empty,
+            directLoadPRGName: TestFileName,
+            // Empty list so the helper does not paste any RunCommands during the test (we only
+            // verify memory mutation here).
+            runCommands: new List<string>());
+
+        await D64AutoDownloadAndRun.MountOrDirectLoadAndRunAsync(
+            c64, d64Bytes, diskInfo, issueRunCommands: true, NullLogger.Instance);
+
+        Assert.Equal(0xEA, c64.Mem[PrgLoadAddress]);
+        Assert.Equal(0xEA, c64.Mem[PrgLoadAddress + 1]);
+        Assert.Equal(0x60, c64.Mem[PrgLoadAddress + 2]);
+
+        // No disk should be mounted on the direct-load branch.
+        var diskDrive = c64.IECBus.Devices.OfType<DiskDrive1541>().Single();
+        Assert.False(diskDrive.IsDisketteInserted);
+    }
+
+    [Fact]
+    public async Task MountOrDirectLoadAndRunAsync_DiskMount_AttachesDiskImageToDrive()
+    {
+        var c64 = BuildC64();
+        var d64Bytes = BuildSyntheticD64();
+        // DirectLoadPRGName=null → mount branch.
+        var diskInfo = new D64DownloadDiskInfo(
+            displayName: "synthetic",
+            downloadUrl: string.Empty,
+            directLoadPRGName: null,
+            runCommands: new List<string>());
+
+        await D64AutoDownloadAndRun.MountOrDirectLoadAndRunAsync(
+            c64, d64Bytes, diskInfo, issueRunCommands: false, NullLogger.Instance);
+
+        var diskDrive = c64.IECBus.Devices.OfType<DiskDrive1541>().Single();
+        Assert.True(diskDrive.IsDisketteInserted);
+
+        // RAM should be untouched at the PRG load address (mount-only path doesn't write memory).
+        Assert.Equal(0x00, c64.Mem[PrgLoadAddress]);
+    }
+
+    private static C64 BuildC64() => C64.BuildC64(new C64Config
+    {
+        LoadROMs = false,
+        C64Model = "C64NTSC",
+        Vic2Model = "NTSC",
+    }, NullLoggerFactory.Instance);
+
+    /// <summary>
+    /// Build a minimal valid D64 byte image with one PRG file named <see cref="TestFileName"/>
+    /// containing <see cref="PrgFileBytes"/>. Layout follows the standard 35-track / 683-sector
+    /// CBM format: track 18 sector 0 = BAM (disk name/id), track 18 sector 1 = first directory
+    /// sector with one entry pointing at the file's start track/sector.
+    /// </summary>
+    private static byte[] BuildSyntheticD64()
+    {
+        const int totalSectors = 683;
+        const int sectorSize = 256;
+        var image = new byte[totalSectors * sectorSize];   // 174848 bytes
+
+        // ── BAM (track 18, sector 0) ─────────────────────────────────────────────────────
+        var bamOffset = SectorOffset(18, 0);
+        // disk name "TEST" at offset 0x90, padded with 0xa0 (shifted-space) for the remaining 12.
+        for (int i = 0; i < 16; i++)
+            image[bamOffset + 0x90 + i] = 0xa0;
+        WriteAsciiUppercaseAsPetscii(image, bamOffset + 0x90, "TEST");
+        // disk id "01" at offset 0xa2.
+        WriteAsciiUppercaseAsPetscii(image, bamOffset + 0xa2, "01");
+
+        // ── First directory sector (track 18, sector 1) ─────────────────────────────────
+        var dirOffset = SectorOffset(18, 1);
+        image[dirOffset + 0] = 0x00;   // no next directory sector
+        image[dirOffset + 1] = 0xff;
+
+        // Pick a file start track/sector inside the image (track 1, sector 0 = offset 0).
+        // Track 1 only — directory entries reference track 0 to mean "no link".
+        const byte fileStartTrack = 1;
+        const byte fileStartSector = 0;
+
+        // First directory entry begins at +2.
+        const int entryOffset = 2;
+        image[dirOffset + entryOffset + 0] = 0x82;   // PRG (file type 2) + closed bit (0x80)
+        image[dirOffset + entryOffset + 1] = fileStartTrack;
+        image[dirOffset + entryOffset + 2] = fileStartSector;
+        // Filename (16 bytes starting at +3) padded with 0xa0.
+        for (int i = 0; i < 16; i++)
+            image[dirOffset + entryOffset + 3 + i] = 0xa0;
+        WriteAsciiUppercaseAsPetscii(image, dirOffset + entryOffset + 3, TestFileName);
+        // Blocks used (bytes 28-29, little-endian). One sector is plenty for our tiny PRG.
+        image[dirOffset + entryOffset + 28] = 0x01;
+        image[dirOffset + entryOffset + 29] = 0x00;
+
+        // ── File sector (track 1, sector 0) ──────────────────────────────────────────────
+        // First two bytes: next track / next sector. nextTrack=0 means "last sector"; in that
+        // case nextSector is the count of payload bytes used in this sector.
+        var fileOffset = SectorOffset(fileStartTrack, fileStartSector);
+        image[fileOffset + 0] = 0x00;                                  // nextTrack = 0 (last)
+        image[fileOffset + 1] = (byte)PrgFileBytes.Length;             // bytes used in this sector
+        Array.Copy(PrgFileBytes, 0, image, fileOffset + 2, PrgFileBytes.Length);
+
+        return image;
+    }
+
+    /// <summary>
+    /// Byte offset for a given (1-based) track and (0-based) sector, summing the sectors-per-track
+    /// table that the production parser uses. Mirrors <c>D64DiskImage.CalculateSectorOffset</c>.
+    /// </summary>
+    private static int SectorOffset(int track, int sector)
+    {
+        int offset = 0;
+        for (int t = 1; t < track; t++)
+            offset += Systems.Commodore64.TimerAndPeripheral.DiskDrive.D64.D64Parser.SectorsPerTrack[t] * 256;
+        offset += sector * 256;
+        return offset;
+    }
+
+    /// <summary>
+    /// Writes uppercase ASCII letters (A-Z) and digits as raw bytes into the buffer. PETSCII codes
+    /// 0x30-0x39 (digits) and 0x41-0x5A (uppercase) coincide with ASCII at the same codepoints,
+    /// and the parser round-trips them via <c>PetsciiToAscii</c>.
+    /// </summary>
+    private static void WriteAsciiUppercaseAsPetscii(byte[] buffer, int offset, string text)
+    {
+        for (int i = 0; i < text.Length; i++)
+            buffer[offset + i] = (byte)text[i];
+    }
+}


### PR DESCRIPTION
# Add C64 .d64 startup parameters and runtime-config knobs to Avalonia apps

Avalonia Desktop and Avalonia Browser can now auto-load a `.d64` disk image at startup, and configure the C64 keyboard-joystick / audio knobs, from a single CLI invocation or URL.

## Desktop CLI

- `--loadD64 <path>`
- `--d64Program <name|*>`
- `--diskMount`
- `--keyboardJoystickEnabled`
- `--keyboardJoystickNumber <1|2>`
- `--audioEnabled <true|false>`

## Browser query params

- `loadD64Url`
- `d64Program`
- `diskMount`
- `keyboardJoystickEnabled`
- `keyboardJoystickNumber`
- `audioEnabled`

## Design

- The `.d64` flow lives in the existing C64 Avalonia startup participant via `AutomatedStartupRequest.ExtraParameters`; the handler stays system-agnostic.
- The participant downloads the `.d64` (browser) inside `OnSystemReadyAsync` via a new `AutomatedStartupContext.FetchBinaryResource` so the BASIC prompt is visible during the fetch instead of a blank Avalonia page.
- The C64 runtime knobs (`keyboardJoystick*`, `audioEnabled`) apply for any C64 start path (plain `--start`, `--loadPrg`, BASIC paste, `--loadD64`), not just the `.d64` flow.

## Refactor

Extract `D64AutoDownloadAndRun.MountOrDirectLoadAndRunAsync` as a shared helper used by both the menu's "Download and Run" flow and the startup participant.
