### PR TITLE
Avalonia stats panel improvements and minor fixes

### DIFF
--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Styles/LayoutStyles.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Styles/LayoutStyles.axaml
@@ -86,7 +86,7 @@
 
     <!-- Statistics container -->
     <Style Selector="Border.stats-container">
-        <Setter Property="Background" Value="#4A5568"/>
+        <Setter Property="Background" Value="{DynamicResource SecondaryBg}"/>
         <Setter Property="Padding" Value="8"/>
         <Setter Property="CornerRadius" Value="4"/>
         <Setter Property="Margin" Value="0,4,0,0"/>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/StatisticsViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/StatisticsViewModel.cs
@@ -1,19 +1,40 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
+using Avalonia;
 using Avalonia.Threading;
 using Highbyte.DotNet6502.Systems.Instrumentation.Stats;
 
 namespace Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
 
-public class StatisticItem
+public class StatisticItem : INotifyPropertyChanged
 {
     public string Name { get; set; } = string.Empty;
-    public string Value { get; set; } = string.Empty;
+
+    // Value changes every refresh; raise change notification so it can be updated in place
+    // without recreating the item (recreating would tear down the hovered tooltip).
+    private string _value = string.Empty;
+    public string Value
+    {
+        get => _value;
+        set
+        {
+            if (_value == value)
+                return;
+            _value = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Value)));
+        }
+    }
 
     // UI-only display order within its group. Lower is shown first; ties fall back to Name.
     public int SortOrder { get; set; } = int.MaxValue;
+
+    // Optional hover tooltip. Null = no tooltip.
+    public string? Tooltip { get; set; }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 }
 
 public class StatisticSection
@@ -23,6 +44,16 @@ public class StatisticSection
 
     // UI-only display order of the group. Lower is shown first; ties fall back to Title.
     public int SortOrder { get; set; } = int.MaxValue;
+
+    // Optional hover tooltip shown on the group title. Null = no tooltip.
+    public string? Tooltip { get; set; }
+
+    // UI-only nesting depth (0 = top-level group, 1 = sub-group shown under its parent).
+    public int IndentLevel { get; set; }
+
+    // Layout margin applied in the view: left indent for nested sub-groups, plus a bit of top
+    // spacing before each top-level group (nested children hug their parent, so no top space).
+    public Thickness GroupMargin => new(IndentLevel * 12, IndentLevel == 0 ? 6 : 0, 0, 0);
 }
 
 public class StatisticsViewModel : ViewModelBase, IDisposable
@@ -42,7 +73,7 @@ public class StatisticsViewModel : ViewModelBase, IDisposable
     // ----------------------------------------------------------------------------------
     private static readonly string[] GroupOrder =
     {
-        "Main",
+        "General",
         "SystemTime",
         "SystemTime-Custom",
         "SystemTime-RenderProvider",
@@ -55,10 +86,64 @@ public class StatisticsViewModel : ViewModelBase, IDisposable
 
     private static readonly Dictionary<string, string[]> StatOrder = new(StringComparer.OrdinalIgnoreCase)
     {
-        ["Main"] = new[] { "SystemTime", "InputTime", "ScriptTime", "OnUpdateFPS" },
+        ["General"] = new[] { "InputTime", "ScriptTime", "OnUpdateFPS" },
+        ["SystemTime"] = new[] { "Total", "Other" },
         ["Render"] = new[] { "FPS", "FlushIfDirty" },
         ["Audio"] = new[] { "CommandsPerSecond", "Execute", "BufferFill", "Underruns", "Overruns" },
     };
+
+    // ----------------------------------------------------------------------------------
+    // UI-only group hierarchy: child group -> parent group. Child groups are rendered
+    // nested (indented) directly beneath their parent. Only true time-containment
+    // relationships are listed (a child's time is part of its parent's time). The
+    // unaccounted remainder of a parent is shown as an "Other" (self) row where derivable.
+    // ----------------------------------------------------------------------------------
+    private static readonly Dictionary<string, string> GroupParent = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["SystemTime-AudioProvider"] = "SystemTime",
+        ["SystemTime-RenderProvider"] = "SystemTime",
+        ["SystemTime-Custom"] = "SystemTime",
+        ["Render-Target"] = "Render",
+    };
+
+    // ----------------------------------------------------------------------------------
+    // UI-only optional tooltips. GroupTooltips is keyed by group name; StatTooltips is keyed
+    // by "<group>/<statName>". Anything not listed simply has no tooltip. Add entries here.
+    // ----------------------------------------------------------------------------------
+    private static readonly Dictionary<string, string> GroupTooltips = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["General"] = "Top-level per-frame timings of the host emulator loop itself — e.g. input handling, scripting hooks, and the update-loop frame rate (OnUpdateFPS).",
+        ["SystemTime"] = "Total time to emulate one frame of the system core — CPU plus on-chip hardware (video, audio, etc.). The sub-groups below are parts of this; host-side rendering, audio output and input are timed separately.",
+        ["SystemTime-Custom"] = "System-specific extra per-frame work that isn't core CPU or a provider — e.g. sprite collision detection.",
+        ["SystemTime-RenderProvider"] = "In-emulation generation of the video output data (per-instruction and end-of-frame hooks). This produces the frame; the host-side Render group draws it.",
+        ["SystemTime-AudioProvider"] = "In-emulation generation of the audio data (per-instruction and end-of-frame hooks). This produces the samples/commands; the host-side Audio group plays them.",
+        ["Render"] = "Host-side rendering of the emulated frame to the screen. FPS is the render rate; FlushIfDirty is the time spent pushing a frame.",
+        ["Render-Target"] = "The host render target backend — time spent presenting the drawn frame (part of the Render group's flush).",
+        ["Audio"] = "Host-side audio coordination — forwarding emulated audio to the output backend (command throughput/apply time, or sample ring-buffer health).",
+        ["Audio-Target"] = "The host audio output backend — how often it pulls samples and how long those reads take.",
+    };
+
+    private static readonly Dictionary<string, string> StatTooltips = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["SystemTime/Other"] = "Mainly the core CPU emulation, plus any other system-specific per-frame work (e.g. video/audio chip emulation) not broken out into the sub-groups below.",
+    };
+
+    private static string? GroupTooltipOf(string group) =>
+        GroupTooltips.TryGetValue(group, out var tip) ? tip : null;
+
+    private static string? StatTooltipOf(string group, string name) =>
+        StatTooltips.TryGetValue($"{group}/{name}", out var tip) ? tip : null;
+
+    // Matches the millisecond formatting of ElapsedMillisecondsTimedStat.GetDescription().
+    private static string FormatMs(double ms) =>
+        ms < 0.01 ? "< 0.01ms" : Math.Round(ms, 2).ToString("0.00") + "ms";
+
+    // Short title for a nested sub-group, e.g. "SystemTime-AudioProvider" -> "AudioProvider".
+    private static string ShortTitle(string group)
+    {
+        var idx = group.LastIndexOf('-');
+        return idx >= 0 && idx < group.Length - 1 ? group[(idx + 1)..] : group;
+    }
 
     private static int GroupSortOrderOf(string group)
     {
@@ -91,7 +176,22 @@ public class StatisticsViewModel : ViewModelBase, IDisposable
     }
 
 
+    /// <summary>
+    /// When true the periodic refresh is suspended. The view sets this while the pointer is over
+    /// the stats panel so values (and the layout) don't change under the cursor — which would
+    /// otherwise dismiss a tooltip the user is reading.
+    /// </summary>
+    public bool UpdatesPaused { get; set; }
+
     private void UpdateStats(object? sender, EventArgs e)
+    {
+        if (UpdatesPaused)
+            return;
+
+        RefreshStats();
+    }
+
+    private void RefreshStats()
     {
         if (_disposed || _hostApp == null)
             return;
@@ -115,6 +215,12 @@ public class StatisticsViewModel : ViewModelBase, IDisposable
 
         var groupedStats = new Dictionary<string, List<StatisticItem>>(StringComparer.OrdinalIgnoreCase);
 
+        // Numeric accumulation (in milliseconds) used to derive the SystemTime "Other" (self) row:
+        // self = SystemTime total - sum of its measured children.
+        double? systemTimeTotalMs = null;
+        double systemTimeChildrenMs = 0;
+        var anySystemTimeChild = false;
+
         foreach ((string name, IStat stat) in stats)
         {
             if (!stat.ShouldShow())
@@ -125,11 +231,26 @@ public class StatisticsViewModel : ViewModelBase, IDisposable
 
             var sectionName = nameParts.Length > 1
                 ? string.Join('-', nameParts[..^1])
-                : "Main";
+                : "General";
 
             var displayName = nameParts.Length > 1
                 ? nameParts[^1]
                 : nameParts[0];
+
+            // Accumulate millisecond totals for the SystemTime hierarchy.
+            if (stat is ElapsedMillisecondsTimedStat ems && ems.GetStatMilliseconds() is { } ms)
+            {
+                if (sectionName.Equals("General", StringComparison.OrdinalIgnoreCase)
+                    && displayName.Equals("SystemTime", StringComparison.OrdinalIgnoreCase))
+                {
+                    systemTimeTotalMs = ms;
+                }
+                else if (sectionName.StartsWith("SystemTime-", StringComparison.OrdinalIgnoreCase))
+                {
+                    systemTimeChildrenMs += ms;
+                    anySystemTimeChild = true;
+                }
+            }
 
             if (!groupedStats.TryGetValue(sectionName, out var items))
             {
@@ -141,33 +262,165 @@ public class StatisticsViewModel : ViewModelBase, IDisposable
             {
                 Name = displayName,
                 Value = description,
-                SortOrder = StatSortOrderOf(sectionName, displayName)
+                SortOrder = StatSortOrderOf(sectionName, displayName),
+                Tooltip = StatTooltipOf(sectionName, displayName)
             });
         }
 
-        // Sort groups by their UI sort order, then alphabetically for any not explicitly ordered.
-        var orderedGroups = groupedStats
-            .OrderBy(kvp => GroupSortOrderOf(kvp.Key))
-            .ThenBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase);
+        PromoteSystemTimeGroup(groupedStats, systemTimeTotalMs, systemTimeChildrenMs, anySystemTimeChild);
 
-        foreach (var group in orderedGroups)
+        // Build a section per group, with its items sorted by UI order then alphabetically.
+        var sectionByGroup = new Dictionary<string, StatisticSection>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (groupName, items) in groupedStats)
         {
             var section = new StatisticSection
             {
-                Title = group.Key,
-                SortOrder = GroupSortOrderOf(group.Key)
+                Title = groupName,
+                SortOrder = GroupSortOrderOf(groupName),
+                Tooltip = GroupTooltipOf(groupName)
             };
-
-            // Sort stats within the group by their UI sort order, then alphabetically.
-            foreach (var item in group.Value
+            foreach (var item in items
                          .OrderBy(i => i.SortOrder)
                          .ThenBy(i => i.Name, StringComparer.OrdinalIgnoreCase))
             {
                 section.Items.Add(item);
             }
-
-            Sections.Add(section);
+            sectionByGroup[groupName] = section;
         }
+
+        // A group is top-level unless it declares a parent that is actually present.
+        bool IsTopLevel(string group) =>
+            !GroupParent.TryGetValue(group, out var parent) || !sectionByGroup.ContainsKey(parent);
+
+        var topLevel = sectionByGroup.Keys
+            .Where(IsTopLevel)
+            .OrderBy(GroupSortOrderOf)
+            .ThenBy(g => g, StringComparer.OrdinalIgnoreCase);
+
+        var newSections = new List<StatisticSection>();
+        foreach (var groupName in topLevel)
+        {
+            newSections.Add(sectionByGroup[groupName]);
+
+            // Emit child groups nested (indented) directly under their parent.
+            var children = sectionByGroup.Keys
+                .Where(c => GroupParent.TryGetValue(c, out var p)
+                            && sectionByGroup.ContainsKey(p)
+                            && p.Equals(groupName, StringComparison.OrdinalIgnoreCase))
+                .OrderBy(GroupSortOrderOf)
+                .ThenBy(c => c, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var childName in children)
+            {
+                var child = sectionByGroup[childName];
+                child.IndentLevel = 1;
+                child.Title = ShortTitle(childName);
+                newSections.Add(child);
+            }
+        }
+
+        ApplySections(newSections);
+    }
+
+    /// <summary>
+    /// Applies the freshly built sections to the bound <see cref="Sections"/> collection. When the
+    /// structure (groups and stat names) is unchanged — the normal case while running — only the
+    /// stat values are updated in place. This avoids recreating the visual elements every refresh,
+    /// which would otherwise dismiss a tooltip the user is hovering. The collection is rebuilt only
+    /// when the structure actually changes (e.g. a system starts/stops, audio mode switches).
+    /// </summary>
+    private void ApplySections(List<StatisticSection> newSections)
+    {
+        if (HasSameStructure(newSections))
+        {
+            for (var s = 0; s < newSections.Count; s++)
+            {
+                var existingItems = Sections[s].Items;
+                var incomingItems = newSections[s].Items;
+                for (var i = 0; i < incomingItems.Count; i++)
+                    existingItems[i].Value = incomingItems[i].Value;
+            }
+            return;
+        }
+
+        Sections.Clear();
+        foreach (var section in newSections)
+            Sections.Add(section);
+    }
+
+    private bool HasSameStructure(List<StatisticSection> incoming)
+    {
+        if (Sections.Count != incoming.Count)
+            return false;
+
+        for (var s = 0; s < incoming.Count; s++)
+        {
+            var current = Sections[s];
+            var next = incoming[s];
+
+            if (current.IndentLevel != next.IndentLevel
+                || !string.Equals(current.Title, next.Title, StringComparison.Ordinal)
+                || current.Items.Count != next.Items.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < next.Items.Count; i++)
+            {
+                if (!string.Equals(current.Items[i].Name, next.Items[i].Name, StringComparison.Ordinal))
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Moves the "SystemTime" total out of the General group into its own parent group (so its
+    /// sub-groups can nest beneath it) and appends an "Other" (self) row = total - sum(children),
+    /// making the breakdown account for the otherwise-invisible core CPU/chip emulation time.
+    /// </summary>
+    private static void PromoteSystemTimeGroup(
+        Dictionary<string, List<StatisticItem>> groupedStats,
+        double? systemTimeTotalMs,
+        double systemTimeChildrenMs,
+        bool anySystemTimeChild)
+    {
+        if (!groupedStats.TryGetValue("General", out var mainItems))
+            return;
+
+        var systemTimeItem = mainItems.FirstOrDefault(i =>
+            i.Name.Equals("SystemTime", StringComparison.OrdinalIgnoreCase));
+        if (systemTimeItem == null)
+            return;
+
+        mainItems.Remove(systemTimeItem);
+
+        var systemTimeGroup = new List<StatisticItem>
+        {
+            new()
+            {
+                Name = "Total",
+                Value = systemTimeItem.Value,
+                SortOrder = StatSortOrderOf("SystemTime", "Total"),
+                Tooltip = StatTooltipOf("SystemTime", "Total")
+            }
+        };
+
+        // Derived self/Other time (only when we have both a total and at least one measured child).
+        if (systemTimeTotalMs.HasValue && anySystemTimeChild)
+        {
+            var selfMs = Math.Max(0, systemTimeTotalMs.Value - systemTimeChildrenMs);
+            systemTimeGroup.Add(new StatisticItem
+            {
+                Name = "Other",
+                Value = FormatMs(selfMs),
+                SortOrder = StatSortOrderOf("SystemTime", "Other"),
+                Tooltip = StatTooltipOf("SystemTime", "Other")
+            });
+        }
+
+        groupedStats["SystemTime"] = systemTimeGroup;
     }
 
     /// <summary>
@@ -179,20 +432,24 @@ public class StatisticsViewModel : ViewModelBase, IDisposable
     /// </summary>
     public string GetStatsText()
     {
-        // Widest stat name across all sections, so every row pads to the same width.
-        // Padding all names to the same width means the tab always starts at the same
-        // column, which makes the value column align in monospaced text too.
-        var nameWidth = 0;
+        // Widest "left field" (group indent + 2-space item indent + name) across all rows.
+        // Padding every row's left field to this width keeps the tab in the same column, so the
+        // value column aligns in monospaced text while the indentation still shows the hierarchy.
+        var leftWidth = 0;
         foreach (var section in Sections)
             foreach (var item in section.Items)
-                nameWidth = Math.Max(nameWidth, item.Name.Length);
+                leftWidth = Math.Max(leftWidth, section.IndentLevel * 2 + 2 + item.Name.Length);
 
         var sb = new System.Text.StringBuilder();
         foreach (var section in Sections)
         {
-            sb.AppendLine($"{section.Title}:");
+            var indent = new string(' ', section.IndentLevel * 2);
+            sb.AppendLine($"{indent}{section.Title}:");
             foreach (var item in section.Items)
-                sb.AppendLine($"  {item.Name.PadRight(nameWidth)}\t{item.Value}");
+            {
+                var left = $"{indent}  {item.Name}";
+                sb.AppendLine($"{left.PadRight(leftWidth)}\t{item.Value}");
+            }
         }
         return sb.ToString();
     }
@@ -210,8 +467,9 @@ public class StatisticsViewModel : ViewModelBase, IDisposable
             foreach ((_, IStat stat) in _hostApp.GetStats())
                 stat.ResetAverage();
 
-            // Refresh the displayed values immediately instead of waiting for the next timer tick.
-            UpdateStats(this, EventArgs.Empty);
+            // Refresh the displayed values immediately (bypassing any hover-pause) instead of
+            // waiting for the next timer tick.
+            RefreshStats();
         }
         catch (Exception)
         {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/StatisticsViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/StatisticsViewModel.cs
@@ -114,6 +114,55 @@ public class StatisticsViewModel : ViewModelBase, IDisposable
         }
     }
 
+    /// <summary>
+    /// Builds a plain-text representation of the currently displayed statistics,
+    /// suitable for copying to the clipboard.
+    /// Each stat name is padded to a fixed width so the value column lines up in a
+    /// monospaced text editor, while a single tab before the value keeps the output
+    /// tab-delimited (two columns) for pasting/importing into a spreadsheet.
+    /// </summary>
+    public string GetStatsText()
+    {
+        // Widest stat name across all sections, so every row pads to the same width.
+        // Padding all names to the same width means the tab always starts at the same
+        // column, which makes the value column align in monospaced text too.
+        var nameWidth = 0;
+        foreach (var section in Sections)
+            foreach (var item in section.Items)
+                nameWidth = Math.Max(nameWidth, item.Name.Length);
+
+        var sb = new System.Text.StringBuilder();
+        foreach (var section in Sections)
+        {
+            sb.AppendLine($"{section.Title}:");
+            foreach (var item in section.Items)
+                sb.AppendLine($"  {item.Name.PadRight(nameWidth)}\t{item.Value}");
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Clears the accumulated/averaged values of all stats so they start fresh.
+    /// </summary>
+    public void ResetStats()
+    {
+        if (_disposed || _hostApp == null)
+            return;
+
+        try
+        {
+            foreach ((_, IStat stat) in _hostApp.GetStats())
+                stat.ResetAverage();
+
+            // Refresh the displayed values immediately instead of waiting for the next timer tick.
+            UpdateStats(this, EventArgs.Empty);
+        }
+        catch (Exception)
+        {
+            // Handle any exceptions gracefully to prevent UI crashes
+        }
+    }
+
     public void Dispose()
     {
         if (!_disposed)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/StatisticsViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/StatisticsViewModel.cs
@@ -11,12 +11,18 @@ public class StatisticItem
 {
     public string Name { get; set; } = string.Empty;
     public string Value { get; set; } = string.Empty;
+
+    // UI-only display order within its group. Lower is shown first; ties fall back to Name.
+    public int SortOrder { get; set; } = int.MaxValue;
 }
 
 public class StatisticSection
 {
     public string Title { get; set; } = string.Empty;
     public ObservableCollection<StatisticItem> Items { get; } = new();
+
+    // UI-only display order of the group. Lower is shown first; ties fall back to Title.
+    public int SortOrder { get; set; } = int.MaxValue;
 }
 
 public class StatisticsViewModel : ViewModelBase, IDisposable
@@ -27,6 +33,49 @@ public class StatisticsViewModel : ViewModelBase, IDisposable
 
     // Dynamic Statistics Collection grouped by section
     public ObservableCollection<StatisticSection> Sections { get; } = new();
+
+    // ----------------------------------------------------------------------------------
+    // UI-only display ordering.
+    // Groups are shown in the order listed here; stat names within a group are shown in
+    // the order listed in StatOrder. Anything not listed is appended after the listed
+    // ones, alphabetically. Edit these lists to change the display order.
+    // ----------------------------------------------------------------------------------
+    private static readonly string[] GroupOrder =
+    {
+        "Main",
+        "SystemTime",
+        "SystemTime-Custom",
+        "SystemTime-RenderProvider",
+        "SystemTime-AudioProvider",
+        "Render",
+        "Render-Target",
+        "Audio",
+        "Audio-Target"
+    };
+
+    private static readonly Dictionary<string, string[]> StatOrder = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Main"] = new[] { "SystemTime", "InputTime", "ScriptTime", "OnUpdateFPS" },
+        ["Render"] = new[] { "FPS", "FlushIfDirty" },
+        ["Audio"] = new[] { "CommandsPerSecond", "Execute", "BufferFill", "Underruns", "Overruns" },
+    };
+
+    private static int GroupSortOrderOf(string group)
+    {
+        var index = Array.FindIndex(GroupOrder, g => string.Equals(g, group, StringComparison.OrdinalIgnoreCase));
+        return index >= 0 ? index : int.MaxValue;
+    }
+
+    private static int StatSortOrderOf(string group, string name)
+    {
+        if (StatOrder.TryGetValue(group, out var names))
+        {
+            var index = Array.FindIndex(names, n => string.Equals(n, name, StringComparison.OrdinalIgnoreCase));
+            if (index >= 0)
+                return index;
+        }
+        return int.MaxValue;
+    }
 
     public StatisticsViewModel(AvaloniaHostApp hostApp)
     {
@@ -66,7 +115,7 @@ public class StatisticsViewModel : ViewModelBase, IDisposable
 
         var groupedStats = new Dictionary<string, List<StatisticItem>>(StringComparer.OrdinalIgnoreCase);
 
-        foreach ((string name, IStat stat) in stats.OrderBy(i => i.name, StringComparer.OrdinalIgnoreCase))
+        foreach ((string name, IStat stat) in stats)
         {
             if (!stat.ShouldShow())
                 continue;
@@ -91,26 +140,33 @@ public class StatisticsViewModel : ViewModelBase, IDisposable
             items.Add(new StatisticItem
             {
                 Name = displayName,
-                Value = description
+                Value = description,
+                SortOrder = StatSortOrderOf(sectionName, displayName)
             });
         }
 
-        foreach (var section in groupedStats
-                     .OrderBy(kvp => kvp.Key.Equals("Root", StringComparison.OrdinalIgnoreCase) ? 0 : 1)
-                     .ThenBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase))
+        // Sort groups by their UI sort order, then alphabetically for any not explicitly ordered.
+        var orderedGroups = groupedStats
+            .OrderBy(kvp => GroupSortOrderOf(kvp.Key))
+            .ThenBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var group in orderedGroups)
         {
-            var statisticSection = new StatisticSection
+            var section = new StatisticSection
             {
-                Title = section.Key
+                Title = group.Key,
+                SortOrder = GroupSortOrderOf(group.Key)
             };
 
-            foreach (var item in section.Value
-                         .OrderBy(i => i.Name, StringComparer.OrdinalIgnoreCase))
+            // Sort stats within the group by their UI sort order, then alphabetically.
+            foreach (var item in group.Value
+                         .OrderBy(i => i.SortOrder)
+                         .ThenBy(i => i.Name, StringComparer.OrdinalIgnoreCase))
             {
-                statisticSection.Items.Add(item);
+                section.Items.Add(item);
             }
 
-            Sections.Add(statisticSection);
+            Sections.Add(section);
         }
     }
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
@@ -1098,6 +1098,7 @@
 
         <!-- Info and Stats Panel (Right) -->
         <Border Grid.Row="0" Grid.Column="2" Grid.RowSpan="3" Classes="panel-container"
+            Width="200"
             IsVisible="{Binding IsStatisticsPanelVisible}">
             <ScrollViewer Classes="h-stretch">
                 <views:StatisticsView DataContext="{Binding StatisticsViewModel}" />

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
@@ -1098,7 +1098,6 @@
 
         <!-- Info and Stats Panel (Right) -->
         <Border Grid.Row="0" Grid.Column="2" Grid.RowSpan="3" Classes="panel-container"
-            Width="200"
             IsVisible="{Binding IsStatisticsPanelVisible}">
             <ScrollViewer Classes="h-stretch">
                 <views:StatisticsView DataContext="{Binding StatisticsViewModel}" />

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/StatisticsView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/StatisticsView.axaml
@@ -43,16 +43,19 @@
             <ItemsControl ItemsSource="{Binding Sections}" Classes="h-left">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <StackPanel>
+                        <StackPanel Margin="{Binding GroupMargin}">
                             <TextBlock Text="{Binding Title, StringFormat='{}{0}:'}"
-                                       Classes="accent bold small"/>
+                                       Classes="accent bold small"
+                                       ToolTip.Tip="{Binding Tooltip}"/>
                             <ItemsControl ItemsSource="{Binding Items}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
-                                        <Grid Classes="">
+                                        <Grid Classes=""
+                                              Background="Transparent"
+                                              ToolTip.Tip="{Binding Tooltip}">
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="Auto"
-                                                                  MinWidth="120"
+                                                                  MinWidth="108"
                                                                   SharedSizeGroup="StatName"/>
                                                 <ColumnDefinition Width="*"/>
                                             </Grid.ColumnDefinitions>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/StatisticsView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/StatisticsView.axaml
@@ -12,8 +12,32 @@
     <StackPanel Classes="spacing-large"
                 Grid.IsSharedSizeScope="True">
         <!-- Performance Stats -->
-        <TextBlock Text="Stats"
-                   Classes="h2"/>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Text="Stats"
+                       VerticalAlignment="Center"
+                       Classes="h2"/>
+            <StackPanel Grid.Column="1"
+                        Orientation="Horizontal"
+                        Classes="spacing-tight"
+                        VerticalAlignment="Center">
+                <Button Content="Copy"
+                        Classes="small"
+                        Click="OnCopyClick"
+                        AutomationProperties.AutomationId="StatsCopyButton"
+                        AutomationProperties.Name="Copy statistics to clipboard"
+                        ToolTip.Tip="Copy statistics to clipboard"/>
+                <Button Content="Reset"
+                        Classes="small"
+                        Click="OnResetClick"
+                        AutomationProperties.AutomationId="StatsResetButton"
+                        AutomationProperties.Name="Reset statistics"
+                        ToolTip.Tip="Reset accumulated statistics"/>
+            </StackPanel>
+        </Grid>
 
         <Border Classes="stats-container">
             <ItemsControl ItemsSource="{Binding Sections}" Classes="h-left">
@@ -28,6 +52,7 @@
                                         <Grid Classes="">
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="Auto"
+                                                                  MinWidth="120"
                                                                   SharedSizeGroup="StatName"/>
                                                 <ColumnDefinition Width="*"/>
                                             </Grid.ColumnDefinitions>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/StatisticsView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/StatisticsView.axaml.cs
@@ -1,5 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
 
 namespace Highbyte.DotNet6502.App.Avalonia.Core.Views;
@@ -21,6 +23,26 @@ public partial class StatisticsView : UserControl
     private void OnDataContextChanged(object? sender, System.EventArgs e)
     {
         // ViewModel is now available through DataContext binding
+    }
+
+    private void OnCopyClick(object? sender, RoutedEventArgs e)
+    {
+        var text = ViewModel?.GetStatsText();
+        if (string.IsNullOrEmpty(text))
+            return;
+
+        var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+        if (clipboard == null)
+            return;
+
+        var dataTransfer = new DataTransfer();
+        dataTransfer.Add(DataTransferItem.CreateText(text));
+        SafeAsyncHelper.Execute(() => clipboard.SetDataAsync(dataTransfer));
+    }
+
+    private void OnResetClick(object? sender, RoutedEventArgs e)
+    {
+        ViewModel?.ResetStats();
     }
 
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/StatisticsView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/StatisticsView.axaml.cs
@@ -45,6 +45,22 @@ public partial class StatisticsView : UserControl
         ViewModel?.ResetStats();
     }
 
+    // Pause the periodic refresh while the pointer is over the panel, so values (and the layout)
+    // don't change under the cursor — which would otherwise dismiss a tooltip being read.
+    protected override void OnPointerEntered(PointerEventArgs e)
+    {
+        base.OnPointerEntered(e);
+        if (ViewModel != null)
+            ViewModel.UpdatesPaused = true;
+    }
+
+    protected override void OnPointerExited(PointerEventArgs e)
+    {
+        base.OnPointerExited(e);
+        if (ViewModel != null)
+            ViewModel.UpdatesPaused = false;
+    }
+
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnDetachedFromVisualTree(e);

--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Commodore64/Transport/WebSocketTransport.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Commodore64/Transport/WebSocketTransport.cs
@@ -192,7 +192,7 @@ public sealed class WebSocketTransport : Systems.Commodore64.Transport.ISwiftLin
         if (_sentByteLogCount < 32)
         {
             _sentByteLogCount++;
-            _logger.LogInformation(
+            _logger.LogDebug(
                 "SwiftLink WebSocket transport sent byte 0x{Value:X2} to {BridgeUri}.",
                 value,
                 _bridgeUri);
@@ -270,7 +270,7 @@ public sealed class WebSocketTransport : Systems.Commodore64.Transport.ISwiftLin
                 if (_receivedByteLogCount < 32)
                 {
                     _receivedByteLogCount++;
-                    _logger.LogInformation(
+                    _logger.LogDebug(
                         "SwiftLink WebSocket transport received byte 0x{Value:X2} from {BridgeUri}.",
                         buffer[i],
                         _bridgeUri);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -84,7 +84,10 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
     public Instrumentations Instrumentations { get; } = new();
     private const string StatsCategory = "Custom";
     private readonly ElapsedMillisecondsTimedStatSystem _spriteCollisionStat;
+
+    private const string StatsCategoryAudioProvider = "AudioProvider";
     private readonly ElapsedMillisecondsTimedStatSystem _audioProviderPerInstructionStat;
+    private readonly ElapsedMillisecondsTimedStatSystem _audioProviderPerFrameStat;
 
     private const string StatsCategoryRenderProvider = "RenderProvider";
     private readonly ElapsedMillisecondsTimedStatSystem _renderProviderPerInstructionStat;
@@ -146,6 +149,14 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
         _spriteCollisionStat.Start();
         Vic2.SpriteManager.SetCollitionDetectionStatesAndIRQ();
         _spriteCollisionStat.Stop();
+
+        // Audio generation at end of frame
+        if (_audioProvider != null)
+        {
+            _audioProviderPerFrameStat.Start();
+            _audioProvider.OnEndFrame();
+            _audioProviderPerFrameStat.Stop();
+        }
 
         // New render pipeline
         _renderProviderPerFrameStat.Start();
@@ -232,7 +243,9 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
     {
         _logger = logger;
         _spriteCollisionStat = Instrumentations.Add($"{StatsCategory}-SpriteCollision", new ElapsedMillisecondsTimedStatSystem(this));
-        _audioProviderPerInstructionStat = Instrumentations.Add($"{StatsCategory}-AudioInstruction", new ElapsedMillisecondsTimedStatSystem(this));
+
+        _audioProviderPerInstructionStat = Instrumentations.Add($"{StatsCategoryAudioProvider}-Instruction", new ElapsedMillisecondsTimedStatSystem(this));
+        _audioProviderPerFrameStat = Instrumentations.Add($"{StatsCategoryAudioProvider}-Frame", new ElapsedMillisecondsTimedStatSystem(this));
 
         _renderProviderPerInstructionStat = Instrumentations.Add($"{StatsCategoryRenderProvider}-Instruction", new ElapsedMillisecondsTimedStatSystem(this));
         _renderProviderPerFrameStat = Instrumentations.Add($"{StatsCategoryRenderProvider}-Frame", new ElapsedMillisecondsTimedStatSystem(this));

--- a/src/libraries/Highbyte.DotNet6502.Systems/Audio/AudioCommandCoordinator.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Audio/AudioCommandCoordinator.cs
@@ -1,4 +1,5 @@
 using Highbyte.DotNet6502.Systems.Instrumentation;
+using Highbyte.DotNet6502.Systems.Instrumentation.Stats;
 
 namespace Highbyte.DotNet6502.Systems.Audio;
 
@@ -19,14 +20,27 @@ public sealed class AudioCommandCoordinator : IAudioCoordinator, IDisposable
     private readonly Instrumentations _instrumentations = new();
     public Instrumentations Instrumentations => _instrumentations;
 
+    // Audio counterpart of the render coordinator's FPS + FlushIfDirty: CommandsPerSecond is the
+    // rate of audio commands forwarded to the host backend; Execute is the time spent applying one.
+    private readonly PerSecondTimedStat _commandsPerSecond;
+    private readonly ElapsedMillisecondsTimedStat _executeStat;
+
     public AudioCommandCoordinator(IAudioCommandStream stream, IAudioCommandTarget target)
     {
         _stream = stream;
         _target = target;
+        _commandsPerSecond = _instrumentations.Add("CommandsPerSecond", new PerSecondTimedStat());
+        _executeStat = _instrumentations.Add("Execute", new ElapsedMillisecondsTimedStat());
         _stream.CommandEmitted += OnCommandEmitted;
     }
 
-    private void OnCommandEmitted(IAudioCommand command) => _target.Execute(command);
+    private void OnCommandEmitted(IAudioCommand command)
+    {
+        _commandsPerSecond.Update();
+        _executeStat.Start();
+        _target.Execute(command);
+        _executeStat.Stop();
+    }
 
     public void Init() => _target.Init(_stream.VoiceCount);
 

--- a/src/libraries/Highbyte.DotNet6502.Systems/Audio/AudioSampleCoordinator.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Audio/AudioSampleCoordinator.cs
@@ -1,4 +1,5 @@
 using Highbyte.DotNet6502.Systems.Instrumentation;
+using Highbyte.DotNet6502.Systems.Instrumentation.Stats;
 
 namespace Highbyte.DotNet6502.Systems.Audio;
 
@@ -65,6 +66,17 @@ public sealed class AudioSampleCoordinator : IAudioCoordinator, IDisposable
         _target = target;
         _ringBuffer = new AudioSampleRingBuffer(ringBufferCapacitySamples);
         _primeSilenceSamples = primeSilenceSamples;
+
+        // Live diagnostics for the producer/consumer ring buffer. BufferFill trending toward 0%
+        // signals imminent underruns (audible glitches); near 100% signals high latency / dropped
+        // samples. The overrun/underrun counters tally how often that has actually happened.
+        _instrumentations.Add("BufferFill", new ValueStat(
+            () => _ringBuffer.Capacity > 0 ? 100.0 * _ringBuffer.Count / _ringBuffer.Capacity : null,
+            unit: "%"));
+        _instrumentations.Add("Overruns", new ValueStat(
+            () => _ringBuffer.OverrunCount, resetAction: _ringBuffer.ResetCounters));
+        _instrumentations.Add("Underruns", new ValueStat(
+            () => _ringBuffer.UnderrunCount, resetAction: _ringBuffer.ResetCounters));
     }
 
     public void Init()

--- a/src/libraries/Highbyte.DotNet6502.Systems/Audio/AudioSampleRingBuffer.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Audio/AudioSampleRingBuffer.cs
@@ -18,6 +18,12 @@ public sealed class AudioSampleRingBuffer
     private int _writePos;
     private int _readPos;
 
+    // Diagnostics counters. Each counter has a single writer thread (overruns: the producer in
+    // TryWrite; underruns: the consumer in TryRead), so plain increments are safe. Reads (and the
+    // diagnostic Reset) go through Volatile for cross-thread visibility.
+    private long _overrunCount;
+    private long _underrunCount;
+
     /// <summary>Construct a ring buffer holding up to <paramref name="capacitySamples"/> samples.</summary>
     public AudioSampleRingBuffer(int capacitySamples)
     {
@@ -28,6 +34,19 @@ public sealed class AudioSampleRingBuffer
 
     /// <summary>Total sample capacity (excluding the one disambiguating slot).</summary>
     public int Capacity => _buffer.Length - 1;
+
+    /// <summary>Number of producer writes that had to drop one or more samples because the buffer was full.</summary>
+    public long OverrunCount => Volatile.Read(ref _overrunCount);
+
+    /// <summary>Number of consumer reads that were starved (fewer samples available than requested).</summary>
+    public long UnderrunCount => Volatile.Read(ref _underrunCount);
+
+    /// <summary>Resets the overrun/underrun diagnostic counters to zero.</summary>
+    public void ResetCounters()
+    {
+        Volatile.Write(ref _overrunCount, 0);
+        Volatile.Write(ref _underrunCount, 0);
+    }
 
     /// <summary>Samples currently in the buffer (snapshot; may change immediately on a live system).</summary>
     public int Count
@@ -57,6 +76,8 @@ public sealed class AudioSampleRingBuffer
             free += _buffer.Length;
 
         int toWrite = Math.Min(samples.Length, free);
+        if (toWrite < samples.Length)
+            _overrunCount++; // Buffer full: one or more samples dropped (producer outran consumer).
         if (toWrite == 0)
             return 0;
 
@@ -88,6 +109,8 @@ public sealed class AudioSampleRingBuffer
             available += _buffer.Length;
 
         int toRead = Math.Min(destination.Length, available);
+        if (toRead < destination.Length)
+            _underrunCount++; // Buffer starved: consumer wanted more than available (tail is silence).
         if (toRead == 0)
             return 0;
 

--- a/src/libraries/Highbyte.DotNet6502.Systems/HostApp.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/HostApp.cs
@@ -855,7 +855,7 @@ public class HostApp : IHostApp, IManualRenderingProvider
         if (_audioCoordinator != null)
             stats.AddRange(_audioCoordinator.Instrumentations.Stats.Select(x => (Name: $"{_statsPrefix}{AudioTimeStatName}-{x.Name}", x.Stat)));
         if (_currentAudioTarget is IInstrumentationSource audioTargetInstrumentation)
-            stats.AddRange(audioTargetInstrumentation.Instrumentations.Stats.Select(x => (Name: $"{_statsPrefix}{AudioTimeStatName}-Target-{x.Name}", x.Stat)));
+            stats.AddRange(audioTargetInstrumentation.Instrumentations.Stats.Select(x => (Name: $"{_statsPrefix}Audio-Target-{x.Name}", x.Stat)));
 
         return stats;
     }

--- a/src/libraries/Highbyte.DotNet6502.Systems/HostApp.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/HostApp.cs
@@ -126,7 +126,7 @@ public class HostApp : IHostApp, IManualRenderingProvider
     private const string SystemTimeStatName = "SystemTime";
     private const string RenderStatName = "Render";
     private const string InputTimeStatName = "InputTime";
-    private const string AudioTimeStatName = "AudioTime";
+    private const string AudioStatName = "Audio";
     private const string ScriptTimeStatName = "ScriptTime";
     private readonly Instrumentations _systemInstrumentations = new();
     private ElapsedMillisecondsTimedStatSystem? _systemTime;
@@ -826,7 +826,7 @@ public class HostApp : IHostApp, IManualRenderingProvider
         _systemTime = _systemInstrumentations.Add($"{_statsPrefix}{SystemTimeStatName}", new ElapsedMillisecondsTimedStatSystem(system));
         _inputTime = _systemInstrumentations.Add($"{_statsPrefix}{InputTimeStatName}", new ElapsedMillisecondsTimedStatSystem(system));
         _scriptTime = _systemInstrumentations.Add($"{_statsPrefix}{ScriptTimeStatName}", new ElapsedMillisecondsTimedStatSystem(system));
-        //_audioTime = InstrumentationBag.Add($"{_statsPrefix}{AudioTimeStatName}", new ElapsedMillisecondsTimedStatSystem(system));
+        //_audioTime = InstrumentationBag.Add($"{_statsPrefix}{AudioStatName}", new ElapsedMillisecondsTimedStatSystem(system));
     }
 
     public List<(string name, IStat stat)> GetStats()
@@ -853,7 +853,7 @@ public class HostApp : IHostApp, IManualRenderingProvider
 
         // Sub-system stat: audio
         if (_audioCoordinator != null)
-            stats.AddRange(_audioCoordinator.Instrumentations.Stats.Select(x => (Name: $"{_statsPrefix}{AudioTimeStatName}-{x.Name}", x.Stat)));
+            stats.AddRange(_audioCoordinator.Instrumentations.Stats.Select(x => (Name: $"{_statsPrefix}{AudioStatName}-{x.Name}", x.Stat)));
         if (_currentAudioTarget is IInstrumentationSource audioTargetInstrumentation)
             stats.AddRange(audioTargetInstrumentation.Instrumentations.Stats.Select(x => (Name: $"{_statsPrefix}Audio-Target-{x.Name}", x.Stat)));
 

--- a/src/libraries/Highbyte.DotNet6502.Systems/Instrumentation/Stats/AveragedStat.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Instrumentation/Stats/AveragedStat.cs
@@ -19,4 +19,6 @@ public abstract class AveragedStat : IStat
     public abstract string GetDescription();
 
     public bool ShouldShow() => Value.HasValue;
+
+    public void ResetAverage() => Value = null;
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems/Instrumentation/Stats/IStat.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Instrumentation/Stats/IStat.cs
@@ -5,4 +5,10 @@ public interface IStat
 {
     string GetDescription();
     bool ShouldShow();
+
+    /// <summary>
+    /// Clears any accumulated/averaged measurement so the stat starts fresh.
+    /// Default is a no-op for stats that don't accumulate.
+    /// </summary>
+    void ResetAverage() { }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems/Instrumentation/Stats/PerSecondTimedStat.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Instrumentation/Stats/PerSecondTimedStat.cs
@@ -56,6 +56,12 @@ public class PerSecondTimedStat : IStat
 
     public bool ShouldShow() => Value.HasValue;
 
+    public void ResetAverage()
+    {
+        _emaElapsedMs = null;
+        _sw.Reset();
+    }
+
     // For unit testing
     public void SetFakeFPSValue(double fps)
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems/Instrumentation/Stats/ValueStat.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Instrumentation/Stats/ValueStat.cs
@@ -1,0 +1,38 @@
+namespace Highbyte.DotNet6502.Systems.Instrumentation.Stats;
+
+/// <summary>
+/// A stat whose value is read lazily from a delegate each time it is displayed — a live gauge
+/// or counter (e.g. a buffer fill percentage or an error count) rather than a value accumulated
+/// over samples. An optional reset delegate lets <see cref="ResetAverage"/> clear the underlying
+/// state (e.g. zero a counter).
+/// </summary>
+public sealed class ValueStat : IStat
+{
+    private readonly Func<double?> _getValue;
+    private readonly string _unit;
+    private readonly int _decimals;
+    private readonly Action? _resetAction;
+
+    public ValueStat(Func<double?> getValue, string unit = "", int decimals = 0, Action? resetAction = null)
+    {
+        _getValue = getValue;
+        _unit = unit;
+        _decimals = decimals;
+        _resetAction = resetAction;
+    }
+
+    public string GetDescription()
+    {
+        var value = _getValue();
+        if (value == null)
+            return "null";
+
+        var rounded = Math.Round(value.Value, _decimals);
+        var text = _decimals > 0 ? rounded.ToString("F" + _decimals) : rounded.ToString("0");
+        return text + _unit;
+    }
+
+    public bool ShouldShow() => _getValue().HasValue;
+
+    public void ResetAverage() => _resetAction?.Invoke();
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems/Timing/FrameTimer.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Timing/FrameTimer.cs
@@ -83,11 +83,15 @@ public class FrameTimer : IScriptingTickTimer, IAsyncDisposable
             while (!ct.IsCancellationRequested)
             {
                 long now;
-                while ((now = Stopwatch.GetTimestamp()) < nextDeadline)
+                while ((now = Stopwatch.GetTimestamp()) < nextDeadline && !ct.IsCancellationRequested)
                 {
                     var remainingMs = (nextDeadline - now) * 1000.0 / Stopwatch.Frequency;
                     if (remainingMs > 2.0)
-                        await Task.Delay(1, ct).ConfigureAwait(false);
+                        // No cancellation token passed to Task.Delay on purpose: cancelling a
+                        // short delay throws TaskCanceledException, which under a debugger spams
+                        // first-chance exceptions on every pause/stop. The IsCancellationRequested
+                        // checks in both while-loops end the loop within ~1ms instead.
+                        await Task.Delay(1).ConfigureAwait(false);
                     else
                         Thread.SpinWait(50);
                 }
@@ -120,14 +124,17 @@ public class FrameTimer : IScriptingTickTimer, IAsyncDisposable
             while (!ct.IsCancellationRequested)
             {
                 long now;
-                while ((now = Stopwatch.GetTimestamp()) < nextDeadlineTicks)
+                while ((now = Stopwatch.GetTimestamp()) < nextDeadlineTicks && !ct.IsCancellationRequested)
                 {
                     var remainingMs = (nextDeadlineTicks - now) * 1000.0 / Stopwatch.Frequency;
                     // Deliberately undershoot Task.Delay by 2ms - it can return slightly early
                     // or late, and browsers clamp small values. Then a Task.Yield loop drains
                     // the final ~2ms with ms-or-better precision.
+                    // No cancellation token passed to Task.Delay on purpose: cancelling it throws
+                    // TaskCanceledException (first-chance exception spam on every pause/stop). The
+                    // IsCancellationRequested checks in both while-loops end the loop instead.
                     if (remainingMs >= 4.0)
-                        await Task.Delay((int)remainingMs - 2, ct).ConfigureAwait(true);
+                        await Task.Delay((int)remainingMs - 2).ConfigureAwait(true);
                     else
                         await Task.Yield();
                 }


### PR DESCRIPTION
Mostly improvements to the Avalonia **Stats panel**, plus a couple of small fixes.

## Stats panel
- **Grouping & hierarchy**: `SystemTime` is promoted to its own group with its sub-groups nested beneath it, plus a derived **Other** (self) row = total − measured children, so the breakdown accounts for the otherwise-invisible core CPU/chip time.
- **Display order**: explicit, UI-only group and per-stat ordering (`General` group renamed from `Main`).
- **Tooltips**: optional tooltips for groups and stats, seeded for `SystemTime`, its sub-groups, `Render`/`Audio`, and `Other`.
- **Copy / Reset buttons**: Copy exports aligned, tab-delimited text (monospaced-friendly and spreadsheet-importable); Reset clears accumulated/averaged values.
- **No tooltip flicker**: values update in place and the refresh pauses while the pointer is over the panel.
- Minor styling tweaks (background, column widths, spacing).

## Audio instrumentation
- New `Audio` group (renamed from `AudioTime`) mirroring `Render`.
- New stats: command path `CommandsPerSecond` / `Execute`; sample path `BufferFill` / `Underruns` / `Overruns` (ring-buffer health, via new counters in `AudioSampleRingBuffer`).
- New `ValueStat` gauge/counter type and an `IStat.ResetAverage()` hook.
- C64: capture audio provider per-instruction and per-frame timing.

## Minor fixes
- Lower `WebSocketTransport` per-byte logging to Debug.
- Avoid harmless `TaskCanceledException` noise on pause/stop (`FrameTimer`).

## Known issue (pre-existing, not addressed here)
The emulator display can intermittently stretch/warp on Stop or when hiding Stats. Confirmed pre-existing on `master`; logged separately in the design-log repo for a focused fix.