### PR TITLE
Feature/monitor toggle fix

### DIFF
--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/EmulatorViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/EmulatorViewModel.cs
@@ -13,6 +13,12 @@ public class EmulatorViewModel : ViewModelBase
     public event EventHandler? RequestFocus;
     public event EventHandler<RenderConfigurationEventArgs>? RequestRenderConfiguration;
 
+    /// <summary>
+    /// Raised when the emulator has stopped, so the view can clear the (now stale) render control.
+    /// Prevents the previous system's last frame from briefly showing when a new system is started.
+    /// </summary>
+    public event EventHandler? RequestClearDisplay;
+
     public EmulatorViewModel(AvaloniaHostApp hostApp)
     {
         _hostApp = hostApp;
@@ -39,6 +45,12 @@ public class EmulatorViewModel : ViewModelBase
 
                 // Also make sure the view has focus to receive keyboard input
                 RequestFocus?.Invoke(this, EventArgs.Empty);
+            }
+            else if (_hostApp.EmulatorState == EmulatorState.Uninitialized)
+            {
+                // Emulator stopped: drop the stale render control so its last frame isn't shown
+                // when the view becomes visible again on the next start.
+                RequestClearDisplay?.Invoke(this, EventArgs.Empty);
             }
         }
     }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
@@ -130,8 +130,12 @@ public class MainViewModel : ViewModelBase, IDisposable
     /// briefly resizing the window (the running render surface is created at a default size before
     /// being sized to the real screen, which otherwise causes a shrink/expand flicker).
     /// </summary>
-    public double EmulatorDisplayWidth => (_hostApp.CurrentSystemScreenInfo?.VisibleWidth ?? 320) * Scale;
-    public double EmulatorDisplayHeight => (_hostApp.CurrentSystemScreenInfo?.VisibleHeight ?? 200) * Scale;
+    // Read the Scale from _hostApp directly rather than via the VM's Scale property (an OAPH).
+    // When _hostApp.Scale changes, the subscription that raises PropertyChanged for these properties
+    // fires before the Scale OAPH updates, so reading the OAPH here would yield the previous scale and
+    // leave the display container lagging one step behind the render control.
+    public double EmulatorDisplayWidth => (_hostApp.CurrentSystemScreenInfo?.VisibleWidth ?? 320) * _hostApp.Scale;
+    public double EmulatorDisplayHeight => (_hostApp.CurrentSystemScreenInfo?.VisibleHeight ?? 200) * _hostApp.Scale;
 
     /// <summary>
     /// Currently-active system menu contributor (supplies macOS native menu + keyboard shortcuts).

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorView.axaml.cs
@@ -82,6 +82,7 @@ public partial class EmulatorView : UserControl
             //_subscribedViewModel.PropertyChanged -= OnViewModelPropertyChanged;
             _subscribedViewModel.RequestFocus -= OnRequestFocus;
             _subscribedViewModel.RequestRenderConfiguration -= OnRequestRenderConfiguration;
+            _subscribedViewModel.RequestClearDisplay -= OnRequestClearDisplay;
         }
 
         // Subscribe to new ViewModel's events and property changes
@@ -91,6 +92,7 @@ public partial class EmulatorView : UserControl
             //_subscribedViewModel.PropertyChanged += OnViewModelPropertyChanged;
             _subscribedViewModel.RequestFocus += OnRequestFocus;
             _subscribedViewModel.RequestRenderConfiguration += OnRequestRenderConfiguration;
+            _subscribedViewModel.RequestClearDisplay += OnRequestClearDisplay;
 
             // Note: We don't register the render control here because it's null at this point.
             // Registration happens in OnRequestRenderConfiguration after the control is created.
@@ -129,6 +131,21 @@ public partial class EmulatorView : UserControl
             if (HostApp != null && _renderControl != null)
             {
                 HostApp.RegisterRenderControl(_renderControl);
+            }
+        }, DispatcherPriority.Background);
+    }
+
+    private void OnRequestClearDisplay(object? sender, EventArgs e)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            // Remove the stale render control (and its last-frame bitmap) when the emulator stops.
+            // Otherwise it would briefly be shown when the view becomes visible again on the next start,
+            // before OnRequestRenderConfiguration creates the new control.
+            if (_renderControl != null)
+            {
+                RenderingControlContainer.Content = null;
+                _renderControl = null;
             }
         }, DispatcherPriority.Background);
     }


### PR DESCRIPTION
## Fix Avalonia emulator display issues: stale frame on restart & scale slider lag

  Two display-control fixes:
  - **Remove flickering on Stats toggle and start/stop.** Skip resizing Window on stats toggle, always show the third column. Change resizing Window from start button to when emulator system/variant is selected.
  
  - **Clear stale frame on stop.** When restarting a system after a previous run, the last
    frame of the prior session briefly flashed before the new system booted. The old render
    control (holding the previous frame's bitmap) was left in place while the view was hidden,
    then repainted when the view became visible on the next start, before the replacement
    control was created. `EmulatorView` now clears the render control when the emulator stops
    (via a new `RequestClearDisplay` event on `EmulatorViewModel`).

  - **Fix scale slider lag.** The emulator display container lagged one step behind the render
    control when dragging the Scale slider (too-large border at low scale, clipped screen at
    high scale). `EmulatorDisplayWidth`/`Height` read the `Scale` OAPH, which updates *after*
    the subscription that refreshes those properties — so the container was sized with the
    previous scale. They now read `_hostApp.Scale` directly, so container and render control
    resize together.