### PR TITLE
Fix Avalonia monitor toggle and improve monitor entry behavior

### DIFF
--- a/dotnet-6502.sln
+++ b/dotnet-6502.sln
@@ -146,6 +146,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Highbyte.DotNet6502.App.Sil
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Highbyte.DotNet6502.App.RemoteClient", "src\apps\Highbyte.DotNet6502.App.RemoteClient\Highbyte.DotNet6502.App.RemoteClient.csproj", "{E3CCF260-CBF8-4B8A-9CE2-0CF711F726FC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Highbyte.DotNet6502.Monitor.Tests", "tests\Highbyte.DotNet6502.Monitor.Tests\Highbyte.DotNet6502.Monitor.Tests.csproj", "{C48A9B47-9DCB-46A2-B47C-AB015AE4871F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -852,6 +854,18 @@ Global
 		{E3CCF260-CBF8-4B8A-9CE2-0CF711F726FC}.Release|x64.Build.0 = Release|Any CPU
 		{E3CCF260-CBF8-4B8A-9CE2-0CF711F726FC}.Release|x86.ActiveCfg = Release|Any CPU
 		{E3CCF260-CBF8-4B8A-9CE2-0CF711F726FC}.Release|x86.Build.0 = Release|Any CPU
+		{C48A9B47-9DCB-46A2-B47C-AB015AE4871F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C48A9B47-9DCB-46A2-B47C-AB015AE4871F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C48A9B47-9DCB-46A2-B47C-AB015AE4871F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C48A9B47-9DCB-46A2-B47C-AB015AE4871F}.Debug|x64.Build.0 = Debug|Any CPU
+		{C48A9B47-9DCB-46A2-B47C-AB015AE4871F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C48A9B47-9DCB-46A2-B47C-AB015AE4871F}.Debug|x86.Build.0 = Debug|Any CPU
+		{C48A9B47-9DCB-46A2-B47C-AB015AE4871F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C48A9B47-9DCB-46A2-B47C-AB015AE4871F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C48A9B47-9DCB-46A2-B47C-AB015AE4871F}.Release|x64.ActiveCfg = Release|Any CPU
+		{C48A9B47-9DCB-46A2-B47C-AB015AE4871F}.Release|x64.Build.0 = Release|Any CPU
+		{C48A9B47-9DCB-46A2-B47C-AB015AE4871F}.Release|x86.ActiveCfg = Release|Any CPU
+		{C48A9B47-9DCB-46A2-B47C-AB015AE4871F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -921,6 +935,7 @@ Global
 		{4F162EBC-F216-40CB-A7D6-6744569721E9} = {21E62BEB-D361-8293-13EC-0E9A9617F8B6}
 		{A7EC272D-C205-40DF-B5D5-4671B361D94C} = {21E62BEB-D361-8293-13EC-0E9A9617F8B6}
 		{E3CCF260-CBF8-4B8A-9CE2-0CF711F726FC} = {179A14B2-B918-4B64-8314-3551D83551D0}
+		{C48A9B47-9DCB-46A2-B47C-AB015AE4871F} = {D7D2C567-4FB5-48D1-BEBF-6B7EE21893FC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0F55B6C2-E4B4-4F2C-9D2A-D63A17F3B5C4}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
@@ -742,6 +742,13 @@ public class MainViewModel : ViewModelBase, IDisposable
 
                 _currentMonitor = monitor;
 
+                // Invalidate any cached MonitorViewModel: it holds a reference to the previous
+                // AvaloniaMonitor instance. On Stop/Start a brand new monitor is created, so the
+                // cached view model would otherwise drive a dead monitor (g/close button and
+                // auto-close stop working, and the emulator never resumes). The getter lazily
+                // recreates it against the current monitor when needed.
+                MonitorViewModel = null;
+
                 // Update visibility when monitor changes (e.g., on Stop, Monitor becomes null)
                 IsMonitorVisible = monitor?.IsVisible ?? false;
 

--- a/src/apps/BlazorWASM/Highbyte.DotNet6502.App.WASM.Core/Emulator/WasmMonitor.cs
+++ b/src/apps/BlazorWASM/Highbyte.DotNet6502.App.WASM.Core/Emulator/WasmMonitor.cs
@@ -35,6 +35,8 @@ public class WasmMonitor : MonitorBase
 
     public void Enable(ExecEvaluatorTriggerResult? execEvaluatorTriggerResult = null)
     {
+        Reset();   // Reset monitor working variables (re-anchor disassembly to PC)
+
         if (!_hasBeenInitializedOnce)
         {
             // Show description and general help text first time
@@ -47,8 +49,8 @@ public class WasmMonitor : MonitorBase
 
         if (execEvaluatorTriggerResult != null)
             ShowInfoAfterBreakTriggerEnabled(execEvaluatorTriggerResult);
-        //else
-        //    WriteOutput("Monitor enabled manually.");
+
+        ShowCurrentInstruction();
 
         DisplayStatus();
 

--- a/src/apps/BlazorWASM/Highbyte.DotNet6502.App.WASM/Pages/Index.razor.cs
+++ b/src/apps/BlazorWASM/Highbyte.DotNet6502.App.WASM/Pages/Index.razor.cs
@@ -554,11 +554,14 @@ public partial class Index : IWasmHostView
     public async Task SetMonitorState(bool visible)
     {
         _monitorVisible = visible;
+        // Render first so the monitor input element is present and visible in the DOM before
+        // focusing it. While the monitor is hidden the element is display:none (see
+        // SetElementVisibleState), and a hidden element can't receive focus.
+        await this.StateHasChangedCustom();
         if (visible)
             await FocusMonitor();
         else
             await FocusEmulator();
-        await this.StateHasChangedCustom();
     }
 
     //private void BeforeUnload_BeforeUnloadHandler(object? sender, blazejewicz.Blazor.BeforeUnload.BeforeUnloadArgs e)
@@ -752,8 +755,7 @@ public partial class Index : IWasmHostView
 
     private async Task FocusMonitor()
     {
-        await Task.Run(async () => await _monitorInputRef.FocusAsync());    // Task.Run fix for focusing on a element that is not yet visible (but about to be)
-        //await _monitorInputRef.FocusAsync();
+        await Js!.InvokeVoidAsync("focusId", "monitor-input", 100);  // Hack: Delay of x ms for focus to work (element just became visible). Mirrors FocusEmulator.
     }
 
     /// <summary>

--- a/src/apps/SadConsole/Highbyte.DotNet6502.App.SadConsole.Core/MonitorConsole.cs
+++ b/src/apps/SadConsole/Highbyte.DotNet6502.App.SadConsole.Core/MonitorConsole.cs
@@ -148,10 +148,28 @@ internal class MonitorConsole : Console
     public void Enable(ExecEvaluatorTriggerResult? execEvaluatorTriggerResult = null)
     {
         var monitor = GetMonitorOrThrow();
-        monitor.Reset();   // Reset monitor working variables (like last disassembly location)
+        monitor.Reset();   // Reset monitor working variables (re-anchor disassembly to PC)
+
+        // Print the entry info (optional break-trigger reason + current instruction at PC) with the
+        // keyboard handler detached. Printing while it's attached advances the cursor below its
+        // CursorLastY without updating it, so the next Enter reads a span of empty cells and splits
+        // them into many empty tokens (a flood of "Unrecognized command or argument ''"). Detaching
+        // and re-adding the handler re-runs OnAdded -> PrintPrompt, which re-syncs CursorLastY.
+        if (SadComponents.Contains(_keyboardHandlerObject))
+            SadComponents.Remove(_keyboardHandlerObject);
+
+        // Overwrite the existing "> " prompt line so the output isn't glued to it.
+        Cursor.CarriageReturn();
 
         if (execEvaluatorTriggerResult != null)
             monitor.ShowInfoAfterBreakTriggerEnabled(execEvaluatorTriggerResult);
+
+        monitor.ShowCurrentInstruction();
+
+        // Printing may have scrolled the surface; reset before re-adding so the handler's
+        // CursorLastY tracking starts clean.
+        Surface.TimesShiftedUp = 0;
+        SadComponents.Add(_keyboardHandlerObject);
 
         IsVisible = true;
         IsFocused = true;

--- a/src/apps/SilkNetNative/Highbyte.DotNet6502.App.SilkNetNative.Core/SilkNetImgUIMonitor.cs
+++ b/src/apps/SilkNetNative/Highbyte.DotNet6502.App.SilkNetNative.Core/SilkNetImgUIMonitor.cs
@@ -66,20 +66,6 @@ public class SilkNetImGuiMonitor : ISilkNetImGuiWindow
         //ImGui.SetWindowPos(new Vector2(POS_X, POS_Y));
         //ImGui.SetWindowSize(new Vector2(WIDTH, HEIGHT));
 
-        if (!_hasBeenInitializedOnce)
-        {
-            // Init monitor list of history commands with blanks
-            for (int i = 0; i < SilkNetNativeMonitor.MONITOR_CMD_HISTORY_VIEW_ROWS; i++)
-                _silkNetNativeMonitor.WriteOutput("");
-
-            // Show description and general help text first time
-            _silkNetNativeMonitor.ShowDescription();
-            _silkNetNativeMonitor.WriteOutput("");
-            _silkNetNativeMonitor.ShowHelp();
-
-            _hasBeenInitializedOnce = true;
-        }
-
         ImGui.Begin($"6502 Monitor: {_silkNetNativeMonitor.System.Name}", ImGuiWindowFlags.NoScrollbar);
 
         if (ImGui.IsWindowFocused())
@@ -178,12 +164,29 @@ public class SilkNetImGuiMonitor : ISilkNetImGuiWindow
         Quit = false;
         Visible = true;
         _setFocusOnInput = true;
-        _silkNetNativeMonitor.Reset();   // Reset monitor working variables (like last disassembly location)
+        _silkNetNativeMonitor.Reset();   // Reset monitor working variables (re-anchor disassembly to PC)
+
+        if (!_hasBeenInitializedOnce)
+        {
+            // Init monitor list of history commands with blanks
+            for (int i = 0; i < SilkNetNativeMonitor.MONITOR_CMD_HISTORY_VIEW_ROWS; i++)
+                _silkNetNativeMonitor.WriteOutput("");
+
+            // Show description and general help text first time. Done here (before the current
+            // instruction below) rather than during render, so the first-entry instruction line
+            // isn't pushed above the help text and out of view.
+            _silkNetNativeMonitor.ShowDescription();
+            _silkNetNativeMonitor.WriteOutput("");
+            _silkNetNativeMonitor.ShowHelp();
+
+            _hasBeenInitializedOnce = true;
+        }
 
         if (execEvaluatorTriggerResult != null)
             _silkNetNativeMonitor.ShowInfoAfterBreakTriggerEnabled(execEvaluatorTriggerResult);
-        //else
-        //    WriteOutput($"Monitor enabled manually.", MessageSeverity.Information);
+
+        _silkNetNativeMonitor.ShowCurrentInstruction();
+
         OnMonitorStateChange(true);
     }
 

--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia/Monitor/AvaloniaMonitor.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia/Monitor/AvaloniaMonitor.cs
@@ -70,6 +70,8 @@ public class AvaloniaMonitor : MonitorBase, INotifyPropertyChanged
         if (execEvaluatorTriggerResult != null)
             ShowInfoAfterBreakTriggerEnabled(execEvaluatorTriggerResult);
 
+        ShowCurrentInstruction();
+
         RefreshStatus();
         ResetHistoryNavigation();
         IsVisible = true;

--- a/src/libraries/Highbyte.DotNet6502.Monitor/MonitorBase.cs
+++ b/src/libraries/Highbyte.DotNet6502.Monitor/MonitorBase.cs
@@ -10,7 +10,7 @@ namespace Highbyte.DotNet6502.Monitor;
 public abstract class MonitorBase
 {
     public MonitorConfig Options { get; private set; }
-    private MonitorVariables _variables;
+    private readonly MonitorVariables _variables;
 
     private readonly SystemRunner _systemRunner;
     public SystemRunner SystemRunner => _systemRunner;
@@ -64,7 +64,10 @@ public abstract class MonitorBase
 
     public void Reset()
     {
-        _variables = new MonitorVariables();
+        // Mutate the existing instance instead of reallocating: the command handlers
+        // captured this MonitorVariables reference when the command line app was built,
+        // so a reassignment here would not be observed by them.
+        _variables.ResetDisassemblyAnchor();
 
         // If there are system-specific monitor commands, issue reset there too
         if (SystemRunner.System is ISystemMonitor systemWithMonitor)
@@ -103,8 +106,16 @@ public abstract class MonitorBase
             default:
                 throw new DotNet6502Exception($"Internal error. Unknown ExecEvaluatorTriggerReasonType: {execEvaluatorTriggerResult.TriggerType}");
         }
+    }
 
-        // Show disassembly of next instruction
+    /// <summary>
+    /// Writes a single disassembled instruction at the current PC to the monitor output.
+    /// Shown each time the monitor is entered (manually or via a break trigger), mirroring how
+    /// VICE prints the current instruction on entry. Does not advance the 'd' command disassembly
+    /// anchor, so a following argument-less 'd' still starts at PC.
+    /// </summary>
+    public void ShowCurrentInstruction()
+    {
         WriteOutput($"{OutputGen.GetNextInstructionDisassembly(Cpu, Mem)}");
     }
     public void ShowDescription()

--- a/src/libraries/Highbyte.DotNet6502.Monitor/MonitorVariables.cs
+++ b/src/libraries/Highbyte.DotNet6502.Monitor/MonitorVariables.cs
@@ -7,4 +7,22 @@ public class MonitorVariables
 {
     public ushort? LatestDisassemblyAddress { get; set; }
     public ushort? LatestMemoryDumpAddress { get; set; }
+
+    /// <summary>
+    /// Re-anchors the disassembly position so the next argument-less 'd' command starts at the
+    /// current PC again. Called each time the monitor is shown, mirroring how VICE re-anchors
+    /// disassembly to PC on every break/entry.
+    /// <para>
+    /// The memory dump pointer (<see cref="LatestMemoryDumpAddress"/>) is intentionally NOT reset
+    /// here: like VICE, the 'm' command keeps its position across monitor sessions within the same
+    /// emulator run, so the data region being browsed is not lost. It resets naturally when a new
+    /// emulator run begins (a fresh monitor, and thus a fresh MonitorVariables, is created).
+    /// </para>
+    /// Mutates this instance in place so references captured by the monitor command handlers
+    /// continue to observe the reset value.
+    /// </summary>
+    public void ResetDisassemblyAnchor()
+    {
+        LatestDisassemblyAddress = null;
+    }
 }

--- a/tests/Highbyte.DotNet6502.Monitor.Tests/DisassemblyAndMemoryDumpCommandTests.cs
+++ b/tests/Highbyte.DotNet6502.Monitor.Tests/DisassemblyAndMemoryDumpCommandTests.cs
@@ -1,0 +1,117 @@
+using Highbyte.DotNet6502.Monitor.Tests.Helpers;
+using Highbyte.DotNet6502.Systems;
+
+namespace Highbyte.DotNet6502.Monitor.Tests;
+
+/// <summary>
+/// Behavior of the monitor 'd' (disassemble) and 'm' (memory dump) commands, with focus on how the
+/// argument-less forms track their position and how <see cref="MonitorBase.Reset"/> (called when the
+/// monitor is (re)entered) re-anchors disassembly to PC while leaving the memory dump position intact.
+/// </summary>
+public class DisassemblyAndMemoryDumpCommandTests
+{
+    private const byte OpCodeNop = 0xEA; // 1-byte instruction, so disassembly advances 1 address per instruction.
+
+    private static TestMonitor CreateMonitor(ushort pc = 0x1000)
+    {
+        var system = new TestSystem();
+
+        // Fill memory with NOPs so the disassembler advances by a known, fixed amount.
+        for (int address = 0; address <= 0xffff; address++)
+            system.Mem[(ushort)address] = OpCodeNop;
+
+        system.CPU.PC = pc;
+
+        var systemRunner = new SystemRunner(system);
+        return new TestMonitor(systemRunner, new MonitorConfig());
+    }
+
+    // ---- 'd' (disassemble) ----
+
+    [Fact]
+    public void Disassemble_WithNoArguments_StartsAtCurrentPc()
+    {
+        var monitor = CreateMonitor(pc: 0x1000);
+
+        monitor.SendCommand("d");
+
+        Assert.StartsWith("1000", monitor.FirstOutputLine);
+    }
+
+    [Fact]
+    public void Disassemble_RepeatedWithNoArguments_ContinuesFromPreviousPosition()
+    {
+        var monitor = CreateMonitor(pc: 0x1000);
+
+        monitor.SendCommand("d"); // 10 single-byte instructions: 0x1000..0x1009, leaving the anchor at 0x100a.
+        monitor.ClearOutput();
+        monitor.SendCommand("d");
+
+        Assert.StartsWith("100a", monitor.FirstOutputLine);
+    }
+
+    [Fact]
+    public void Disassemble_WithExplicitStartAddress_StartsThere()
+    {
+        var monitor = CreateMonitor(pc: 0x1000);
+
+        monitor.SendCommand("d 2000");
+
+        Assert.StartsWith("2000", monitor.FirstOutputLine);
+    }
+
+    [Fact]
+    public void Reset_ReAnchorsDisassemblyToCurrentPc()
+    {
+        var monitor = CreateMonitor(pc: 0x1000);
+        monitor.SendCommand("d"); // Advance the disassembly anchor past PC.
+
+        // Simulate re-entering the monitor at a new PC.
+        monitor.System.CPU.PC = 0x3000;
+        monitor.Reset();
+        monitor.ClearOutput();
+
+        monitor.SendCommand("d");
+
+        Assert.StartsWith("3000", monitor.FirstOutputLine);
+    }
+
+    // ---- 'm' (memory dump) ----
+
+    [Fact]
+    public void MemoryDump_WithNoArguments_StartsAtZero()
+    {
+        var monitor = CreateMonitor();
+
+        monitor.SendCommand("m");
+
+        Assert.StartsWith("0000", monitor.FirstOutputLine);
+    }
+
+    [Fact]
+    public void MemoryDump_RepeatedWithNoArguments_ContinuesFromPreviousPosition()
+    {
+        var monitor = CreateMonitor();
+
+        monitor.SendCommand("m"); // Shows 128 bytes (0x0000..0x007f), leaving the position at 0x0080.
+        monitor.ClearOutput();
+        monitor.SendCommand("m");
+
+        Assert.StartsWith("0080", monitor.FirstOutputLine);
+    }
+
+    [Fact]
+    public void Reset_DoesNotResetMemoryDumpPosition()
+    {
+        var monitor = CreateMonitor();
+        monitor.SendCommand("m"); // Advance the memory dump position to 0x0080.
+
+        // Re-entering the monitor must NOT snap the memory dump back to 0x0000 (unlike disassembly).
+        monitor.Reset();
+        monitor.ClearOutput();
+
+        monitor.SendCommand("m");
+
+        Assert.StartsWith("0080", monitor.FirstOutputLine);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Monitor.Tests/GlobalUsings.cs
+++ b/tests/Highbyte.DotNet6502.Monitor.Tests/GlobalUsings.cs
@@ -1,0 +1,3 @@
+// If <ImplicitUsings>enable</ImplicitUsings> is added to the .csproj file, a bunch of standard .NET namespaces are added by default (and not needed to be added here).
+
+global using Xunit;

--- a/tests/Highbyte.DotNet6502.Monitor.Tests/Helpers/TestMonitor.cs
+++ b/tests/Highbyte.DotNet6502.Monitor.Tests/Helpers/TestMonitor.cs
@@ -1,0 +1,67 @@
+using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Instrumentation;
+using Highbyte.DotNet6502.Systems.Rendering;
+
+namespace Highbyte.DotNet6502.Monitor.Tests.Helpers;
+
+/// <summary>
+/// Minimal <see cref="ISystem"/> with a real <see cref="CPU"/> and <see cref="Memory"/> so the
+/// monitor's disassembly ('d') and memory dump ('m') commands can be exercised. Members not used
+/// by those commands are left unimplemented.
+/// </summary>
+internal sealed class TestSystem : ISystem
+{
+    public string Name => "Test";
+    public List<string> SystemInfo => new();
+    public List<KeyValuePair<string, Func<string>>> DebugInfo => new();
+
+    public CPU CPU { get; } = new();
+    public Memory Mem { get; } = new();
+    public IScreen Screen => throw new NotImplementedException();
+
+    public bool InstrumentationEnabled { get; set; }
+    public Instrumentations Instrumentations { get; } = new();
+
+    public IRenderProvider? RenderProvider => null;
+    public List<IRenderProvider> RenderProviders { get; } = new();
+
+    public ExecEvaluatorTriggerResult ExecuteOneFrame(IExecEvaluator? execEvaluator = null) => new();
+
+    public ExecEvaluatorTriggerResult ExecuteOneInstruction(out InstructionExecResult instructionExecResult, IExecEvaluator? execEvaluator = null)
+    {
+        instructionExecResult = new InstructionExecResult();
+        return new();
+    }
+}
+
+/// <summary>
+/// Concrete <see cref="MonitorBase"/> used in tests. Captures everything written to the monitor
+/// output so command behavior can be asserted.
+/// </summary>
+internal sealed class TestMonitor : MonitorBase
+{
+    public List<string> Output { get; } = new();
+
+    public TestMonitor(SystemRunner systemRunner, MonitorConfig config)
+        : base(systemRunner, config)
+    {
+    }
+
+    /// <summary>The first line written by the most recent command (or null if none).</summary>
+    public string? FirstOutputLine => Output.Count > 0 ? Output[0] : null;
+
+    public void ClearOutput() => Output.Clear();
+
+    public override void WriteOutput(string message) => Output.Add(message);
+
+    public override void WriteOutput(string message, MessageSeverity severity) => Output.Add(message);
+
+    public override bool LoadBinary(string fileName, out ushort loadedAtAddress, out ushort fileLength, ushort? forceLoadAddress = null, Action<MonitorBase, ushort, ushort>? afterLoadCallback = null)
+        => throw new NotImplementedException();
+
+    public override bool LoadBinary(out ushort loadedAtAddress, out ushort fileLength, ushort? forceLoadAddress = null, Action<MonitorBase, ushort, ushort>? afterLoadCallback = null)
+        => throw new NotImplementedException();
+
+    public override void SaveBinary(string fileName, ushort startAddress, ushort endAddress, bool addFileHeaderWithLoadAddress)
+        => throw new NotImplementedException();
+}

--- a/tests/Highbyte.DotNet6502.Monitor.Tests/Highbyte.DotNet6502.Monitor.Tests.csproj
+++ b/tests/Highbyte.DotNet6502.Monitor.Tests/Highbyte.DotNet6502.Monitor.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\libraries\Highbyte.DotNet6502.Monitor\Highbyte.DotNet6502.Monitor.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Fixes a monitor toggle bug in the Avalonia app and improves built-in monitor behavior consistently across all front-ends (Avalonia, SilkNet, SadConsole, WASM), aligning entry/command behavior with VICE.

## Changes

**Avalonia monitor toggle (the original bug)**
- After Stop → Start, the cached `MonitorViewModel` still referenced the previous (dead) `AvaloniaMonitor` instance, so `g`/close button and auto-close stopped working and the emulator wouldn't resume. The cached view model is now invalidated whenever the `Monitor` instance changes, so it always tracks the live monitor.

**Disassemble (`d`) and memory dump (`m`) commands**
- `MonitorBase.Reset()` was a no-op (it reallocated `MonitorVariables` instead of mutating the instance captured by the command handlers), so the disassembly position never re-anchored to PC on monitor re-entry. Reset now mutates in place.
- `d` re-anchors to the current PC on each monitor entry (matching VICE); repeated `d` still continues forward.
- `m` now persists its position across monitor sessions within the same emulator run (matching VICE) instead of snapping back to `0000` each entry. A fresh emulator run still resets it.

**Show current instruction on monitor entry (all front-ends)**
- Factored the "disassemble instruction at PC" line into `MonitorBase.ShowCurrentInstruction()`; `ShowInfoAfterBreakTriggerEnabled` now only reports the trigger reason.
- Every monitor entry (manual F12 and break trigger) now shows a single current-instruction line at PC, consistent across front-ends.

**Front-end specific fixes**
- **SadConsole**: printing the entry instruction while the keyboard handler was attached desynced its input-line tracking, causing a flood of empty-argument parse errors on the next command. Now prints with the handler detached and re-syncs the prompt.
- **SilkNet**: moved one-time init (help text) into `Enable()` so the first-entry instruction line isn't pushed out of view.
- **WASM**: monitor input row now receives focus on open (render-then-focus ordering + the shared `focusId` JS helper), so you no longer have to click it first.

**Tests**
- New `Highbyte.DotNet6502.Monitor.Tests` project with unit tests covering `d`/`m` start position, continuation, explicit address, and the `Reset()` asymmetry (re-anchors `d`, leaves `m`).
