### PR TITLE
Fix Avalonia desktop window resize flicker on Stop/Start and Stats toggle

### DIFF
--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
@@ -123,6 +123,17 @@ public class MainViewModel : ViewModelBase, IDisposable
     }
 
     /// <summary>
+    /// Pixel size of the emulator display area for the currently selected system/variant
+    /// (screen Visible size × <see cref="Scale"/>). The emulator display container is bound to this,
+    /// so its size — and therefore the window size — only changes when the selected system/variant or
+    /// the Scale changes, NOT when the emulator is started/stopped. This keeps Start/Stop from
+    /// briefly resizing the window (the running render surface is created at a default size before
+    /// being sized to the real screen, which otherwise causes a shrink/expand flicker).
+    /// </summary>
+    public double EmulatorDisplayWidth => (_hostApp.CurrentSystemScreenInfo?.VisibleWidth ?? 320) * Scale;
+    public double EmulatorDisplayHeight => (_hostApp.CurrentSystemScreenInfo?.VisibleHeight ?? 200) * Scale;
+
+    /// <summary>
     /// Currently-active system menu contributor (supplies macOS native menu + keyboard shortcuts).
     /// Swaps when <see cref="SelectedSystemName"/> changes; null when no system is selected.
     /// </summary>
@@ -668,7 +679,24 @@ public class MainViewModel : ViewModelBase, IDisposable
               });
 
         this.WhenAnyValue(x => x.SelectedSystemName, x => x.SelectedSystemVariant)
-            .Subscribe(_ => this.RaisePropertyChanged(nameof(StatusSystemText)));
+            .Subscribe(_ =>
+            {
+                this.RaisePropertyChanged(nameof(StatusSystemText));
+                // The selected system/variant determines the emulator display size; refresh it so the
+                // display container (and window) resizes here — and only here (plus Scale changes).
+                this.RaisePropertyChanged(nameof(EmulatorDisplayWidth));
+                this.RaisePropertyChanged(nameof(EmulatorDisplayHeight));
+            });
+
+        // Scale also changes the emulator display size (the only other case the window should resize).
+        // Observe the HostApp's Scale source directly — the VM's own Scale getter reads _scale, which
+        // is not assigned until later in this constructor.
+        _hostApp.WhenAnyValue(x => x.Scale)
+            .Subscribe(_ =>
+            {
+                this.RaisePropertyChanged(nameof(EmulatorDisplayWidth));
+                this.RaisePropertyChanged(nameof(EmulatorDisplayHeight));
+            });
 
         _statusFpsTimer = new global::Avalonia.Threading.DispatcherTimer
         {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
@@ -44,7 +44,10 @@
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="200" />
             <ColumnDefinition Width="Auto" />
-            <ColumnDefinition MaxWidth="200" />
+            <!-- Stats column: fixed width, always reserved. The Stats button toggles only the stats
+                 *content* inside this column (not the column itself), so the window width never changes
+                 when Stats is shown/hidden — which avoids the SizeToContent resize flicker. -->
+            <ColumnDefinition Width="200" />
         </Grid.ColumnDefinitions>
 
         <!-- Menu and Controls Panel (Left) -->
@@ -263,11 +266,16 @@
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
 
+                <!-- Fixed to the selected system/variant display size (× Scale) so Start/Stop don't
+                     resize the window. Both the running emulator and the placeholder sit inside this
+                     stable container; it only changes on system/variant or Scale changes. -->
                 <Grid Grid.Row="0"
                     Name="EmulatorDisplayGrid"
                     HorizontalAlignment="Left"
-                    VerticalAlignment="Top">
-                    
+                    VerticalAlignment="Top"
+                    Width="{Binding EmulatorDisplayWidth}"
+                    Height="{Binding EmulatorDisplayHeight}">
+
                     <!-- Emulator Display Control -->
                     <views:EmulatorView Name="EmulatorView"
                         DataContext="{Binding EmulatorViewModel}"
@@ -1096,18 +1104,21 @@
             </Grid>
         </Border>
 
-        <!-- Info and Stats Panel (Right) -->
-        <Border Grid.Row="0" Grid.Column="2" Grid.RowSpan="3" Classes="panel-container"
-            IsVisible="{Binding IsStatisticsPanelVisible}">
-            <ScrollViewer Classes="h-stretch">
+        <!-- Info and Stats Panel (Right) — column is always present (see ColumnDefinition above).
+             Only the stats content toggles via IsStatisticsPanelVisible, so toggling Stats does not
+             resize the window. -->
+        <Border Grid.Row="0" Grid.Column="2" Grid.RowSpan="3" Classes="panel-container">
+            <ScrollViewer Classes="h-stretch"
+                IsVisible="{Binding IsStatisticsPanelVisible}">
                 <views:StatisticsView DataContext="{Binding StatisticsViewModel}" />
             </ScrollViewer>
         </Border>
 
-        <!-- Status Bar (Bottom; always present) -->
+        <!-- Status Bar (Bottom; always present). Spans the full width of all three columns (the stats
+             column is now always present), so it stretches edge-to-edge rather than stopping at the
+             end of the emulator column. -->
         <views:StatusBar Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3"
-                         HorizontalAlignment="Left"
-                         Width="{Binding ElementName=CenterPanel, Path=Bounds.Right}"/>
+                         HorizontalAlignment="Stretch"/>
         </Grid>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary

The Avalonia desktop main window uses `SizeToContent`, so any content size change auto-resized the window — and macOS redraws/stretches content during that resize, showing as a flicker (and intermittently a stuck/warped layout). Two common actions triggered it:

- **Stats toggle** collapsed/expanded the right-hand column, changing window width.
- **Start/Stop** swapped between the placeholder and the emulator render surface (created at a default 320×200 before being sized to the real screen), briefly shrinking/expanding the window.

## Changes

- **Stats column** is now a fixed, always-reserved width; the Stats button toggles only the stats *content* inside it, so the window width never changes on toggle.
- **Emulator display area** is bound to a fixed size derived from the selected system/variant screen size × Scale (`EmulatorDisplayWidth`/`Height` on `MainViewModel`), updated only on system/variant or Scale changes — so Start/Stop no longer resize the window.
- **Status bar** stretches the full window width now that the stats column is always present.

Net effect: the window resizes **only** when the system, variant, or scale changes — not on Start/Stop or Stats toggle.
