### PR TITLE
Improve SwiftLink receive rate for Compunet

### DIFF
--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Commodore64/C64Setup.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Commodore64/C64Setup.cs
@@ -65,7 +65,7 @@ public class C64Setup : C64SystemConfigurerCore
             c64.SwiftLink.ReceivePacingCycles =
                 c64HostConfig.SwiftLinkTransportMode == C64SwiftLinkTransportMode.HayesModem
                 && c64.SwiftLink.ReceiveMode == C64SwiftLinkReceiveMode.Compatible
-                    ? GetCyclesPer1200BaudCharacter(c64)
+                    ? GetReceivePacingCyclesPerCharacter(c64)
                     : 0;
             c64.SwiftLink.Transport = transport;
 
@@ -97,10 +97,13 @@ public class C64Setup : C64SystemConfigurerCore
                 LoggerFactory.CreateLogger(nameof(WebSocketTransport)))
         };
 
-    private static ulong GetCyclesPer1200BaudCharacter(C64 c64)
+    // See C64SystemConfigurerCore.GetReceivePacingCyclesPerCharacter for the full rationale:
+    // pace at Compunet's programmed 19200 baud (the highest rate that stays stable here), not the
+    // SwiftLink-doubled 38400 which starves the client's handshake in this emulator.
+    private static ulong GetReceivePacingCyclesPerCharacter(C64 c64)
     {
-        const double BitsPerCharacter = 10.0; // 8N1 framing
-        const double BaudRate = 1200.0;
-        return (ulong)Math.Ceiling(c64.CpuFrequencyHz * (BitsPerCharacter / BaudRate));
+        const double BitsPerCharacter = 10.0;      // 8N1 framing
+        const double EffectiveBaudRate = 19200.0;  // Compunet's programmed ACIA rate; highest stable receive pace in this emulator
+        return (ulong)Math.Ceiling(c64.CpuFrequencyHz * (BitsPerCharacter / EffectiveBaudRate));
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64SystemConfigurerCore.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64SystemConfigurerCore.cs
@@ -141,7 +141,7 @@ public class C64SystemConfigurerCore : ISystemConfigurer
             c64.SwiftLink.ReceivePacingCycles =
                 swiftLinkHostConfig.SwiftLinkTransportMode == C64SwiftLinkTransportMode.HayesModem
                 && c64.SwiftLink.ReceiveMode == C64SwiftLinkReceiveMode.Compatible
-                    ? GetCyclesPer1200BaudCharacter(c64)
+                    ? GetReceivePacingCyclesPerCharacter(c64)
                     : 0;
 
             ISwiftLinkTransport transport = swiftLinkHostConfig.SwiftLinkTransportMode switch
@@ -165,11 +165,22 @@ public class C64SystemConfigurerCore : ISystemConfigurer
         return new SystemRunner(c64);
     }
 
-    private static ulong GetCyclesPer1200BaudCharacter(C64 c64)
+    // Paces received SwiftLink bytes for modem-style software (e.g. Compunet) in Compatible mode.
+    // Compunet programs the ACIA control register to 19200 baud (low nibble 0xF); a real CMD
+    // SwiftLink doubles that to 38400 via its 3.6864 MHz crystal (twice the standard 6551's
+    // 1.8432 MHz). The Compunet server paces its send rate to how fast the client drains the ACIA,
+    // so faster delivery directly speeds up screen downloads.
+    //
+    // We pace at the programmed 19200 (not the doubled 38400): at 38400 the per-byte receive NMI
+    // fires roughly every ~270 CPU cycles, which starves the client's foreground handshake in this
+    // emulator and makes it drop back to BASIC during connect. 19200 is the highest rate that stays
+    // stable here while bringing throughput close to VICE / real SwiftLink — about 6× the old flat
+    // 1200-baud pacing, which ran downloads at roughly half VICE's speed.
+    private static ulong GetReceivePacingCyclesPerCharacter(C64 c64)
     {
-        const double BitsPerCharacter = 10.0; // 8N1 framing
-        const double BaudRate = 1200.0;
-        return (ulong)Math.Ceiling(c64.CpuFrequencyHz * (BitsPerCharacter / BaudRate));
+        const double BitsPerCharacter = 10.0;      // 8N1 framing
+        const double EffectiveBaudRate = 19200.0;  // Compunet's programmed ACIA rate; highest stable receive pace in this emulator
+        return (ulong)Math.Ceiling(c64.CpuFrequencyHz * (BitsPerCharacter / EffectiveBaudRate));
     }
 
     /// <summary>


### PR DESCRIPTION
## What

Speeds up SwiftLink received-byte delivery for modem-style software (Compunet Reborn) by pacing at **19200 baud effective** instead of a flat **1200**, in HayesModem + Compatible mode.

## Why

The Compunet server paces its send rate to how fast the client drains the ACIA, so receive pacing directly controls download speed. The old flat 1200-baud pace made downloads run at roughly half VICE's speed. Compunet programs the ACIA to 19200; pacing there raises throughput from ~121 B/s to ~688 B/s (~5.7×), verified live against Compunet.

19200 is the highest rate that stays stable here — the SwiftLink-doubled 38400 starves the client's connect handshake in the emulator (a deeper receive/NMI fix, tracked separately in the design log).

## Changes

- `GetReceivePacingCyclesPerCharacter` (renamed from `GetCyclesPer1200BaudCharacter`) now uses 19200 baud, in `C64SystemConfigurerCore.cs` (desktop/headless) and `C64Setup.cs` (browser).
