### PR TITLE
Make the Terminal (TUI) app fully keyboard-navigable

### DIFF
--- a/docs/host-apps/terminal/overview.md
+++ b/docs/host-apps/terminal/overview.md
@@ -80,20 +80,51 @@ of direct host hotkeys. Instead, host commands hang off a single **leader key** 
 | `Q` | Quit the app |
 | `Y` | Cycle the selected **System** (only while stopped) |
 | `V` | Cycle the selected **Variant** (only while stopped) |
+| `Tab` | Toggle focus between the emulator screen and the host UI (see below) |
 | `Esc` (or any other key) | Cancel host mode |
 
-The bottom line shows just the leader-key reminder (e.g. `F9 Menu`) normally, so it is obvious when
-host mode is *not* active; it expands to the full command menu only while host mode is armed. Every
-command also has a button in the **Controls** column — including a **Quit** button — so a mouse (or
-`Tab` + `Enter`) works without the keyboard. (Terminals offer no clickable window close control, and
-`Esc` is reserved for the emulator's RUN/STOP, so quitting is via the **Quit** button or `F9` `Q`.)
-`Tab` moves focus to the emulator screen so typing reaches the running system.
+The bottom line shows just the leader-key reminder (e.g. `[UI NAV]  F9 Menu`) normally, so it is
+obvious when host mode is *not* active; it expands to the full command menu only while host mode is
+armed. Every command also has a button in the **Controls** column — including a **Quit** button — so a
+mouse works without the keyboard. (Terminals offer no clickable window close control, and `Esc` is
+reserved for the emulator's RUN/STOP, so quitting is via the **Quit** button or `F9` `Q`.)
 
 The leader key defaults to `F9` because it is reliable across terminals (unlike `F10`/`F11`). If your
 terminal grabs `F9`, rebind it with the `LeaderKey` setting in `appsettings.json` (any `KeyCode` name,
 e.g. `"F12"`). Host mode is suppressed while a modal dialog (config, file picker, monitor) is open, so
 keys reach the dialog's fields normally. `F1`–`F8` are reserved for the emulated systems (e.g. the C64
 function keys).
+
+### Keyboard navigation (focus modes)
+
+There are two focus modes; `F9` `Tab` (or `F9` `F6`) toggles between them, and the bottom-line
+indicator (`[EMULATOR]` / `[UI NAV]`) shows which is active:
+
+- **Emulator mode** — the emulator screen has focus, so every key (except the leader key) goes to the
+  emulated machine. The host-UI panels are **dimmed** to signal they're inactive. Start/Resume enters
+  this mode automatically.
+- **UI mode** — focus is on the host controls, so the keyboard navigates every control with no
+  per-control shortcuts. Stopping or pausing the emulator returns to this mode automatically.
+
+While the emulator is running it owns every key, so plain `Tab`/`F6` reach the machine, not the host.
+The leader key is the way out: press **`F9` then `Tab`** (or `F9` `F6`) to hand the keyboard back to
+the host UI. The same `F9` `Tab` gives it back to the emulator. (The emulator screen is also kept out
+of the `Tab`/`F6` rings, so once in UI mode navigation never falls back into it by accident.)
+
+In UI mode the controls are organised into **areas**, each a Terminal.Gui *tab group*: the **Controls
+column**, the **per-system menu** (e.g. the C64 menu), and the **Info/Config/Logs pane**. Focus is
+scoped per area — `Tab` stays within one area and `F6` moves between them:
+
+| Key | Moves focus |
+|-----|-------------|
+| `Tab` / `Shift+Tab` | Next / previous control **within** the current area |
+| `F6` / `Shift+F6` | Next / previous **area** (Controls → per-system menu → tabbed pane) |
+| `↑` `↓` `←` `→` | Within a control (tab strip, log list, radio group, …) |
+| `Enter` / `Space` | Activate the focused button / toggle |
+
+So to reach the C64 menu buttons, press `F6` to step into the C64 menu area, then `Tab` to cycle its
+buttons. The emulator screen is deliberately left out of these rings; enter it with Start/Resume or
+`F9` `Tab`.
 
 ## Config dialog
 

--- a/docs/host-apps/terminal/overview.md
+++ b/docs/host-apps/terminal/overview.md
@@ -36,8 +36,8 @@ emulator — older or minimal terminals may render incorrectly:
   (~100 columns) shows everything without the panes clipping. Smaller still runs, but content is
   truncated.
 - **Mouse (optional)** — buttons, the per-system menu, and the Info/Config/Logs tabs are clickable
-  when the terminal reports mouse events, but every action also has a keyboard hotkey, so a mouse is
-  not required.
+  when the terminal reports mouse events, but every action also has a keyboard command (via the
+  leader key, see below), so a mouse is not required.
 - **Modifier-key reporting** — some C64 colour-key chords use Alt/Ctrl; whether they reach the
   emulator depends on the terminal forwarding those modifiers (see the in-app Info panel).
 
@@ -65,21 +65,35 @@ The window has a **Controls** column (left), the **Screen** in the middle, and a
 a tabbed **Info / Config / Logs** pane on the right. A per-system menu (contributed by the shell
 plugin) appears below the standard controls.
 
-Hotkeys (shown in the bottom hint line):
+### Host commands (leader key)
 
-| Key | Action |
-|-----|--------|
-| `9` | Cycle the selected **System** (only while stopped) |
-| `0` | Cycle the selected **Variant** (only while stopped) |
-| `F9` | Start / Stop toggle |
-| `F10` | Quit the app |
-| `F11` | Toggle the **Stats** (instrumentation) box |
-| `F12` | Toggle the **Monitor** |
-| `Tab` | Move focus to the emulator screen (so typing reaches the running system) |
+A running emulator claims almost every key, and terminals/window managers reserve the rest (`F10` =
+menu, `F11` = fullscreen, `Ctrl`/`Alt`/`Shift` = emulator modifiers), so there is no room for a row
+of direct host hotkeys. Instead, host commands hang off a single **leader key** — press it to arm
+*host mode*, then press one command key:
 
-Hotkeys are suppressed while a modal dialog (config, file picker, monitor) is open, so keys —
-including the digits `9`/`0` — reach the dialog's fields normally. `F1`–`F8` are reserved for the
-emulated systems (e.g. the C64 function keys).
+| Press `F9`, then… | Action |
+|-------------------|--------|
+| `S` | Start / Stop toggle |
+| `M` | Toggle the **Monitor** |
+| `T` | Toggle the **Stats** (instrumentation) box |
+| `Q` | Quit the app |
+| `Y` | Cycle the selected **System** (only while stopped) |
+| `V` | Cycle the selected **Variant** (only while stopped) |
+| `Esc` (or any other key) | Cancel host mode |
+
+The bottom line shows just the leader-key reminder (e.g. `F9 Menu`) normally, so it is obvious when
+host mode is *not* active; it expands to the full command menu only while host mode is armed. Every
+command also has a button in the **Controls** column — including a **Quit** button — so a mouse (or
+`Tab` + `Enter`) works without the keyboard. (Terminals offer no clickable window close control, and
+`Esc` is reserved for the emulator's RUN/STOP, so quitting is via the **Quit** button or `F9` `Q`.)
+`Tab` moves focus to the emulator screen so typing reaches the running system.
+
+The leader key defaults to `F9` because it is reliable across terminals (unlike `F10`/`F11`). If your
+terminal grabs `F9`, rebind it with the `LeaderKey` setting in `appsettings.json` (any `KeyCode` name,
+e.g. `"F12"`). Host mode is suppressed while a modal dialog (config, file picker, monitor) is open, so
+keys reach the dialog's fields normally. `F1`–`F8` are reserved for the emulated systems (e.g. the C64
+function keys).
 
 ## Config dialog
 
@@ -96,11 +110,11 @@ and [Systems / C64 / SwiftLink](../../systems/c64/swiftlink.md).
 
 ## Monitor
 
-Press the **Monitor** button or `F12` (while a system is running or paused) to open the built-in
+Press the **Monitor** button or `F9` `M` (while a system is running or paused) to open the built-in
 6502 machine-code monitor — the same command set as the other host apps' monitor (type `?` for
 help). It opens full-screen over the UI, shows the accumulated output plus the current CPU/system
 status, and has a command input line. While the monitor is open, emulation is halted so the
-monitor has exclusive access to the CPU and memory; closing it (`Esc` / `F12`) or a `g` (go) command
+monitor has exclusive access to the CPU and memory; closing it (`Esc`) or a `g` (go) command
 resumes. Breakpoints and other break triggers open the monitor automatically.
 
 Load/save commands that take no filename (`l`, and the C64 `lb`) open a terminal file picker;
@@ -109,7 +123,7 @@ the `ll <file>` / `llb <file>` variants take an explicit path. See
 
 ## Stats
 
-Press the **Stats** button or `F11` to show host instrumentation (FPS, per-frame timings, …) in the
+Press the **Stats** button or `F9` `T` to show host instrumentation (FPS, per-frame timings, …) in the
 right-hand box while a system runs.
 
 ## How to run locally for development

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Core/EmulatorConfig.cs
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Core/EmulatorConfig.cs
@@ -11,6 +11,15 @@ public class EmulatorConfig
     public string DefaultEmulator { get; set; } = "C64";
 
     /// <summary>
+    /// The host-command "leader" key. Pressing it arms host mode; the next keystroke selects a command
+    /// (Start/Stop, Monitor, Stats, Quit, cycle System/Variant). A single leader key keeps every other
+    /// key free for the emulated system, and avoids keys terminals reserve (F10 = menu, F11 =
+    /// fullscreen). Accepts a <c>KeyCode</c> name such as "F9" (default) or "F12"; an unrecognised
+    /// value falls back to F9.
+    /// </summary>
+    public string LeaderKey { get; set; } = "F9";
+
+    /// <summary>
     /// How often the terminal screen is repainted, in Hz. Kept below the emulator frame rate to
     /// stay smooth on slower terminals; the emulator itself still runs at its native frame rate.
     /// </summary>

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Core/TuiHostApp.cs
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Core/TuiHostApp.cs
@@ -37,6 +37,7 @@ public class TuiHostApp : HostApp
     // system name. Returns null for systems with no contribution. Results are cached per system.
     private readonly Func<string, ITerminalMenuContribution?> _resolveMenuContribution;
     private readonly Dictionary<string, ITerminalMenuContribution?> _menuContributionCache = new(StringComparer.OrdinalIgnoreCase);
+    private FrameView _controlsFrame = default!;       // left controls column (focus target when entering UI mode)
     private FrameView _systemMenuFrame = default!;     // container in the controls column for the active contribution
     private ITerminalMenuContribution? _activeMenuContribution;
 
@@ -92,6 +93,14 @@ public class TuiHostApp : HostApp
     // free for the emulated system.
     private KeyCode _leaderKeyCode = KeyCode.F9;
     private bool _hostModeActive;
+
+    // Focus modes. While the emulator screen has focus ("Emulator mode") every key goes to the
+    // machine and Terminal.Gui's Tab/arrow navigation is unavailable; moving focus to any host control
+    // ("UI mode") restores native keyboard navigation across all controls. The leader key (F9, then
+    // Tab) toggles between the two, since it is the one key that reaches the host even while running.
+    // The current mode is shown in the hint line and by dimming the host-UI borders in Emulator mode.
+    private Scheme? _dimBorderScheme;               // greyed panel scheme (incl. border) shown in Emulator mode
+    private readonly List<View> _uiPanels = new();  // host-UI frames whose scheme recolors by focus mode
 
     // Machine-code monitor: created lazily on first open while a system runs (bound to the current
     // SystemRunner) and discarded on stop. While the monitor dialog is open, _monitorActive halts the
@@ -281,6 +290,7 @@ public class TuiHostApp : HostApp
             Height = Dim.Fill(1),
             BorderStyle = LineStyle.Single,
         };
+        _controlsFrame = controlsFrame;
 
         // Layout (mirrors the other host apps' menu column):
         //   System: <name>
@@ -378,6 +388,14 @@ public class TuiHostApp : HostApp
             HorizontalBorderColumns = _emulatorConfig.HorizontalBorderColumns,
         };
         _screenView.EmulatorKeyPressed += key => _inputContext.OnKeyDown(key);
+        // Keep the emulator screen out of the Tab ring: in UI mode, Tab then cycles only the host
+        // controls and never lands back on the screen and re-traps the keyboard. Focusing the screen
+        // ("Emulator mode") stays an explicit action (Start/Resume, or the F9-Tab toggle). The screen
+        // can still be focused via SetFocus()/mouse — NoStop only removes it from Tab navigation.
+        _screenView.TabStop = TabBehavior.NoStop;
+        // Recompute the mode indicator + border colours whenever focus enters or leaves the screen
+        // (covers the F9-Tab toggle, Start/Resume forcing focus, and mouse clicks).
+        _screenView.HasFocusChanged += (_, _) => UpdateFocusModeVisuals();
         _screenFrame.Add(_screenView);
 
         // --- Stats / Logs column (right), same width as the controls column ---
@@ -445,10 +463,38 @@ public class TuiHostApp : HostApp
 
         _window.Add(controlsFrame, _screenFrame, statsFrame, _tabsFrame, _hintLabel);
 
+        // Host-UI panels whose scheme (border + contents) reflects the focus mode: dimmed in Emulator
+        // mode (keyboard goes to the machine), normal in UI mode. The screen frame is excluded — it is
+        // the active area in Emulator mode and is borderless anyway.
+        _uiPanels.AddRange(new View[] { controlsFrame, _systemMenuFrame, statsFrame, _tabsFrame });
+
+        // Tab-group structure for keyboard navigation. Terminal.Gui scopes focus per frame: Tab cannot
+        // cross from one frame into another (verified empirically), so each area is a TabGroup and
+        // F6/Shift-F6 (NextTabGroup/PrevTabGroup) move *between* areas while Tab/Shift-Tab cycle the
+        // controls *within* the focused area. The areas: the Controls column, the per-system menu (e.g.
+        // the C64 menu), and the tabbed pane.
+        controlsFrame.TabStop = TabBehavior.TabGroup;
+        _tabsFrame.TabStop = TabBehavior.TabGroup;
+        // The per-system menu is a sub-frame of the Controls column but a *separate* focus area (Tab
+        // can't reach it from the Controls buttons — only F6 can). Keep it a TabGroup so F6 includes it.
+        // Its contribution view also needs CanFocus=true (set in RefreshSystemMenu) so F6 lands on the
+        // first button rather than the empty frame title.
+        _systemMenuFrame.CanFocus = true;
+        _systemMenuFrame.TabStop = TabBehavior.TabGroup;
+        // Stats holds no focusable controls — keep it out of the F6 ring so it isn't an empty stop.
+        statsFrame.TabStop = TabBehavior.NoStop;
+        // Exclude the emulator screen (and its borderless frame) from F6: it is entered deliberately via
+        // Start/Resume or F9-Tab, not by cycling areas. Without this, F6 dumps focus onto the screen and
+        // strands the keyboard (no UI element focused, so F6 can't get back).
+        _screenFrame.TabStop = TabBehavior.NoStop;
+
         // Make focus/hover indication a background change (keeping text readable) instead of the
         // theme default, which flips button text to near-black — unreadable on the dark window.
         // Applied window-wide so buttons and the tab strip stay consistent (children inherit it).
         ApplyReadableFocusScheme(_window);
+
+        // Apply the initial mode visuals (UI mode at startup: nothing has forced focus to the screen).
+        UpdateFocusModeVisuals();
     }
 
     /// <summary>
@@ -490,6 +536,11 @@ public class TuiHostApp : HostApp
             Editable = editable,
             ReadOnly = editable,
         };
+        // Dimmed variant for host-UI panels while in Emulator mode: border line, title and panel text
+        // use the grey "disabled" attribute so the panels read as inactive (keyboard goes to the
+        // emulator). Terminal.Gui 2.4.5 ties the border colour to the panel's own scheme (the rendering
+        // BorderView is internal), so this dims the whole panel rather than the border lines alone.
+        _dimBorderScheme = _uiScheme with { Normal = disabled, HotNormal = disabled };
         view.SetScheme(_uiScheme);
     }
 
@@ -570,6 +621,12 @@ public class TuiHostApp : HostApp
             case KeyCode.M: DoMonitor(); break;
             case KeyCode.T: ToggleStats(); break;
             case KeyCode.Q: Application.RequestStop(_window); break;
+            // Tab and F6 both toggle the keyboard between the emulator and the host UI. F6 is accepted
+            // because it is the "move between areas" key in the UI, so reaching for it to leave the
+            // running emulator is a natural instinct (it can't be used directly there — while the screen
+            // is focused F6 goes to the emulated machine, so the leader key is the way out).
+            case KeyCode.Tab:
+            case KeyCode.F6: ToggleFocusMode(); break;
 
             // System/Variant cycling is only meaningful while the emulator is stopped.
             case KeyCode.Y when stopped: CycleSystem(+1); break;
@@ -580,19 +637,67 @@ public class TuiHostApp : HostApp
     }
 
     /// <summary>
-    /// Bottom hint line: shows the leader-key reminder normally, and the command menu while host mode
-    /// is armed (so the user can see the available commands after pressing the leader key).
+    /// Toggle between Emulator mode (screen focused, keys go to the machine) and UI mode (focus on the
+    /// host controls, so native Tab/arrow navigation works). The leader-key Tab command, plus a focus
+    /// change, are the only ways to switch; the resulting focus change drives <see
+    /// cref="UpdateFocusModeVisuals"/> via the screen's HasFocusChanged hook.
+    /// </summary>
+    private void ToggleFocusMode()
+    {
+        if (_screenView.HasFocus)
+            FocusHostUi();
+        else
+            _screenView.SetFocus();
+    }
+
+    /// <summary>
+    /// Move focus to the host UI's Controls column. Focuses the *frame* (not a specific button) so
+    /// Terminal.Gui lands on the first enabled control: focusing a fixed button fails silently when
+    /// that button is disabled for the current state (e.g. System/Start are disabled while running),
+    /// which previously made F9-Tab do nothing mid-run. From here Tab/F6/arrows reach every control.
+    /// </summary>
+    private void FocusHostUi() => _controlsFrame.SetFocus();
+
+    /// <summary>True while the emulator screen holds focus (keys go to the emulated machine).</summary>
+    private bool InEmulatorMode => _screenView is not null && _screenView.HasFocus;
+
+    /// <summary>
+    /// Reflect the current focus mode: update the hint-line indicator and dim the host-UI panels in
+    /// Emulator mode (so it is obvious the keyboard is going to the machine, not the UI).
+    /// </summary>
+    private void UpdateFocusModeVisuals()
+    {
+        var panelScheme = InEmulatorMode ? _dimBorderScheme : _uiScheme;
+        if (panelScheme is not null)
+        {
+            foreach (var panel in _uiPanels)
+            {
+                panel.SetScheme(panelScheme);
+                panel.SetNeedsDraw();
+            }
+        }
+        UpdateHintLine();
+    }
+
+    /// <summary>
+    /// Bottom hint line: shows the focus-mode indicator plus the leader-key reminder normally, and the
+    /// command menu while host mode is armed (so the available commands are visible after the leader key).
     /// </summary>
     private void UpdateHintLine()
     {
         if (_hintLabel is null)
             return;
 
-        // Normal: a single short reminder so it's obvious host mode is *not* active. The full command
-        // list appears only once the leader key arms host mode.
-        _hintLabel.Text = _hostModeActive
-            ? $" HOST: S Start/Stop  M Monitor  T Stats  Q Quit  Y System  V Variant   (Esc cancels)"
-            : $" {LeaderKeyName} Menu";
+        // Normal: a mode indicator + a short reminder, so it's obvious which mode is active and that
+        // host mode is *not* armed. The full command list appears only once the leader key arms it.
+        // In UI mode also advertise the navigation keys (Tab within an area, F6 between areas).
+        if (_hostModeActive)
+            _hintLabel.Text =
+                $" HOST: S Start/Stop  M Monitor  T Stats  Q Quit  Y System  V Variant  Tab/F6 Emu⇄UI   (Esc cancels)";
+        else if (InEmulatorMode)
+            _hintLabel.Text = $" [EMULATOR]  {LeaderKeyName} Menu";
+        else
+            _hintLabel.Text = $" [UI NAV]  {LeaderKeyName} Menu   Tab move · F6 area";
     }
 
     /// <summary>Display name of the configured leader key (e.g. "F9").</summary>
@@ -681,6 +786,9 @@ public class TuiHostApp : HostApp
         Pause();
         UpdateButtonStates();
         UpdateLeftStatus();
+        // The machine isn't consuming input while paused — hand the keyboard back to the host UI
+        // (switches to UI mode: panels un-dim and Tab/arrow navigation works).
+        FocusHostUi();
     });
 
     /// <summary>The Start/Stop command toggles between Start/Resume and Stop depending on the current state.</summary>
@@ -792,6 +900,8 @@ public class TuiHostApp : HostApp
         UpdateButtonStates();
         UpdateLeftStatus();
         UpdateStatsBox();
+        // Emulator no longer running — return focus to the host UI (UI mode: panels un-dim, Tab works).
+        FocusHostUi();
     });
 
     private void DoReset() => Safe(() =>
@@ -1217,6 +1327,12 @@ public class TuiHostApp : HostApp
             next.View.Y = 0;
             next.View.Width = Dim.Fill();
             next.View.Height = Dim.Fill();
+            // A contribution's root is a plain View (CanFocus defaults to false), which blocks focus
+            // from descending to its buttons — so Tab would never reach the per-system menu. Make it
+            // focus-permeable (CanFocus) but not a stop itself (NoStop), so its buttons join the
+            // Controls column's tab ring and Tab cycles through them with the standard host buttons.
+            next.View.CanFocus = true;
+            next.View.TabStop = TabBehavior.NoStop;
             _systemMenuFrame.Add(next.View);
             _systemMenuFrame.Title = next.MenuTitle;
             _systemMenuFrame.Height = next.MenuRowCount + 2; // + top/bottom border

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Core/TuiHostApp.cs
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Core/TuiHostApp.cs
@@ -79,11 +79,21 @@ public class TuiHostApp : HostApp
     private Button _resetButton = default!;
     private Button _monitorButton = default!;
     private Button _statsButton = default!;
+    private Button _quitButton = default!;
+    private Label _hintLabel = default!;           // bottom hint line; flips to a command menu in host mode
 
-    // Whether the right "Stats" box shows instrumentation (toggled by the Stats button / F11).
+    // Whether the right "Stats" box shows instrumentation (toggled by the Stats button / host menu).
     private bool _statsEnabled;
 
-    // Machine-code monitor: created lazily on first F12 while a system runs (bound to the current
+    // Host-command "leader key" support. Terminals/window managers grab most keys (F10 = menu,
+    // F11 = fullscreen, Ctrl/Alt/Shift = emulator), so host actions hang off a single reliable
+    // leader key (default F9, configurable via EmulatorConfig.LeaderKey). Pressing it enters host
+    // mode; the next keystroke selects a command (see OnGlobalKeyDown). This keeps every other key
+    // free for the emulated system.
+    private KeyCode _leaderKeyCode = KeyCode.F9;
+    private bool _hostModeActive;
+
+    // Machine-code monitor: created lazily on first open while a system runs (bound to the current
     // SystemRunner) and discarded on stop. While the monitor dialog is open, _monitorActive halts the
     // background emulator loop so the monitor has exclusive access to the CPU/memory.
     private TuiMonitor? _monitor;
@@ -143,11 +153,13 @@ public class TuiHostApp : HostApp
 
         Application.Init();
         // Terminal.Gui binds Esc → Quit at the application level by default. We don't want Esc to
-        // quit the host (F10 is the only quit key), and the emulator maps Esc to RUN/STOP, so remove
+        // quit the host (Quit is a leader-key command), and the emulator maps Esc to RUN/STOP, so remove
         // that binding. The log-entry popup still closes on Esc via its own key handler.
         Application.KeyBindings.Remove(Key.Esc);
-        // Global hotkeys (F9–F12): handled app-wide so they work regardless of which control has
-        // focus. Kept off F1–F8, which the emulated systems (e.g. the C64) use.
+        // Host commands hang off a single leader key (default F9), handled app-wide so it works
+        // regardless of which control has focus. Kept off F1–F8 (the emulated systems use those) and
+        // off F10/F11 (terminals bind those to their own menu/fullscreen). See OnGlobalKeyDown.
+        _leaderKeyCode = ParseLeaderKey(_emulatorConfig.LeaderKey);
         Application.KeyDown += OnGlobalKeyDown;
         try
         {
@@ -254,7 +266,7 @@ public class TuiHostApp : HostApp
     {
         _window = new Window
         {
-            Title = "DotNet 6502 — Terminal Host   (F10 = Quit)",
+            Title = $"DotNet 6502 — Terminal Host   ({LeaderKeyName} = Menu)",
             BorderStyle = LineStyle.Single,
         };
 
@@ -278,6 +290,7 @@ public class TuiHostApp : HostApp
         //   Start    Pause
         //   Reset    Stop
         //   Monitor  Stats
+        //   Quit
         const int col2X = 12; // X of the right button in each pair
 
         // System + variant pickers (only changeable while the emulator is stopped).
@@ -294,21 +307,26 @@ public class TuiHostApp : HostApp
         _stopButton = new Button { X = col2X, Y = 5, Text = "Stop" };
         _monitorButton = new Button { X = 0, Y = 6, Text = "Monitor", Enabled = false };
         _statsButton = new Button { X = col2X, Y = 6, Text = "Stats" };
+        // Quit always available via a button (not just the leader-key Q command), since terminals
+        // offer no clickable window close control and Esc is reserved for the emulator (RUN/STOP).
+        _quitButton = new Button { X = 0, Y = 7, Text = "Quit" };
 
         _startButton.Accepting += (_, e) => { e.Handled = true; DoStart(); };
         _pauseButton.Accepting += (_, e) => { e.Handled = true; DoPause(); };
         _stopButton.Accepting += (_, e) => { e.Handled = true; DoStop(); };
         _resetButton.Accepting += (_, e) => { e.Handled = true; DoReset(); };
         _statsButton.Accepting += (_, e) => { e.Handled = true; ToggleStats(); };
-        // Monitor button and F12 both open the machine-code monitor (enabled once a system is running).
+        // Monitor button and the leader-key Monitor command both open the machine-code monitor
+        // (enabled once a system is running).
         _monitorButton.Accepting += (_, e) => { e.Handled = true; DoMonitor(); };
+        _quitButton.Accepting += (_, e) => { e.Handled = true; Application.RequestStop(_window); };
 
         // Disable Terminal.Gui's default button drop-shadow: in this dense column the shadows of
         // adjacent buttons are mostly overlapped by neighbours, leaving stray black stripes.
         foreach (var button in new[]
                  {
                      _systemButton, _variantButton, _startButton, _pauseButton,
-                     _resetButton, _stopButton, _monitorButton, _statsButton,
+                     _resetButton, _stopButton, _monitorButton, _statsButton, _quitButton,
                  })
         {
             button.ShadowStyle = ShadowStyles.None;
@@ -316,7 +334,8 @@ public class TuiHostApp : HostApp
 
         controlsFrame.Add(
             _systemButton, _variantButton, _leftStatusLabel,
-            _startButton, _pauseButton, _resetButton, _stopButton, _monitorButton, _statsButton);
+            _startButton, _pauseButton, _resetButton, _stopButton, _monitorButton, _statsButton,
+            _quitButton);
 
         // Per-system menu area (below the standard controls). A discovered system plugin may
         // contribute a system-specific control here (see ITerminalMenuContribution); systems without
@@ -414,15 +433,17 @@ public class TuiHostApp : HostApp
         _tabsFrame.Add(_infoTabStrip, _logsListView, _configLabel, _infoLabel);
 
         // --- Bottom hint line ---
-        var hintLabel = new Label
+        // Doubles as the host-command menu: shows the leader-key hint normally, and the available
+        // commands while host mode is active (see UpdateHintLine / OnGlobalKeyDown).
+        _hintLabel = new Label
         {
             X = 0,
             Y = Pos.AnchorEnd(1),
             Width = Dim.Fill(),
-            Text = " 9 System  0 Variant   F9 Start/Stop  F10 Quit  F11 Stats  F12 Monitor",
         };
+        UpdateHintLine();
 
-        _window.Add(controlsFrame, _screenFrame, statsFrame, _tabsFrame, hintLabel);
+        _window.Add(controlsFrame, _screenFrame, statsFrame, _tabsFrame, _hintLabel);
 
         // Make focus/hover indication a background change (keeping text readable) instead of the
         // theme default, which flips button text to near-black — unreadable on the dark window.
@@ -487,20 +508,31 @@ public class TuiHostApp : HostApp
     // ----------------------------------------------------------------------
 
     /// <summary>
-    /// Application-wide key handler so host hotkeys work no matter which control is focused. Only
-    /// F9–F12 are used — F1–F8 are reserved for the emulated systems (e.g. the C64). Unhandled keys
-    /// fall through to the focused view (so the emulator still receives F1–F8 and typing).
-    /// System/Variant/Pause/Stop have no hotkey (their buttons remain) to stay within F9–F12.
+    /// Application-wide key handler so host commands work no matter which control is focused. A single
+    /// "leader" key (default F9, configurable) enters host mode; the next keystroke selects a command.
+    /// This keeps F1–F8 free for the emulated systems (e.g. the C64) and avoids F10/F11, which
+    /// terminals bind to their own menu/fullscreen. Unhandled keys fall through to the focused view
+    /// (so the emulator still receives F1–F8 and typing).
     /// </summary>
     private void OnGlobalKeyDown(object? sender, Key key)
     {
-        // While a modal dialog (or any other top-level) is the running top, host hotkeys must not
-        // fire — every key has to reach the dialog so its fields and buttons work (e.g. typing the
-        // digits 9/0 into a config text field, or Esc/F10 closing only the dialog).
+        // While a modal dialog (or any other top-level) is the running top, host commands must not
+        // fire — every key has to reach the dialog so its fields and buttons work (e.g. typing into a
+        // config text field, or Esc closing only the dialog).
         if (!ReferenceEquals(Application.TopRunnableView, _window))
             return;
 
         var code = key.KeyCode & ~(KeyCode.ShiftMask | KeyCode.CtrlMask | KeyCode.AltMask);
+
+        // Host mode is armed: this keystroke is a command (or a cancel). Handle it before anything
+        // else so a command letter never leaks through to the emulator.
+        if (_hostModeActive)
+        {
+            HandleHostCommand(code);
+            key.Handled = true;
+            return;
+        }
+
         var stopped = EmulatorState == EmulatorState.Uninitialized;
 
         if (!stopped && IsEmulatorScreenFocused() && IsEmulatorGlobalInputKey(key, code))
@@ -510,33 +542,83 @@ public class TuiHostApp : HostApp
             return;
         }
 
+        // The leader key arms host mode; the next keystroke (HandleHostCommand) is the actual command.
+        if (code == _leaderKeyCode)
+        {
+            _hostModeActive = true;
+            UpdateHintLine();
+            key.Handled = true;
+            return;
+        }
+
+        // Not the leader — let it reach the focused view (e.g. the emulator).
+    }
+
+    /// <summary>
+    /// Dispatch the second keystroke of a leader-key sequence to a host command, then leave host mode.
+    /// Unknown keys (including the leader key again, or Esc) simply cancel without doing anything.
+    /// </summary>
+    private void HandleHostCommand(KeyCode code)
+    {
+        _hostModeActive = false;
+        UpdateHintLine();
+
+        var stopped = EmulatorState == EmulatorState.Uninitialized;
         switch (code)
         {
-            // Running-time actions: only plain F9–F12 are conflict-free while the emulator runs
-            // (Ctrl = the C64/VIC-20 Commodore key, Shift/Tab/Alt are also emulator keys).
-            case KeyCode.F9: DoStartStopToggle(); break;
-            case KeyCode.F10: Application.RequestStop(_window); break; // quit
-            case KeyCode.F11: ToggleStats(); break;
-            case KeyCode.F12: DoMonitor(); break;
+            case KeyCode.S: DoStartStopToggle(); break;
+            case KeyCode.M: DoMonitor(); break;
+            case KeyCode.T: ToggleStats(); break;
+            case KeyCode.Q: Application.RequestStop(_window); break;
 
-            // System/Variant cycling: only meaningful while stopped, so we intercept 9/0 only then
-            // (chosen for being next to F9). While running, 9/0 fall through to the emulator. They are
-            // also left alone when a text-input control is focused, so digits can be typed there.
-            case KeyCode.D9 when stopped && !IsTextInputFocused(): CycleSystem(+1); break;
-            case KeyCode.D0 when stopped && !IsTextInputFocused(): CycleVariant(+1); break;
+            // System/Variant cycling is only meaningful while the emulator is stopped.
+            case KeyCode.Y when stopped: CycleSystem(+1); break;
+            case KeyCode.V when stopped: CycleVariant(+1); break;
 
-            default: return; // not a host hotkey — let it reach the focused view (e.g. the emulator)
+            default: break; // unknown command (or Esc / leader again): cancel, no-op
         }
-        key.Handled = true;
+    }
+
+    /// <summary>
+    /// Bottom hint line: shows the leader-key reminder normally, and the command menu while host mode
+    /// is armed (so the user can see the available commands after pressing the leader key).
+    /// </summary>
+    private void UpdateHintLine()
+    {
+        if (_hintLabel is null)
+            return;
+
+        // Normal: a single short reminder so it's obvious host mode is *not* active. The full command
+        // list appears only once the leader key arms host mode.
+        _hintLabel.Text = _hostModeActive
+            ? $" HOST: S Start/Stop  M Monitor  T Stats  Q Quit  Y System  V Variant   (Esc cancels)"
+            : $" {LeaderKeyName} Menu";
+    }
+
+    /// <summary>Display name of the configured leader key (e.g. "F9").</summary>
+    private string LeaderKeyName => _leaderKeyCode.ToString();
+
+    /// <summary>
+    /// Parse the configured leader key name (e.g. "F9") into a <see cref="KeyCode"/>. Falls back to F9
+    /// on an empty or unrecognised value so the host always has a working command key.
+    /// </summary>
+    private KeyCode ParseLeaderKey(string? configured)
+    {
+        const KeyCode fallback = KeyCode.F9;
+        if (string.IsNullOrWhiteSpace(configured))
+            return fallback;
+
+        if (Enum.TryParse<KeyCode>(configured.Trim(), ignoreCase: true, out var parsed))
+            return parsed;
+
+        _logger.LogWarning(
+            "Unrecognised LeaderKey '{Configured}' in config; falling back to {Fallback}.",
+            configured, fallback);
+        return fallback;
     }
 
     private bool IsEmulatorScreenFocused()
         => ReferenceEquals(Application.Navigation?.GetFocused(), _screenView);
-
-    // True when a text-entry control has focus, so character keys (e.g. the 9/0 hotkeys) are left to
-    // it rather than being treated as host hotkeys.
-    private static bool IsTextInputFocused()
-        => Application.Navigation?.GetFocused() is TextField or TextView;
 
     private static bool IsEmulatorGlobalInputKey(Key key, KeyCode code)
         // Tab is otherwise used by Terminal.Gui focus navigation before the screen view sees it.
@@ -601,7 +683,7 @@ public class TuiHostApp : HostApp
         UpdateLeftStatus();
     });
 
-    /// <summary>F9 toggles between Start/Resume and Stop depending on the current state.</summary>
+    /// <summary>The Start/Stop command toggles between Start/Resume and Stop depending on the current state.</summary>
     private void DoStartStopToggle()
     {
         if (EmulatorState == EmulatorState.Running)
@@ -612,7 +694,7 @@ public class TuiHostApp : HostApp
 
 
     /// <summary>
-    /// Monitor (F12 / Monitor button): open the machine-code monitor against the running (or paused)
+    /// Monitor (leader-key Monitor command / Monitor button): open the machine-code monitor against the running (or paused)
     /// system. Needs a built SystemRunner, so it is unavailable while the emulator is uninitialized.
     /// </summary>
     private void DoMonitor() => Safe(() =>
@@ -650,7 +732,7 @@ public class TuiHostApp : HostApp
 
     /// <summary>
     /// Show the monitor dialog (optionally with a break-trigger reason). Halts emulation while open,
-    /// then resumes the previous run state on close (a 'g' command continues; Esc/F12 leaves it paused
+    /// then resumes the previous run state on close (a 'g' command continues; Esc leaves it paused
     /// in effect until the dialog reopens — the background loop simply resumes where it left off).
     /// </summary>
     private void OpenMonitor(ExecEvaluatorTriggerResult? trigger)
@@ -1048,7 +1130,7 @@ public class TuiHostApp : HostApp
     }
 
     /// <summary>
-    /// Updates the right "Stats" box. When stats are toggled on (Stats button / F11) and a system is
+    /// Updates the right "Stats" box. When stats are toggled on (Stats button / leader-key command) and a system is
     /// running, shows the host instrumentation list (FPS, per-frame timings, …) like the other host
     /// apps; otherwise a short hint.
     /// </summary>
@@ -1056,7 +1138,7 @@ public class TuiHostApp : HostApp
     {
         if (!_statsEnabled)
         {
-            _statsLabel.Text = "(stats off — press Stats / F11)";
+            _statsLabel.Text = $"(stats off — press Stats button or {LeaderKeyName} then T)";
             return;
         }
 

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/appsettings.json
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/appsettings.json
@@ -3,7 +3,12 @@
 
   "Highbyte.DotNet6502.TerminalConfig": {
     "DefaultEmulator": "C64",
-    "DisplayRefreshHz": 30
+    "DisplayRefreshHz": 30,
+
+    // Host-command leader key. Press it, then a command letter (S Start/Stop, M Monitor, T Stats,
+    // Q Quit, Y/V cycle System/Variant). Avoids keys terminals reserve (F10 menu, F11 fullscreen).
+    // Rebind here if your terminal grabs F9; accepts a KeyCode name like "F9" or "F12".
+    "LeaderKey": "F9"
   },
 
   "Highbyte.DotNet6502.C64.Terminal": {


### PR DESCRIPTION
Reworks the Terminal (TUI) host's keyboard handling so every control is reachable without a mouse, and so the host shortcuts stop colliding with keys that terminals reserve.

## What changed
- **Leader key instead of direct F-keys.** Host actions previously used `F9`–`F12`, but terminals grab `F10` (menu) and `F11` (fullscreen). Now a single leader key (`F9`) arms a host-command mode; the next key picks the command (`S` Start/Stop, `M` Monitor, `T` Stats, `Q` Quit, `Y`/`V` System/Variant). The leader key is configurable via `LeaderKey` in `appsettings.json`.
- **Quit button** added to the Controls column (terminals offer no window close control, and `Esc` is reserved for the emulator).
- **Two focus modes** with a bottom-line indicator (`[EMULATOR]` / `[UI NAV]`): `F9` `Tab` (or `F9` `F6`) hands the keyboard between the running emulator and the host UI. Host-UI panels dim while the emulator owns the keyboard.
- **Area navigation:** `Tab`/`Shift+Tab` cycle within a UI area; `F6`/`Shift+F6` move between areas (Controls → per-system menu → tabbed pane). The per-system menu (e.g. the C64 menu) and the emulator screen are handled correctly in the focus rings.
- Docs updated (`docs/host-apps/terminal/overview.md`).