### PR TITLE
Add Commodore 64 cartridge support and related emulator updates

### DIFF
--- a/benchmarks/Highbyte.DotNet6502.Benchmarks/Commodore64/C64CiaTimerBenchmark.cs
+++ b/benchmarks/Highbyte.DotNet6502.Benchmarks/Commodore64/C64CiaTimerBenchmark.cs
@@ -1,0 +1,84 @@
+using BenchmarkDotNet.Attributes;
+using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Benchmarks.Commodore64;
+
+/// <summary>
+/// Micro-benchmarks for the C64 CIA timer hot path.
+///
+/// The normal C64 frame benchmarks currently use <see cref="TimerMode.UpdateEachRasterLine"/>,
+/// while timing-sensitive cartridges such as Expert need timers updated on each
+/// executed instruction. These benchmarks isolate that cost without renderer/audio
+/// noise.
+/// </summary>
+[Config(typeof(C64HotPathConfig))]
+public class C64CiaTimerBenchmark
+{
+    private const int TimerProcessCallsPerOperation = 1024;
+
+    private C64 _c64WithStoppedTimers = default!;
+    private C64 _c64WithRunningTimers = default!;
+    private C64 _c64WithUnderflowingTimers = default!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _c64WithStoppedTimers = CreateC64();
+
+        _c64WithRunningTimers = CreateC64();
+        ConfigureTimerB(_c64WithRunningTimers, latch: 0x7fff, enableInterrupt: true);
+
+        _c64WithUnderflowingTimers = CreateC64();
+        ConfigureTimerB(_c64WithUnderflowingTimers, latch: 1, enableInterrupt: true);
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = TimerProcessCallsPerOperation)]
+    public void ProcessAllCiaTimers_Stopped()
+    {
+        for (var i = 0; i < TimerProcessCallsPerOperation; i++)
+            ProcessAllCiaTimers(_c64WithStoppedTimers, cyclesExecuted: 2);
+    }
+
+    [Benchmark(OperationsPerInvoke = TimerProcessCallsPerOperation)]
+    public void ProcessAllCiaTimers_Running_NoUnderflow()
+    {
+        for (var i = 0; i < TimerProcessCallsPerOperation; i++)
+            ProcessAllCiaTimers(_c64WithRunningTimers, cyclesExecuted: 2);
+    }
+
+    [Benchmark(OperationsPerInvoke = TimerProcessCallsPerOperation)]
+    public void ProcessAllCiaTimers_Running_FrequentUnderflow()
+    {
+        for (var i = 0; i < TimerProcessCallsPerOperation; i++)
+            ProcessAllCiaTimers(_c64WithUnderflowingTimers, cyclesExecuted: 2);
+    }
+
+    private static C64 CreateC64()
+        => C64.BuildC64(new C64Config
+        {
+            C64Model = "C64NTSC",
+            Vic2Model = "NTSC",
+            LoadROMs = false,
+            TimerMode = TimerMode.UpdateEachInstruction,
+            AudioEnabled = false,
+            RenderProviderType = null,
+            InstrumentationEnabled = false,
+        }, NullLoggerFactory.Instance);
+
+    private static void ConfigureTimerB(C64 c64, ushort latch, bool enableInterrupt)
+    {
+        c64.Cia2.TimerBLOStore(0, (byte)(latch & 0xff));
+        c64.Cia2.TimerBHIStore(0, (byte)(latch >> 8));
+        if (enableInterrupt)
+            c64.Cia2.InterruptControlStore(0, 0x82);
+        c64.Cia2.TimerBControlStore(0, 0x11);
+    }
+
+    private static void ProcessAllCiaTimers(C64 c64, ulong cyclesExecuted)
+    {
+        c64.Cia1.ProcessTimers(cyclesExecuted);
+        c64.Cia2.ProcessTimers(cyclesExecuted);
+    }
+}

--- a/benchmarks/Highbyte.DotNet6502.Benchmarks/Program.cs
+++ b/benchmarks/Highbyte.DotNet6502.Benchmarks/Program.cs
@@ -54,6 +54,9 @@ var summary = BenchmarkRunner
 //    .Run<C64ExecuteFrameBenchmark>();
 
 //var summary = BenchmarkRunner
+//    .Run<C64CiaTimerBenchmark>();
+
+//var summary = BenchmarkRunner
 //    .Run<C64SpriteManagerBenchmark>();
 
 //var summary = BenchmarkRunner

--- a/docs/host-apps/avalonia/browser.md
+++ b/docs/host-apps/avalonia/browser.md
@@ -68,6 +68,9 @@ When a URL starts `system=C64` and the app does not yet have the required C64 RO
 # Direct-load the first PRG from a .d64 (no disk mount) and RUN it
 ?system=C64&start=1&waitForSystemReady=1&loadD64Url=d64%2Fgiana-sisters.d64&d64Program=*&runLoadedProgram=1
 
+# Attach a .crt cartridge image
+?system=C64&start=1&loadCrtUrl=crt%2Ffc3.crt
+
 # Start C64 with keyboard-joystick on port 2 and audio disabled (no .d64, no PRG)
 ?system=C64&start=1&waitForSystemReady=1&keyboardJoystickEnabled=1&keyboardJoystickNumber=2&audioEnabled=false
 
@@ -93,10 +96,11 @@ The browser app ships the `basicUrl` sample above as `basic/c64/hello-world.bas`
 
 ### Important differences from desktop automation
 
-- `loadPrgUrl`, `basicUrl`, `loadD64Url`, and `scriptUrl` use browser HTTP fetch semantics, so normal browser origin and CORS rules apply. The desktop app reads its load sources from the local filesystem (`--loadPrg` / `--loadD64` / `--basicFile` / `--script`) and additionally offers HTTP variants (`--loadPrgUrl` / `--loadD64Url` / `--basicUrl`).
+- `loadPrgUrl`, `basicUrl`, `loadD64Url`, `loadCrtUrl`, and `scriptUrl` use browser HTTP fetch semantics, so normal browser origin and CORS rules apply. The desktop app reads its load sources from the local filesystem (`--loadPrg` / `--loadD64` / `--loadCrt` / `--basicFile` / `--script`) and additionally offers HTTP variants (`--loadPrgUrl` / `--loadD64Url` / `--loadCrtUrl` / `--basicUrl`).
 - `basicText` is **base64url-encoded** in the browser (it travels in a URL); the desktop `--basicText` takes plain text, and `--basicFile` reads a local file.
 - `basicText` / `basicUrl` are C64-only and use the normal keyboard paste path after BASIC is ready; `runBasic=1` simply appends `RUN` and Return after the pasted source.
 - `loadD64Url` is fetched **after** the C64 has booted to BASIC ready, so a slow remote `.d64` shows progress as a visible BASIC prompt rather than a blank Avalonia page. The desktop equivalents (`--loadD64 <path>` local, `--loadD64Url <url>`) read from the filesystem or HTTP respectively.
+- `loadCrtUrl` does **not** require `waitForSystemReady`; attaching the cartridge resets / boots the C64 into the cartridge.
 - URL-driven Lua is **disabled by default**. Enable **Allow URL-driven scripts (script / scriptUrl query params)** in the browser app's general settings, save, then reload the page.
 - URL-driven scripts do not behave exactly like desktop `--script`: the browser app still selects the configured default system first, then enables the injected script. The script can still take over by calling APIs such as `emu.select(...)` and `emu.start()`.
 

--- a/docs/host-apps/avalonia/browser.md
+++ b/docs/host-apps/avalonia/browser.md
@@ -68,8 +68,14 @@ When a URL starts `system=C64` and the app does not yet have the required C64 RO
 # Direct-load the first PRG from a .d64 (no disk mount) and RUN it
 ?system=C64&start=1&waitForSystemReady=1&loadD64Url=d64%2Fgiana-sisters.d64&d64Program=*&runLoadedProgram=1
 
+# Direct-load the first PRG from a selected .d64 inside a ZIP archive
+?system=C64&start=1&waitForSystemReady=1&loadD64Url=archives%2Fgames.zip&loadD64ZipEntry=side-b%2Fgiana-sisters.d64&d64Program=*&runLoadedProgram=1
+
 # Attach a .crt cartridge image
 ?system=C64&start=1&loadCrtUrl=crt%2Ffc3.crt
+
+# Attach a selected .crt inside a ZIP archive
+?system=C64&start=1&loadCrtUrl=archives%2Fcarts.zip&loadCrtZipEntry=carts%2Ffc3.crt
 
 # Start C64 with keyboard-joystick on port 2 and audio disabled (no .d64, no PRG)
 ?system=C64&start=1&waitForSystemReady=1&keyboardJoystickEnabled=1&keyboardJoystickNumber=2&audioEnabled=false
@@ -99,8 +105,8 @@ The browser app ships the `basicUrl` sample above as `basic/c64/hello-world.bas`
 - `loadPrgUrl`, `basicUrl`, `loadD64Url`, `loadCrtUrl`, and `scriptUrl` use browser HTTP fetch semantics, so normal browser origin and CORS rules apply. The desktop app reads its load sources from the local filesystem (`--loadPrg` / `--loadD64` / `--loadCrt` / `--basicFile` / `--script`) and additionally offers HTTP variants (`--loadPrgUrl` / `--loadD64Url` / `--loadCrtUrl` / `--basicUrl`).
 - `basicText` is **base64url-encoded** in the browser (it travels in a URL); the desktop `--basicText` takes plain text, and `--basicFile` reads a local file.
 - `basicText` / `basicUrl` are C64-only and use the normal keyboard paste path after BASIC is ready; `runBasic=1` simply appends `RUN` and Return after the pasted source.
-- `loadD64Url` is fetched **after** the C64 has booted to BASIC ready, so a slow remote `.d64` shows progress as a visible BASIC prompt rather than a blank Avalonia page. The desktop equivalents (`--loadD64 <path>` local, `--loadD64Url <url>`) read from the filesystem or HTTP respectively.
-- `loadCrtUrl` does **not** require `waitForSystemReady`; attaching the cartridge resets / boots the C64 into the cartridge.
+- `loadD64Url` is fetched **after** the C64 has booted to BASIC ready, so a slow remote `.d64` shows progress as a visible BASIC prompt rather than a blank Avalonia page. The desktop equivalents (`--loadD64 <path>` local, `--loadD64Url <url>`) read from the filesystem or HTTP respectively. If the URL points at a ZIP archive, `loadD64ZipEntry` can select an exact `.d64`; otherwise the first `.d64` entry is used.
+- `loadCrtUrl` does **not** require `waitForSystemReady`; attaching the cartridge resets / boots the C64 into the cartridge. The URL may point at a raw `.crt`, at a ZIP archive containing exactly one `.crt`, or at a ZIP archive with an exact `.crt` selected by `loadCrtZipEntry`.
 - URL-driven Lua is **disabled by default**. Enable **Allow URL-driven scripts (script / scriptUrl query params)** in the browser app's general settings, save, then reload the page.
 - URL-driven scripts do not behave exactly like desktop `--script`: the browser app still selects the configured default system first, then enables the injected script. The script can still take over by calling APIs such as `emu.select(...)` and `emu.start()`.
 

--- a/docs/host-apps/avalonia/desktop.md
+++ b/docs/host-apps/avalonia/desktop.md
@@ -90,6 +90,9 @@ remote control.
 # Start C64, fetch a .d64 over HTTP, direct-load the first PRG (no disk mount) and RUN it
 ./Highbyte.DotNet6502.App.Avalonia.Desktop --system C64 --start --waitForSystemReady --loadD64Url https://example.com/game.d64 --d64Program "*" --runLoadedProgram
 
+# Start C64 and attach a local .crt cartridge image
+./Highbyte.DotNet6502.App.Avalonia.Desktop --system C64 --start --loadCrt "/path/to/fc3.crt"
+
 # Start with debug adapter for VS Code, waiting for client
 ./Highbyte.DotNet6502.App.Avalonia.Desktop --system C64 --start --enableExternalDebug --debug-port 6502 --debug-wait
 

--- a/docs/host-apps/headless/overview.md
+++ b/docs/host-apps/headless/overview.md
@@ -70,8 +70,8 @@ The headless app is driven entirely from the command line.
     - **URL load sources**: `--loadPrgUrl`, `--loadD64Url`, and `--loadCrtUrl` (the headless app loads only a local
       `--loadPrg`).
     - **C64 BASIC paste**: `--basicText` / `--basicFile` / `--basicUrl` / `--runBasic`.
-    - **C64 `.d64` startup**: `--loadD64` / `--d64Program` / `--diskMount`.
-    - **C64 `.crt` startup**: `--loadCrt` / `--loadCrtUrl`.
+    - **C64 `.d64` startup**: `--loadD64` / `--loadD64Url` / `--loadD64ZipEntry` / `--d64Program` / `--diskMount`.
+    - **C64 `.crt` startup**: `--loadCrt` / `--loadCrtUrl` / `--loadCrtZipEntry`.
     - **C64 runtime config**: `--keyboardJoystickEnabled` / `--keyboardJoystickNumber` / `--audioEnabled`.
     - **Diagnostics & auto-exit**: `--stats-interval` / `--exit-after`.
 

--- a/docs/host-apps/headless/overview.md
+++ b/docs/host-apps/headless/overview.md
@@ -67,10 +67,11 @@ The headless app is driven entirely from the command line.
     Several automated-startup parameters are currently wired **only in the Avalonia Desktop app** and
     are ignored by the headless app (each is marked *(Avalonia Desktop only)* in the table above):
 
-    - **URL load sources**: `--loadPrgUrl` and `--loadD64Url` (the headless app loads only a local
+    - **URL load sources**: `--loadPrgUrl`, `--loadD64Url`, and `--loadCrtUrl` (the headless app loads only a local
       `--loadPrg`).
     - **C64 BASIC paste**: `--basicText` / `--basicFile` / `--basicUrl` / `--runBasic`.
     - **C64 `.d64` startup**: `--loadD64` / `--d64Program` / `--diskMount`.
+    - **C64 `.crt` startup**: `--loadCrt` / `--loadCrtUrl`.
     - **C64 runtime config**: `--keyboardJoystickEnabled` / `--keyboardJoystickNumber` / `--audioEnabled`.
     - **Diagnostics & auto-exit**: `--stats-interval` / `--exit-after`.
 

--- a/docs/systems/c64/cartridges.md
+++ b/docs/systems/c64/cartridges.md
@@ -39,6 +39,11 @@ Unlike PRG, BASIC, and D64 startup flows, cartridge startup does **not** require
 `waitForSystemReady`. A cartridge is attached as a reset / boot-time device, not loaded after the
 BASIC prompt is ready.
 
+Startup cartridge sources may be raw `.crt` images or ZIP archives. By default, a ZIP archive must
+contain exactly one `.crt` entry; archives with multiple `.crt` files are rejected as ambiguous. Use
+`--loadCrtZipEntry` in Avalonia Desktop or `loadCrtZipEntry` in Avalonia Browser to select an exact
+entry from a multi-cartridge ZIP archive, for example `carts/fc3.crt`.
+
 ## Supported `.crt` hardware types
 
 The emulator currently supports these `.crt` hardware type IDs:
@@ -66,6 +71,9 @@ IRQ/NMI routing, and host-side raw TCP or Hayes modem transport modes.
 ## General limitations
 
 - The `.crt` parser supports ROM CHIP packets for ROM cartridges and the Expert 8K RAM image form.
+- Startup `.crt` attachment can unwrap a ZIP archive containing exactly one `.crt`, or an explicit
+  `.crt` entry selected with `--loadCrtZipEntry` / `loadCrtZipEntry`. Interactive Avalonia
+  file-picker attachment expects the selected file itself to be a `.crt`.
 - Writing modified cartridge RAM or bank state back to a `.crt` file is not implemented.
 - The Freeze button is only available for cartridge implementations that expose a freezer function.
 - Fast-loader cartridges can install and run their own code, but the emulator's disk-drive model is

--- a/docs/systems/c64/cartridges.md
+++ b/docs/systems/c64/cartridges.md
@@ -16,9 +16,11 @@ In the Avalonia C64 UI, use the **Cartridge** section to:
 - detach the current cartridge;
 - press the cartridge **Freeze** button when the attached cartridge supports it.
 
-Attaching a `.crt` image resets the C64, matching the practical emulator model of inserting a
-cartridge before booting the machine. Detaching also resets the machine so the memory map returns to
-normal cleanly.
+When the C64 is already running, attaching a `.crt` image resets / boots the machine into that
+cartridge. When the C64 is stopped, the UI stores the selected cartridge as a pending insert for the
+next start; the **Cartridge** section shows it as `Pending cartridge: ...`, and the next C64 start
+attaches it automatically. Detaching while stopped clears the pending cartridge. Detaching a live
+cartridge resets the machine so the memory map returns to normal cleanly.
 
 The Avalonia Desktop and Browser apps can also attach a cartridge during automated startup:
 

--- a/docs/systems/c64/cartridges.md
+++ b/docs/systems/c64/cartridges.md
@@ -1,0 +1,75 @@
+# C64 cartridge support
+
+The C64 emulator includes cartridge-slot support for optional built-in devices and for attaching
+`.crt` cartridge image files.
+
+Cartridge support is intentionally incremental. Many C64 cartridges are small ROM boards, but
+freezer, fast-load, and banked game cartridges often contain their own control registers, RAM,
+banking rules, and NMI / GAME / EXROM line behavior. Unsupported cartridge hardware types fail with
+an explicit error instead of silently attaching incorrectly.
+
+## Using cartridges
+
+In the Avalonia C64 UI, use the **Cartridge** section to:
+
+- attach a `.crt` cartridge image;
+- detach the current cartridge;
+- press the cartridge **Freeze** button when the attached cartridge supports it.
+
+Attaching a `.crt` image resets the C64, matching the practical emulator model of inserting a
+cartridge before booting the machine. Detaching also resets the machine so the memory map returns to
+normal cleanly.
+
+The Avalonia Desktop and Browser apps can also attach a cartridge during automated startup:
+
+```sh
+# Local file, Avalonia Desktop
+./Highbyte.DotNet6502.App.Avalonia.Desktop --system C64 --start --loadCrt ~/Downloads/fc3.crt
+
+# URL, Avalonia Desktop
+./Highbyte.DotNet6502.App.Avalonia.Desktop --system C64 --start --loadCrtUrl https://example.com/fc3.crt
+```
+
+```text
+# Avalonia Browser query parameter
+?system=C64&start=1&loadCrtUrl=https%3A%2F%2Fexample.com%2Ffc3.crt
+```
+
+Unlike PRG, BASIC, and D64 startup flows, cartridge startup does **not** require
+`waitForSystemReady`. A cartridge is attached as a reset / boot-time device, not loaded after the
+BASIC prompt is ready.
+
+## Supported `.crt` hardware types
+
+The emulator currently supports these `.crt` hardware type IDs:
+
+| CRT type | Cartridge | Implemented behavior | Main limitations |
+|---:|---|---|---|
+| `0` | Generic / normal cartridge | Fixed ROM cartridge using the CRT header GAME / EXROM lines. Supports 8K, 16K, and Ultimax-style shapes when the CHIP data maps cleanly to the selected ROM windows. | Banked or I/O-driven cartridges must use their specific CRT hardware type; generic images are bank 0 only. |
+| `1` | Action Replay | Action Replay 4.2/5/6 style cartridge with four 8K ROM banks, 8K RAM, I/O controlled banking / mode register, cartridge RAM export, and Freeze support. | Disk fast-loader usefulness is limited by the emulator's current basic 1541 support. Very timing-sensitive freezer functions may expose remaining VIC-II/CIA timing inaccuracies. |
+| `3` | Final Cartridge III | Standard four-bank Final Cartridge III and 16-bank FC3+ style images. Supports ROML / ROMH banking, I/O mirrors, GAME / EXROM control, hidden register behavior, NMI line handling, and Freeze support. | The menu and freezer are usable, but some display edge cases can still reveal non-cycle-exact VIC-II raster timing. |
+| `5` | Ocean | Banked Ocean game cartridges with up to 64 8K banks. Smaller images use 16K mode; 512K / 64-bank images use 8K ROML-only mode. Bank register is handled through IO1. | Requires a power-of-two bank count. Only ROM CHIP packets are supported. |
+| `6` | Expert Cartridge | Trilogic Expert saved-RAM image support with 8K RAM, ON / PRG / OFF style mapping behavior, NMI acknowledge handling, and Freeze support. | Treated as a saved 8K RAM image; persistence back to the `.crt` file is not implemented. |
+| `10` | Epyx FastLoad | 8K Epyx FastLoad ROM with capacitor-style ROM timeout behavior: ROML / IO1 reads enable ROML for 512 CPU cycles, IO2 exposes the final ROM page. | The cartridge boots, but the fast-load benefit is limited until the emulator has more complete 1541 drive emulation. |
+| `19` | Magic Desk | Banked 8K ROML cartridge with a write-only IO1 bank / disable register. Supports up to 128 ROM banks. | ROM CHIP packets only; no cartridge RAM or nonstandard Magic Desk variants. |
+
+Images with other hardware type IDs currently report an unsupported CRT hardware error.
+
+## Built-in cartridge-style devices
+
+The emulator also models SwiftLink as a cartridge-slot device rather than as a loose I/O hack.
+
+SwiftLink is configured separately from `.crt` images and is documented in
+[SwiftLink support](swiftlink.md). It provides ACIA-style serial I/O at `$DE00` or `$DF00`, optional
+IRQ/NMI routing, and host-side raw TCP or Hayes modem transport modes.
+
+## General limitations
+
+- The `.crt` parser supports ROM CHIP packets for ROM cartridges and the Expert 8K RAM image form.
+- Writing modified cartridge RAM or bank state back to a `.crt` file is not implemented.
+- The Freeze button is only available for cartridge implementations that expose a freezer function.
+- Fast-loader cartridges can install and run their own code, but the emulator's disk-drive model is
+  still a simplified `.d64` loader, not a cycle-exact 1541.
+- Some freezer cartridges stress VIC-II, CIA, NMI, and memory-mapping behavior much harder than
+  normal games. Several such core issues have been fixed while adding cartridge support, but this is
+  still not a cycle-exact C64.

--- a/docs/systems/c64/overview.md
+++ b/docs/systems/c64/overview.md
@@ -37,6 +37,11 @@ Core library: [`Highbyte.DotNet6502.Systems.Commodore64`](../../libraries/system
 - **Limited 1541 disk drive support**
     - Attach `.d64` disk images.
     - Load directory and files to the C64 using the Basic `LOAD` command.
+- **Limited cartridge support**
+    - Attach and detach `.crt` cartridge images.
+    - Supported CRT hardware types include Generic, Magic Desk, Ocean, Epyx FastLoad, Action Replay,
+      Final Cartridge III, and Expert Cartridge.
+    - Freezer button support for cartridges that implement it.
 - **SwiftLink-compatible ACIA support**
     - Optional SwiftLink cartridge at `$DE00` or `$DF00`.
     - `RawTcp` and `HayesModem` host transport modes.
@@ -68,6 +73,11 @@ You can:
 
 For host availability, modem support, and configuration details, see
 [SwiftLink support](swiftlink.md).
+
+## Cartridge support
+
+For `.crt` image support, supported cartridge types, Freeze button behavior, and limitations, see
+[C64 cartridge support](cartridges.md).
 
 ## Implementation libraries
 

--- a/includes/startup-params/browser-c64.md
+++ b/includes/startup-params/browser-c64.md
@@ -33,7 +33,8 @@ Desktop equivalents: `--loadD64` (local file) / `--loadD64Url` (URL), `--d64Prog
 
 | Query parameter | Description | Depends on | Example |
 |---|---|---|---|
-| `loadD64Url` | Fetch a C64 `.d64` disk image over HTTP. | Requires `system=C64`, `start`, `waitForSystemReady`, and exactly one of `d64Program` / `diskMount`. Exclusive with `loadPrgUrl` / `loadCrtUrl` / `basicText` / `basicUrl`. | `loadD64Url=d64/game.d64` |
+| `loadD64Url` | Fetch a C64 `.d64` disk image over HTTP. ZIP archives are also accepted; by default the first `.d64` entry is used. | Requires `system=C64`, `start`, `waitForSystemReady`, and exactly one of `d64Program` / `diskMount`. Exclusive with `loadPrgUrl` / `loadCrtUrl` / `basicText` / `basicUrl`. | `loadD64Url=d64/game.d64` |
+| `loadD64ZipEntry` | Select an exact `.d64` entry inside a ZIP archive. Use forward slashes for folders. | Requires `loadD64Url` and the source must be a ZIP archive. | `loadD64ZipEntry=side-b/game.d64` |
 | `d64Program` | Direct-load a PRG from the image into memory (no disk mount). `*` selects the first directory entry; URL-encode names with spaces. | Requires `loadD64Url`. Exclusive with `diskMount`. | `d64Program=*` |
 | `diskMount` | Mount the image in drive 8 and prepare `LOAD"*",8,1` + `RUN`. | Requires `loadD64Url`. Exclusive with `d64Program`. | `diskMount=1` |
 
@@ -43,11 +44,13 @@ With `loadD64Url`, `runLoadedProgram` pastes the disk's run commands after load 
 
 Desktop equivalents: `--loadCrt` (local file) / `--loadCrtUrl` (URL). Bytes are fetched during the
 C64 startup lifecycle, and the cartridge attach operation resets / boots the machine into the
-cartridge.
+cartridge. The target may be a raw `.crt` image or a ZIP archive containing exactly one `.crt`
+entry, or a ZIP archive with an explicit `loadCrtZipEntry`.
 
 | Query parameter | Description | Depends on | Example |
 |---|---|---|---|
-| `loadCrtUrl` | Fetch and attach a C64 `.crt` cartridge image over HTTP. | Requires `system=C64`, `start`. `waitForSystemReady` is not required. Exclusive with `loadPrgUrl`, `loadD64Url`, `basicText`, and `basicUrl`. | `loadCrtUrl=crt/fc3.crt` |
+| `loadCrtUrl` | Fetch and attach a C64 `.crt` cartridge image over HTTP. ZIP archives containing exactly one `.crt` are also accepted. | Requires `system=C64`, `start`. `waitForSystemReady` is not required. Exclusive with `loadPrgUrl`, `loadD64Url`, `basicText`, and `basicUrl`. | `loadCrtUrl=crt/fc3.crt` |
+| `loadCrtZipEntry` | Select an exact `.crt` entry inside a ZIP archive. Use forward slashes for folders. | Requires `loadCrtUrl` and the source must be a ZIP archive. Allows archives with multiple `.crt` files when the entry is explicit. | `loadCrtZipEntry=carts/fc3.crt` |
 
 The `runLoadedProgram` parameter does not apply to `.crt` images.
 

--- a/includes/startup-params/browser-c64.md
+++ b/includes/startup-params/browser-c64.md
@@ -23,7 +23,7 @@ Desktop equivalents: `--basicText` (plain text), `--basicFile` (local file), `--
 
 | Query parameter | Description | Depends on | Example |
 |---|---|---|---|
-| `basicText` | Paste inline C64 BASIC source. **Base64url-encoded** UTF-8 text. | Requires `system=C64`, `start`, `waitForSystemReady`. Exclusive with `basicUrl`, `loadPrgUrl`, `loadD64Url`. | `basicText=MTAgcHJpbnQ...` |
+| `basicText` | Paste inline C64 BASIC source. **Base64url-encoded** UTF-8 text. | Requires `system=C64`, `start`, `waitForSystemReady`. Exclusive with `basicUrl`, `loadPrgUrl`, `loadD64Url`, `loadCrtUrl`. | `basicText=MTAgcHJpbnQ...` |
 | `basicUrl` | Fetch C64 BASIC source text over HTTP and paste it. | Same as `basicText`. | `basicUrl=basic/c64/hello-world.bas` |
 | `runBasic` | Queue `RUN` after the BASIC source is pasted. | Requires `basicText` or `basicUrl`. | `runBasic=1` |
 
@@ -33,15 +33,27 @@ Desktop equivalents: `--loadD64` (local file) / `--loadD64Url` (URL), `--d64Prog
 
 | Query parameter | Description | Depends on | Example |
 |---|---|---|---|
-| `loadD64Url` | Fetch a C64 `.d64` disk image over HTTP. | Requires `system=C64`, `start`, `waitForSystemReady`, and exactly one of `d64Program` / `diskMount`. Exclusive with `loadPrgUrl` / `basicText` / `basicUrl`. | `loadD64Url=d64/game.d64` |
+| `loadD64Url` | Fetch a C64 `.d64` disk image over HTTP. | Requires `system=C64`, `start`, `waitForSystemReady`, and exactly one of `d64Program` / `diskMount`. Exclusive with `loadPrgUrl` / `loadCrtUrl` / `basicText` / `basicUrl`. | `loadD64Url=d64/game.d64` |
 | `d64Program` | Direct-load a PRG from the image into memory (no disk mount). `*` selects the first directory entry; URL-encode names with spaces. | Requires `loadD64Url`. Exclusive with `diskMount`. | `d64Program=*` |
 | `diskMount` | Mount the image in drive 8 and prepare `LOAD"*",8,1` + `RUN`. | Requires `loadD64Url`. Exclusive with `d64Program`. | `diskMount=1` |
 
 With `loadD64Url`, `runLoadedProgram` pastes the disk's run commands after load / mount: `LOAD"*",8,1` + `RUN` for `diskMount`, just `RUN` for `d64Program`.
 
+#### Cartridge image (`.crt`)
+
+Desktop equivalents: `--loadCrt` (local file) / `--loadCrtUrl` (URL). Bytes are fetched during the
+C64 startup lifecycle, and the cartridge attach operation resets / boots the machine into the
+cartridge.
+
+| Query parameter | Description | Depends on | Example |
+|---|---|---|---|
+| `loadCrtUrl` | Fetch and attach a C64 `.crt` cartridge image over HTTP. | Requires `system=C64`, `start`. `waitForSystemReady` is not required. Exclusive with `loadPrgUrl`, `loadD64Url`, `basicText`, and `basicUrl`. | `loadCrtUrl=crt/fc3.crt` |
+
+The `runLoadedProgram` parameter does not apply to `.crt` images.
+
 #### Runtime config
 
-Desktop equivalents: `--keyboardJoystickEnabled`, `--keyboardJoystickNumber`, `--audioEnabled`. These apply for **any** C64 start path (plain `start`, `loadPrgUrl`, BASIC paste, `loadD64Url`).
+Desktop equivalents: `--keyboardJoystickEnabled`, `--keyboardJoystickNumber`, `--audioEnabled`. These apply for **any** C64 start path (plain `start`, `loadPrgUrl`, BASIC paste, `loadD64Url`, `loadCrtUrl`).
 
 | Query parameter | Description | Depends on | Example |
 |---|---|---|---|

--- a/includes/startup-params/browser-general.md
+++ b/includes/startup-params/browser-general.md
@@ -12,13 +12,13 @@ Desktop equivalents: `--system`, `--systemVariant`, `--start`, `--waitForSystemR
 | `systemVariant` | Select a system variant (e.g. `C64PAL`, `C64NTSC`). | Requires `system`. | `systemVariant=C64PAL` |
 | `start` | Auto-start the selected system. | Requires `system`. | `start=1` |
 | `waitForSystemReady` | Wait until the system reports ready (e.g. C64 BASIC prompt). | Requires `system` and `start`. | `waitForSystemReady=1` |
-| `loadPrgUrl` | Fetch a `.prg` over HTTP and load it into memory. Relative URLs resolve from the app origin. | Requires `system` and `start`. Exclusive with `loadD64Url` / `basicText` / `basicUrl`. | `loadPrgUrl=prg/c64/demo.prg` |
+| `loadPrgUrl` | Fetch a `.prg` over HTTP and load it into memory. Relative URLs resolve from the app origin. | Requires `system` and `start`. Exclusive with `loadD64Url` / `loadCrtUrl` / `basicText` / `basicUrl`. | `loadPrgUrl=prg/c64/demo.prg` |
 | `runLoadedProgram` | Start executing the loaded program from its load address (or, with `loadD64Url`, paste the disk run commands). | Requires `loadPrgUrl` or `loadD64Url`. | `runLoadedProgram=1` |
 
 `loadPrgUrl` copies the fetched file's bytes to the load address in its 2-byte header — but how a
 loaded `.prg` is *interpreted and run* is system-specific. The systems documented below may add
 behavior on top of this (e.g. based on the load address); see the relevant system's parameter
-group.
+group. Cartridge images use the C64-specific `.crt` startup flow instead of PRG loading.
 
 #### Lua scripting *(browser only)*
 

--- a/includes/startup-params/browser-intro.md
+++ b/includes/startup-params/browser-intro.md
@@ -2,7 +2,7 @@ The Avalonia Browser app supports URL-driven startup automation. This is the bro
 
 Parameters are grouped below into **General parameters** (system-agnostic — valid for any system) and one group per **system** (interpreted by that system's plugin; currently only **C64**).
 
-The **Depends on** column lists each parameter's requirements and any parameters it is mutually exclusive with. The **desktop equivalent** is noted per group: the main difference is that the browser fetches its load sources over HTTP (`loadPrgUrl` / `loadD64Url` / `basicUrl` / `scriptUrl`), whereas the desktop app reads from the local filesystem (`--loadPrg` / `--loadD64` / `--basicFile` / `--script`) and additionally offers URL variants (`--loadPrgUrl` / `--loadD64Url`).
+The **Depends on** column lists each parameter's requirements and any parameters it is mutually exclusive with. The **desktop equivalent** is noted per group: the main difference is that the browser fetches its load sources over HTTP (`loadPrgUrl` / `loadD64Url` / `loadCrtUrl` / `basicUrl` / `scriptUrl`), whereas the desktop app reads from the local filesystem (`--loadPrg` / `--loadD64` / `--loadCrt` / `--basicFile` / `--script`) and additionally offers URL variants (`--loadPrgUrl` / `--loadD64Url` / `--loadCrtUrl`).
 
 Query parameter names are case-insensitive. Boolean flags treat an empty value, `1`, `true`, and `yes` as true.
 

--- a/includes/startup-params/cli-c64.md
+++ b/includes/startup-params/cli-c64.md
@@ -23,7 +23,7 @@ on the general `--system C64`, `--start`, and `--waitForSystemReady` flags.
 
 | Parameter | Description | Depends on | Example |
 |---|---|---|---|
-| `--basicText <text>` | Paste inline C64 BASIC source (plain text) after BASIC is ready. | Requires `--system C64`, `--start`, `--waitForSystemReady`. Exclusive with `--basicFile`, `--basicUrl`, and any PRG / `.d64` load. | `--basicText "10 print \"hi\":goto 10"` |
+| `--basicText <text>` | Paste inline C64 BASIC source (plain text) after BASIC is ready. | Requires `--system C64`, `--start`, `--waitForSystemReady`. Exclusive with `--basicFile`, `--basicUrl`, and any PRG / `.d64` / `.crt` load. | `--basicText "10 print \"hi\":goto 10"` |
 | `--basicFile <path>` | Paste C64 BASIC source read from a local file. | Same as `--basicText`. | `--basicFile hello.bas` |
 | `--basicUrl <url>` | Fetch C64 BASIC source over HTTP(S) and paste it. | Same as `--basicText`. | `--basicUrl https://example.com/hello.bas` |
 | `--runBasic` | Queue `run` + Return after the BASIC source is pasted. | Requires `--basicText` / `--basicFile` / `--basicUrl`. | `--runBasic` |
@@ -32,8 +32,8 @@ on the general `--system C64`, `--start`, and `--waitForSystemReady` flags.
 
 | Parameter | Description | Depends on | Example |
 |---|---|---|---|
-| `--loadD64 <path>` | Load a local C64 `.d64` disk image. | Requires `--system C64`, `--start`, `--waitForSystemReady`, and exactly one of `--d64Program` / `--diskMount`. Exclusive with `--loadPrg` / `--loadPrgUrl` / `--loadD64Url`. | `--loadD64 game.d64` |
-| `--loadD64Url <url>` | *(Avalonia Desktop only.)* Fetch a `.d64` over HTTP(S). | Same as `--loadD64`. Exclusive with `--loadD64` and the PRG loads. | `--loadD64Url https://example.com/game.d64` |
+| `--loadD64 <path>` | Load a local C64 `.d64` disk image. | Requires `--system C64`, `--start`, `--waitForSystemReady`, and exactly one of `--d64Program` / `--diskMount`. Exclusive with `--loadPrg` / `--loadPrgUrl` / `--loadD64Url` / `--loadCrt` / `--loadCrtUrl`. | `--loadD64 game.d64` |
+| `--loadD64Url <url>` | *(Avalonia Desktop only.)* Fetch a `.d64` over HTTP(S). | Same as `--loadD64`. Exclusive with `--loadD64`, the PRG loads, and the CRT loads. | `--loadD64Url https://example.com/game.d64` |
 | `--d64Program <name\|*>` | Direct-load a PRG from the disk image into memory (no disk mount). `*` selects the first directory entry. | Requires `--loadD64` / `--loadD64Url`. Exclusive with `--diskMount`. | `--d64Program "*"` |
 | `--diskMount` | Mount the image in drive 8 and prepare `LOAD"*",8,1` + `RUN` via the keyboard buffer. | Requires `--loadD64` / `--loadD64Url`. Exclusive with `--d64Program`. | `--diskMount` |
 
@@ -41,10 +41,22 @@ When loading a `.d64`, the general `--runLoadedProgram` flag controls whether th
 commands are pasted after the load / mount: `LOAD"*",8,1` + `RUN` for `--diskMount`, just `RUN` for
 `--d64Program`.
 
+#### Cartridge image (`.crt`)
+
+| Parameter | Description | Depends on | Example |
+|---|---|---|---|
+| `--loadCrt <path>` | Attach a local C64 `.crt` cartridge image at startup. | Requires `--system C64`, `--start`. `--waitForSystemReady` is not required. Exclusive with PRG, BASIC, and `.d64` startup loads. | `--loadCrt fc3.crt` |
+| `--loadCrtUrl <url>` | *(Avalonia Desktop only.)* Fetch and attach a `.crt` over HTTP(S). | Same as `--loadCrt`. Exclusive with `--loadCrt`. | `--loadCrtUrl https://example.com/fc3.crt` |
+
+Cartridge startup attaches the image after the C64 instance has been started, and the cartridge
+attach operation resets / boots the machine into the cartridge. The general `--runLoadedProgram`
+flag does not apply to `.crt` images.
+
 #### Runtime config
 
 These knobs override the C64 host config before the system starts. They apply for **any** C64 start
-path — plain `--start`, `--loadPrg` / `--loadPrgUrl`, BASIC paste, or `--loadD64` / `--loadD64Url`.
+path — plain `--start`, `--loadPrg` / `--loadPrgUrl`, BASIC paste, `--loadD64` / `--loadD64Url`,
+or `--loadCrt` / `--loadCrtUrl`.
 
 | Parameter | Description | Depends on | Example |
 |---|---|---|---|

--- a/includes/startup-params/cli-c64.md
+++ b/includes/startup-params/cli-c64.md
@@ -32,8 +32,9 @@ on the general `--system C64`, `--start`, and `--waitForSystemReady` flags.
 
 | Parameter | Description | Depends on | Example |
 |---|---|---|---|
-| `--loadD64 <path>` | Load a local C64 `.d64` disk image. | Requires `--system C64`, `--start`, `--waitForSystemReady`, and exactly one of `--d64Program` / `--diskMount`. Exclusive with `--loadPrg` / `--loadPrgUrl` / `--loadD64Url` / `--loadCrt` / `--loadCrtUrl`. | `--loadD64 game.d64` |
-| `--loadD64Url <url>` | *(Avalonia Desktop only.)* Fetch a `.d64` over HTTP(S). | Same as `--loadD64`. Exclusive with `--loadD64`, the PRG loads, and the CRT loads. | `--loadD64Url https://example.com/game.d64` |
+| `--loadD64 <path>` | Load a local C64 `.d64` disk image. ZIP archives are also accepted; by default the first `.d64` entry is used. | Requires `--system C64`, `--start`, `--waitForSystemReady`, and exactly one of `--d64Program` / `--diskMount`. Exclusive with `--loadPrg` / `--loadPrgUrl` / `--loadD64Url` / `--loadCrt` / `--loadCrtUrl`. | `--loadD64 game.d64` |
+| `--loadD64Url <url>` | *(Avalonia Desktop only.)* Fetch a `.d64` over HTTP(S). ZIP archives are also accepted; by default the first `.d64` entry is used. | Same as `--loadD64`. Exclusive with `--loadD64`, the PRG loads, and the CRT loads. | `--loadD64Url https://example.com/game.d64` |
+| `--loadD64ZipEntry <entry>` | Select an exact `.d64` entry inside a ZIP archive. Use forward slashes for folders. | Requires `--loadD64` / `--loadD64Url` and the source must be a ZIP archive. | `--loadD64ZipEntry side-b/game.d64` |
 | `--d64Program <name\|*>` | Direct-load a PRG from the disk image into memory (no disk mount). `*` selects the first directory entry. | Requires `--loadD64` / `--loadD64Url`. Exclusive with `--diskMount`. | `--d64Program "*"` |
 | `--diskMount` | Mount the image in drive 8 and prepare `LOAD"*",8,1` + `RUN` via the keyboard buffer. | Requires `--loadD64` / `--loadD64Url`. Exclusive with `--d64Program`. | `--diskMount` |
 
@@ -45,8 +46,9 @@ commands are pasted after the load / mount: `LOAD"*",8,1` + `RUN` for `--diskMou
 
 | Parameter | Description | Depends on | Example |
 |---|---|---|---|
-| `--loadCrt <path>` | Attach a local C64 `.crt` cartridge image at startup. | Requires `--system C64`, `--start`. `--waitForSystemReady` is not required. Exclusive with PRG, BASIC, and `.d64` startup loads. | `--loadCrt fc3.crt` |
-| `--loadCrtUrl <url>` | *(Avalonia Desktop only.)* Fetch and attach a `.crt` over HTTP(S). | Same as `--loadCrt`. Exclusive with `--loadCrt`. | `--loadCrtUrl https://example.com/fc3.crt` |
+| `--loadCrt <path>` | Attach a local C64 `.crt` cartridge image at startup. ZIP archives containing exactly one `.crt` are also accepted. | Requires `--system C64`, `--start`. `--waitForSystemReady` is not required. Exclusive with PRG, BASIC, and `.d64` startup loads. | `--loadCrt fc3.crt` |
+| `--loadCrtUrl <url>` | *(Avalonia Desktop only.)* Fetch and attach a `.crt` over HTTP(S). ZIP archives containing exactly one `.crt` are also accepted. | Same as `--loadCrt`. Exclusive with `--loadCrt`. | `--loadCrtUrl https://example.com/fc3.crt` |
+| `--loadCrtZipEntry <entry>` | Select an exact `.crt` entry inside a ZIP archive. Use forward slashes for folders. | Requires `--loadCrt` / `--loadCrtUrl` and the source must be a ZIP archive. Allows archives with multiple `.crt` files when the entry is explicit. | `--loadCrtZipEntry carts/fc3.crt` |
 
 Cartridge startup attaches the image after the C64 instance has been started, and the cartridge
 attach operation resets / boots the machine into the cartridge. The general `--runLoadedProgram`

--- a/includes/startup-params/cli-general.md
+++ b/includes/startup-params/cli-general.md
@@ -17,14 +17,14 @@ These are interpreted by the shared startup pipeline and are valid for any syste
 | `--systemVariant <name>` | Select a system variant (e.g. `C64PAL`, `C64NTSC`). | Requires `--system`. | `--systemVariant C64PAL` |
 | `--start` | Auto-start the emulator after selection. | Requires `--system`. | `--start` |
 | `--waitForSystemReady` | Wait until the system reports ready (e.g. C64 BASIC prompt) before continuing. | Requires `--start`. | `--waitForSystemReady` |
-| `--loadPrg <path>` | Load a local `.prg` file into memory. | Requires `--start`. Exclusive with `--loadPrgUrl` and C64 `--loadD64` / `--loadD64Url`. | `--loadPrg game.prg` |
-| `--loadPrgUrl <url>` | *(Avalonia Desktop only.)* Fetch a `.prg` over HTTP(S) and load it into memory. | Requires `--start`. Exclusive with `--loadPrg` and C64 `--loadD64` / `--loadD64Url`. | `--loadPrgUrl https://example.com/game.prg` |
+| `--loadPrg <path>` | Load a local `.prg` file into memory. | Requires `--start`. Exclusive with `--loadPrgUrl` and C64 `--loadD64` / `--loadD64Url` / `--loadCrt` / `--loadCrtUrl`. | `--loadPrg game.prg` |
+| `--loadPrgUrl <url>` | *(Avalonia Desktop only.)* Fetch a `.prg` over HTTP(S) and load it into memory. | Requires `--start`. Exclusive with `--loadPrg` and C64 `--loadD64` / `--loadD64Url` / `--loadCrt` / `--loadCrtUrl`. | `--loadPrgUrl https://example.com/game.prg` |
 | `--runLoadedProgram` | Run the loaded program after loading. | Requires `--start` and a load source (`--loadPrg` / `--loadPrgUrl`, or C64 `--loadD64` / `--loadD64Url`). | `--runLoadedProgram` |
 
 `--loadPrg` / `--loadPrgUrl` copy the file's bytes to the load address in its 2-byte header — but
 how a loaded `.prg` is *interpreted and run* is system-specific. The systems documented below may
 add behavior on top of this (e.g. based on the load address); see the relevant system's parameter
-group.
+group. Cartridge images use the C64-specific `.crt` startup flow instead of PRG loading.
 
 #### Logging
 

--- a/includes/startup-params/cli-intro.md
+++ b/includes/startup-params/cli-intro.md
@@ -15,5 +15,6 @@ other app.
 !!! important
     `--script` / `--scriptDir` are **mutually exclusive** with all automated-startup parameters
     (`--system`, `--systemVariant`, `--start`, `--waitForSystemReady`, `--loadPrg`, `--loadPrgUrl`,
-    `--runLoadedProgram`, and the C64-specific parameters). In scripting mode the Lua script is
+    `--runLoadedProgram`, and the C64-specific parameters such as `.d64`, `.crt`, and BASIC paste
+    startup). In scripting mode the Lua script is
     responsible for all emulator setup and lifecycle; combining the two modes is an error.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ nav:
           - Libraries: systems/c64/libraries.md
           - Keyboard mapping: systems/c64/keyboard.md
           - ROMs: systems/c64/roms.md
+          - Cartridge support: systems/c64/cartridges.md
           - SwiftLink support: systems/c64/swiftlink.md
           - Basic code completion: systems/c64/code-completion.md
           - Compatible programs: systems/c64/compatible-programs.md

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/Program.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/Program.cs
@@ -113,7 +113,7 @@ internal sealed partial class Program
     ///       URL (relative or absolute) to fetch C64 BASIC source text from. Same semantics as
     ///       <c>basicText</c> but unconstrained by URL length. Requires <c>system=C64</c>,
     ///       <c>start</c>, and <c>waitForSystemReady</c>. Mutually exclusive with
-    ///       <c>loadPrgUrl</c> / <c>runLoadedProgram</c>.
+    ///       <c>loadPrgUrl</c> / <c>loadD64Url</c> / <c>loadCrtUrl</c> / <c>runLoadedProgram</c>.
     ///     </description>
     ///   </item>
     ///   <item>
@@ -131,8 +131,17 @@ internal sealed partial class Program
     ///       URL (relative or absolute) to fetch a C64 <c>.d64</c> disk image from. Requires
     ///       <c>system=C64</c>, <c>start</c>, <c>waitForSystemReady</c>, and exactly one of
     ///       <c>d64Program</c> or <c>diskMount</c>. Mutually exclusive with <c>loadPrgUrl</c> /
-    ///       <c>basicText</c> / <c>basicUrl</c>. Bytes are pre-fetched on the main thread (mirrors
-    ///       <c>loadPrgUrl</c>).
+    ///       <c>loadCrtUrl</c> / <c>basicText</c> / <c>basicUrl</c>. The bytes are fetched by the
+    ///       C64 startup participant after the emulator is visible.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <term><c>loadCrtUrl</c></term>
+    ///     <description>
+    ///       URL (relative or absolute) to fetch and attach a C64 <c>.crt</c> cartridge image from.
+    ///       Requires <c>system=C64</c> and <c>start</c>; <c>waitForSystemReady</c> is not required
+    ///       because cartridges reset / boot the machine when attached. Mutually exclusive with
+    ///       <c>loadPrgUrl</c>, <c>loadD64Url</c>, <c>basicText</c>, and <c>basicUrl</c>.
     ///     </description>
     ///   </item>
     ///   <item>
@@ -155,7 +164,7 @@ internal sealed partial class Program
     ///     <description>
     ///       Force-enable the C64 keyboard-emulated joystick. Requires <c>system=C64</c>; applies
     ///       for any C64 start path (plain <c>start</c>, <c>loadPrgUrl</c>, BASIC paste,
-    ///       <c>loadD64Url</c>).
+    ///       <c>loadD64Url</c>, <c>loadCrtUrl</c>).
     ///     </description>
     ///   </item>
     ///   <item>
@@ -175,7 +184,8 @@ internal sealed partial class Program
     ///       Base64url-encoded inline Lua script to load and auto-enable at startup. The script
     ///       owns the emulator lifecycle, so this parameter is mutually exclusive with
     ///       <c>system</c>, <c>start</c>, <c>waitForSystemReady</c>, <c>loadPrgUrl</c>,
-    ///       <c>runLoadedProgram</c>, <c>basicText</c>, <c>basicUrl</c>, and <c>runBasic</c>.
+    ///       <c>loadD64Url</c>, <c>loadCrtUrl</c>, <c>runLoadedProgram</c>, <c>basicText</c>,
+    ///       <c>basicUrl</c>, and <c>runBasic</c>.
     ///       Gated by <c>Scripting.AllowUrlScripts</c> (default false).
     ///     </description>
     ///   </item>
@@ -214,6 +224,9 @@ internal sealed partial class Program
     ///
     /// # Direct-load the first PRG from a .d64 (no disk mount) and RUN it
     /// ?system=C64&amp;start=1&amp;waitForSystemReady=1&amp;loadD64Url=https%3A%2F%2Fexample.com%2Fgame.d64&amp;d64Program=*&amp;runLoadedProgram=1
+    ///
+    /// # Attach a .crt cartridge image
+    /// ?system=C64&amp;start=1&amp;loadCrtUrl=https%3A%2F%2Fexample.com%2Ffc3.crt
     ///
     /// # Run an inline Lua script (requires Scripting.AllowUrlScripts=true in browser localStorage config)
     /// ?script=bG9nLmluZm8oJ2hlbGxvJyk        # base64url of: log.info('hello')
@@ -265,6 +278,7 @@ internal sealed partial class Program
                 $"waitForSystemReady={automation.WaitForSystemReady}, " +
                 $"loadPrgUrl={automation.LoadPrgUrl ?? "(none)"}, runLoadedProgram={automation.RunLoadedProgram}, " +
                 $"loadD64Url={automation.LoadD64Url ?? "(none)"}, " +
+                $"loadCrtUrl={automation.LoadCrtUrl ?? "(none)"}, " +
                 $"extraParameters={automation.ExtraParameters.Count}");
         }
         else if (automation.ScriptContent != null || automation.ScriptUrl != null)
@@ -314,7 +328,7 @@ internal sealed partial class Program
         // Set the Lua store prefix for display in the settings UI (browser only)
         emulatorConfig.LuaStorePrefix = LOCAL_STORAGE_STORE_PREFIX;
 
-        // CORS proxy for URL-driven startup fetches (loadPrgUrl / loadD64Url / basicUrl / scriptUrl).
+        // CORS proxy for URL-driven startup fetches (loadPrgUrl / loadD64Url / loadCrtUrl / basicUrl / scriptUrl).
         // A user-supplied cross-origin URL usually lacks CORS headers and can't be fetched directly
         // from WebAssembly, so route it through the configured proxy. Same-origin (bundled) and
         // already-proxied URLs are left unwrapped. See CorsProxyHelper.
@@ -517,16 +531,17 @@ internal sealed partial class Program
         }
         else if (automation.SystemName != null)
         {
-            // .d64 bytes are deliberately NOT pre-fetched here. The participant downloads them via
-            // AutomatedStartupContext.FetchBinaryResource after the C64 reports BASIC ready, so the
-            // user sees the live BASIC prompt during the .d64 download (a pre-fetch here would
-            // block the Avalonia app from starting and leave the page blank).
+            // .d64/.crt bytes are deliberately NOT pre-fetched here. The participant downloads them
+            // via AutomatedStartupContext.FetchBinaryResource from the C64 startup lifecycle, so the
+            // user sees the live emulator rather than a blank page during a remote download.
             // Copy the extras and surface the load-source URLs so the C64 participant can both fetch
-            // (.d64) and *display* them in the pre-selection startup acknowledgement dialog. The .prg
-            // URL is otherwise only captured in the prgBytesProvider closure below.
+            // (.d64/.crt) and *display* them in the pre-selection startup acknowledgement dialog.
+            // The .prg URL is otherwise only captured in the prgBytesProvider closure below.
             var startupExtras = new Dictionary<string, string>(automation.ExtraParameters, StringComparer.OrdinalIgnoreCase);
             if (automation.LoadD64Url != null)
                 startupExtras["loadD64Url"] = automation.LoadD64Url;
+            if (automation.LoadCrtUrl != null)
+                startupExtras["loadCrtUrl"] = automation.LoadCrtUrl;
             if (automation.LoadPrgUrl != null)
                 startupExtras["loadPrgUrl"] = automation.LoadPrgUrl;
 
@@ -560,8 +575,8 @@ internal sealed partial class Program
 
                 // Host capabilities for the participant's post-ready automation:
                 //  - text fetch: used by C64 'basicUrl'.
-                //  - binary fetch: used by C64 'loadD64Url' (deferred until BASIC is ready, so the
-                //    user sees the boot rather than a blank page while a remote .d64 downloads).
+                //  - binary fetch: used by C64 'loadD64Url' / 'loadCrtUrl' (deferred into the
+                //    C64 startup lifecycle so the user sees the emulator during remote downloads).
                 var startupContext = new AutomatedStartupContext
                 {
                     FetchTextResource = async url =>
@@ -738,6 +753,7 @@ internal sealed partial class Program
         string? ScriptContent,
         string? ScriptUrl,
         string? LoadD64Url,
+        string? LoadCrtUrl,
         IReadOnlyDictionary<string, string> ExtraParameters);
 
     /// <summary>
@@ -746,7 +762,7 @@ internal sealed partial class Program
     /// </summary>
     private static BrowserAutomationParams ParseAutomationQuery(string? url)
     {
-        var empty = new BrowserAutomationParams(null, null, false, false, null, false, null, null, null, new Dictionary<string, string>());
+        var empty = new BrowserAutomationParams(null, null, false, false, null, false, null, null, null, null, new Dictionary<string, string>());
         if (string.IsNullOrWhiteSpace(url))
             return empty;
 
@@ -789,6 +805,7 @@ internal sealed partial class Program
         string? scriptB64 = map.TryGetValue("script", out var sc) && !string.IsNullOrWhiteSpace(sc) ? sc : null;
         string? scriptUrl = map.TryGetValue("scriptUrl", out var su) && !string.IsNullOrWhiteSpace(su) ? su : null;
         string? loadD64Url = map.TryGetValue("loadD64Url", out var ld64) && !string.IsNullOrWhiteSpace(ld64) ? ld64 : null;
+        string? loadCrtUrl = map.TryGetValue("loadCrtUrl", out var lcrt) && !string.IsNullOrWhiteSpace(lcrt) ? lcrt : null;
         string? d64Program = map.TryGetValue("d64Program", out var d64p) && !string.IsNullOrWhiteSpace(d64p) ? d64p : null;
         bool diskMount = map.TryGetValue("diskMount", out var dm) && IsTruthy(dm);
         bool keyboardJoystickEnabled = map.TryGetValue("keyboardJoystickEnabled", out var kje) && IsTruthy(kje);
@@ -820,6 +837,25 @@ internal sealed partial class Program
             WriteBootstrapLog("Query parameter 'loadPrgUrl' requires 'system' and 'start'; ignoring 'loadPrgUrl'.", LogLevel.Warning);
             loadPrgUrl = null;
         }
+        // ── .crt automation validation ───────────────────────────────────────────────────
+        if (loadCrtUrl != null)
+        {
+            if (!string.Equals(systemName, "C64", StringComparison.OrdinalIgnoreCase))
+            {
+                WriteBootstrapLog("Query parameter 'loadCrtUrl' requires 'system=C64'; ignoring 'loadCrtUrl'.", LogLevel.Warning);
+                loadCrtUrl = null;
+            }
+            else if (!autoStart)
+            {
+                WriteBootstrapLog("Query parameter 'loadCrtUrl' requires 'start'; ignoring.", LogLevel.Warning);
+                loadCrtUrl = null;
+            }
+            else if (loadPrgUrl != null)
+            {
+                WriteBootstrapLog("Query parameter 'loadCrtUrl' is mutually exclusive with 'loadPrgUrl'; ignoring 'loadCrtUrl'.", LogLevel.Warning);
+                loadCrtUrl = null;
+            }
+        }
         // ── .d64 automation validation ───────────────────────────────────────────────────
         // Runs before the 'runLoadedProgram requires loadPrgUrl' check below so a
         // loadD64Url + runLoadedProgram URL is accepted (loadD64 is also a valid load source).
@@ -838,6 +874,11 @@ internal sealed partial class Program
             else if (loadPrgUrl != null)
             {
                 WriteBootstrapLog("Query parameter 'loadD64Url' is mutually exclusive with 'loadPrgUrl'; ignoring 'loadD64Url'.", LogLevel.Warning);
+                loadD64Url = null;
+            }
+            else if (loadCrtUrl != null)
+            {
+                WriteBootstrapLog("Query parameter 'loadD64Url' is mutually exclusive with 'loadCrtUrl'; ignoring 'loadD64Url'.", LogLevel.Warning);
                 loadD64Url = null;
             }
             else if (d64Program == null && !diskMount)
@@ -880,7 +921,8 @@ internal sealed partial class Program
             WriteBootstrapLog("Query parameter 'audioEnabled' must be 'true' or 'false'; ignoring.", LogLevel.Warning);
             audioEnabledRaw = null;
         }
-        // 'runLoadedProgram' needs a load source — either a PRG URL or a .d64 image.
+        // 'runLoadedProgram' needs a load source — either a PRG URL or a .d64 image. CRT cartridges
+        // boot/reset themselves and are not "loaded programs" in this automation contract.
         if (runLoaded && loadPrgUrl == null && loadD64Url == null)
         {
             WriteBootstrapLog("Query parameter 'runLoadedProgram' requires 'loadPrgUrl' or 'loadD64Url'; ignoring 'runLoadedProgram'.", LogLevel.Warning);
@@ -897,11 +939,11 @@ internal sealed partial class Program
         }
         // Scripts own the lifecycle: incompatible with system-driven automation.
         if ((scriptContent != null || scriptUrl != null) &&
-            (systemName != null || autoStart || waitForReady || loadPrgUrl != null || runLoaded))
+            (systemName != null || autoStart || waitForReady || loadPrgUrl != null || loadD64Url != null || loadCrtUrl != null || runLoaded))
         {
             WriteBootstrapLog(
                 "Query parameters 'script'/'scriptUrl' are mutually exclusive with 'system', 'start', " +
-                "'waitForSystemReady', 'loadPrgUrl', and 'runLoadedProgram'; ignoring script parameters.",
+                "'waitForSystemReady', 'loadPrgUrl', 'loadD64Url', 'loadCrtUrl', and 'runLoadedProgram'; ignoring script parameters.",
                 LogLevel.Warning);
             scriptContent = null;
             scriptUrl = null;
@@ -914,10 +956,11 @@ internal sealed partial class Program
         {
             "system", "systemVariant", "start", "waitForSystemReady",
             "loadPrgUrl", "runLoadedProgram", "script", "scriptUrl",
-            // .d64 startup keys: 'loadD64Url' is consumed by Program.cs (bytes are pre-fetched
-            // into ExtraParameters as 'd64BytesB64'); the others are forwarded into extras after
-            // validation has filtered out invalid combinations.
+            // .d64 startup keys: 'loadD64Url' is consumed by Program.cs; the participant fetches
+            // its bytes via AutomatedStartupContext.FetchBinaryResource after validation. The other
+            // .d64 keys are forwarded into extras after invalid combinations have been filtered out.
             "loadD64Url", "d64Program", "diskMount",
+            "loadCrtUrl",
             "keyboardJoystickEnabled", "keyboardJoystickNumber", "audioEnabled",
         };
         var extraParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -940,6 +983,8 @@ internal sealed partial class Program
             if (diskMount)
                 extraParameters["diskMount"] = "true";
         }
+        if (loadCrtUrl != null)
+            extraParameters["loadCrtUrl"] = loadCrtUrl;
         // C64 runtime knobs apply to any C64 start path — emit whenever the user supplied them
         // and 'system=C64' (the validator already enforced the latter).
         if (keyboardJoystickEnabled)
@@ -950,7 +995,7 @@ internal sealed partial class Program
             extraParameters["audioEnabled"] = audioEnabledRaw;
 
         return new BrowserAutomationParams(systemName, systemVariant, autoStart, waitForReady,
-            loadPrgUrl, runLoaded, scriptContent, scriptUrl, loadD64Url, extraParameters);
+            loadPrgUrl, runLoaded, scriptContent, scriptUrl, loadD64Url, loadCrtUrl, extraParameters);
     }
 
     private static string? DecodeBase64UrlUtf8QueryValue(string parameterName, string? base64UrlValue, bool logRawValue = false)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/Program.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/Program.cs
@@ -128,11 +128,19 @@ internal sealed partial class Program
     ///   <item>
     ///     <term><c>loadD64Url</c></term>
     ///     <description>
-    ///       URL (relative or absolute) to fetch a C64 <c>.d64</c> disk image from. Requires
+    ///       URL (relative or absolute) to fetch a C64 <c>.d64</c> disk image from. ZIP archives are
+    ///       accepted; by default the first <c>.d64</c> entry is used. Requires
     ///       <c>system=C64</c>, <c>start</c>, <c>waitForSystemReady</c>, and exactly one of
     ///       <c>d64Program</c> or <c>diskMount</c>. Mutually exclusive with <c>loadPrgUrl</c> /
     ///       <c>loadCrtUrl</c> / <c>basicText</c> / <c>basicUrl</c>. The bytes are fetched by the
     ///       C64 startup participant after the emulator is visible.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <term><c>loadD64ZipEntry</c></term>
+    ///     <description>
+    ///       Exact <c>.d64</c> entry to select when <c>loadD64Url</c> points at a ZIP archive. Use
+    ///       forward slashes for folders.
     ///     </description>
     ///   </item>
     ///   <item>
@@ -141,7 +149,16 @@ internal sealed partial class Program
     ///       URL (relative or absolute) to fetch and attach a C64 <c>.crt</c> cartridge image from.
     ///       Requires <c>system=C64</c> and <c>start</c>; <c>waitForSystemReady</c> is not required
     ///       because cartridges reset / boot the machine when attached. Mutually exclusive with
-    ///       <c>loadPrgUrl</c>, <c>loadD64Url</c>, <c>basicText</c>, and <c>basicUrl</c>.
+    ///       <c>loadPrgUrl</c>, <c>loadD64Url</c>, <c>basicText</c>, and <c>basicUrl</c>. ZIP
+    ///       archives containing exactly one <c>.crt</c> are accepted by default.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <term><c>loadCrtZipEntry</c></term>
+    ///     <description>
+    ///       Exact <c>.crt</c> entry to select when <c>loadCrtUrl</c> points at a ZIP archive. Use
+    ///       forward slashes for folders; this is required for ZIP archives with multiple
+    ///       <c>.crt</c> files.
     ///     </description>
     ///   </item>
     ///   <item>
@@ -806,6 +823,8 @@ internal sealed partial class Program
         string? scriptUrl = map.TryGetValue("scriptUrl", out var su) && !string.IsNullOrWhiteSpace(su) ? su : null;
         string? loadD64Url = map.TryGetValue("loadD64Url", out var ld64) && !string.IsNullOrWhiteSpace(ld64) ? ld64 : null;
         string? loadCrtUrl = map.TryGetValue("loadCrtUrl", out var lcrt) && !string.IsNullOrWhiteSpace(lcrt) ? lcrt : null;
+        string? loadD64ZipEntry = map.TryGetValue("loadD64ZipEntry", out var d64ze) && !string.IsNullOrWhiteSpace(d64ze) ? d64ze : null;
+        string? loadCrtZipEntry = map.TryGetValue("loadCrtZipEntry", out var crtze) && !string.IsNullOrWhiteSpace(crtze) ? crtze : null;
         string? d64Program = map.TryGetValue("d64Program", out var d64p) && !string.IsNullOrWhiteSpace(d64p) ? d64p : null;
         bool diskMount = map.TryGetValue("diskMount", out var dm) && IsTruthy(dm);
         bool keyboardJoystickEnabled = map.TryGetValue("keyboardJoystickEnabled", out var kje) && IsTruthy(kje);
@@ -844,17 +863,25 @@ internal sealed partial class Program
             {
                 WriteBootstrapLog("Query parameter 'loadCrtUrl' requires 'system=C64'; ignoring 'loadCrtUrl'.", LogLevel.Warning);
                 loadCrtUrl = null;
+                loadCrtZipEntry = null;
             }
             else if (!autoStart)
             {
                 WriteBootstrapLog("Query parameter 'loadCrtUrl' requires 'start'; ignoring.", LogLevel.Warning);
                 loadCrtUrl = null;
+                loadCrtZipEntry = null;
             }
             else if (loadPrgUrl != null)
             {
                 WriteBootstrapLog("Query parameter 'loadCrtUrl' is mutually exclusive with 'loadPrgUrl'; ignoring 'loadCrtUrl'.", LogLevel.Warning);
                 loadCrtUrl = null;
+                loadCrtZipEntry = null;
             }
+        }
+        if (loadCrtUrl == null && loadCrtZipEntry != null)
+        {
+            WriteBootstrapLog("Query parameter 'loadCrtZipEntry' has no effect without 'loadCrtUrl'; ignoring.", LogLevel.Warning);
+            loadCrtZipEntry = null;
         }
         // ── .d64 automation validation ───────────────────────────────────────────────────
         // Runs before the 'runLoadedProgram requires loadPrgUrl' check below so a
@@ -865,38 +892,45 @@ internal sealed partial class Program
             {
                 WriteBootstrapLog("Query parameter 'loadD64Url' requires 'system=C64'; ignoring 'loadD64Url' and related .d64 params.", LogLevel.Warning);
                 loadD64Url = null;
+                loadD64ZipEntry = null;
             }
             else if (!autoStart || !waitForReady)
             {
                 WriteBootstrapLog("Query parameter 'loadD64Url' requires 'start' and 'waitForSystemReady'; ignoring.", LogLevel.Warning);
                 loadD64Url = null;
+                loadD64ZipEntry = null;
             }
             else if (loadPrgUrl != null)
             {
                 WriteBootstrapLog("Query parameter 'loadD64Url' is mutually exclusive with 'loadPrgUrl'; ignoring 'loadD64Url'.", LogLevel.Warning);
                 loadD64Url = null;
+                loadD64ZipEntry = null;
             }
             else if (loadCrtUrl != null)
             {
                 WriteBootstrapLog("Query parameter 'loadD64Url' is mutually exclusive with 'loadCrtUrl'; ignoring 'loadD64Url'.", LogLevel.Warning);
                 loadD64Url = null;
+                loadD64ZipEntry = null;
             }
             else if (d64Program == null && !diskMount)
             {
                 WriteBootstrapLog("Query parameter 'loadD64Url' requires exactly one of 'd64Program' or 'diskMount'; ignoring.", LogLevel.Warning);
                 loadD64Url = null;
+                loadD64ZipEntry = null;
             }
             else if (d64Program != null && diskMount)
             {
                 WriteBootstrapLog("Query parameters 'd64Program' and 'diskMount' are mutually exclusive; ignoring 'loadD64Url'.", LogLevel.Warning);
                 loadD64Url = null;
+                loadD64ZipEntry = null;
             }
         }
         // 'd64Program' / 'diskMount' only make sense with 'loadD64Url'.
-        if (loadD64Url == null && (d64Program != null || diskMount))
+        if (loadD64Url == null && (d64Program != null || diskMount || loadD64ZipEntry != null))
         {
-            WriteBootstrapLog("Query parameters 'd64Program' / 'diskMount' have no effect without 'loadD64Url'; ignoring.", LogLevel.Warning);
+            WriteBootstrapLog("Query parameters 'd64Program' / 'diskMount' / 'loadD64ZipEntry' have no effect without 'loadD64Url'; ignoring.", LogLevel.Warning);
             d64Program = null;
+            loadD64ZipEntry = null;
             diskMount = false;
         }
         // 'keyboardJoystick*' / 'audioEnabled' are general C64 runtime knobs — they apply
@@ -959,8 +993,8 @@ internal sealed partial class Program
             // .d64 startup keys: 'loadD64Url' is consumed by Program.cs; the participant fetches
             // its bytes via AutomatedStartupContext.FetchBinaryResource after validation. The other
             // .d64 keys are forwarded into extras after invalid combinations have been filtered out.
-            "loadD64Url", "d64Program", "diskMount",
-            "loadCrtUrl",
+            "loadD64Url", "loadD64ZipEntry", "d64Program", "diskMount",
+            "loadCrtUrl", "loadCrtZipEntry",
             "keyboardJoystickEnabled", "keyboardJoystickNumber", "audioEnabled",
         };
         var extraParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -980,11 +1014,17 @@ internal sealed partial class Program
         {
             if (d64Program != null)
                 extraParameters["d64Program"] = d64Program;
+            if (loadD64ZipEntry != null)
+                extraParameters["loadD64ZipEntry"] = loadD64ZipEntry;
             if (diskMount)
                 extraParameters["diskMount"] = "true";
         }
         if (loadCrtUrl != null)
+        {
             extraParameters["loadCrtUrl"] = loadCrtUrl;
+            if (loadCrtZipEntry != null)
+                extraParameters["loadCrtZipEntry"] = loadCrtZipEntry;
+        }
         // C64 runtime knobs apply to any C64 start path — emit whenever the user supplied them
         // and 'system=C64' (the validator already enforced the latter).
         if (keyboardJoystickEnabled)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/EmulatorConfig.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/EmulatorConfig.cs
@@ -26,7 +26,7 @@ public class EmulatorConfig
     /// <summary>
     /// CORS proxy prefix used to route cross-origin HTTP fetches when running in the browser
     /// (WebAssembly). General browser setting shared by all systems and by URL-driven startup
-    /// (<c>loadPrgUrl</c> / <c>loadD64Url</c> / <c>basicUrl</c> / <c>scriptUrl</c>). Defaults to
+    /// (<c>loadPrgUrl</c> / <c>loadD64Url</c> / <c>loadCrtUrl</c> / <c>basicUrl</c> / <c>scriptUrl</c>). Defaults to
     /// <see cref="BrowserServiceDefaults.DefaultCorsProxyUrl"/>; ignored on desktop (no proxy). See
     /// <see cref="GetCorsProxyUrl"/>.
     /// </summary>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/EmulatorConfigViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/EmulatorConfigViewModel.cs
@@ -270,7 +270,7 @@ public class EmulatorConfigViewModel : ViewModelBase
 
     /// <summary>
     /// Browser-only: CORS proxy prefix used to fetch cross-origin resources — system downloads
-    /// (games / ROMs) and URL-driven startup (<c>loadPrgUrl</c> / <c>loadD64Url</c> / <c>basicUrl</c>
+    /// (games / ROMs) and URL-driven startup (<c>loadPrgUrl</c> / <c>loadD64Url</c> / <c>loadCrtUrl</c> / <c>basicUrl</c>
     /// / <c>scriptUrl</c>). Blank falls back to the built-in default
     /// (<see cref="BrowserServiceDefaults.DefaultCorsProxyUrl"/>). Ignored on desktop.
     /// </summary>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Program.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Program.cs
@@ -144,15 +144,17 @@ internal sealed partial class Program
     ///       Fetch a <c>.prg</c> file from an absolute <c>http</c>/<c>https</c> URL and load it into
     ///       memory. Same semantics as <c>--loadPrg</c> but the bytes are downloaded instead of read
     ///       from the local filesystem. Requires <c>--start</c>; mutually exclusive with
-    ///       <c>--loadPrg</c>, <c>--loadD64</c>, and <c>--loadD64Url</c>. For C64 BASIC-style
-    ///       programs, use <c>--waitForSystemReady</c>. Browser-equivalent of <c>loadPrgUrl</c>.
+    ///       <c>--loadPrg</c>, <c>--loadD64</c>, <c>--loadD64Url</c>, <c>--loadCrt</c>, and
+    ///       <c>--loadCrtUrl</c>. For C64 BASIC-style programs, use <c>--waitForSystemReady</c>.
+    ///       Browser-equivalent of <c>loadPrgUrl</c>.
     ///     </description>
     ///   </item>
     ///   <item>
     ///     <term><c>--runLoadedProgram</c></term>
     ///     <description>
     ///       Run the loaded program after loading. Requires <c>--start</c> and one of <c>--loadPrg</c>,
-    ///       <c>--loadPrgUrl</c>, <c>--loadD64</c>, or <c>--loadD64Url</c>. For C64 BASIC-style programs, pair with <c>--waitForSystemReady</c>.
+    ///       <c>--loadPrgUrl</c>, <c>--loadD64</c>, or <c>--loadD64Url</c>. Does not apply to
+    ///       <c>--loadCrt</c> / <c>--loadCrtUrl</c>. For C64 BASIC-style programs, pair with <c>--waitForSystemReady</c>.
     ///       In the <c>--loadD64</c> flow, controls whether the disk-info <c>RunCommands</c>
     ///       (e.g. <c>LOAD"*",8,1</c> + <c>RUN</c>) are pasted after the load / mount.
     ///     </description>
@@ -162,7 +164,8 @@ internal sealed partial class Program
     ///     <description>
     ///       Load a C64 <c>.d64</c> disk image. Requires <c>--system C64</c>, <c>--start</c>,
     ///       <c>--waitForSystemReady</c>, and exactly one of <c>--d64Program</c> or <c>--diskMount</c>.
-    ///       Mutually exclusive with <c>--loadPrg</c>, <c>--loadPrgUrl</c>, and <c>--loadD64Url</c>.
+    ///       Mutually exclusive with <c>--loadPrg</c>, <c>--loadPrgUrl</c>, <c>--loadD64Url</c>,
+    ///       <c>--loadCrt</c>, and <c>--loadCrtUrl</c>.
     ///     </description>
     ///   </item>
     ///   <item>
@@ -171,7 +174,24 @@ internal sealed partial class Program
     ///       Fetch a C64 <c>.d64</c> disk image from an absolute <c>http</c>/<c>https</c> URL. Same
     ///       semantics and requirements as <c>--loadD64</c> but the bytes are downloaded instead of
     ///       read from the local filesystem. Mutually exclusive with <c>--loadD64</c>,
-    ///       <c>--loadPrg</c>, and <c>--loadPrgUrl</c>. Browser-equivalent of <c>loadD64Url</c>.
+    ///       <c>--loadPrg</c>, <c>--loadPrgUrl</c>, <c>--loadCrt</c>, and <c>--loadCrtUrl</c>.
+    ///       Browser-equivalent of <c>loadD64Url</c>.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <term><c>--loadCrt &lt;path&gt;</c></term>
+    ///     <description>
+    ///       Attach a C64 <c>.crt</c> cartridge image at startup. Requires <c>--system C64</c> and
+    ///       <c>--start</c>; <c>--waitForSystemReady</c> is not required because cartridges reset /
+    ///       boot the machine when attached. Mutually exclusive with PRG, D64, and BASIC startup loads.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <term><c>--loadCrtUrl &lt;url&gt;</c></term>
+    ///     <description>
+    ///       Fetch and attach a C64 <c>.crt</c> cartridge image from an absolute <c>http</c>/<c>https</c>
+    ///       URL. Same semantics as <c>--loadCrt</c> but the bytes are downloaded instead of read from
+    ///       the local filesystem. Browser-equivalent of <c>loadCrtUrl</c>.
     ///     </description>
     ///   </item>
     ///   <item>
@@ -307,6 +327,9 @@ internal sealed partial class Program
     /// # Start C64, fetch a .d64 over HTTP, direct-load the first PRG (no disk mount) and RUN it
     /// ./Highbyte.DotNet6502.App.Avalonia.Desktop --system C64 --start --waitForSystemReady --loadD64Url https://example.com/game.d64 --d64Program "*" --runLoadedProgram
     ///
+    /// # Start C64 and attach a .crt cartridge image
+    /// ./Highbyte.DotNet6502.App.Avalonia.Desktop --system C64 --start --loadCrt ~/Downloads/fc3.crt
+    ///
     /// # Start C64, paste BASIC source from a local .bas file and run it
     /// ./Highbyte.DotNet6502.App.Avalonia.Desktop --system C64 --start --waitForSystemReady --basicFile hello.bas --runBasic
     /// </code>
@@ -413,6 +436,8 @@ internal sealed partial class Program
         string? loadD64Path = AutomatedStartupHandler.ParseStringArgument(args, "--loadD64");
         string? loadD64Url = AutomatedStartupHandler.ParseStringArgument(args, "--loadD64Url");
         string? d64Program = AutomatedStartupHandler.ParseStringArgument(args, "--d64Program");
+        string? loadCrtPath = AutomatedStartupHandler.ParseStringArgument(args, "--loadCrt");
+        string? loadCrtUrl = AutomatedStartupHandler.ParseStringArgument(args, "--loadCrtUrl");
         bool diskMount = args.Contains("--diskMount");
         string? keyboardJoystickNumberRaw = AutomatedStartupHandler.ParseStringArgument(args, "--keyboardJoystickNumber");
         bool keyboardJoystickEnabledFlag = args.Contains("--keyboardJoystickEnabled");
@@ -445,8 +470,15 @@ internal sealed partial class Program
             Console.Error.WriteLine("Error: --loadD64 and --loadD64Url are mutually exclusive.");
             return 1;
         }
+        if (loadCrtPath != null && loadCrtUrl != null)
+        {
+            Console.Error.WriteLine("Error: --loadCrt and --loadCrtUrl are mutually exclusive.");
+            return 1;
+        }
         // Validate any supplied load URL is an absolute http/https URL (desktop fetches over HTTP).
-        if (!ValidateAbsoluteHttpUrl(loadPrgUrl, "--loadPrgUrl") || !ValidateAbsoluteHttpUrl(loadD64Url, "--loadD64Url"))
+        if (!ValidateAbsoluteHttpUrl(loadPrgUrl, "--loadPrgUrl")
+            || !ValidateAbsoluteHttpUrl(loadD64Url, "--loadD64Url")
+            || !ValidateAbsoluteHttpUrl(loadCrtUrl, "--loadCrtUrl"))
         {
             return 1;
         }
@@ -471,11 +503,20 @@ internal sealed partial class Program
         // source-agnostic: it takes the effective .d64 load (local path or URL) and the effective
         // PRG load (local path or URL) so the same rules apply regardless of where the bytes come from.
         var effectiveLoadD64 = loadD64Path ?? loadD64Url;
+        var effectiveLoadCrt = loadCrtPath ?? loadCrtUrl;
         if (!ValidateD64Arguments(
                 effectiveLoadD64, d64Program, diskMount,
                 keyboardJoystickEnabledFlag, keyboardJoystickNumberRaw, audioEnabledRaw,
-                systemName, autoStart, waitForSystemReady, effectiveLoadPrg,
+                systemName, autoStart, waitForSystemReady, effectiveLoadPrg, effectiveLoadCrt,
                 out int parsedKeyboardJoystickNumber, out bool? parsedAudioEnabled))
+        {
+            return 1;
+        }
+
+        if (!ValidateCrtArguments(
+                effectiveLoadCrt,
+                systemName, autoStart,
+                effectiveLoadPrg, effectiveLoadD64, runLoadedProgram))
         {
             return 1;
         }
@@ -485,7 +526,7 @@ internal sealed partial class Program
         if (!ValidateBasicArguments(
                 basicTextArg, basicFileArg, basicUrl, runBasic,
                 systemName, autoStart, waitForSystemReady,
-                effectiveLoadPrg, effectiveLoadD64,
+                effectiveLoadPrg, effectiveLoadD64, effectiveLoadCrt,
                 out string? basicTextEncoded))
         {
             return 1;
@@ -624,10 +665,10 @@ internal sealed partial class Program
         // ----------
         // Initialize Lua scripting engine
         // ----------
-        bool automatedStartupMode = autoStart || waitForSystemReady || effectiveLoadPrg != null || loadD64Url != null || runLoadedProgram || basicTextEncoded != null || basicUrl != null;
+        bool automatedStartupMode = autoStart || waitForSystemReady || effectiveLoadPrg != null || effectiveLoadD64 != null || effectiveLoadCrt != null || runLoadedProgram || basicTextEncoded != null || basicUrl != null;
         var scriptingEngine = MoonSharpScriptingConfigurator.Create(configuration, loggerFactory, scriptFilePaths, scriptDirectoryOverride, suppressConfigScripts: automatedStartupMode, hostType: "desktop");
 
-        // HTTP-backed load sources for the URL variants (--loadPrgUrl / --loadD64Url). Desktop
+        // HTTP-backed load sources for the URL variants (--loadPrgUrl / --loadD64Url / --loadCrtUrl). Desktop
         // downloads the bytes itself; the Browser host does the equivalent. Both stay null in the
         // local-file path so the existing filesystem load path is unchanged.
         Func<Task<byte[]>>? loadPrgBytesProvider = null;
@@ -644,11 +685,11 @@ internal sealed partial class Program
             };
         }
 
-        // When a .d64 URL or a --basicUrl is supplied, give the C64 startup participant resource
-        // fetchers so it can download the image / BASIC text after BASIC reports ready (mirrors the
-        // Browser host). FetchBinaryResource serves --loadD64Url; FetchTextResource serves --basicUrl.
+        // When a .d64/.crt URL or a --basicUrl is supplied, give the C64 startup participant
+        // resource fetchers so it can download the image / BASIC text from the appropriate point
+        // in the startup lifecycle (mirrors the Browser host).
         AutomatedStartupContext? automatedStartupContext = null;
-        if (loadD64Url != null || basicUrl != null)
+        if (loadD64Url != null || loadCrtUrl != null || basicUrl != null)
         {
             automatedStartupContext = new AutomatedStartupContext
             {
@@ -713,9 +754,11 @@ internal sealed partial class Program
                     ?.GetKeyedService<IAutomatedStartupParticipant>(systemName);
 
                 var startupExtras = new Dictionary<string, string>(
-                    BuildD64Extras(
+                    BuildC64AutomationExtras(
                         loadD64Path,
                         loadD64Url,
+                        loadCrtPath,
+                        loadCrtUrl,
                         d64Program,
                         diskMount,
                         keyboardJoystickEnabledFlag,
@@ -910,7 +953,7 @@ internal sealed partial class Program
     }
 
     /// <summary>
-    /// Validates that a supplied load URL (<c>--loadPrgUrl</c> / <c>--loadD64Url</c>) is an absolute
+    /// Validates that a supplied load URL (<c>--loadPrgUrl</c> / <c>--loadD64Url</c> / <c>--loadCrtUrl</c>) is an absolute
     /// <c>http</c>/<c>https</c> URL. Null (flag absent) passes. Prints to stderr and returns false on
     /// a malformed or non-HTTP URL so the caller exits 1.
     /// </summary>
@@ -944,6 +987,7 @@ internal sealed partial class Program
         bool autoStart,
         bool waitForSystemReady,
         string? loadPrgPath,
+        string? loadCrtPath,
         out int keyboardJoystickNumber,
         out bool? audioEnabled)
     {
@@ -982,7 +1026,8 @@ internal sealed partial class Program
 
         // --keyboardJoystick* / --audioEnabled are general C64 runtime knobs. They only need
         // --system C64 to apply (they take effect when the C64 starts, regardless of how it was
-        // started — plain --start, --loadPrg / --loadPrgUrl, or --loadD64 / --loadD64Url).
+        // started — plain --start, --loadPrg / --loadPrgUrl, --loadD64 / --loadD64Url, or
+        // --loadCrt / --loadCrtUrl).
         var hasRuntimeConfigKnobs = keyboardJoystickEnabled || keyboardJoystickNumberRaw != null || audioEnabledRaw != null;
         if (hasRuntimeConfigKnobs
             && !string.Equals(systemName, "C64", StringComparison.OrdinalIgnoreCase))
@@ -1010,6 +1055,11 @@ internal sealed partial class Program
             Console.Error.WriteLine("Error: --loadD64/--loadD64Url is mutually exclusive with --loadPrg/--loadPrgUrl.");
             return false;
         }
+        if (loadCrtPath != null)
+        {
+            Console.Error.WriteLine("Error: --loadD64/--loadD64Url is mutually exclusive with --loadCrt/--loadCrtUrl.");
+            return false;
+        }
         if (d64Program == null && !diskMount)
         {
             Console.Error.WriteLine("Error: --loadD64/--loadD64Url requires exactly one of --d64Program or --diskMount.");
@@ -1018,6 +1068,45 @@ internal sealed partial class Program
         if (d64Program != null && diskMount)
         {
             Console.Error.WriteLine("Error: --d64Program and --diskMount are mutually exclusive.");
+            return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Validates the C64 cartridge startup CLI flags (<c>--loadCrt</c> / <c>--loadCrtUrl</c>).
+    /// Cartridge attach is a reset/boot-time action, so <c>--waitForSystemReady</c> is allowed but
+    /// not required.
+    /// </summary>
+    private static bool ValidateCrtArguments(
+        string? loadCrtPath,
+        string? systemName,
+        bool autoStart,
+        string? effectiveLoadPrg,
+        string? effectiveLoadD64,
+        bool runLoadedProgram)
+    {
+        if (loadCrtPath == null)
+            return true;
+
+        if (!string.Equals(systemName, "C64", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.Error.WriteLine("Error: --loadCrt/--loadCrtUrl requires --system C64.");
+            return false;
+        }
+        if (!autoStart)
+        {
+            Console.Error.WriteLine("Error: --loadCrt/--loadCrtUrl requires --start.");
+            return false;
+        }
+        if (effectiveLoadPrg != null || effectiveLoadD64 != null)
+        {
+            Console.Error.WriteLine("Error: --loadCrt/--loadCrtUrl is mutually exclusive with --loadPrg/--loadPrgUrl and --loadD64/--loadD64Url.");
+            return false;
+        }
+        if (runLoadedProgram)
+        {
+            Console.Error.WriteLine("Error: --runLoadedProgram does not apply to --loadCrt/--loadCrtUrl.");
             return false;
         }
         return true;
@@ -1041,6 +1130,7 @@ internal sealed partial class Program
         bool waitForSystemReady,
         string? effectiveLoadPrg,
         string? effectiveLoadD64,
+        string? effectiveLoadCrt,
         out string? basicTextEncoded)
     {
         basicTextEncoded = null;
@@ -1072,9 +1162,9 @@ internal sealed partial class Program
             Console.Error.WriteLine("Error: --basicText/--basicFile/--basicUrl require --start and --waitForSystemReady.");
             return false;
         }
-        if (effectiveLoadPrg != null || effectiveLoadD64 != null)
+        if (effectiveLoadPrg != null || effectiveLoadD64 != null || effectiveLoadCrt != null)
         {
-            Console.Error.WriteLine("Error: --basicText/--basicFile/--basicUrl are mutually exclusive with --loadPrg/--loadPrgUrl and --loadD64/--loadD64Url.");
+            Console.Error.WriteLine("Error: --basicText/--basicFile/--basicUrl are mutually exclusive with --loadPrg/--loadPrgUrl, --loadD64/--loadD64Url, and --loadCrt/--loadCrtUrl.");
             return false;
         }
         if (!ValidateAbsoluteHttpUrl(basicUrl, "--basicUrl"))
@@ -1126,14 +1216,18 @@ internal sealed partial class Program
     /// Build the <see cref="AutomatedStartupRequest.ExtraParameters"/> dictionary the C64 Avalonia
     /// startup participant reads. <c>.d64</c> keys
     /// (<c>loadD64Path</c> or <c>loadD64Url</c>, plus <c>d64Program</c>/<c>diskMount</c>) are only
-    /// emitted when <c>--loadD64</c> or <c>--loadD64Url</c> is supplied; the C64 runtime knobs
+    /// emitted when <c>--loadD64</c> or <c>--loadD64Url</c> is supplied. <c>.crt</c> keys
+    /// (<c>loadCrtPath</c> or <c>loadCrtUrl</c>) are only emitted when <c>--loadCrt</c> or
+    /// <c>--loadCrtUrl</c> is supplied. The C64 runtime knobs
     /// (<c>keyboardJoystickEnabled</c>/<c>keyboardJoystickNumber</c>/<c>audioEnabled</c>) are
     /// emitted whenever the user supplied them, since they apply for any C64 start path.
     /// Empty / null entries are skipped so the participant sees only what the user actually supplied.
     /// </summary>
-    private static IReadOnlyDictionary<string, string> BuildD64Extras(
+    private static IReadOnlyDictionary<string, string> BuildC64AutomationExtras(
         string? loadD64Path,
         string? loadD64Url,
+        string? loadCrtPath,
+        string? loadCrtUrl,
         string? d64Program,
         bool diskMount,
         bool keyboardJoystickEnabled,
@@ -1154,6 +1248,16 @@ internal sealed partial class Program
                 extras["d64Program"] = d64Program;
             if (diskMount)
                 extras["diskMount"] = "true";
+        }
+
+        if (loadCrtPath != null || loadCrtUrl != null)
+        {
+            // The participant resolves the bytes from whichever key is present: 'loadCrtPath' reads
+            // the local file, 'loadCrtUrl' downloads via AutomatedStartupContext.FetchBinaryResource.
+            if (loadCrtPath != null)
+                extras["loadCrtPath"] = loadCrtPath;
+            if (loadCrtUrl != null)
+                extras["loadCrtUrl"] = loadCrtUrl;
         }
 
         if (keyboardJoystickEnabled)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Program.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Program.cs
@@ -165,7 +165,8 @@ internal sealed partial class Program
     ///       Load a C64 <c>.d64</c> disk image. Requires <c>--system C64</c>, <c>--start</c>,
     ///       <c>--waitForSystemReady</c>, and exactly one of <c>--d64Program</c> or <c>--diskMount</c>.
     ///       Mutually exclusive with <c>--loadPrg</c>, <c>--loadPrgUrl</c>, <c>--loadD64Url</c>,
-    ///       <c>--loadCrt</c>, and <c>--loadCrtUrl</c>.
+    ///       <c>--loadCrt</c>, and <c>--loadCrtUrl</c>. ZIP archives are accepted; by default the
+    ///       first <c>.d64</c> entry is used.
     ///     </description>
     ///   </item>
     ///   <item>
@@ -179,11 +180,19 @@ internal sealed partial class Program
     ///     </description>
     ///   </item>
     ///   <item>
+    ///     <term><c>--loadD64ZipEntry &lt;entry&gt;</c></term>
+    ///     <description>
+    ///       Select an exact <c>.d64</c> entry when <c>--loadD64</c> / <c>--loadD64Url</c> points at
+    ///       a ZIP archive. Use forward slashes for folders.
+    ///     </description>
+    ///   </item>
+    ///   <item>
     ///     <term><c>--loadCrt &lt;path&gt;</c></term>
     ///     <description>
     ///       Attach a C64 <c>.crt</c> cartridge image at startup. Requires <c>--system C64</c> and
     ///       <c>--start</c>; <c>--waitForSystemReady</c> is not required because cartridges reset /
     ///       boot the machine when attached. Mutually exclusive with PRG, D64, and BASIC startup loads.
+    ///       ZIP archives containing exactly one <c>.crt</c> are accepted by default.
     ///     </description>
     ///   </item>
     ///   <item>
@@ -192,6 +201,14 @@ internal sealed partial class Program
     ///       Fetch and attach a C64 <c>.crt</c> cartridge image from an absolute <c>http</c>/<c>https</c>
     ///       URL. Same semantics as <c>--loadCrt</c> but the bytes are downloaded instead of read from
     ///       the local filesystem. Browser-equivalent of <c>loadCrtUrl</c>.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <term><c>--loadCrtZipEntry &lt;entry&gt;</c></term>
+    ///     <description>
+    ///       Select an exact <c>.crt</c> entry when <c>--loadCrt</c> / <c>--loadCrtUrl</c> points at
+    ///       a ZIP archive. Use forward slashes for folders; this is required for ZIP archives with
+    ///       multiple <c>.crt</c> files.
     ///     </description>
     ///   </item>
     ///   <item>
@@ -435,9 +452,11 @@ internal sealed partial class Program
         // Parse C64 .d64 startup arguments (handled by C64AvaloniaStartupParticipant via ExtraParameters)
         string? loadD64Path = AutomatedStartupHandler.ParseStringArgument(args, "--loadD64");
         string? loadD64Url = AutomatedStartupHandler.ParseStringArgument(args, "--loadD64Url");
+        string? loadD64ZipEntry = AutomatedStartupHandler.ParseStringArgument(args, "--loadD64ZipEntry");
         string? d64Program = AutomatedStartupHandler.ParseStringArgument(args, "--d64Program");
         string? loadCrtPath = AutomatedStartupHandler.ParseStringArgument(args, "--loadCrt");
         string? loadCrtUrl = AutomatedStartupHandler.ParseStringArgument(args, "--loadCrtUrl");
+        string? loadCrtZipEntry = AutomatedStartupHandler.ParseStringArgument(args, "--loadCrtZipEntry");
         bool diskMount = args.Contains("--diskMount");
         string? keyboardJoystickNumberRaw = AutomatedStartupHandler.ParseStringArgument(args, "--keyboardJoystickNumber");
         bool keyboardJoystickEnabledFlag = args.Contains("--keyboardJoystickEnabled");
@@ -505,7 +524,7 @@ internal sealed partial class Program
         var effectiveLoadD64 = loadD64Path ?? loadD64Url;
         var effectiveLoadCrt = loadCrtPath ?? loadCrtUrl;
         if (!ValidateD64Arguments(
-                effectiveLoadD64, d64Program, diskMount,
+                effectiveLoadD64, loadD64ZipEntry, d64Program, diskMount,
                 keyboardJoystickEnabledFlag, keyboardJoystickNumberRaw, audioEnabledRaw,
                 systemName, autoStart, waitForSystemReady, effectiveLoadPrg, effectiveLoadCrt,
                 out int parsedKeyboardJoystickNumber, out bool? parsedAudioEnabled))
@@ -515,6 +534,7 @@ internal sealed partial class Program
 
         if (!ValidateCrtArguments(
                 effectiveLoadCrt,
+                loadCrtZipEntry,
                 systemName, autoStart,
                 effectiveLoadPrg, effectiveLoadD64, runLoadedProgram))
         {
@@ -757,8 +777,10 @@ internal sealed partial class Program
                     BuildC64AutomationExtras(
                         loadD64Path,
                         loadD64Url,
+                        loadD64ZipEntry,
                         loadCrtPath,
                         loadCrtUrl,
+                        loadCrtZipEntry,
                         d64Program,
                         diskMount,
                         keyboardJoystickEnabledFlag,
@@ -978,6 +1000,7 @@ internal sealed partial class Program
     /// </summary>
     private static bool ValidateD64Arguments(
         string? loadD64Path,
+        string? loadD64ZipEntry,
         string? d64Program,
         bool diskMount,
         bool keyboardJoystickEnabled,
@@ -1019,9 +1042,9 @@ internal sealed partial class Program
         }
 
         // --d64Program / --diskMount only make sense with --loadD64.
-        if (loadD64Path == null && (d64Program != null || diskMount))
+        if (loadD64Path == null && (d64Program != null || diskMount || loadD64ZipEntry != null))
         {
-            Console.Error.WriteLine("Warning: --d64Program / --diskMount have no effect without --loadD64; ignoring.");
+            Console.Error.WriteLine("Warning: --d64Program / --diskMount / --loadD64ZipEntry have no effect without --loadD64/--loadD64Url; ignoring.");
         }
 
         // --keyboardJoystick* / --audioEnabled are general C64 runtime knobs. They only need
@@ -1080,6 +1103,7 @@ internal sealed partial class Program
     /// </summary>
     private static bool ValidateCrtArguments(
         string? loadCrtPath,
+        string? loadCrtZipEntry,
         string? systemName,
         bool autoStart,
         string? effectiveLoadPrg,
@@ -1087,7 +1111,11 @@ internal sealed partial class Program
         bool runLoadedProgram)
     {
         if (loadCrtPath == null)
+        {
+            if (loadCrtZipEntry != null)
+                Console.Error.WriteLine("Warning: --loadCrtZipEntry has no effect without --loadCrt/--loadCrtUrl; ignoring.");
             return true;
+        }
 
         if (!string.Equals(systemName, "C64", StringComparison.OrdinalIgnoreCase))
         {
@@ -1215,10 +1243,11 @@ internal sealed partial class Program
     /// <summary>
     /// Build the <see cref="AutomatedStartupRequest.ExtraParameters"/> dictionary the C64 Avalonia
     /// startup participant reads. <c>.d64</c> keys
-    /// (<c>loadD64Path</c> or <c>loadD64Url</c>, plus <c>d64Program</c>/<c>diskMount</c>) are only
+    /// (<c>loadD64Path</c> or <c>loadD64Url</c>, optional <c>loadD64ZipEntry</c>, plus
+    /// <c>d64Program</c>/<c>diskMount</c>) are only
     /// emitted when <c>--loadD64</c> or <c>--loadD64Url</c> is supplied. <c>.crt</c> keys
-    /// (<c>loadCrtPath</c> or <c>loadCrtUrl</c>) are only emitted when <c>--loadCrt</c> or
-    /// <c>--loadCrtUrl</c> is supplied. The C64 runtime knobs
+    /// (<c>loadCrtPath</c> or <c>loadCrtUrl</c>, optional <c>loadCrtZipEntry</c>) are only emitted
+    /// when <c>--loadCrt</c> or <c>--loadCrtUrl</c> is supplied. The C64 runtime knobs
     /// (<c>keyboardJoystickEnabled</c>/<c>keyboardJoystickNumber</c>/<c>audioEnabled</c>) are
     /// emitted whenever the user supplied them, since they apply for any C64 start path.
     /// Empty / null entries are skipped so the participant sees only what the user actually supplied.
@@ -1226,8 +1255,10 @@ internal sealed partial class Program
     private static IReadOnlyDictionary<string, string> BuildC64AutomationExtras(
         string? loadD64Path,
         string? loadD64Url,
+        string? loadD64ZipEntry,
         string? loadCrtPath,
         string? loadCrtUrl,
+        string? loadCrtZipEntry,
         string? d64Program,
         bool diskMount,
         bool keyboardJoystickEnabled,
@@ -1244,6 +1275,8 @@ internal sealed partial class Program
                 extras["loadD64Path"] = loadD64Path;
             if (loadD64Url != null)
                 extras["loadD64Url"] = loadD64Url;
+            if (loadD64ZipEntry != null)
+                extras["loadD64ZipEntry"] = loadD64ZipEntry;
             if (d64Program != null)
                 extras["d64Program"] = d64Program;
             if (diskMount)
@@ -1258,6 +1291,8 @@ internal sealed partial class Program
                 extras["loadCrtPath"] = loadCrtPath;
             if (loadCrtUrl != null)
                 extras["loadCrtUrl"] = loadCrtUrl;
+            if (loadCrtZipEntry != null)
+                extras["loadCrtZipEntry"] = loadCrtZipEntry;
         }
 
         if (keyboardJoystickEnabled)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/C64AvaloniaStartupParticipant.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/C64AvaloniaStartupParticipant.cs
@@ -11,6 +11,7 @@ using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Commodore64;
 using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.DiskDrive.D64.Download;
 using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.DiskDrive.Download;
+using Highbyte.DotNet6502.Systems.Commodore64.Utils;
 using Highbyte.DotNet6502.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -39,6 +40,8 @@ public sealed class C64AvaloniaStartupParticipant : IAutomatedStartupParticipant
     internal const string ExtraKeyLoadD64Url = "loadD64Url";
     internal const string ExtraKeyLoadCrtPath = "loadCrtPath";
     internal const string ExtraKeyLoadCrtUrl = "loadCrtUrl";
+    internal const string ExtraKeyLoadD64ZipEntry = "loadD64ZipEntry";
+    internal const string ExtraKeyLoadCrtZipEntry = "loadCrtZipEntry";
     internal const string ExtraKeyD64Program = "d64Program";
     internal const string ExtraKeyDiskMount = "diskMount";
     internal const string ExtraKeyKeyboardJoystickEnabled = "keyboardJoystickEnabled";
@@ -195,7 +198,8 @@ public sealed class C64AvaloniaStartupParticipant : IAutomatedStartupParticipant
         => errors.Count > 0 && errors.All(error => error.StartsWith("Missing ROMs:", StringComparison.Ordinal));
 
     /// <summary>
-    /// Post-ready automation: attach a CRT cartridge (<c>loadCrtPath</c> / <c>loadCrtUrl</c>),
+    /// Post-ready automation: attach a CRT cartridge (<c>loadCrtPath</c> / <c>loadCrtUrl</c>;
+    /// raw <c>.crt</c> or a ZIP containing exactly one <c>.crt</c>),
     /// paste C64 BASIC source (<c>basicText</c> / <c>basicUrl</c>), or run the .d64 startup flow
     /// (<c>loadD64Path</c> / <c>loadD64Url</c>) — mount the disk or direct-load a PRG and
     /// optionally paste the run commands. Invalid combinations are logged and skipped; the emulator
@@ -218,8 +222,13 @@ public sealed class C64AvaloniaStartupParticipant : IAutomatedStartupParticipant
     {
         var loadCrtPath = GetExtra(extras, ExtraKeyLoadCrtPath);
         var loadCrtUrl = GetExtra(extras, ExtraKeyLoadCrtUrl);
+        var loadCrtZipEntry = GetExtra(extras, ExtraKeyLoadCrtZipEntry);
         if (loadCrtPath is null && loadCrtUrl is null)
+        {
+            if (loadCrtZipEntry is not null)
+                _logger.LogWarning("Automation 'loadCrtZipEntry' has no effect without 'loadCrtPath'/'loadCrtUrl'; ignoring.");
             return;
+        }
 
         if (!request.AutoStart)
         {
@@ -269,6 +278,24 @@ public sealed class C64AvaloniaStartupParticipant : IAutomatedStartupParticipant
         if (crtBytes.Length == 0)
         {
             _logger.LogWarning(".crt bytes resolved to an empty buffer; skipping .crt startup.");
+            return;
+        }
+
+        // The fetched/read bytes may be a raw .crt or a ZIP archive containing one. Unlike the
+        // existing .d64 ZIP path, multiple .crt files are rejected as ambiguous because a cartridge
+        // image usually represents a single hardware device rather than a multi-disk set.
+        try
+        {
+            crtBytes = ZipImageExtractor.EnsureImageBytes(
+                crtBytes,
+                ".crt",
+                ZipImageMultipleMatchBehavior.Throw,
+                _logger,
+                loadCrtZipEntry);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to extract .crt from the ZIP archive; skipping .crt startup.");
             return;
         }
 
@@ -372,8 +399,13 @@ public sealed class C64AvaloniaStartupParticipant : IAutomatedStartupParticipant
     {
         var loadD64Path = GetExtra(extras, ExtraKeyLoadD64Path);
         var loadD64Url = GetExtra(extras, ExtraKeyLoadD64Url);
+        var loadD64ZipEntry = GetExtra(extras, ExtraKeyLoadD64ZipEntry);
         if (loadD64Path is null && loadD64Url is null)
+        {
+            if (loadD64ZipEntry is not null)
+                _logger.LogWarning("Automation 'loadD64ZipEntry' has no effect without 'loadD64Path'/'loadD64Url'; ignoring.");
             return;
+        }
 
         if (!request.AutoStart || !request.WaitForSystemReady)
         {
@@ -441,7 +473,7 @@ public sealed class C64AvaloniaStartupParticipant : IAutomatedStartupParticipant
         // contract carries no download-type hint, so content-sniff and extract if needed.
         try
         {
-            d64Bytes = D64ZipExtractor.EnsureD64Bytes(d64Bytes, _logger);
+            d64Bytes = D64ZipExtractor.EnsureD64Bytes(d64Bytes, _logger, loadD64ZipEntry);
         }
         catch (Exception ex)
         {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/C64AvaloniaStartupParticipant.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/C64AvaloniaStartupParticipant.cs
@@ -32,11 +32,13 @@ public sealed class C64AvaloniaStartupParticipant : IAutomatedStartupParticipant
 {
     private const ushort C64BasicProgramLoadAddress = 0x0801;
 
-    // Extra-parameter keys shared by Desktop and Browser (Desktop: --loadD64 etc.; Browser: query
-    // params loadD64Url etc. pre-fetched into d64BytesB64). The participant never sees raw HTTP /
+    // Extra-parameter keys shared by Desktop and Browser (Desktop: --loadD64/--loadCrt etc.;
+    // Browser: query params loadD64Url/loadCrtUrl etc.). The participant never sees raw HTTP /
     // CLI parsing — only these typed extras.
     internal const string ExtraKeyLoadD64Path = "loadD64Path";
     internal const string ExtraKeyLoadD64Url = "loadD64Url";
+    internal const string ExtraKeyLoadCrtPath = "loadCrtPath";
+    internal const string ExtraKeyLoadCrtUrl = "loadCrtUrl";
     internal const string ExtraKeyD64Program = "d64Program";
     internal const string ExtraKeyDiskMount = "diskMount";
     internal const string ExtraKeyKeyboardJoystickEnabled = "keyboardJoystickEnabled";
@@ -116,6 +118,10 @@ public sealed class C64AvaloniaStartupParticipant : IAutomatedStartupParticipant
             return new C64StartupProgramInfo(kind, loadD64Url, audioEnabled);
         }
 
+        var loadCrtUrl = GetExtra(extras, ExtraKeyLoadCrtUrl);
+        if (loadCrtUrl != null)
+            return new C64StartupProgramInfo(".crt cartridge image", loadCrtUrl, audioEnabled);
+
         return new C64StartupProgramInfo("C64 (no program)", Url: null, audioEnabled);
     }
 
@@ -189,17 +195,93 @@ public sealed class C64AvaloniaStartupParticipant : IAutomatedStartupParticipant
         => errors.Count > 0 && errors.All(error => error.StartsWith("Missing ROMs:", StringComparison.Ordinal));
 
     /// <summary>
-    /// Post-ready automation: paste C64 BASIC source (<c>basicText</c> / <c>basicUrl</c>), or run
-    /// the .d64 startup flow (<c>loadD64Path</c> / <c>d64BytesB64</c>) — mount the disk or
-    /// direct-load a PRG and optionally paste the run commands. Invalid combinations are logged
-    /// and skipped; the emulator keeps running. See <c>docs/automated-startup-seam2.md</c>.
+    /// Post-ready automation: attach a CRT cartridge (<c>loadCrtPath</c> / <c>loadCrtUrl</c>),
+    /// paste C64 BASIC source (<c>basicText</c> / <c>basicUrl</c>), or run the .d64 startup flow
+    /// (<c>loadD64Path</c> / <c>loadD64Url</c>) — mount the disk or direct-load a PRG and
+    /// optionally paste the run commands. Invalid combinations are logged and skipped; the emulator
+    /// keeps running. See <c>docs/automated-startup-seam2.md</c>.
     /// </summary>
     public async Task OnSystemReadyAsync(
         IHostApp hostApp, AutomatedStartupRequest request, AutomatedStartupContext context)
     {
         var extras = request.ExtraParameters;
+        await TryHandleCrtAutomationAsync(hostApp, request, context, extras);
         await TryHandleBasicAutomationAsync(hostApp, request, context, extras);
         await TryHandleD64AutomationAsync(hostApp, request, context, extras);
+    }
+
+    private async Task TryHandleCrtAutomationAsync(
+        IHostApp hostApp,
+        AutomatedStartupRequest request,
+        AutomatedStartupContext context,
+        IReadOnlyDictionary<string, string> extras)
+    {
+        var loadCrtPath = GetExtra(extras, ExtraKeyLoadCrtPath);
+        var loadCrtUrl = GetExtra(extras, ExtraKeyLoadCrtUrl);
+        if (loadCrtPath is null && loadCrtUrl is null)
+            return;
+
+        if (!request.AutoStart)
+        {
+            _logger.LogWarning("Automation 'loadCrtPath'/'loadCrtUrl' requires start; skipping .crt startup.");
+            return;
+        }
+        if (request.LoadPrgPath is not null
+            || GetExtra(extras, ExtraKeyLoadD64Path) is not null
+            || GetExtra(extras, ExtraKeyLoadD64Url) is not null)
+        {
+            _logger.LogWarning("Automation .crt load is mutually exclusive with PRG and .d64 startup flows; skipping .crt startup.");
+            return;
+        }
+        if (loadCrtPath is not null && loadCrtUrl is not null)
+        {
+            _logger.LogWarning("Automation 'loadCrtPath' and 'loadCrtUrl' are mutually exclusive; skipping .crt startup.");
+            return;
+        }
+        if (request.RunLoadedProgram)
+        {
+            _logger.LogWarning("Automation 'runLoadedProgram' does not apply to .crt startup; skipping .crt startup.");
+            return;
+        }
+        if (hostApp.CurrentRunningSystem is not C64 c64)
+        {
+            _logger.LogError(".crt startup requires the running system to be C64.");
+            return;
+        }
+        if (loadCrtUrl is not null && context.FetchBinaryResource is null)
+        {
+            _logger.LogWarning("Automation 'loadCrtUrl' supplied but host provides no binary-resource fetcher; skipping .crt startup.");
+            return;
+        }
+
+        byte[] crtBytes;
+        try
+        {
+            crtBytes = loadCrtUrl is not null
+                ? await context.FetchBinaryResource!(loadCrtUrl)
+                : await ResolveCrtBytesFromFileAsync(loadCrtPath!);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to read .crt bytes; skipping .crt startup.");
+            return;
+        }
+        if (crtBytes.Length == 0)
+        {
+            _logger.LogWarning(".crt bytes resolved to an empty buffer; skipping .crt startup.");
+            return;
+        }
+
+        try
+        {
+            var sourceName = loadCrtUrl ?? loadCrtPath ?? "Startup .crt";
+            _logger.LogInformation("Attaching startup .crt cartridge image from {Source}.", sourceName);
+            c64.AttachCrtImage(crtBytes, sourceName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error attaching startup .crt cartridge image.");
+        }
     }
 
     private async Task TryHandleBasicAutomationAsync(
@@ -225,9 +307,13 @@ public sealed class C64AvaloniaStartupParticipant : IAutomatedStartupParticipant
             _logger.LogWarning("Automation 'basicText'/'basicUrl' require the system to be started and ready (start + waitForSystemReady); skipping BASIC source.");
             return;
         }
-        if (request.LoadPrgPath is not null)
+        if (request.LoadPrgPath is not null
+            || GetExtra(extras, ExtraKeyLoadD64Path) is not null
+            || GetExtra(extras, ExtraKeyLoadD64Url) is not null
+            || GetExtra(extras, ExtraKeyLoadCrtPath) is not null
+            || GetExtra(extras, ExtraKeyLoadCrtUrl) is not null)
         {
-            _logger.LogWarning("Automation 'basicText'/'basicUrl' are mutually exclusive with loading a PRG; skipping BASIC source.");
+            _logger.LogWarning("Automation 'basicText'/'basicUrl' are mutually exclusive with PRG, .d64, and .crt startup flows; skipping BASIC source.");
             return;
         }
 
@@ -297,6 +383,11 @@ public sealed class C64AvaloniaStartupParticipant : IAutomatedStartupParticipant
         if (request.LoadPrgPath is not null)
         {
             _logger.LogWarning("Automation .d64 load is mutually exclusive with loading a PRG; skipping .d64 startup.");
+            return;
+        }
+        if (GetExtra(extras, ExtraKeyLoadCrtPath) is not null || GetExtra(extras, ExtraKeyLoadCrtUrl) is not null)
+        {
+            _logger.LogWarning("Automation .d64 load is mutually exclusive with .crt startup; skipping .d64 startup.");
             return;
         }
         if (hostApp.CurrentRunningSystem is not C64 c64)
@@ -403,6 +494,14 @@ public sealed class C64AvaloniaStartupParticipant : IAutomatedStartupParticipant
         var expanded = PathHelper.ExpandOSEnvironmentVariables(loadD64Path);
         if (!File.Exists(expanded))
             throw new FileNotFoundException($".d64 file not found: {expanded}", expanded);
+        return await File.ReadAllBytesAsync(expanded);
+    }
+
+    private static async Task<byte[]> ResolveCrtBytesFromFileAsync(string loadCrtPath)
+    {
+        var expanded = PathHelper.ExpandOSEnvironmentVariables(loadCrtPath);
+        if (!File.Exists(expanded))
+            throw new FileNotFoundException($".crt file not found: {expanded}", expanded);
         return await File.ReadAllBytesAsync(expanded);
     }
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
@@ -63,6 +63,7 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
     public ReactiveCommand<Unit, Unit> ToggleDiskImageCommand { get; }
     public ReactiveCommand<Unit, Unit> AttachCartridgeImageCommand { get; }
     public ReactiveCommand<Unit, Unit> DetachCartridgeCommand { get; }
+    public ReactiveCommand<Unit, Unit> FreezeCartridgeCommand { get; }
     public ReactiveCommand<Unit, Unit> LoadPreloadedProgramCommand { get; }
     public ReactiveCommand<Unit, Unit> LoadAssemblyExampleCommand { get; }
     public ReactiveCommand<Unit, Unit> LoadBasicExampleCommand { get; }
@@ -142,6 +143,11 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
         DetachCartridgeCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () => await DetachCartridgeInternalAsync(),
             canChangeCartridge,
+            RxSchedulers.MainThreadScheduler);
+
+        FreezeCartridgeCommand = ReactiveCommandHelper.CreateSafeCommand(
+            async () => await FreezeCartridgeInternalAsync(),
+            this.WhenAnyValue(x => x.CanFreezeCartridge),
             RxSchedulers.MainThreadScheduler);
 
         LoadPreloadedProgramCommand = ReactiveCommandHelper.CreateSafeCommand(
@@ -288,6 +294,10 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
     public string CartridgeAttachButtonText
         => IsCartridgeAttached ? "Replace cartridge..." : "Attach .crt cartridge image";
 
+    public bool CanFreezeCartridge
+        => _avaloniaHostApp.CurrentRunningSystem is C64 { CanFreezeAttachedCartridge: true } &&
+           !IsCartridgeOperationInProgress;
+
     public string CartridgeSummary
     {
         get
@@ -302,7 +312,9 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
 
             var mode = image.HardwareType switch
             {
+                (ushort)C64CrtHardwareType.ActionReplay => "Action Replay",
                 (ushort)C64CrtHardwareType.Ocean => "Ocean",
+                (ushort)C64CrtHardwareType.EpyxFastLoad => "Epyx FastLoad",
                 (ushort)C64CrtHardwareType.MagicDesk => "Magic Desk",
                 (ushort)C64CrtHardwareType.Generic when image.Lines is { GameHigh: true, ExromHigh: false } => "generic 8K",
                 (ushort)C64CrtHardwareType.Generic when image.Lines is { GameHigh: false, ExromHigh: false } => "generic 16K",
@@ -318,7 +330,11 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
     public bool IsCartridgeOperationInProgress
     {
         get => _isCartridgeOperationInProgress;
-        private set => this.RaiseAndSetIfChanged(ref _isCartridgeOperationInProgress, value);
+        private set
+        {
+            this.RaiseAndSetIfChanged(ref _isCartridgeOperationInProgress, value);
+            this.RaisePropertyChanged(nameof(CanFreezeCartridge));
+        }
     }
 
     private string _latestCartridgeError = string.Empty;
@@ -1133,6 +1149,39 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
         }
     }
 
+    private async Task FreezeCartridgeInternalAsync()
+    {
+        if (_avaloniaHostApp.CurrentRunningSystem is not C64 c64 ||
+            !c64.CanFreezeAttachedCartridge)
+            return;
+
+        LatestCartridgeError = string.Empty;
+        IsCartridgeOperationInProgress = true;
+        var wasRunning = _avaloniaHostApp.EmulatorState == EmulatorState.Running;
+        try
+        {
+            if (wasRunning)
+                _avaloniaHostApp.Pause();
+
+            if (!c64.FreezeAttachedCartridge())
+                LatestCartridgeError = "The attached cartridge does not support freezing.";
+        }
+        catch (Exception ex)
+        {
+            LatestCartridgeError = string.IsNullOrWhiteSpace(ex.Message)
+                ? "Could not activate the cartridge freeze button."
+                : ex.Message;
+            _logger.LogError(ex, "Error activating C64 cartridge freeze");
+        }
+        finally
+        {
+            if (wasRunning && _avaloniaHostApp.EmulatorState == EmulatorState.Paused)
+                await _avaloniaHostApp.Start();
+            IsCartridgeOperationInProgress = false;
+            RaiseCartridgePropertiesChanged();
+        }
+    }
+
     private async Task<SelectedBinaryFile?> RequestAttachCartridgeImageAsync()
     {
         if (AttachCartridgeImageRequested == null)
@@ -1160,6 +1209,7 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
         this.RaisePropertyChanged(nameof(IsCartridgeAttached));
         this.RaisePropertyChanged(nameof(CartridgeAttachButtonText));
         this.RaisePropertyChanged(nameof(CartridgeSummary));
+        this.RaisePropertyChanged(nameof(CanFreezeCartridge));
         this.RaisePropertyChanged(nameof(HasLatestCartridgeError));
     }
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
@@ -95,7 +95,7 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
 
         _avaloniaHostApp
             .WhenAnyValue(x => x.EmulatorState)
-            .Subscribe(_ =>
+            .Subscribe(state =>
             {
                 this.RaisePropertyChanged(nameof(IsC64ConfigEnabled));
                 this.RaisePropertyChanged(nameof(IsCopyPasteEnabled));
@@ -107,6 +107,8 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
                 this.RaisePropertyChanged(nameof(BasicCodingAssistantEnabled));
                 this.RaisePropertyChanged(nameof(IsFileOperationEnabled));
                 RecomputeShareLink();
+                if (state != EmulatorState.Uninitialized)
+                    _ = AttachPendingCartridgeOnStartAsync();
             });
 
         // Subscribe to KeyDown events from AvaloniaHostApp
@@ -130,10 +132,12 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
             RxSchedulers.MainThreadScheduler);
 
         var canChangeCartridge = _avaloniaHostApp
-            .WhenAnyValue(x => x.EmulatorState)
+            .WhenAnyValue(x => x.SelectedSystemName, x => x.EmulatorState)
             .CombineLatest(
                 this.WhenAnyValue(x => x.IsCartridgeOperationInProgress),
-                (state, inProgress) => state != EmulatorState.Uninitialized && !inProgress);
+                (systemAndState, inProgress) =>
+                    string.Equals(systemAndState.Item1, C64.SystemName, StringComparison.OrdinalIgnoreCase)
+                    && !inProgress);
 
         AttachCartridgeImageCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () => await AttachCartridgeImageInternalAsync(),
@@ -291,8 +295,16 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
         => _avaloniaHostApp.CurrentRunningSystem is C64 c64 &&
            c64.CartridgeSlot.AttachedCartridge != null;
 
+    public bool HasPendingCartridge
+        => _pendingCartridgeImage != null;
+
+    public bool CanDetachCartridge
+        => IsCartridgeAttached || HasPendingCartridge;
+
     public string CartridgeAttachButtonText
-        => IsCartridgeAttached ? "Replace cartridge..." : "Attach .crt cartridge image";
+        => EmulatorState == EmulatorState.Uninitialized
+            ? "Attach .crt for next start..."
+            : IsCartridgeAttached ? "Replace cartridge..." : "Attach .crt cartridge image";
 
     public bool CanFreezeCartridge
         => _avaloniaHostApp.CurrentRunningSystem is C64 { CanFreezeAttachedCartridge: true } &&
@@ -304,7 +316,11 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
         {
             if (_avaloniaHostApp.CurrentRunningSystem is not C64 c64 ||
                 c64.CartridgeSlot.AttachedCartridge is not { } cartridge)
+            {
+                if (_pendingCartridgeImage != null)
+                    return $"Pending cartridge: {_pendingCartridgeDisplayName ?? _pendingCartridgeImage.Name}";
                 return "No cartridge attached";
+            }
 
             var image = c64.AttachedCartridgeImage;
             if (image == null)
@@ -327,6 +343,10 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
             return $"{image.CartridgeName} — {mode}{source}";
         }
     }
+
+    private SelectedBinaryFile? _pendingCartridgeImage;
+    private string? _pendingCartridgeDisplayName;
+    private bool _isAttachingPendingCartridge;
 
     private bool _isCartridgeOperationInProgress;
     public bool IsCartridgeOperationInProgress
@@ -1079,10 +1099,35 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
 
     private async Task AttachCartridgeImageInternalAsync()
     {
-        if (_avaloniaHostApp.CurrentRunningSystem is not C64 c64)
-            return;
-
         LatestCartridgeError = string.Empty;
+
+        if (_avaloniaHostApp.CurrentRunningSystem is not C64 c64)
+        {
+            if (!IsC64System())
+                return;
+
+            var pendingFile = await RequestAttachCartridgeImageAsync();
+            if (pendingFile == null)
+                return;
+
+            try
+            {
+                SetPendingCartridge(pendingFile);
+            }
+            catch (Exception ex)
+            {
+                LatestCartridgeError = string.IsNullOrWhiteSpace(ex.Message)
+                    ? "Could not prepare the CRT cartridge image for next start."
+                    : ex.Message;
+                _logger.LogError(ex, "Error preparing pending CRT cartridge image {FileName}", pendingFile.Name);
+            }
+            finally
+            {
+                RaiseCartridgePropertiesChanged();
+            }
+            return;
+        }
+
         if (c64.CartridgeSlot.AttachedCartridge is { } current)
         {
             var confirmed = await RequestCartridgeReplaceConfirmationAsync(current.Name);
@@ -1102,6 +1147,7 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
                 _avaloniaHostApp.Pause();
 
             c64.AttachCrtImage(selectedFile.Bytes, selectedFile.Name);
+            ClearPendingCartridge();
         }
         catch (Exception ex)
         {
@@ -1121,9 +1167,25 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
 
     private async Task DetachCartridgeInternalAsync()
     {
-        if (_avaloniaHostApp.CurrentRunningSystem is not C64 c64 ||
-            c64.CartridgeSlot.AttachedCartridge == null)
+        if (_avaloniaHostApp.CurrentRunningSystem is not C64 c64)
+        {
+            if (_pendingCartridgeImage != null)
+            {
+                LatestCartridgeError = string.Empty;
+                ClearPendingCartridge();
+            }
             return;
+        }
+
+        if (c64.CartridgeSlot.AttachedCartridge == null)
+        {
+            if (_pendingCartridgeImage != null)
+            {
+                LatestCartridgeError = string.Empty;
+                ClearPendingCartridge();
+            }
+            return;
+        }
 
         LatestCartridgeError = string.Empty;
         IsCartridgeOperationInProgress = true;
@@ -1209,10 +1271,69 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
     private void RaiseCartridgePropertiesChanged()
     {
         this.RaisePropertyChanged(nameof(IsCartridgeAttached));
+        this.RaisePropertyChanged(nameof(HasPendingCartridge));
+        this.RaisePropertyChanged(nameof(CanDetachCartridge));
         this.RaisePropertyChanged(nameof(CartridgeAttachButtonText));
         this.RaisePropertyChanged(nameof(CartridgeSummary));
         this.RaisePropertyChanged(nameof(CanFreezeCartridge));
         this.RaisePropertyChanged(nameof(HasLatestCartridgeError));
+    }
+
+    private void SetPendingCartridge(SelectedBinaryFile selectedFile)
+    {
+        var crtImage = C64CrtParser.Parse(selectedFile.Bytes);
+        var cartridge = C64CrtCartridgeFactory.Create(crtImage);
+
+        _pendingCartridgeImage = selectedFile;
+        _pendingCartridgeDisplayName = cartridge.Name;
+    }
+
+    private void ClearPendingCartridge()
+    {
+        _pendingCartridgeImage = null;
+        _pendingCartridgeDisplayName = null;
+        RaiseCartridgePropertiesChanged();
+    }
+
+    private async Task AttachPendingCartridgeOnStartAsync()
+    {
+        if (_isAttachingPendingCartridge ||
+            _pendingCartridgeImage == null ||
+            !IsC64System() ||
+            _avaloniaHostApp.CurrentRunningSystem is not C64 c64 ||
+            c64.CartridgeSlot.AttachedCartridge != null)
+        {
+            return;
+        }
+
+        _isAttachingPendingCartridge = true;
+        IsCartridgeOperationInProgress = true;
+        var wasRunning = _avaloniaHostApp.EmulatorState == EmulatorState.Running;
+        var pending = _pendingCartridgeImage;
+        try
+        {
+            if (wasRunning)
+                _avaloniaHostApp.Pause();
+
+            c64.AttachCrtImage(pending.Bytes, pending.Name);
+            ClearPendingCartridge();
+            LatestCartridgeError = string.Empty;
+        }
+        catch (Exception ex)
+        {
+            LatestCartridgeError = string.IsNullOrWhiteSpace(ex.Message)
+                ? "Could not attach the pending CRT cartridge image."
+                : ex.Message;
+            _logger.LogError(ex, "Error attaching pending CRT cartridge image {FileName}", pending.Name);
+        }
+        finally
+        {
+            if (wasRunning && _avaloniaHostApp.EmulatorState == EmulatorState.Paused)
+                await _avaloniaHostApp.Start();
+            _isAttachingPendingCartridge = false;
+            IsCartridgeOperationInProgress = false;
+            RaiseCartridgePropertiesChanged();
+        }
     }
 
     private bool IsC64System()

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
@@ -18,6 +18,7 @@ using Highbyte.DotNet6502.Impl.Avalonia.Commodore64;
 using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Commodore64.Input;
 using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.Crt;
 using Highbyte.DotNet6502.Systems.Commodore64.Render.Rasterizer;
 using Highbyte.DotNet6502.Systems.Commodore64.Sharing;
 using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.DiskDrive.Download;
@@ -60,6 +61,8 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
     public ReactiveCommand<Unit, Unit> CopyBasicSourceCommand { get; }
     public ReactiveCommand<Unit, Unit> PasteTextCommand { get; }
     public ReactiveCommand<Unit, Unit> ToggleDiskImageCommand { get; }
+    public ReactiveCommand<Unit, Unit> AttachCartridgeImageCommand { get; }
+    public ReactiveCommand<Unit, Unit> DetachCartridgeCommand { get; }
     public ReactiveCommand<Unit, Unit> LoadPreloadedProgramCommand { get; }
     public ReactiveCommand<Unit, Unit> LoadAssemblyExampleCommand { get; }
     public ReactiveCommand<Unit, Unit> LoadBasicExampleCommand { get; }
@@ -69,6 +72,7 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
 
     // Section toggle / joystick commands used by both the UI click handlers and the menu/shortcut bridge.
     public ReactiveCommand<Unit, Unit> ToggleDiskSectionCommand { get; }
+    public ReactiveCommand<Unit, Unit> ToggleCartridgeSectionCommand { get; }
     public ReactiveCommand<Unit, Unit> ToggleLoadSaveSectionCommand { get; }
     public ReactiveCommand<Unit, Unit> ToggleConfigSectionCommand { get; }
     public ReactiveCommand<Unit, Unit> CopyShareLinkCommand { get; }
@@ -97,6 +101,7 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
                 this.RaisePropertyChanged(nameof(IsDiskImageAttached));
                 this.RaisePropertyChanged(nameof(CanToggleDisk));
                 this.RaisePropertyChanged(nameof(DiskToggleButtonText));
+                RaiseCartridgePropertiesChanged();
                 this.RaisePropertyChanged(nameof(BasicCodingAssistantAvailable));
                 this.RaisePropertyChanged(nameof(BasicCodingAssistantEnabled));
                 this.RaisePropertyChanged(nameof(IsFileOperationEnabled));
@@ -121,6 +126,22 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
         ToggleDiskImageCommand = ReactiveCommandHelper.CreateSafeCommand(
             async () => await ToggleDiskImageInternalAsync(),
             this.WhenAnyValue(x => x.CanToggleDisk),
+            RxSchedulers.MainThreadScheduler);
+
+        var canChangeCartridge = _avaloniaHostApp
+            .WhenAnyValue(x => x.EmulatorState)
+            .CombineLatest(
+                this.WhenAnyValue(x => x.IsCartridgeOperationInProgress),
+                (state, inProgress) => state != EmulatorState.Uninitialized && !inProgress);
+
+        AttachCartridgeImageCommand = ReactiveCommandHelper.CreateSafeCommand(
+            async () => await AttachCartridgeImageInternalAsync(),
+            canChangeCartridge,
+            RxSchedulers.MainThreadScheduler);
+
+        DetachCartridgeCommand = ReactiveCommandHelper.CreateSafeCommand(
+            async () => await DetachCartridgeInternalAsync(),
+            canChangeCartridge,
             RxSchedulers.MainThreadScheduler);
 
         LoadPreloadedProgramCommand = ReactiveCommandHelper.CreateSafeCommand(
@@ -155,6 +176,11 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
 
         ToggleDiskSectionCommand = ReactiveCommandHelper.CreateSafeCommand(
             () => ToggleSection(C64MenuSection.Disk),
+            null,
+            RxSchedulers.MainThreadScheduler);
+
+        ToggleCartridgeSectionCommand = ReactiveCommandHelper.CreateSafeCommand(
+            () => ToggleSection(C64MenuSection.Cartridge),
             null,
             RxSchedulers.MainThreadScheduler);
 
@@ -254,6 +280,56 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
     public bool CanToggleDisk => EmulatorState != EmulatorState.Uninitialized;
 
     public string DiskToggleButtonText => IsDiskImageAttached ? "Detach .d64 disk image" : "Attach .d64 disk image";
+
+    public bool IsCartridgeAttached
+        => _avaloniaHostApp.CurrentRunningSystem is C64 c64 &&
+           c64.CartridgeSlot.AttachedCartridge != null;
+
+    public string CartridgeAttachButtonText
+        => IsCartridgeAttached ? "Replace cartridge..." : "Attach .crt cartridge image";
+
+    public string CartridgeSummary
+    {
+        get
+        {
+            if (_avaloniaHostApp.CurrentRunningSystem is not C64 c64 ||
+                c64.CartridgeSlot.AttachedCartridge is not { } cartridge)
+                return "No cartridge attached";
+
+            var image = c64.AttachedCartridgeImage;
+            if (image == null)
+                return cartridge.Name;
+
+            var mode = image.Lines switch
+            {
+                { GameHigh: true, ExromHigh: false } => "generic 8K",
+                { GameHigh: false, ExromHigh: false } => "generic 16K",
+                { GameHigh: false, ExromHigh: true } => "Ultimax",
+                _ => $"hardware type {image.HardwareType}",
+            };
+            var source = string.IsNullOrWhiteSpace(image.SourceName) ? string.Empty : $" ({image.SourceName})";
+            return $"{image.CartridgeName} — {mode}{source}";
+        }
+    }
+
+    private bool _isCartridgeOperationInProgress;
+    public bool IsCartridgeOperationInProgress
+    {
+        get => _isCartridgeOperationInProgress;
+        private set => this.RaiseAndSetIfChanged(ref _isCartridgeOperationInProgress, value);
+    }
+
+    private string _latestCartridgeError = string.Empty;
+    public string LatestCartridgeError
+    {
+        get => _latestCartridgeError;
+        private set
+        {
+            this.RaiseAndSetIfChanged(ref _latestCartridgeError, value);
+            this.RaisePropertyChanged(nameof(HasLatestCartridgeError));
+        }
+    }
+    public bool HasLatestCartridgeError => !string.IsNullOrWhiteSpace(LatestCartridgeError);
 
     // Preloaded downloadable programs
     public ObservableCollection<KeyValuePair<string, string>> PreloadedPrograms { get; } = new();
@@ -430,6 +506,19 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
         }
     }
 
+    private bool _isCartridgeSectionExpanded;
+    public bool IsCartridgeSectionExpanded
+    {
+        get => _isCartridgeSectionExpanded;
+        private set
+        {
+            if (_isCartridgeSectionExpanded == value)
+                return;
+            _isCartridgeSectionExpanded = value;
+            this.RaisePropertyChanged(nameof(IsCartridgeSectionExpanded));
+        }
+    }
+
     private bool _isLoadSaveSectionExpanded = false;
     public bool IsLoadSaveSectionExpanded
     {
@@ -462,13 +551,14 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
     public string LoadSaveSectionHeaderText => "Load/Save";
     public string ConfigSectionHeaderText => "Configuration";
 
-    private enum C64MenuSection { Disk, LoadSave, Config }
+    private enum C64MenuSection { Disk, Cartridge, LoadSave, Config }
 
     private void ToggleSection(C64MenuSection section)
     {
         bool newState = section switch
         {
             C64MenuSection.Disk => !IsDiskSectionExpanded,
+            C64MenuSection.Cartridge => !IsCartridgeSectionExpanded,
             C64MenuSection.LoadSave => !IsLoadSaveSectionExpanded,
             C64MenuSection.Config => !IsConfigSectionExpanded,
             _ => false,
@@ -487,6 +577,16 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
                 {
                     IsLoadSaveSectionExpanded = false;
                     IsConfigSectionExpanded = false;
+                    IsCartridgeSectionExpanded = false;
+                }
+                break;
+            case C64MenuSection.Cartridge:
+                IsCartridgeSectionExpanded = expanded;
+                if (collapseOthers && expanded)
+                {
+                    IsDiskSectionExpanded = false;
+                    IsLoadSaveSectionExpanded = false;
+                    IsConfigSectionExpanded = false;
                 }
                 break;
             case C64MenuSection.LoadSave:
@@ -495,6 +595,7 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
                 {
                     IsDiskSectionExpanded = false;
                     IsConfigSectionExpanded = false;
+                    IsCartridgeSectionExpanded = false;
                 }
                 break;
             case C64MenuSection.Config:
@@ -503,6 +604,7 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
                 {
                     IsDiskSectionExpanded = false;
                     IsLoadSaveSectionExpanded = false;
+                    IsCartridgeSectionExpanded = false;
                 }
                 break;
         }
@@ -514,6 +616,7 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
     public void ExpandConfigSectionOnValidationError()
     {
         IsDiskSectionExpanded = false;
+        IsCartridgeSectionExpanded = false;
         IsLoadSaveSectionExpanded = false;
         IsConfigSectionExpanded = true;
     }
@@ -954,6 +1057,110 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
         }
     }
 
+    private async Task AttachCartridgeImageInternalAsync()
+    {
+        if (_avaloniaHostApp.CurrentRunningSystem is not C64 c64)
+            return;
+
+        LatestCartridgeError = string.Empty;
+        if (c64.CartridgeSlot.AttachedCartridge is { } current)
+        {
+            var confirmed = await RequestCartridgeReplaceConfirmationAsync(current.Name);
+            if (!confirmed)
+                return;
+        }
+
+        var selectedFile = await RequestAttachCartridgeImageAsync();
+        if (selectedFile == null)
+            return;
+
+        IsCartridgeOperationInProgress = true;
+        var wasRunning = _avaloniaHostApp.EmulatorState == EmulatorState.Running;
+        try
+        {
+            if (wasRunning)
+                _avaloniaHostApp.Pause();
+
+            c64.AttachCrtImage(selectedFile.Bytes, selectedFile.Name);
+        }
+        catch (Exception ex)
+        {
+            LatestCartridgeError = string.IsNullOrWhiteSpace(ex.Message)
+                ? "Could not attach the CRT cartridge image."
+                : ex.Message;
+            _logger.LogError(ex, "Error attaching CRT cartridge image {FileName}", selectedFile.Name);
+        }
+        finally
+        {
+            if (wasRunning && _avaloniaHostApp.EmulatorState == EmulatorState.Paused)
+                await _avaloniaHostApp.Start();
+            IsCartridgeOperationInProgress = false;
+            RaiseCartridgePropertiesChanged();
+        }
+    }
+
+    private async Task DetachCartridgeInternalAsync()
+    {
+        if (_avaloniaHostApp.CurrentRunningSystem is not C64 c64 ||
+            c64.CartridgeSlot.AttachedCartridge == null)
+            return;
+
+        LatestCartridgeError = string.Empty;
+        IsCartridgeOperationInProgress = true;
+        var wasRunning = _avaloniaHostApp.EmulatorState == EmulatorState.Running;
+        try
+        {
+            if (wasRunning)
+                _avaloniaHostApp.Pause();
+
+            c64.DetachCartridgeAndReset();
+        }
+        catch (Exception ex)
+        {
+            LatestCartridgeError = string.IsNullOrWhiteSpace(ex.Message)
+                ? "Could not detach the cartridge."
+                : ex.Message;
+            _logger.LogError(ex, "Error detaching C64 cartridge");
+        }
+        finally
+        {
+            if (wasRunning && _avaloniaHostApp.EmulatorState == EmulatorState.Paused)
+                await _avaloniaHostApp.Start();
+            IsCartridgeOperationInProgress = false;
+            RaiseCartridgePropertiesChanged();
+        }
+    }
+
+    private async Task<SelectedBinaryFile?> RequestAttachCartridgeImageAsync()
+    {
+        if (AttachCartridgeImageRequested == null)
+            return null;
+
+        var tcs = new TaskCompletionSource<SelectedBinaryFile?>();
+        AttachCartridgeImageRequested.Invoke(this, tcs);
+        return await tcs.Task;
+    }
+
+    private async Task<bool> RequestCartridgeReplaceConfirmationAsync(string cartridgeName)
+    {
+        if (ConfirmCartridgeReplaceRequested == null)
+            return false;
+
+        var tcs = new TaskCompletionSource<bool>();
+        ConfirmCartridgeReplaceRequested.Invoke(
+            this,
+            new CartridgeReplaceConfirmationEventArgs(cartridgeName, tcs));
+        return await tcs.Task;
+    }
+
+    private void RaiseCartridgePropertiesChanged()
+    {
+        this.RaisePropertyChanged(nameof(IsCartridgeAttached));
+        this.RaisePropertyChanged(nameof(CartridgeAttachButtonText));
+        this.RaisePropertyChanged(nameof(CartridgeSummary));
+        this.RaisePropertyChanged(nameof(HasLatestCartridgeError));
+    }
+
     private bool IsC64System()
     {
         return string.Equals(_avaloniaHostApp?.SelectedSystemName, C64.SystemName, StringComparison.OrdinalIgnoreCase);
@@ -963,6 +1170,8 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
     public event EventHandler<string>? ClipboardCopyRequested;
     public event EventHandler<TaskCompletionSource<string?>>? ClipboardPasteRequested;
     public event EventHandler<TaskCompletionSource<byte[]?>>? AttachDiskImageRequested;
+    public event EventHandler<TaskCompletionSource<SelectedBinaryFile?>>? AttachCartridgeImageRequested;
+    public event EventHandler<CartridgeReplaceConfirmationEventArgs>? ConfirmCartridgeReplaceRequested;
 
     private async Task RequestClipboardCopyAsync(string text)
     {
@@ -1341,4 +1550,20 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
     {
         // Currently no special handling for KeyUp events
     }
+}
+
+public sealed record SelectedBinaryFile(string Name, byte[] Bytes);
+
+public sealed class CartridgeReplaceConfirmationEventArgs : EventArgs
+{
+    public CartridgeReplaceConfirmationEventArgs(
+        string cartridgeName,
+        TaskCompletionSource<bool> completion)
+    {
+        CartridgeName = cartridgeName;
+        Completion = completion;
+    }
+
+    public string CartridgeName { get; }
+    public TaskCompletionSource<bool> Completion { get; }
 }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
@@ -315,6 +315,7 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
                 (ushort)C64CrtHardwareType.ActionReplay => "Action Replay",
                 (ushort)C64CrtHardwareType.FinalCartridgeIII => "Final Cartridge III",
                 (ushort)C64CrtHardwareType.Ocean => "Ocean",
+                (ushort)C64CrtHardwareType.Expert => "Expert Cartridge",
                 (ushort)C64CrtHardwareType.EpyxFastLoad => "Epyx FastLoad",
                 (ushort)C64CrtHardwareType.MagicDesk => "Magic Desk",
                 (ushort)C64CrtHardwareType.Generic when image.Lines is { GameHigh: true, ExromHigh: false } => "generic 8K",

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
@@ -313,6 +313,7 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
             var mode = image.HardwareType switch
             {
                 (ushort)C64CrtHardwareType.ActionReplay => "Action Replay",
+                (ushort)C64CrtHardwareType.FinalCartridgeIII => "Final Cartridge III",
                 (ushort)C64CrtHardwareType.Ocean => "Ocean",
                 (ushort)C64CrtHardwareType.EpyxFastLoad => "Epyx FastLoad",
                 (ushort)C64CrtHardwareType.MagicDesk => "Magic Desk",

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
@@ -302,6 +302,7 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
 
             var mode = image.HardwareType switch
             {
+                (ushort)C64CrtHardwareType.Ocean => "Ocean",
                 (ushort)C64CrtHardwareType.MagicDesk => "Magic Desk",
                 (ushort)C64CrtHardwareType.Generic when image.Lines is { GameHigh: true, ExromHigh: false } => "generic 8K",
                 (ushort)C64CrtHardwareType.Generic when image.Lines is { GameHigh: false, ExromHigh: false } => "generic 16K",

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
@@ -300,11 +300,12 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
             if (image == null)
                 return cartridge.Name;
 
-            var mode = image.Lines switch
+            var mode = image.HardwareType switch
             {
-                { GameHigh: true, ExromHigh: false } => "generic 8K",
-                { GameHigh: false, ExromHigh: false } => "generic 16K",
-                { GameHigh: false, ExromHigh: true } => "Ultimax",
+                (ushort)C64CrtHardwareType.MagicDesk => "Magic Desk",
+                (ushort)C64CrtHardwareType.Generic when image.Lines is { GameHigh: true, ExromHigh: false } => "generic 8K",
+                (ushort)C64CrtHardwareType.Generic when image.Lines is { GameHigh: false, ExromHigh: false } => "generic 16K",
+                (ushort)C64CrtHardwareType.Generic when image.Lines is { GameHigh: false, ExromHigh: true } => "Ultimax",
                 _ => $"hardware type {image.HardwareType}",
             };
             var source = string.IsNullOrWhiteSpace(image.SourceName) ? string.Empty : $" ({image.SourceName})";

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml
@@ -194,7 +194,7 @@
                     <Button Content="Detach cartridge"
                             AutomationProperties.AutomationId="DetachCartridgeButton"
                             Command="{Binding DetachCartridgeCommand}"
-                            IsVisible="{Binding IsCartridgeAttached}"
+                            IsVisible="{Binding CanDetachCartridge}"
                             Classes="small danger"/>
 
                     <Button Content="Freeze (cartridge button)"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml
@@ -197,6 +197,12 @@
                             IsVisible="{Binding IsCartridgeAttached}"
                             Classes="small danger"/>
 
+                    <Button Content="Freeze (cartridge button)"
+                            AutomationProperties.AutomationId="FreezeCartridgeButton"
+                            Command="{Binding FreezeCartridgeCommand}"
+                            IsVisible="{Binding CanFreezeCartridge}"
+                            Classes="small"/>
+
                     <TextBlock Text="Attaching cartridge..."
                                Classes="small secondary-text"
                                IsVisible="{Binding IsCartridgeOperationInProgress}"/>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml
@@ -143,6 +143,74 @@
             </Border>
         </StackPanel>
 
+        <!-- Cartridge & CRT images -->
+        <StackPanel>
+            <Button Name="CartridgeSectionHeader"
+                    AutomationProperties.AutomationId="CartridgeSectionHeader"
+                    AutomationProperties.Name="Toggle cartridge section"
+                    Classes="section-toggle"
+                    Command="{Binding ToggleCartridgeSectionCommand}">
+                <StackPanel Orientation="Horizontal" Spacing="6">
+                    <Grid Width="10" Height="10" VerticalAlignment="Center">
+                        <controls:SymbolIcon Width="8" Height="8"
+                                             Kind="TriangleRight"
+                                             IsVisible="{Binding !IsCartridgeSectionExpanded}"/>
+                        <controls:SymbolIcon Width="8" Height="8"
+                                             Kind="TriangleDown"
+                                             IsVisible="{Binding IsCartridgeSectionExpanded}"/>
+                    </Grid>
+                    <TextBlock Text="Cartridge &amp; .CRT images"
+                               VerticalAlignment="Center"/>
+                </StackPanel>
+            </Button>
+
+            <Border Name="CartridgeSectionContent"
+                    AutomationProperties.AutomationId="CartridgeSectionContent"
+                    Classes="collapsible-content"
+                    IsVisible="{Binding IsCartridgeSectionExpanded}">
+                <StackPanel Classes="spacing-tight">
+                    <TextBlock Text="{Binding CartridgeSummary}"
+                               Classes="small secondary-text"
+                               TextWrapping="Wrap"/>
+
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Button Grid.Column="0"
+                                Content="{Binding CartridgeAttachButtonText}"
+                                AutomationProperties.AutomationId="AttachCartridgeButton"
+                                Command="{Binding AttachCartridgeImageCommand}"
+                                Classes="small"/>
+                        <Button Grid.Column="1"
+                                Content="i"
+                                AutomationProperties.AutomationId="CartridgeInfoButton"
+                                AutomationProperties.Name="About cartridge images"
+                                Classes="info"
+                                Click="OpenCartridgeInfo_Click"/>
+                    </Grid>
+
+                    <Button Content="Detach cartridge"
+                            AutomationProperties.AutomationId="DetachCartridgeButton"
+                            Command="{Binding DetachCartridgeCommand}"
+                            IsVisible="{Binding IsCartridgeAttached}"
+                            Classes="small danger"/>
+
+                    <TextBlock Text="Attaching cartridge..."
+                               Classes="small secondary-text"
+                               IsVisible="{Binding IsCartridgeOperationInProgress}"/>
+
+                    <Border Classes="error-container-small"
+                            IsVisible="{Binding HasLatestCartridgeError}">
+                        <TextBlock Text="{Binding LatestCartridgeError}"
+                                   Classes="small"
+                                   TextWrapping="Wrap"/>
+                    </Border>
+                </StackPanel>
+            </Border>
+        </StackPanel>
+
         <!-- Load/Save -->
         <StackPanel>
             <Button Name="LoadSaveSectionHeader"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml.cs
@@ -516,7 +516,7 @@ public partial class C64MenuView : UserControl
     private void OpenCartridgeInfo_Click(object? sender, RoutedEventArgs e)
         => SafeAsyncHelper.Execute(() => ShowMessageOverlayAsync(
             "C64 Cartridge Images",
-            "Attach generic 8K, generic 16K, Ultimax, Magic Desk, Ocean, Epyx FastLoad, or Action Replay .crt images. Freezer cartridges expose a Freeze button while attached. Other cartridge hardware types are rejected until their banking or device behavior is implemented."));
+            "Attach generic 8K, generic 16K, Ultimax, Magic Desk, Ocean, Epyx FastLoad, Action Replay, or Final Cartridge III .crt images. Freezer cartridges expose a Freeze button while attached. Other cartridge hardware types are rejected until their banking or device behavior is implemented."));
 
     private async Task<bool> ShowConfirmationOverlayAsync(string title, string message)
     {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml.cs
@@ -1,10 +1,12 @@
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Platform.Storage;
 using AvaloniaApp = Highbyte.DotNet6502.App.Avalonia.Core.App;
@@ -88,6 +90,8 @@ public partial class C64MenuView : UserControl
             _subscribedViewModel.ClipboardCopyRequested -= OnClipboardCopyRequested;
             _subscribedViewModel.ClipboardPasteRequested -= OnClipboardPasteRequested;
             _subscribedViewModel.AttachDiskImageRequested -= OnAttachDiskImageRequested;
+            _subscribedViewModel.AttachCartridgeImageRequested -= OnAttachCartridgeImageRequested;
+            _subscribedViewModel.ConfirmCartridgeReplaceRequested -= OnConfirmCartridgeReplaceRequested;
         }
 
         _subscribedViewModel = newViewModel;
@@ -97,6 +101,8 @@ public partial class C64MenuView : UserControl
             _subscribedViewModel.ClipboardCopyRequested += OnClipboardCopyRequested;
             _subscribedViewModel.ClipboardPasteRequested += OnClipboardPasteRequested;
             _subscribedViewModel.AttachDiskImageRequested += OnAttachDiskImageRequested;
+            _subscribedViewModel.AttachCartridgeImageRequested += OnAttachCartridgeImageRequested;
+            _subscribedViewModel.ConfirmCartridgeReplaceRequested += OnConfirmCartridgeReplaceRequested;
         }
     }
 
@@ -111,6 +117,62 @@ public partial class C64MenuView : UserControl
                 await clipboard.SetDataAsync(data);
             }
         });
+
+    private void OnAttachCartridgeImageRequested(
+        object? sender,
+        TaskCompletionSource<SelectedBinaryFile?> tcs)
+        => SafeAsyncHelper.Execute(async () =>
+        {
+            try
+            {
+                if (TopLevel.GetTopLevel(this) is not { } topLevel ||
+                    !topLevel.StorageProvider.CanOpen)
+                {
+                    tcs.TrySetResult(null);
+                    return;
+                }
+
+                var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+                {
+                    Title = "Select C64 CRT Cartridge Image",
+                    AllowMultiple = false,
+                    FileTypeFilter =
+                    [
+                        new FilePickerFileType("C64 CRT Cartridge Images") { Patterns = ["*.crt"] },
+                        new FilePickerFileType("All Files") { Patterns = ["*"] },
+                    ],
+                });
+
+                if (files.Count == 0)
+                {
+                    tcs.TrySetResult(null);
+                    return;
+                }
+
+                await using var stream = await files[0].OpenReadAsync();
+                using var buffer = new MemoryStream();
+                await stream.CopyToAsync(buffer);
+                tcs.TrySetResult(new SelectedBinaryFile(files[0].Name, buffer.ToArray()));
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error reading CRT cartridge image");
+                tcs.TrySetResult(null);
+                await ShowMessageOverlayAsync(
+                    "Could Not Read Cartridge Image",
+                    string.IsNullOrWhiteSpace(ex.Message)
+                        ? "The selected CRT cartridge image could not be read."
+                        : ex.Message);
+            }
+        });
+
+    private void OnConfirmCartridgeReplaceRequested(
+        object? sender,
+        CartridgeReplaceConfirmationEventArgs e)
+        => SafeAsyncHelper.Execute(async () =>
+            e.Completion.TrySetResult(await ShowConfirmationOverlayAsync(
+                "Replace Cartridge",
+                $"Replace the currently attached cartridge '{e.CartridgeName}'?")));
 
     private void OnClipboardPasteRequested(object? sender, TaskCompletionSource<string?> tcs)
         => SafeAsyncHelper.Execute(async () =>
@@ -450,6 +512,106 @@ public partial class C64MenuView : UserControl
 
     private void OpenDiskInfo_Click(object? sender, RoutedEventArgs e)
         => SafeAsyncHelper.Execute(() => LaunchUriIfAvailableAsync("https://highbyte.github.io/dotnet-6502/docs/systems/c64/compatible-programs/"));
+
+    private void OpenCartridgeInfo_Click(object? sender, RoutedEventArgs e)
+        => SafeAsyncHelper.Execute(() => ShowMessageOverlayAsync(
+            "C64 Cartridge Images",
+            "Attach generic 8K, generic 16K, or Ultimax .crt images. Other cartridge hardware types are rejected until their banking or device behavior is implemented."));
+
+    private async Task<bool> ShowConfirmationOverlayAsync(string title, string message)
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        Panel? overlayPanel = null;
+        Grid? hostGrid = null;
+
+        void Close(bool result)
+        {
+            if (overlayPanel != null && hostGrid != null)
+                hostGrid.Children.Remove(overlayPanel);
+            tcs.TrySetResult(result);
+        }
+
+        var cancelButton = new Button { Content = "Cancel", Classes = { "small", "cancel" } };
+        cancelButton.Click += (_, _) => Close(false);
+        var replaceButton = new Button { Content = "Replace", Classes = { "small", "danger" } };
+        replaceButton.Click += (_, _) => Close(true);
+
+        overlayPanel = BuildMessageOverlay(
+            title,
+            message,
+            new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Spacing = 10,
+                Children = { cancelButton, replaceButton },
+            });
+        hostGrid = ShowOverlay(overlayPanel);
+        if (hostGrid == null)
+            return false;
+        return await tcs.Task;
+    }
+
+    private async Task ShowMessageOverlayAsync(string title, string message)
+    {
+        var tcs = new TaskCompletionSource();
+        Panel? overlayPanel = null;
+        Grid? hostGrid = null;
+        var closeButton = new Button { Content = "OK", Classes = { "small", "primary" } };
+        closeButton.Click += (_, _) =>
+        {
+            if (overlayPanel != null && hostGrid != null)
+                hostGrid.Children.Remove(overlayPanel);
+            tcs.TrySetResult();
+        };
+        overlayPanel = BuildMessageOverlay(title, message, closeButton);
+        hostGrid = ShowOverlay(overlayPanel);
+        if (hostGrid != null)
+            await tcs.Task;
+    }
+
+    private static Panel BuildMessageOverlay(string title, string message, Control actions)
+        => new Panel
+        {
+            Background = new SolidColorBrush(Color.FromArgb(180, 0, 0, 0)),
+            ZIndex = 1000,
+            Children =
+            {
+                new Border
+                {
+                    Background = new SolidColorBrush(Color.FromRgb(26, 32, 44)),
+                    BorderBrush = new SolidColorBrush(Color.FromRgb(74, 85, 104)),
+                    BorderThickness = new Thickness(1),
+                    CornerRadius = new CornerRadius(8),
+                    Padding = new Thickness(16),
+                    MaxWidth = 420,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Child = new StackPanel
+                    {
+                        Spacing = 12,
+                        Children =
+                        {
+                            new TextBlock { Text = title, FontSize = 14, FontWeight = FontWeight.Bold },
+                            new TextBlock { Text = message, FontSize = 11, TextWrapping = TextWrapping.Wrap },
+                            actions,
+                        },
+                    },
+                },
+            },
+        };
+
+    private Grid? ShowOverlay(Panel overlayPanel)
+    {
+        var serviceProvider = (Application.Current as AvaloniaApp)?.GetServiceProvider();
+        if (serviceProvider == null)
+        {
+            Logger.LogError("Could not get service provider for cartridge dialog");
+            return null;
+        }
+        var helper = serviceProvider.GetRequiredService<OverlayDialogHelper>();
+        return helper.ShowOverlayDialog(overlayPanel, this);
+    }
 
     private Task LaunchUriIfAvailableAsync(string uri)
     {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml.cs
@@ -516,7 +516,7 @@ public partial class C64MenuView : UserControl
     private void OpenCartridgeInfo_Click(object? sender, RoutedEventArgs e)
         => SafeAsyncHelper.Execute(() => ShowMessageOverlayAsync(
             "C64 Cartridge Images",
-            "Attach generic 8K, generic 16K, Ultimax, Magic Desk, Ocean, Epyx FastLoad, Action Replay, or Final Cartridge III .crt images. Freezer cartridges expose a Freeze button while attached. Other cartridge hardware types are rejected until their banking or device behavior is implemented."));
+            "Attach generic 8K, generic 16K, Ultimax, Magic Desk, Ocean, Expert, Epyx FastLoad, Action Replay, or Final Cartridge III .crt images. Freezer cartridges expose a Freeze button while attached. Other cartridge hardware types are rejected until their banking or device behavior is implemented."));
 
     private async Task<bool> ShowConfirmationOverlayAsync(string title, string message)
     {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml.cs
@@ -516,7 +516,7 @@ public partial class C64MenuView : UserControl
     private void OpenCartridgeInfo_Click(object? sender, RoutedEventArgs e)
         => SafeAsyncHelper.Execute(() => ShowMessageOverlayAsync(
             "C64 Cartridge Images",
-            "Attach generic 8K, generic 16K, Ultimax, Magic Desk, or Ocean .crt images. Other cartridge hardware types are rejected until their banking or device behavior is implemented."));
+            "Attach generic 8K, generic 16K, Ultimax, Magic Desk, Ocean, Epyx FastLoad, or Action Replay .crt images. Freezer cartridges expose a Freeze button while attached. Other cartridge hardware types are rejected until their banking or device behavior is implemented."));
 
     private async Task<bool> ShowConfirmationOverlayAsync(string title, string message)
     {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml.cs
@@ -516,7 +516,7 @@ public partial class C64MenuView : UserControl
     private void OpenCartridgeInfo_Click(object? sender, RoutedEventArgs e)
         => SafeAsyncHelper.Execute(() => ShowMessageOverlayAsync(
             "C64 Cartridge Images",
-            "Attach generic 8K, generic 16K, Ultimax, or Magic Desk .crt images. Other cartridge hardware types are rejected until their banking or device behavior is implemented."));
+            "Attach generic 8K, generic 16K, Ultimax, Magic Desk, or Ocean .crt images. Other cartridge hardware types are rejected until their banking or device behavior is implemented."));
 
     private async Task<bool> ShowConfirmationOverlayAsync(string title, string message)
     {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml.cs
@@ -516,7 +516,7 @@ public partial class C64MenuView : UserControl
     private void OpenCartridgeInfo_Click(object? sender, RoutedEventArgs e)
         => SafeAsyncHelper.Execute(() => ShowMessageOverlayAsync(
             "C64 Cartridge Images",
-            "Attach generic 8K, generic 16K, or Ultimax .crt images. Other cartridge hardware types are rejected until their banking or device behavior is implemented."));
+            "Attach generic 8K, generic 16K, Ultimax, or Magic Desk .crt images. Other cartridge hardware types are rejected until their banking or device behavior is implemented."));
 
     private async Task<bool> ShowConfirmationOverlayAsync(string title, string message)
     {

--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Commodore64/C64Setup.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Commodore64/C64Setup.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Highbyte.DotNet6502.AI.CodingAssistant;
 using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
 using Highbyte.DotNet6502.Systems.Commodore64.Input;
 using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 using Highbyte.DotNet6502.Impl.Avalonia.Commodore64.Transport;
@@ -59,15 +60,16 @@ public class C64Setup : C64SystemConfigurerCore
         c64.InputConsumer = new C64InputHandler(c64, LoggerFactory, c64HostConfig.InputConfig,
             c64BasicCodingAssistant, c64HostConfig.BasicAIAssistantDefaultEnabled);
 
-        if (PlatformDetection.IsRunningInWebAssembly() && c64.SwiftLink != null)
+        var swiftLink = c64.CartridgeSlot.GetCartridge<SwiftLinkDevice>();
+        if (PlatformDetection.IsRunningInWebAssembly() && swiftLink != null)
         {
             var transport = CreateBrowserSwiftLinkTransport(c64HostConfig);
-            c64.SwiftLink.ReceivePacingCycles =
+            swiftLink.ReceivePacingCycles =
                 c64HostConfig.SwiftLinkTransportMode == C64SwiftLinkTransportMode.HayesModem
-                && c64.SwiftLink.ReceiveMode == C64SwiftLinkReceiveMode.Compatible
+                && swiftLink.ReceiveMode == C64SwiftLinkReceiveMode.Compatible
                     ? GetReceivePacingCyclesPerCharacter(c64)
                     : 0;
-            c64.SwiftLink.Transport = transport;
+            swiftLink.Transport = transport;
 
             if (c64HostConfig.SwiftLinkConnectOnBoot)
                 await transport.ConnectAsync();

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Audio/Sid.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Audio/Sid.cs
@@ -98,6 +98,12 @@ public class Sid
         c64Mem.MapReader(SidAddr.SIGVOL, (_) => 0);
         c64Mem.MapWriter(SidAddr.SIGVOL, InternalSidState.SetSidRegValue);
 
+        // Paddle/mouse analog inputs. With no paddle/mouse emulation connected, return the
+        // idle/open value instead of the zero-filled backing IO RAM. Some software probes
+        // POTX/POTY before deciding whether to use mouse-style or joystick-style pointer input.
+        c64Mem.MapReader(SidAddr.POTX, (_) => 0xff);
+        c64Mem.MapReader(SidAddr.POTY, (_) => 0xff);
+
         // Voice 3 read-only registers. Tunes that read $D41B/$D41C for waveform- or
         // envelope-driven effects (vibrato, sweeps, etc.) depend on these. The active audio
         // provider installs a lazy getter so the value is computed only on read (currently only

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -525,7 +525,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapRAM(0x0000, ram, preWriteIntercept: RamPreWriteIntercept);
             mem.MapRAM(0xd000, io);
             CartridgeSlot.MapROMLLocations(mem, address => ram[address], WriteUnderlyingRam);
-            CartridgeSlot.MapROMHLocations(mem, 0xe000, address => ram[address]);
+            CartridgeSlot.MapROMHLocations(mem, 0xe000, address => ram[address], WriteUnderlyingRam);
             MapLocationsOnCurrentCPUBank(mem, mapIO: true);
         }
         foreach (var bank in new int[] { 15 })
@@ -561,7 +561,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapRAM(0xd000, io);
             mem.MapROM(0xe000, kernal);
             CartridgeSlot.MapROMLLocations(mem, address => ram[address], WriteUnderlyingRam);
-            CartridgeSlot.MapROMHLocations(mem, 0xa000, address => ram[address]);
+            CartridgeSlot.MapROMHLocations(mem, 0xa000, address => ram[address], WriteUnderlyingRam);
             MapLocationsOnCurrentCPUBank(mem, mapIO: true);
         }
         foreach (var bank in new int[] { 6 })
@@ -570,7 +570,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapRAM(0x0000, ram, preWriteIntercept: RamPreWriteIntercept);
             mem.MapRAM(0xd000, io);
             mem.MapROM(0xe000, kernal);
-            CartridgeSlot.MapROMHLocations(mem, 0xa000, address => ram[address]);
+            CartridgeSlot.MapROMHLocations(mem, 0xa000, address => ram[address], WriteUnderlyingRam);
             MapLocationsOnCurrentCPUBank(mem, mapIO: true);
         }
         foreach (var bank in new int[] { 5 })
@@ -587,7 +587,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapROM(0xd000, chargen);
             mem.MapROM(0xe000, kernal);
             CartridgeSlot.MapROMLLocations(mem, address => ram[address], WriteUnderlyingRam);
-            CartridgeSlot.MapROMHLocations(mem, 0xa000, address => ram[address]);
+            CartridgeSlot.MapROMHLocations(mem, 0xa000, address => ram[address], WriteUnderlyingRam);
             MapLocationsOnCurrentCPUBank(mem, mapIO: false);
         }
         foreach (var bank in new int[] { 2 })
@@ -596,7 +596,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapRAM(0x0000, ram, preWriteIntercept: RamPreWriteIntercept);
             mem.MapROM(0xd000, chargen);
             mem.MapROM(0xe000, kernal);
-            CartridgeSlot.MapROMHLocations(mem, 0xa000, address => ram[address]);
+            CartridgeSlot.MapROMHLocations(mem, 0xa000, address => ram[address], WriteUnderlyingRam);
             MapLocationsOnCurrentCPUBank(mem, mapIO: false);
         }
         foreach (var bank in new int[] { 1 })
@@ -645,10 +645,13 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
 
     private void ApplyCpuPortMemoryConfiguration()
     {
+        var previousBank = CurrentBank;
         var cpuPortBits = (byte)(GetCpuPortEffectiveValue() & CpuPortBankBitsMask);
         var cartridgeLineBits = CartridgeSlot.Lines.GetMemoryConfigurationBits();
         CurrentBank = (byte)(cartridgeLineBits | cpuPortBits);
         Mem.SetMemoryConfiguration(CurrentBank);
+        if (CurrentBank != previousBank && Vic2 is not null)
+            Vic2.SpriteManager.SetAllChanged(Vic2Sprite.Vic2SpriteChangeType.Data);
     }
 
     private byte GetCpuPortEffectiveValue()
@@ -732,7 +735,8 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             CartridgeSlot.Lines,
             CurrentBank,
             freezeVector);
-        CPU.CPUInterrupts.SetNMISourceActive(freezeNmiSource);
+        if (!CartridgeSlot.NmiLineActive)
+            CPU.CPUInterrupts.SetNMISourceActive(freezeNmiSource);
         CPU.ProcessPendingInterrupts(Mem);
         CPU.CPUInterrupts.SetNMISourceInactive(freezeNmiSource);
         return true;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -46,7 +46,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
 
     public byte[] RAM { get; set; } = default!;
     public byte[] IO { get; set; } = default!;
-    public byte CurrentBank { get; set; }
+    public byte CurrentBank { get; private set; }
     public Vic2 Vic2 { get; set; } = default!;
     public Cia1 Cia1 { get; set; } = default!;
     public Cia2 Cia2 { get; set; } = default!;
@@ -240,6 +240,11 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
     private C64(ILogger logger, ILoggerFactory loggerFactory)
     {
         _logger = logger;
+        CartridgeSlot.LinesChanged += () =>
+        {
+            if (Mem is not null)
+                ApplyCpuPortMemoryConfiguration();
+        };
         _spriteCollisionStat = Instrumentations.Add($"{StatsCategory}-SpriteCollision", new ElapsedMillisecondsTimedStatSystem(this));
 
         _audioProviderPerInstructionStat = Instrumentations.Add($"{StatsCategoryAudioProvider}-Instruction", new ElapsedMillisecondsTimedStatSystem(this));
@@ -427,9 +432,6 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
     {
         var mem = c64.Mem;
 
-        // Preserve the cartridge control bits (GAME/EXROM) while restoring the 6510
-        // processor port to the C64 startup defaults.
-        c64.CurrentBank = 0x18;
         c64._cpuPortDataDirectionRegister = CpuPortDataDirectionResetValue;
         c64._cpuPortDataRegister = CpuPortDataResetValue;
         c64.ApplyCpuPortMemoryConfiguration();
@@ -624,10 +626,9 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
 
     private void ApplyCpuPortMemoryConfiguration()
     {
-        var bank = CurrentBank;
-        bank.ClearBits(CpuPortBankBitsMask);
-        bank |= (byte)(GetCpuPortEffectiveValue() & CpuPortBankBitsMask);
-        CurrentBank = bank;
+        var cpuPortBits = (byte)(GetCpuPortEffectiveValue() & CpuPortBankBitsMask);
+        var cartridgeLineBits = CartridgeSlot.Lines.GetMemoryConfigurationBits();
+        CurrentBank = (byte)(cartridgeLineBits | cpuPortBits);
         Mem.SetMemoryConfiguration(CurrentBank);
     }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -53,8 +53,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
     public Sid Sid { get; set; } = default!;
     public IECBus IECBus { get; set; } = default!;
     public Dictionary<string, byte[]> ROMData { get; set; } = default!;
-    public List<IC64CartridgeDevice> CartridgeDevices { get; } = new();
-    public SwiftLinkDevice? SwiftLink { get; private set; }
+    public C64CartridgeSlot CartridgeSlot { get; } = new();
 
     public bool AudioEnabled { get; private set; }
     public TimerMode TimerMode { get; private set; }
@@ -210,8 +209,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
 
         // Update IEC bus devices
         IECBus.TickDevices();
-        foreach (var cartridgeDevice in CartridgeDevices)
-            cartridgeDevice.Tick();
+        CartridgeSlot.Tick();
 
         // General emulator timing fix: devices tick after the CPU instruction has already
         // completed, so newly raised hardware IRQ/NMI lines must be serviced here to land
@@ -306,9 +304,10 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
         var diskDrive1541 = new DiskDrive1541(loggerFactory);
         iecBus.Attach(diskDrive1541);
 
+        SwiftLinkDevice? swiftLink = null;
         if (c64Config.SwiftLink.Enabled)
         {
-            var swiftLink = new SwiftLinkDevice(
+            swiftLink = new SwiftLinkDevice(
                 c64Config.SwiftLink.CartridgeIOAddress,
                 loggerFactory.CreateLogger(nameof(SwiftLinkDevice)))
             {
@@ -317,8 +316,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
                 ReceiveMode = c64Config.SwiftLink.ReceiveMode,
                 GetCurrentCycleCount = () => cpu.ExecState.CyclesConsumed,
             };
-            c64.SwiftLink = swiftLink;
-            c64.CartridgeDevices.Add(swiftLink);
+            c64.AttachCartridge(swiftLink);
         }
 
         c64.CPU = cpu;
@@ -330,12 +328,12 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
 
         var mem = c64.CreateC64Memory(ram, io, romData);
         c64.Mem = mem;
-        if (c64.SwiftLink != null)
+        if (swiftLink != null)
         {
             // SwiftLink-specific compatibility hook: some modem software temporarily banks
             // out the mapped NMI vector area. SwiftLink can consult this callback and defer
             // asserting its NMI source until the currently mapped vector is usable again.
-            c64.SwiftLink.CanDeliverNmi =
+            swiftLink.CanDeliverNmi =
                 () => c64.Mem.FetchWord(CPU.NonMaskableIRQHandlerVector) != 0;
         }
 
@@ -421,8 +419,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             Cia1.MapIOLocations(mem);
             Cia2.MapIOLocations(mem);
             Sid.MapIOLocations(mem);
-            foreach (var cartridgeDevice in CartridgeDevices)
-                cartridgeDevice.MapIOLocations(mem);
+            CartridgeSlot.MapIOLocations(mem);
         }
     }
 
@@ -512,7 +509,8 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.SetMemoryConfiguration(bank);
             mem.MapRAM(0x0000, ram, preWriteIntercept: RamPreWriteIntercept);
             mem.MapRAM(0xd000, io);
-            // TODO: Cartridge low + high mapping
+            CartridgeSlot.MapROMLLocations(mem);
+            CartridgeSlot.MapROMHLocations(mem);
             MapLocationsOnCurrentCPUBank(mem, mapIO: true);
         }
         foreach (var bank in new int[] { 15 })
@@ -522,7 +520,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapROM(0xa000, basic);
             mem.MapRAM(0xd000, io);
             mem.MapROM(0xe000, kernal);
-            // TODO: Cartridge low mapping
+            CartridgeSlot.MapROMLLocations(mem);
             MapLocationsOnCurrentCPUBank(mem, mapIO: true);
         }
         foreach (var bank in new int[] { 12, 8, 4, 0 })
@@ -538,7 +536,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapROM(0xa000, basic);
             mem.MapROM(0xd000, chargen);
             mem.MapROM(0xe000, kernal);
-            // TODO: Cartridge low mapping
+            CartridgeSlot.MapROMLLocations(mem);
             MapLocationsOnCurrentCPUBank(mem, mapIO: false);
         }
         foreach (var bank in new int[] { 7 })
@@ -547,7 +545,8 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapRAM(0x0000, ram, preWriteIntercept: RamPreWriteIntercept);
             mem.MapRAM(0xd000, io);
             mem.MapROM(0xe000, kernal);
-            // TODO: Cartridge low + high mapping
+            CartridgeSlot.MapROMLLocations(mem);
+            CartridgeSlot.MapROMHLocations(mem);
             MapLocationsOnCurrentCPUBank(mem, mapIO: true);
         }
         foreach (var bank in new int[] { 6 })
@@ -556,7 +555,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapRAM(0x0000, ram, preWriteIntercept: RamPreWriteIntercept);
             mem.MapRAM(0xd000, io);
             mem.MapROM(0xe000, kernal);
-            // TODO: Cartridge high mapping
+            CartridgeSlot.MapROMHLocations(mem);
             MapLocationsOnCurrentCPUBank(mem, mapIO: true);
         }
         foreach (var bank in new int[] { 5 })
@@ -572,7 +571,8 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapRAM(0x0000, ram, preWriteIntercept: RamPreWriteIntercept);
             mem.MapROM(0xd000, chargen);
             mem.MapROM(0xe000, kernal);
-            // TODO: Cartridge low + high mapping
+            CartridgeSlot.MapROMLLocations(mem);
+            CartridgeSlot.MapROMHLocations(mem);
             MapLocationsOnCurrentCPUBank(mem, mapIO: false);
         }
         foreach (var bank in new int[] { 2 })
@@ -581,7 +581,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapRAM(0x0000, ram, preWriteIntercept: RamPreWriteIntercept);
             mem.MapROM(0xd000, chargen);
             mem.MapROM(0xe000, kernal);
-            // TODO: Cartridge high mapping
+            CartridgeSlot.MapROMHLocations(mem);
             MapLocationsOnCurrentCPUBank(mem, mapIO: false);
         }
         foreach (var bank in new int[] { 1 })
@@ -669,8 +669,17 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
 
     public void Cleanup()
     {
-        SwiftLink?.Transport?.Dispose();
+        CartridgeSlot.Dispose();
     }
+
+    public void AttachCartridge(IC64Cartridge cartridge)
+        => CartridgeSlot.Attach(cartridge);
+
+    public void DetachCartridge()
+        => CartridgeSlot.Detach();
+
+    public void ResetAttachedCartridge()
+        => CartridgeSlot.Reset();
 
     private List<KeyValuePair<string, Func<string>>> BuildDebugInfo()
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -211,7 +211,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
 
         // Update IEC bus devices
         IECBus.TickDevices();
-        CartridgeSlot.Tick();
+        CartridgeSlot.Tick(instructionExecResult.CyclesConsumed);
 
         // General emulator timing fix: devices tick after the CPU instruction has already
         // completed, so newly raised hardware IRQ/NMI lines must be serviced here to land
@@ -513,7 +513,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.SetMemoryConfiguration(bank);
             mem.MapRAM(0x0000, ram, preWriteIntercept: RamPreWriteIntercept);
             mem.MapRAM(0xd000, io);
-            CartridgeSlot.MapROMLLocations(mem, address => ram[address]);
+            CartridgeSlot.MapROMLLocations(mem, address => ram[address], WriteUnderlyingRam);
             CartridgeSlot.MapROMHLocations(mem, 0xe000, address => ram[address]);
             MapLocationsOnCurrentCPUBank(mem, mapIO: true);
         }
@@ -524,7 +524,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapROM(0xa000, basic);
             mem.MapRAM(0xd000, io);
             mem.MapROM(0xe000, kernal);
-            CartridgeSlot.MapROMLLocations(mem, address => ram[address]);
+            CartridgeSlot.MapROMLLocations(mem, address => ram[address], WriteUnderlyingRam);
             MapLocationsOnCurrentCPUBank(mem, mapIO: true);
         }
         foreach (var bank in new int[] { 12, 8, 4, 0 })
@@ -540,7 +540,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapROM(0xa000, basic);
             mem.MapROM(0xd000, chargen);
             mem.MapROM(0xe000, kernal);
-            CartridgeSlot.MapROMLLocations(mem, address => ram[address]);
+            CartridgeSlot.MapROMLLocations(mem, address => ram[address], WriteUnderlyingRam);
             MapLocationsOnCurrentCPUBank(mem, mapIO: false);
         }
         foreach (var bank in new int[] { 7 })
@@ -549,7 +549,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapRAM(0x0000, ram, preWriteIntercept: RamPreWriteIntercept);
             mem.MapRAM(0xd000, io);
             mem.MapROM(0xe000, kernal);
-            CartridgeSlot.MapROMLLocations(mem, address => ram[address]);
+            CartridgeSlot.MapROMLLocations(mem, address => ram[address], WriteUnderlyingRam);
             CartridgeSlot.MapROMHLocations(mem, 0xa000, address => ram[address]);
             MapLocationsOnCurrentCPUBank(mem, mapIO: true);
         }
@@ -575,7 +575,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapRAM(0x0000, ram, preWriteIntercept: RamPreWriteIntercept);
             mem.MapROM(0xd000, chargen);
             mem.MapROM(0xe000, kernal);
-            CartridgeSlot.MapROMLLocations(mem, address => ram[address]);
+            CartridgeSlot.MapROMLLocations(mem, address => ram[address], WriteUnderlyingRam);
             CartridgeSlot.MapROMHLocations(mem, 0xa000, address => ram[address]);
             MapLocationsOnCurrentCPUBank(mem, mapIO: false);
         }
@@ -596,6 +596,12 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
         }
 
         return mem;
+
+        void WriteUnderlyingRam(ushort address, byte value)
+        {
+            if (RamPreWriteIntercept(address, value))
+                ram[address] = value;
+        }
     }
 
     private bool RamPreWriteIntercept(ushort address, byte value)
@@ -689,6 +695,21 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
 
     public void ResetAttachedCartridge()
         => CartridgeSlot.Reset();
+
+    public bool CanFreezeAttachedCartridge
+        => CartridgeSlot.AttachedCartridge is IC64FreezableCartridge;
+
+    public bool FreezeAttachedCartridge()
+    {
+        if (!CartridgeSlot.Freeze())
+            return false;
+
+        const string freezeNmiSource = "CartridgeFreeze";
+        CPU.CPUInterrupts.SetNMISourceActive(freezeNmiSource);
+        CPU.ProcessPendingInterrupts(Mem);
+        CPU.CPUInterrupts.SetNMISourceInactive(freezeNmiSource);
+        return true;
+    }
 
     public C64CartridgeImageAttachResult AttachCrtImage(
         ReadOnlyMemory<byte> image,

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -29,6 +29,7 @@ namespace Highbyte.DotNet6502.Systems.Commodore64;
 
 public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
 {
+    private const string CartridgeNmiSource = "CartridgeNmi";
     private const byte CpuPortBankBitsMask = 0x07;
     private const byte CpuPortDataDirectionResetValue = 0x2F;
     private const byte CpuPortDataResetValue = 0x37;
@@ -246,6 +247,16 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
         {
             if (Mem is not null)
                 ApplyCpuPortMemoryConfiguration();
+        };
+        CartridgeSlot.NmiLineChanged += () =>
+        {
+            if (CPU is null)
+                return;
+
+            if (CartridgeSlot.NmiLineActive)
+                CPU.CPUInterrupts.SetNMISourceActive(CartridgeNmiSource);
+            else
+                CPU.CPUInterrupts.SetNMISourceInactive(CartridgeNmiSource);
         };
         _spriteCollisionStat = Instrumentations.Add($"{StatsCategory}-SpriteCollision", new ElapsedMillisecondsTimedStatSystem(this));
 
@@ -701,10 +712,26 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
 
     public bool FreezeAttachedCartridge()
     {
+        _logger.LogDebug(
+            "Activating cartridge Freeze. Cartridge={Cartridge}, Lines={Lines}, MemoryConfiguration={MemoryConfiguration}, PC={PC:X4}",
+            CartridgeSlot.AttachedCartridge?.Name ?? "none",
+            CartridgeSlot.Lines,
+            CurrentBank,
+            CPU.PC);
+
         if (!CartridgeSlot.Freeze())
             return false;
 
+        ApplyCpuPortMemoryConfiguration();
         const string freezeNmiSource = "CartridgeFreeze";
+        var freezeVector = (ushort)(
+            Mem.Read(CPU.NonMaskableIRQHandlerVector) |
+            Mem.Read(CPU.NonMaskableIRQHandlerVector + 1) << 8);
+        _logger.LogDebug(
+            "Cartridge Freeze mapping applied. Lines={Lines}, MemoryConfiguration={MemoryConfiguration}, Vector={Vector:X4}",
+            CartridgeSlot.Lines,
+            CurrentBank,
+            freezeVector);
         CPU.CPUInterrupts.SetNMISourceActive(freezeNmiSource);
         CPU.ProcessPendingInterrupts(Mem);
         CPU.CPUInterrupts.SetNMISourceInactive(freezeNmiSource);
@@ -717,6 +744,13 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
     {
         var crtImage = C64CrtParser.Parse(image.Span);
         var cartridge = C64CrtCartridgeFactory.Create(crtImage);
+        _logger.LogInformation(
+            "Attaching CRT cartridge. Source={Source}, Name={Name}, HardwareType={HardwareType}, Chips={ChipCount}, InitialLines={Lines}",
+            sourceName ?? string.Empty,
+            cartridge.Name,
+            crtImage.Header.HardwareType,
+            crtImage.Chips.Count,
+            cartridge.Lines);
         var result = new C64CartridgeImageAttachResult(
             cartridge.Name,
             crtImage.Header.HardwareType,
@@ -728,6 +762,12 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
         CartridgeSlot.Replace(cartridge);
         AttachedCartridgeImage = result;
         HardReset();
+        _logger.LogInformation(
+            "CRT cartridge attached and reset. Name={Name}, Lines={Lines}, MemoryConfiguration={MemoryConfiguration}, PC={PC:X4}",
+            cartridge.Name,
+            CartridgeSlot.Lines,
+            CurrentBank,
+            CPU.PC);
         return result;
     }
 
@@ -740,8 +780,15 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
     public void HardReset()
     {
         CartridgeSlot.Reset();
+        Array.Clear(IO);
         SetStartupBank(this);
         CPU.Reset(Mem);
+        _logger.LogDebug(
+            "C64 hard reset complete. Cartridge={Cartridge}, Lines={Lines}, MemoryConfiguration={MemoryConfiguration}, ResetPC={PC:X4}",
+            CartridgeSlot.AttachedCartridge?.Name ?? "none",
+            CartridgeSlot.Lines,
+            CurrentBank,
+            CPU.PC);
     }
 
     private List<KeyValuePair<string, Func<string>>> BuildDebugInfo()

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -419,7 +419,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             Cia1.MapIOLocations(mem);
             Cia2.MapIOLocations(mem);
             Sid.MapIOLocations(mem);
-            CartridgeSlot.MapIOLocations(mem);
+            CartridgeSlot.MapIOLocations(mem, ReadIOStorage, WriteIOStorage);
         }
     }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -3,6 +3,7 @@ using Highbyte.DotNet6502.Monitor.SystemSpecific;
 using Highbyte.DotNet6502.Systems.Commodore64.Audio;
 using Highbyte.DotNet6502.Systems.Commodore64.Audio.Sample;
 using Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.Crt;
 using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
 using Highbyte.DotNet6502.Systems.Commodore64.Models;
@@ -54,6 +55,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
     public IECBus IECBus { get; set; } = default!;
     public Dictionary<string, byte[]> ROMData { get; set; } = default!;
     public C64CartridgeSlot CartridgeSlot { get; } = new();
+    public C64CartridgeImageAttachResult? AttachedCartridgeImage { get; private set; }
 
     public bool AudioEnabled { get; private set; }
     public TimerMode TimerMode { get; private set; }
@@ -674,13 +676,52 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
     }
 
     public void AttachCartridge(IC64Cartridge cartridge)
-        => CartridgeSlot.Attach(cartridge);
+    {
+        CartridgeSlot.Attach(cartridge);
+        AttachedCartridgeImage = null;
+    }
 
     public void DetachCartridge()
-        => CartridgeSlot.Detach();
+    {
+        CartridgeSlot.Detach();
+        AttachedCartridgeImage = null;
+    }
 
     public void ResetAttachedCartridge()
         => CartridgeSlot.Reset();
+
+    public C64CartridgeImageAttachResult AttachCrtImage(
+        ReadOnlyMemory<byte> image,
+        string? sourceName = null)
+    {
+        var crtImage = C64CrtParser.Parse(image.Span);
+        var cartridge = C64CrtCartridgeFactory.Create(crtImage);
+        var result = new C64CartridgeImageAttachResult(
+            cartridge.Name,
+            crtImage.Header.HardwareType,
+            crtImage.Header.Subtype,
+            cartridge.Lines,
+            crtImage.Chips.Count,
+            sourceName);
+
+        CartridgeSlot.Replace(cartridge);
+        AttachedCartridgeImage = result;
+        HardReset();
+        return result;
+    }
+
+    public void DetachCartridgeAndReset()
+    {
+        DetachCartridge();
+        HardReset();
+    }
+
+    public void HardReset()
+    {
+        CartridgeSlot.Reset();
+        SetStartupBank(this);
+        CPU.Reset(Mem);
+    }
 
     private List<KeyValuePair<string, Func<string>>> BuildDebugInfo()
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -338,6 +338,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
         }
 
         c64.CPU = cpu;
+        c64.CPU.NmiAcknowledging += (_, _) => c64.CartridgeSlot.AcknowledgeNmi();
         c64.Vic2 = vic2;
         c64.Cia1 = cia1;
         c64.Cia2 = cia2;
@@ -525,7 +526,12 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapRAM(0x0000, ram, preWriteIntercept: RamPreWriteIntercept);
             mem.MapRAM(0xd000, io);
             CartridgeSlot.MapROMLLocations(mem, address => ram[address], WriteUnderlyingRam);
-            CartridgeSlot.MapROMHLocations(mem, 0xe000, address => ram[address], WriteUnderlyingRam);
+            CartridgeSlot.MapROMHLocations(
+                mem,
+                0xe000,
+                address => ram[address],
+                WriteUnderlyingRam,
+                ReadUltimaxRomHAsReleasedCartridge);
             MapLocationsOnCurrentCPUBank(mem, mapIO: true);
         }
         foreach (var bank in new int[] { 15 })
@@ -612,6 +618,20 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
         {
             if (RamPreWriteIntercept(address, value))
                 ram[address] = value;
+        }
+
+        byte ReadUltimaxRomHAsReleasedCartridge(ushort address)
+        {
+            // Expert can keep the C64 in Ultimax while its RAM is hidden. In that
+            // state ROMH reads should see the normal C64 $E000-$FFFF map as if
+            // GAME/EXROM were released, but without changing the active memory
+            // configuration for every read.
+            var cpuPortBits = mem.CurrentConfiguration & CpuPortBankBitsMask;
+            var kernalVisible = address >= 0xE000 &&
+                (cpuPortBits is 0x07 or 0x06 or 0x03 or 0x02);
+            return kernalVisible
+                ? kernal[address - 0xE000]
+                : ram[address];
         }
     }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -511,8 +511,8 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.SetMemoryConfiguration(bank);
             mem.MapRAM(0x0000, ram, preWriteIntercept: RamPreWriteIntercept);
             mem.MapRAM(0xd000, io);
-            CartridgeSlot.MapROMLLocations(mem);
-            CartridgeSlot.MapROMHLocations(mem);
+            CartridgeSlot.MapROMLLocations(mem, address => ram[address]);
+            CartridgeSlot.MapROMHLocations(mem, 0xe000, address => ram[address]);
             MapLocationsOnCurrentCPUBank(mem, mapIO: true);
         }
         foreach (var bank in new int[] { 15 })
@@ -522,7 +522,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapROM(0xa000, basic);
             mem.MapRAM(0xd000, io);
             mem.MapROM(0xe000, kernal);
-            CartridgeSlot.MapROMLLocations(mem);
+            CartridgeSlot.MapROMLLocations(mem, address => ram[address]);
             MapLocationsOnCurrentCPUBank(mem, mapIO: true);
         }
         foreach (var bank in new int[] { 12, 8, 4, 0 })
@@ -538,7 +538,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapROM(0xa000, basic);
             mem.MapROM(0xd000, chargen);
             mem.MapROM(0xe000, kernal);
-            CartridgeSlot.MapROMLLocations(mem);
+            CartridgeSlot.MapROMLLocations(mem, address => ram[address]);
             MapLocationsOnCurrentCPUBank(mem, mapIO: false);
         }
         foreach (var bank in new int[] { 7 })
@@ -547,8 +547,8 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapRAM(0x0000, ram, preWriteIntercept: RamPreWriteIntercept);
             mem.MapRAM(0xd000, io);
             mem.MapROM(0xe000, kernal);
-            CartridgeSlot.MapROMLLocations(mem);
-            CartridgeSlot.MapROMHLocations(mem);
+            CartridgeSlot.MapROMLLocations(mem, address => ram[address]);
+            CartridgeSlot.MapROMHLocations(mem, 0xa000, address => ram[address]);
             MapLocationsOnCurrentCPUBank(mem, mapIO: true);
         }
         foreach (var bank in new int[] { 6 })
@@ -557,7 +557,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapRAM(0x0000, ram, preWriteIntercept: RamPreWriteIntercept);
             mem.MapRAM(0xd000, io);
             mem.MapROM(0xe000, kernal);
-            CartridgeSlot.MapROMHLocations(mem);
+            CartridgeSlot.MapROMHLocations(mem, 0xa000, address => ram[address]);
             MapLocationsOnCurrentCPUBank(mem, mapIO: true);
         }
         foreach (var bank in new int[] { 5 })
@@ -573,8 +573,8 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapRAM(0x0000, ram, preWriteIntercept: RamPreWriteIntercept);
             mem.MapROM(0xd000, chargen);
             mem.MapROM(0xe000, kernal);
-            CartridgeSlot.MapROMLLocations(mem);
-            CartridgeSlot.MapROMHLocations(mem);
+            CartridgeSlot.MapROMLLocations(mem, address => ram[address]);
+            CartridgeSlot.MapROMHLocations(mem, 0xa000, address => ram[address]);
             MapLocationsOnCurrentCPUBank(mem, mapIO: false);
         }
         foreach (var bank in new int[] { 2 })
@@ -583,7 +583,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             mem.MapRAM(0x0000, ram, preWriteIntercept: RamPreWriteIntercept);
             mem.MapROM(0xd000, chargen);
             mem.MapROM(0xe000, kernal);
-            CartridgeSlot.MapROMHLocations(mem);
+            CartridgeSlot.MapROMHLocations(mem, 0xa000, address => ram[address]);
             MapLocationsOnCurrentCPUBank(mem, mapIO: false);
         }
         foreach (var bank in new int[] { 1 })

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64SystemConfigurerCore.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64SystemConfigurerCore.cs
@@ -1,4 +1,5 @@
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
 using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 using Highbyte.DotNet6502.Systems.Commodore64.Transport;
 using Highbyte.DotNet6502.Systems.Commodore64.Models;
@@ -136,11 +137,12 @@ public class C64SystemConfigurerCore : ISystemConfigurer
     public virtual async Task<SystemRunner> BuildSystemRunner(ISystem system, IHostSystemConfig hostSystemConfig)
     {
         var c64 = (C64)system;
-        if (SupportsSwiftLinkTcpTransport && c64.SwiftLink != null && hostSystemConfig is IC64SwiftLinkTcpHostConfig swiftLinkHostConfig)
+        var swiftLink = c64.CartridgeSlot.GetCartridge<SwiftLinkDevice>();
+        if (SupportsSwiftLinkTcpTransport && swiftLink != null && hostSystemConfig is IC64SwiftLinkTcpHostConfig swiftLinkHostConfig)
         {
-            c64.SwiftLink.ReceivePacingCycles =
+            swiftLink.ReceivePacingCycles =
                 swiftLinkHostConfig.SwiftLinkTransportMode == C64SwiftLinkTransportMode.HayesModem
-                && c64.SwiftLink.ReceiveMode == C64SwiftLinkReceiveMode.Compatible
+                && swiftLink.ReceiveMode == C64SwiftLinkReceiveMode.Compatible
                     ? GetReceivePacingCyclesPerCharacter(c64)
                     : 0;
 
@@ -157,7 +159,7 @@ public class C64SystemConfigurerCore : ISystemConfigurer
                     swiftLinkHostConfig.SwiftLinkTcpPort,
                     LoggerFactory.CreateLogger(nameof(TcpTransport)))
             };
-            c64.SwiftLink.Transport = transport;
+            swiftLink.Transport = transport;
             if (swiftLinkHostConfig.SwiftLinkConnectOnBoot)
                 await transport.ConnectAsync();
         }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64ActionReplayCartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64ActionReplayCartridge.cs
@@ -1,0 +1,186 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+
+/// <summary>
+/// Action Replay 4.2/5/6 cartridge with four 8K ROM banks, 8K RAM,
+/// register-controlled cartridge lines, and freeze-button support.
+/// </summary>
+public sealed class C64ActionReplayCartridge : IC64Cartridge, IC64FreezableCartridge
+{
+    public const int RomBankCount = 4;
+    public const int RamSize = 0x2000;
+
+    private const ushort IO1StartAddress = 0xDE00;
+    private const ushort IO1EndAddress = 0xDEFF;
+    private const ushort IO2StartAddress = 0xDF00;
+    private const ushort IO2EndAddress = 0xDFFF;
+    private const int IO2WindowOffset = 0x1F00;
+
+    private const byte DisableBit = 0x04;
+    private const byte BankMask = 0x18;
+    private const byte ExportRamBit = 0x20;
+
+    private static readonly C64CartridgeLines EightKLines = new(GameHigh: true, ExromHigh: false);
+    private static readonly C64CartridgeLines SixteenKLines = new(GameHigh: false, ExromHigh: false);
+    private static readonly C64CartridgeLines UltimaxLines = new(GameHigh: false, ExromHigh: true);
+
+    private readonly C64BankedRom _rom;
+    private readonly byte[] _ram = new byte[RamSize];
+    private byte _register;
+    private bool _active;
+    private bool _freezeMode;
+
+    public C64ActionReplayCartridge(C64BankedRom rom, string name = "Action Replay")
+    {
+        _rom = rom ?? throw new ArgumentNullException(nameof(rom));
+        if (rom.Count != RomBankCount || rom.HighestBank != RomBankCount - 1)
+            throw new ArgumentException("Action Replay requires exactly four ROM banks numbered 0-3.", nameof(rom));
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Cartridge name must not be empty.", nameof(name));
+
+        Name = name;
+        Array.Fill(_ram, (byte)0xFF);
+        Reset();
+    }
+
+    public string Name { get; }
+    public byte Register => _register;
+    public ushort CurrentBank
+        => _freezeMode ? (ushort)0 : (ushort)((_register & BankMask) >> 3);
+    public bool IsActive => _active;
+    public bool IsFreezeMode => _freezeMode;
+    public bool IsRamExported => _freezeMode || (_register & ExportRamBit) != 0;
+    public C64CartridgeLines Lines => GetLines();
+    public event Action? LinesChanged;
+
+    public bool HandlesIORead(ushort address)
+        => _active && address is >= IO2StartAddress and <= IO2EndAddress;
+
+    public byte ReadIO(ushort address)
+    {
+        if (!HandlesIORead(address))
+            throw new InvalidOperationException($"{Name} does not handle I/O reads at 0x{address:X4}.");
+
+        var offset = IO2WindowOffset + (address & 0xFF);
+        return IsRamExported
+            ? _ram[offset]
+            : _rom.Read(CurrentBank, (ushort)offset);
+    }
+
+    public bool HandlesIOWrite(ushort address)
+        => _active &&
+           (address is >= IO1StartAddress and <= IO1EndAddress ||
+            IsRamExported && address is >= IO2StartAddress and <= IO2EndAddress);
+
+    public void WriteIO(ushort address, byte value)
+    {
+        if (!_active)
+            throw new InvalidOperationException($"{Name} is disabled.");
+
+        if (address is >= IO1StartAddress and <= IO1EndAddress)
+        {
+            WriteControlRegister(value);
+            return;
+        }
+
+        if (IsRamExported && address is >= IO2StartAddress and <= IO2EndAddress)
+        {
+            _ram[IO2WindowOffset + (address & 0xFF)] = value;
+            return;
+        }
+
+        throw new InvalidOperationException($"{Name} does not handle I/O writes at 0x{address:X4}.");
+    }
+
+    public bool HasROML => _active && Lines != C64CartridgeLines.Released;
+
+    public byte ReadROML(ushort address)
+    {
+        if (!HasROML)
+            throw new InvalidOperationException($"{Name} does not currently provide ROML.");
+
+        return IsRamExported
+            ? _ram[address & (RamSize - 1)]
+            : _rom.Read(CurrentBank, address);
+    }
+
+    public bool HandlesROMLWrite => HasROML && IsRamExported;
+
+    public void WriteROML(ushort address, byte value)
+    {
+        if (!HandlesROMLWrite)
+            throw new InvalidOperationException($"{Name} ROML is not currently writable.");
+
+        _ram[address & (RamSize - 1)] = value;
+    }
+
+    public bool HasROMH => _active && !Lines.GameHigh;
+
+    public byte ReadROMH(ushort address)
+        => HasROMH
+            ? _rom.Read(CurrentBank, address)
+            : throw new InvalidOperationException($"{Name} does not currently provide ROMH.");
+
+    public void Freeze()
+    {
+        var previousLines = Lines;
+        _active = true;
+        _freezeMode = true;
+        if (previousLines != Lines)
+            LinesChanged?.Invoke();
+    }
+
+    public void Tick(ulong cyclesElapsed = 0)
+    {
+    }
+
+    public void Reset()
+    {
+        var previousLines = Lines;
+        _register = 0;
+        _active = true;
+        _freezeMode = false;
+        if (previousLines != Lines)
+            LinesChanged?.Invoke();
+    }
+
+    public void Dispose()
+    {
+    }
+
+    public byte ReadRam(ushort offset)
+        => _ram[offset & (RamSize - 1)];
+
+    private void WriteControlRegister(byte value)
+    {
+        var previousLines = Lines;
+        _register = value;
+        _freezeMode = false;
+        if ((value & DisableBit) != 0)
+            _active = false;
+
+        if (previousLines != Lines)
+            LinesChanged?.Invoke();
+    }
+
+    private C64CartridgeLines GetLines()
+    {
+        if (!_active)
+            return C64CartridgeLines.Released;
+        if (_freezeMode)
+            return UltimaxLines;
+
+        // Original Action Replay hardware has bus contention in register mode $22.
+        // VICE treats it as 8K mode while both C64 RAM and cartridge RAM are selected.
+        if ((_register & 0x23) == 0x22)
+            return EightKLines;
+
+        return (_register & 0x03) switch
+        {
+            0 => EightKLines,
+            1 => SixteenKLines,
+            2 => C64CartridgeLines.Released,
+            3 => UltimaxLines,
+            _ => throw new InvalidOperationException(),
+        };
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64BankedRom.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64BankedRom.cs
@@ -1,0 +1,45 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+
+/// <summary>
+/// Validated fixed-size ROM banks used by bank-switched cartridges.
+/// Missing banks read as unprogrammed ROM.
+/// </summary>
+public sealed class C64BankedRom
+{
+    public const int BankSize = 0x2000;
+
+    private readonly IReadOnlyDictionary<ushort, byte[]> _banks;
+
+    public C64BankedRom(
+        IEnumerable<KeyValuePair<ushort, byte[]>> banks,
+        ushort maximumBank)
+    {
+        ArgumentNullException.ThrowIfNull(banks);
+
+        var copiedBanks = new Dictionary<ushort, byte[]>();
+        foreach (var (bank, data) in banks)
+        {
+            ArgumentNullException.ThrowIfNull(data);
+            if (bank > maximumBank)
+                throw new ArgumentOutOfRangeException(nameof(banks), $"ROM bank {bank} exceeds maximum bank {maximumBank}.");
+            if (data.Length != BankSize)
+                throw new ArgumentException($"ROM bank {bank} must be exactly {BankSize} bytes.", nameof(banks));
+            if (!copiedBanks.TryAdd(bank, data.ToArray()))
+                throw new ArgumentException($"ROM bank {bank} is duplicated.", nameof(banks));
+        }
+
+        if (copiedBanks.Count == 0)
+            throw new ArgumentException("At least one ROM bank must be supplied.", nameof(banks));
+
+        _banks = copiedBanks;
+        HighestBank = copiedBanks.Keys.Max();
+    }
+
+    public int Count => _banks.Count;
+    public ushort HighestBank { get; }
+
+    public byte Read(ushort bank, ushort address)
+        => _banks.TryGetValue(bank, out var data)
+            ? data[address & (BankSize - 1)]
+            : (byte)0xFF;
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeLines.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeLines.cs
@@ -1,0 +1,22 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+
+/// <summary>
+/// The active-low C64 cartridge port control lines. A high value means that the cartridge
+/// releases the line; a low value means that it pulls the line active.
+/// </summary>
+public readonly record struct C64CartridgeLines(bool GameHigh, bool ExromHigh)
+{
+    public static C64CartridgeLines Released { get; } = new(GameHigh: true, ExromHigh: true);
+
+    internal byte GetMemoryConfigurationBits()
+    {
+        // The C64 memory configuration table uses GAME as bit 3 and EXROM as bit 4.
+        // The lower three bits come from LORAM, HIRAM, and CHAREN on the 6510 port.
+        byte value = 0;
+        if (GameHigh)
+            value |= 0x08;
+        if (ExromHigh)
+            value |= 0x10;
+        return value;
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
@@ -9,7 +9,10 @@ public sealed class C64CartridgeSlot : IDisposable
 
     public IC64Cartridge? AttachedCartridge { get; private set; }
     public C64CartridgeLines Lines => AttachedCartridge?.Lines ?? C64CartridgeLines.Released;
+    public bool NmiLineActive
+        => AttachedCartridge is IC64CartridgeNmiSource { NmiLineActive: true };
     public event Action? LinesChanged;
+    public event Action? NmiLineChanged;
 
     public void Attach(IC64Cartridge cartridge)
     {
@@ -21,7 +24,10 @@ public sealed class C64CartridgeSlot : IDisposable
         cartridge.Reset();
         AttachedCartridge = cartridge;
         cartridge.LinesChanged += OnCartridgeLinesChanged;
+        SubscribeToNmiSource(cartridge);
         LinesChanged?.Invoke();
+        if (cartridge is IC64CartridgeNmiSource)
+            NmiLineChanged?.Invoke();
     }
 
     public void Replace(IC64Cartridge cartridge)
@@ -31,11 +37,17 @@ public sealed class C64CartridgeSlot : IDisposable
 
         var previous = AttachedCartridge;
         if (previous != null)
+        {
             previous.LinesChanged -= OnCartridgeLinesChanged;
+            UnsubscribeFromNmiSource(previous);
+        }
 
         AttachedCartridge = cartridge;
         cartridge.LinesChanged += OnCartridgeLinesChanged;
+        SubscribeToNmiSource(cartridge);
         LinesChanged?.Invoke();
+        if (previous is IC64CartridgeNmiSource || cartridge is IC64CartridgeNmiSource)
+            NmiLineChanged?.Invoke();
 
         if (previous != null)
         {
@@ -52,7 +64,10 @@ public sealed class C64CartridgeSlot : IDisposable
             return;
 
         LinesChanged?.Invoke();
+        if (cartridge is IC64CartridgeNmiSource)
+            NmiLineChanged?.Invoke();
         cartridge.LinesChanged -= OnCartridgeLinesChanged;
+        UnsubscribeFromNmiSource(cartridge);
         cartridge.Reset();
         cartridge.Dispose();
     }
@@ -143,6 +158,21 @@ public sealed class C64CartridgeSlot : IDisposable
 
     private void OnCartridgeLinesChanged()
         => LinesChanged?.Invoke();
+
+    private void OnCartridgeNmiLineChanged()
+        => NmiLineChanged?.Invoke();
+
+    private void SubscribeToNmiSource(IC64Cartridge cartridge)
+    {
+        if (cartridge is IC64CartridgeNmiSource nmiSource)
+            nmiSource.NmiLineChanged += OnCartridgeNmiLineChanged;
+    }
+
+    private void UnsubscribeFromNmiSource(IC64Cartridge cartridge)
+    {
+        if (cartridge is IC64CartridgeNmiSource nmiSource)
+            nmiSource.NmiLineChanged -= OnCartridgeNmiLineChanged;
+    }
 
     private byte ReadIO(ushort address, Func<ushort, byte> fallbackReader)
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
@@ -129,6 +129,13 @@ public sealed class C64CartridgeSlot : IDisposable
         Memory mem,
         ushort baseAddress,
         Func<ushort, byte> fallbackReader)
+        => MapROMHLocations(mem, baseAddress, fallbackReader, fallbackWriter: null);
+
+    public void MapROMHLocations(
+        Memory mem,
+        ushort baseAddress,
+        Func<ushort, byte> fallbackReader,
+        Action<ushort, byte>? fallbackWriter)
     {
         MapRomWindow(
             mem,
@@ -136,6 +143,14 @@ public sealed class C64CartridgeSlot : IDisposable
             fallbackReader,
             cartridge => cartridge.HasROMH,
             (cartridge, address) => cartridge.ReadROMH(address));
+
+        if (fallbackWriter == null)
+            return;
+
+        Memory.StoreByte writer = (mappedAddress, value) => fallbackWriter(mappedAddress, value);
+        var endAddress = baseAddress + CartridgeRomWindowSize;
+        for (var address = (int)baseAddress; address < endAddress; address++)
+            mem.MapWriter((ushort)address, writer);
     }
 
     public void Tick(ulong cyclesElapsed = 0)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
@@ -1,0 +1,45 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+
+public sealed class C64CartridgeSlot : IDisposable
+{
+    public IC64Cartridge? AttachedCartridge { get; private set; }
+
+    public void Attach(IC64Cartridge cartridge)
+    {
+        ArgumentNullException.ThrowIfNull(cartridge);
+
+        if (AttachedCartridge != null)
+            throw new InvalidOperationException($"Cartridge '{AttachedCartridge.Name}' is already attached.");
+
+        AttachedCartridge = cartridge;
+    }
+
+    public void Detach()
+    {
+        var cartridge = AttachedCartridge;
+        AttachedCartridge = null;
+        cartridge?.Dispose();
+    }
+
+    public TCartridge? GetCartridge<TCartridge>()
+        where TCartridge : class, IC64Cartridge
+        => AttachedCartridge as TCartridge;
+
+    public void MapIOLocations(Memory mem)
+        => AttachedCartridge?.MapIOLocations(mem);
+
+    public void MapROMLLocations(Memory mem)
+        => AttachedCartridge?.MapROMLLocations(mem);
+
+    public void MapROMHLocations(Memory mem)
+        => AttachedCartridge?.MapROMHLocations(mem);
+
+    public void Tick()
+        => AttachedCartridge?.Tick();
+
+    public void Reset()
+        => AttachedCartridge?.Reset();
+
+    public void Dispose()
+        => Detach();
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
@@ -2,6 +2,9 @@ namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
 
 public sealed class C64CartridgeSlot : IDisposable
 {
+    private const ushort IO1StartAddress = 0xDE00;
+    private const ushort IO2EndAddress = 0xDFFF;
+
     public IC64Cartridge? AttachedCartridge { get; private set; }
 
     public void Attach(IC64Cartridge cartridge)
@@ -11,6 +14,7 @@ public sealed class C64CartridgeSlot : IDisposable
         if (AttachedCartridge != null)
             throw new InvalidOperationException($"Cartridge '{AttachedCartridge.Name}' is already attached.");
 
+        cartridge.Reset();
         AttachedCartridge = cartridge;
     }
 
@@ -18,15 +22,29 @@ public sealed class C64CartridgeSlot : IDisposable
     {
         var cartridge = AttachedCartridge;
         AttachedCartridge = null;
-        cartridge?.Dispose();
+        if (cartridge == null)
+            return;
+
+        cartridge.Reset();
+        cartridge.Dispose();
     }
 
     public TCartridge? GetCartridge<TCartridge>()
         where TCartridge : class, IC64Cartridge
         => AttachedCartridge as TCartridge;
 
-    public void MapIOLocations(Memory mem)
-        => AttachedCartridge?.MapIOLocations(mem);
+    public void MapIOLocations(
+        Memory mem,
+        Func<ushort, byte> fallbackReader,
+        Action<ushort, byte> fallbackWriter)
+    {
+        for (var address = (int)IO1StartAddress; address <= IO2EndAddress; address++)
+        {
+            var mappedAddress = (ushort)address;
+            mem.MapReader(mappedAddress, ioAddress => ReadIO(ioAddress, fallbackReader));
+            mem.MapWriter(mappedAddress, (ioAddress, value) => WriteIO(ioAddress, value, fallbackWriter));
+        }
+    }
 
     public void MapROMLLocations(Memory mem)
         => AttachedCartridge?.MapROMLLocations(mem);
@@ -42,4 +60,21 @@ public sealed class C64CartridgeSlot : IDisposable
 
     public void Dispose()
         => Detach();
+
+    private byte ReadIO(ushort address, Func<ushort, byte> fallbackReader)
+    {
+        var cartridge = AttachedCartridge;
+        return cartridge?.HandlesIOAddress(address) == true
+            ? cartridge.ReadIO(address)
+            : fallbackReader(address);
+    }
+
+    private void WriteIO(ushort address, byte value, Action<ushort, byte> fallbackWriter)
+    {
+        var cartridge = AttachedCartridge;
+        if (cartridge?.HandlesIOAddress(address) == true)
+            cartridge.WriteIO(address, value);
+        else
+            fallbackWriter(address, value);
+    }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
@@ -114,7 +114,7 @@ public sealed class C64CartridgeSlot : IDisposable
     private byte ReadIO(ushort address, Func<ushort, byte> fallbackReader)
     {
         var cartridge = AttachedCartridge;
-        return cartridge?.HandlesIOAddress(address) == true
+        return cartridge?.HandlesIORead(address) == true
             ? cartridge.ReadIO(address)
             : fallbackReader(address);
     }
@@ -122,7 +122,7 @@ public sealed class C64CartridgeSlot : IDisposable
     private void WriteIO(ushort address, byte value, Action<ushort, byte> fallbackWriter)
     {
         var cartridge = AttachedCartridge;
-        if (cartridge?.HandlesIOAddress(address) == true)
+        if (cartridge?.HandlesIOWrite(address) == true)
             cartridge.WriteIO(address, value);
         else
             fallbackWriter(address, value);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
@@ -77,6 +77,12 @@ public sealed class C64CartridgeSlot : IDisposable
     }
 
     public void MapROMLLocations(Memory mem, Func<ushort, byte> fallbackReader)
+        => MapROMLLocations(mem, fallbackReader, fallbackWriter: null);
+
+    public void MapROMLLocations(
+        Memory mem,
+        Func<ushort, byte> fallbackReader,
+        Action<ushort, byte>? fallbackWriter)
     {
         MapRomWindow(
             mem,
@@ -84,6 +90,24 @@ public sealed class C64CartridgeSlot : IDisposable
             fallbackReader,
             cartridge => cartridge.HasROML,
             (cartridge, address) => cartridge.ReadROML(address));
+
+        if (fallbackWriter == null)
+            return;
+
+        Memory.StoreByte writer = (mappedAddress, value) =>
+        {
+            var cartridge = AttachedCartridge;
+            if (cartridge?.HandlesROMLWrite == true)
+                cartridge.WriteROML(mappedAddress, value);
+            else
+                fallbackWriter(mappedAddress, value);
+        };
+        for (var address = (int)ROMLStartAddress;
+             address < ROMLStartAddress + CartridgeRomWindowSize;
+             address++)
+        {
+            mem.MapWriter((ushort)address, writer);
+        }
     }
 
     public void MapROMHLocations(
@@ -99,11 +123,20 @@ public sealed class C64CartridgeSlot : IDisposable
             (cartridge, address) => cartridge.ReadROMH(address));
     }
 
-    public void Tick()
-        => AttachedCartridge?.Tick();
+    public void Tick(ulong cyclesElapsed = 0)
+        => AttachedCartridge?.Tick(cyclesElapsed);
 
     public void Reset()
         => AttachedCartridge?.Reset();
+
+    public bool Freeze()
+    {
+        if (AttachedCartridge is not IC64FreezableCartridge freezableCartridge)
+            return false;
+
+        freezableCartridge.Freeze();
+        return true;
+    }
 
     public void Dispose()
         => Detach();

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
@@ -6,6 +6,8 @@ public sealed class C64CartridgeSlot : IDisposable
     private const ushort IO2EndAddress = 0xDFFF;
 
     public IC64Cartridge? AttachedCartridge { get; private set; }
+    public C64CartridgeLines Lines => AttachedCartridge?.Lines ?? C64CartridgeLines.Released;
+    public event Action? LinesChanged;
 
     public void Attach(IC64Cartridge cartridge)
     {
@@ -16,6 +18,8 @@ public sealed class C64CartridgeSlot : IDisposable
 
         cartridge.Reset();
         AttachedCartridge = cartridge;
+        cartridge.LinesChanged += OnCartridgeLinesChanged;
+        LinesChanged?.Invoke();
     }
 
     public void Detach()
@@ -25,6 +29,8 @@ public sealed class C64CartridgeSlot : IDisposable
         if (cartridge == null)
             return;
 
+        LinesChanged?.Invoke();
+        cartridge.LinesChanged -= OnCartridgeLinesChanged;
         cartridge.Reset();
         cartridge.Dispose();
     }
@@ -60,6 +66,9 @@ public sealed class C64CartridgeSlot : IDisposable
 
     public void Dispose()
         => Detach();
+
+    private void OnCartridgeLinesChanged()
+        => LinesChanged?.Invoke();
 
     private byte ReadIO(ushort address, Func<ushort, byte> fallbackReader)
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
@@ -4,6 +4,8 @@ public sealed class C64CartridgeSlot : IDisposable
 {
     private const ushort IO1StartAddress = 0xDE00;
     private const ushort IO2EndAddress = 0xDFFF;
+    private const ushort ROMLStartAddress = 0x8000;
+    private const ushort CartridgeRomWindowSize = 0x2000;
 
     public IC64Cartridge? AttachedCartridge { get; private set; }
     public C64CartridgeLines Lines => AttachedCartridge?.Lines ?? C64CartridgeLines.Released;
@@ -44,19 +46,38 @@ public sealed class C64CartridgeSlot : IDisposable
         Func<ushort, byte> fallbackReader,
         Action<ushort, byte> fallbackWriter)
     {
+        Memory.LoadByte reader = ioAddress => ReadIO(ioAddress, fallbackReader);
+        Memory.StoreByte writer = (ioAddress, value) => WriteIO(ioAddress, value, fallbackWriter);
         for (var address = (int)IO1StartAddress; address <= IO2EndAddress; address++)
         {
             var mappedAddress = (ushort)address;
-            mem.MapReader(mappedAddress, ioAddress => ReadIO(ioAddress, fallbackReader));
-            mem.MapWriter(mappedAddress, (ioAddress, value) => WriteIO(ioAddress, value, fallbackWriter));
+            mem.MapReader(mappedAddress, reader);
+            mem.MapWriter(mappedAddress, writer);
         }
     }
 
-    public void MapROMLLocations(Memory mem)
-        => AttachedCartridge?.MapROMLLocations(mem);
+    public void MapROMLLocations(Memory mem, Func<ushort, byte> fallbackReader)
+    {
+        MapRomWindow(
+            mem,
+            ROMLStartAddress,
+            fallbackReader,
+            cartridge => cartridge.HasROML,
+            (cartridge, address) => cartridge.ReadROML(address));
+    }
 
-    public void MapROMHLocations(Memory mem)
-        => AttachedCartridge?.MapROMHLocations(mem);
+    public void MapROMHLocations(
+        Memory mem,
+        ushort baseAddress,
+        Func<ushort, byte> fallbackReader)
+    {
+        MapRomWindow(
+            mem,
+            baseAddress,
+            fallbackReader,
+            cartridge => cartridge.HasROMH,
+            (cartridge, address) => cartridge.ReadROMH(address));
+    }
 
     public void Tick()
         => AttachedCartridge?.Tick();
@@ -85,5 +106,24 @@ public sealed class C64CartridgeSlot : IDisposable
             cartridge.WriteIO(address, value);
         else
             fallbackWriter(address, value);
+    }
+
+    private void MapRomWindow(
+        Memory mem,
+        ushort baseAddress,
+        Func<ushort, byte> fallbackReader,
+        Func<IC64Cartridge, bool> isAvailable,
+        Func<IC64Cartridge, ushort, byte> cartridgeReader)
+    {
+        var endAddress = baseAddress + CartridgeRomWindowSize;
+        Memory.LoadByte reader = mappedAddress =>
+        {
+            var cartridge = AttachedCartridge;
+            return cartridge != null && isAvailable(cartridge)
+                ? cartridgeReader(cartridge, mappedAddress)
+                : fallbackReader(mappedAddress);
+        };
+        for (var address = (int)baseAddress; address < endAddress; address++)
+            mem.MapReader((ushort)address, reader);
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
@@ -24,6 +24,26 @@ public sealed class C64CartridgeSlot : IDisposable
         LinesChanged?.Invoke();
     }
 
+    public void Replace(IC64Cartridge cartridge)
+    {
+        ArgumentNullException.ThrowIfNull(cartridge);
+        cartridge.Reset();
+
+        var previous = AttachedCartridge;
+        if (previous != null)
+            previous.LinesChanged -= OnCartridgeLinesChanged;
+
+        AttachedCartridge = cartridge;
+        cartridge.LinesChanged += OnCartridgeLinesChanged;
+        LinesChanged?.Invoke();
+
+        if (previous != null)
+        {
+            previous.Reset();
+            previous.Dispose();
+        }
+    }
+
     public void Detach()
     {
         var cartridge = AttachedCartridge;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
@@ -135,14 +135,19 @@ public sealed class C64CartridgeSlot : IDisposable
         Memory mem,
         ushort baseAddress,
         Func<ushort, byte> fallbackReader,
-        Action<ushort, byte>? fallbackWriter)
+        Action<ushort, byte>? fallbackWriter,
+        Func<ushort, byte>? normalMemoryFallbackReader = null)
     {
         MapRomWindow(
             mem,
             baseAddress,
             fallbackReader,
             cartridge => cartridge.HasROMH,
-            (cartridge, address) => cartridge.ReadROMH(address));
+            (cartridge, address) => cartridge.ReadROMH(address),
+            normalMemoryFallbackReader,
+            (cartridge, address) =>
+                cartridge is IC64CartridgeNormalMemoryFallback normalFallback &&
+                normalFallback.UsesNormalMemoryFallbackForROMH(address));
 
         if (fallbackWriter == null)
             return;
@@ -166,6 +171,12 @@ public sealed class C64CartridgeSlot : IDisposable
 
         freezableCartridge.Freeze();
         return true;
+    }
+
+    public void AcknowledgeNmi()
+    {
+        if (AttachedCartridge is IC64CartridgeNmiAcknowledgeHandler handler)
+            handler.AcknowledgeNmi();
     }
 
     public void Dispose()
@@ -192,8 +203,12 @@ public sealed class C64CartridgeSlot : IDisposable
     private byte ReadIO(ushort address, Func<ushort, byte> fallbackReader)
     {
         var cartridge = AttachedCartridge;
-        return cartridge?.HandlesIORead(address) == true
-            ? cartridge.ReadIO(address)
+        if (cartridge?.HandlesIORead(address) != true)
+            return fallbackReader(address);
+
+        var cartridgeValue = cartridge.ReadIO(address);
+        return cartridge.ProvidesIOReadValue(address)
+            ? cartridgeValue
             : fallbackReader(address);
     }
 
@@ -211,16 +226,31 @@ public sealed class C64CartridgeSlot : IDisposable
         ushort baseAddress,
         Func<ushort, byte> fallbackReader,
         Func<IC64Cartridge, bool> isAvailable,
-        Func<IC64Cartridge, ushort, byte> cartridgeReader)
+        Func<IC64Cartridge, ushort, byte> cartridgeReader,
+        Func<ushort, byte>? normalMemoryFallbackReader = null,
+        Func<IC64Cartridge, ushort, bool>? usesNormalMemoryFallback = null)
     {
         var endAddress = baseAddress + CartridgeRomWindowSize;
-        Memory.LoadByte reader = mappedAddress =>
-        {
-            var cartridge = AttachedCartridge;
-            return cartridge != null && isAvailable(cartridge)
-                ? cartridgeReader(cartridge, mappedAddress)
-                : fallbackReader(mappedAddress);
-        };
+        Memory.LoadByte reader =
+            normalMemoryFallbackReader == null || usesNormalMemoryFallback == null
+                ? mappedAddress =>
+                {
+                    var cartridge = AttachedCartridge;
+                    return cartridge != null && isAvailable(cartridge)
+                        ? cartridgeReader(cartridge, mappedAddress)
+                        : fallbackReader(mappedAddress);
+                }
+                : mappedAddress =>
+                {
+                    var cartridge = AttachedCartridge;
+                    if (cartridge != null && isAvailable(cartridge))
+                        return cartridgeReader(cartridge, mappedAddress);
+
+                    if (cartridge != null && usesNormalMemoryFallback(cartridge, mappedAddress))
+                        return normalMemoryFallbackReader(mappedAddress);
+
+                    return fallbackReader(mappedAddress);
+                };
         for (var address = (int)baseAddress; address < endAddress; address++)
             mem.MapReader((ushort)address, reader);
     }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64EpyxFastLoadCartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64EpyxFastLoadCartridge.cs
@@ -1,0 +1,107 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+
+/// <summary>
+/// Epyx FastLoad cartridge with a capacitor-style ROM timeout.
+/// ROML and IO1 reads enable ROML for 512 CPU cycles; IO2 always exposes the final ROM page.
+/// </summary>
+public sealed class C64EpyxFastLoadCartridge : IC64Cartridge
+{
+    public const int RomSize = 0x2000;
+    public const ulong RomEnableCycles = 512;
+
+    private const ushort IO1StartAddress = 0xDE00;
+    private const ushort IO1EndAddress = 0xDEFF;
+    private const ushort IO2StartAddress = 0xDF00;
+    private const ushort IO2EndAddress = 0xDFFF;
+    private const int IO2RomOffset = 0x1F00;
+
+    private static readonly C64CartridgeLines EnabledLines = new(GameHigh: true, ExromHigh: false);
+
+    private readonly byte[] _rom;
+    private ulong _cyclesUntilDisabled;
+
+    public C64EpyxFastLoadCartridge(byte[] rom, string name = "Epyx FastLoad")
+    {
+        ArgumentNullException.ThrowIfNull(rom);
+        if (rom.Length != RomSize)
+            throw new ArgumentException($"Epyx FastLoad ROM must be exactly {RomSize} bytes.", nameof(rom));
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Cartridge name must not be empty.", nameof(name));
+
+        _rom = rom.ToArray();
+        Name = name;
+        Reset();
+    }
+
+    public string Name { get; }
+    public bool IsRomEnabled => _cyclesUntilDisabled > 0;
+    public ulong CyclesUntilDisabled => _cyclesUntilDisabled;
+    public C64CartridgeLines Lines => IsRomEnabled ? EnabledLines : C64CartridgeLines.Released;
+    public event Action? LinesChanged;
+
+    public bool HandlesIORead(ushort address)
+        => address is >= IO1StartAddress and <= IO2EndAddress;
+
+    public byte ReadIO(ushort address)
+    {
+        if (address is >= IO1StartAddress and <= IO1EndAddress)
+        {
+            TriggerRom();
+            return 0;
+        }
+
+        if (address is >= IO2StartAddress and <= IO2EndAddress)
+            return _rom[IO2RomOffset + (address & 0xFF)];
+
+        throw new ArgumentOutOfRangeException(nameof(address));
+    }
+
+    public bool HandlesIOWrite(ushort address) => false;
+    public void WriteIO(ushort address, byte value)
+        => throw new InvalidOperationException($"{Name} has no writable cartridge I/O registers.");
+
+    public bool HasROML => IsRomEnabled;
+
+    public byte ReadROML(ushort address)
+    {
+        if (!IsRomEnabled)
+            throw new InvalidOperationException($"{Name} ROML is disabled.");
+
+        TriggerRom();
+        return _rom[address & (RomSize - 1)];
+    }
+
+    public bool HasROMH => false;
+    public byte ReadROMH(ushort address)
+        => throw new InvalidOperationException($"{Name} does not provide ROMH.");
+
+    public void Tick(ulong cyclesElapsed = 0)
+    {
+        if (!IsRomEnabled || cyclesElapsed == 0)
+            return;
+
+        if (cyclesElapsed < _cyclesUntilDisabled)
+        {
+            _cyclesUntilDisabled -= cyclesElapsed;
+            return;
+        }
+
+        _cyclesUntilDisabled = 0;
+        LinesChanged?.Invoke();
+    }
+
+    public void Reset()
+        => TriggerRom();
+
+    public void Dispose()
+    {
+    }
+
+    private void TriggerRom()
+    {
+        var wasEnabled = IsRomEnabled;
+        _cyclesUntilDisabled = RomEnableCycles;
+        if (!wasEnabled)
+            LinesChanged?.Invoke();
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64ExpertCartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64ExpertCartridge.cs
@@ -1,0 +1,226 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+
+/// <summary>
+/// Trilogic Expert Cartridge saved-RAM image support.
+/// </summary>
+public sealed class C64ExpertCartridge :
+    IC64Cartridge,
+    IC64FreezableCartridge,
+    IC64CartridgeNmiAcknowledgeHandler,
+    IC64CartridgeNormalMemoryFallback
+{
+    public const int RamSize = 0x2000;
+
+    private const ushort IO1ToggleStartAddress = 0xDE00;
+    private const ushort IO1ToggleEndAddress = 0xDE01;
+
+    private static readonly C64CartridgeLines EightKLines = new(GameHigh: true, ExromHigh: false);
+    private static readonly C64CartridgeLines UltimaxLines = new(GameHigh: false, ExromHigh: true);
+
+    private readonly byte[] _ram;
+    private C64ExpertMode _mode;
+    private bool _registerEnabled;
+    private bool _ramWriteable;
+    private bool _ramVisible;
+
+    public C64ExpertCartridge(
+        byte[] ramImage,
+        string name = "Expert Cartridge",
+        C64ExpertMode mode = C64ExpertMode.On)
+    {
+        ArgumentNullException.ThrowIfNull(ramImage);
+        if (ramImage.Length != RamSize)
+            throw new ArgumentException($"Expert Cartridge requires exactly {RamSize} bytes of RAM image data.", nameof(ramImage));
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Cartridge name must not be empty.", nameof(name));
+
+        _ram = ramImage.ToArray();
+        Name = name;
+        _mode = mode;
+        Reset();
+    }
+
+    public string Name { get; }
+    public C64ExpertMode Mode => _mode;
+    public bool IsRegisterEnabled => _registerEnabled;
+    public bool IsRamWriteable => _ramWriteable;
+    public bool IsRamVisible => _ramVisible;
+
+    public C64CartridgeLines Lines
+        => _mode switch
+        {
+            C64ExpertMode.Prg => EightKLines,
+            C64ExpertMode.On => UltimaxLines,
+            _ => C64CartridgeLines.Released,
+        };
+
+    public event Action? LinesChanged;
+
+    public void SetMode(C64ExpertMode mode)
+    {
+        if (_mode == mode)
+            return;
+
+        var previousLines = Lines;
+        _mode = mode;
+
+        switch (_mode)
+        {
+            case C64ExpertMode.Prg:
+                _registerEnabled = true;
+                _ramWriteable = true;
+                _ramVisible = true;
+                break;
+            case C64ExpertMode.On:
+            case C64ExpertMode.Off:
+                _registerEnabled = false;
+                _ramWriteable = false;
+                _ramVisible = false;
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported Expert mode {_mode}.");
+        }
+
+        if (previousLines != Lines)
+            LinesChanged?.Invoke();
+    }
+
+    public bool HandlesIORead(ushort address)
+        => address is >= IO1ToggleStartAddress and <= IO1ToggleEndAddress;
+
+    public byte ReadIO(ushort address)
+    {
+        if (!HandlesIORead(address))
+            throw new InvalidOperationException($"{Name} does not handle I/O reads at 0x{address:X4}.");
+
+        ToggleRegisterIfActive();
+        return 0;
+    }
+
+    public bool ProvidesIOReadValue(ushort address)
+        => false;
+
+    public bool HandlesIOWrite(ushort address)
+        => address is >= IO1ToggleStartAddress and <= IO1ToggleEndAddress;
+
+    public void WriteIO(ushort address, byte value)
+    {
+        if (!HandlesIOWrite(address))
+            throw new InvalidOperationException($"{Name} does not handle I/O writes at 0x{address:X4}.");
+
+        ToggleRegisterIfActive();
+    }
+
+    public bool HasROML
+        => _mode == C64ExpertMode.Prg ||
+           _mode == C64ExpertMode.On && _ramVisible;
+
+    public byte ReadROML(ushort address)
+        => HasROML
+            ? _ram[address & (RamSize - 1)]
+            : throw new InvalidOperationException($"{Name} does not currently provide ROML.");
+
+    public bool HandlesROMLWrite => HasROML && _ramWriteable;
+
+    public void WriteROML(ushort address, byte value)
+    {
+        if (!HandlesROMLWrite)
+            throw new InvalidOperationException($"{Name} ROML is not currently writable.");
+
+        _ram[address & (RamSize - 1)] = value;
+    }
+
+    public bool HasROMH
+        => _mode == C64ExpertMode.On && _ramVisible;
+
+    public byte ReadROMH(ushort address)
+        => HasROMH
+            ? _ram[address & (RamSize - 1)]
+            : throw new InvalidOperationException($"{Name} does not currently provide ROMH.");
+
+    public bool UsesNormalMemoryFallbackForROMH(ushort address)
+        => _mode == C64ExpertMode.On && !_ramVisible;
+
+    public void Freeze()
+    {
+        MapWritableRamOnNmi();
+    }
+
+    public void AcknowledgeNmi()
+    {
+        MapWritableRamOnNmi();
+    }
+
+    public void Tick(ulong cyclesElapsed = 0)
+    {
+    }
+
+    public void Reset()
+    {
+        var previousLines = Lines;
+        switch (_mode)
+        {
+            case C64ExpertMode.Prg:
+                _registerEnabled = true;
+                _ramWriteable = true;
+                _ramVisible = true;
+                break;
+            case C64ExpertMode.On:
+                _registerEnabled = true;
+                _ramWriteable = true;
+                _ramVisible = true;
+                break;
+            case C64ExpertMode.Off:
+                _registerEnabled = false;
+                _ramWriteable = false;
+                _ramVisible = false;
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported Expert mode {_mode}.");
+        }
+
+        if (previousLines != Lines)
+            LinesChanged?.Invoke();
+    }
+
+    public void Dispose()
+    {
+    }
+
+    public byte ReadRam(ushort offset)
+        => _ram[offset & (RamSize - 1)];
+
+    private void ToggleRegisterIfActive()
+    {
+        if (_mode != C64ExpertMode.On || !_registerEnabled)
+            return;
+
+        var previousLines = Lines;
+        _ramVisible = !_ramVisible;
+        _ramWriteable = false;
+
+        if (previousLines != Lines)
+            LinesChanged?.Invoke();
+    }
+
+    private void MapWritableRamOnNmi()
+    {
+        if (_mode != C64ExpertMode.On)
+            return;
+
+        var previousLines = Lines;
+        _registerEnabled = true;
+        _ramWriteable = true;
+        _ramVisible = true;
+
+        if (previousLines != Lines)
+            LinesChanged?.Invoke();
+    }
+}
+
+public enum C64ExpertMode
+{
+    Off,
+    Prg,
+    On,
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64FinalCartridgeIIICartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64FinalCartridgeIIICartridge.cs
@@ -128,10 +128,14 @@ public sealed class C64FinalCartridgeIIICartridge :
     public void Freeze()
     {
         var previousLines = Lines;
+        var previousNmiLineActive = _nmiLineActive;
         _registerEnabled = true;
         _freezeMode = true;
+        _nmiLineActive = true;
         if (previousLines != Lines)
             LinesChanged?.Invoke();
+        if (previousNmiLineActive != _nmiLineActive)
+            NmiLineChanged?.Invoke();
     }
 
     public void Tick(ulong cyclesElapsed = 0)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64FinalCartridgeIIICartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64FinalCartridgeIIICartridge.cs
@@ -1,0 +1,160 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+
+/// <summary>
+/// The Final Cartridge III, including the 16-bank community FC3+ extension.
+/// </summary>
+public sealed class C64FinalCartridgeIIICartridge :
+    IC64Cartridge,
+    IC64FreezableCartridge,
+    IC64CartridgeNmiSource
+{
+    public const int StandardRomBankCount = 4;
+    public const int ExtendedRomBankCount = 16;
+    public const int CrtBankSize = 0x4000;
+
+    private const ushort IO1StartAddress = 0xDE00;
+    private const ushort IO1EndAddress = 0xDEFF;
+    private const ushort IO2StartAddress = 0xDF00;
+    private const ushort IO2EndAddress = 0xDFFF;
+    private const ushort ControlRegisterAddress = 0xDFFF;
+    private const ushort IO1RomOffset = 0x1E00;
+    private const ushort IO2RomOffset = 0x1F00;
+
+    private const byte ExromHighBit = 0x10;
+    private const byte GameHighBit = 0x20;
+    private const byte NmiReleasedBit = 0x40;
+    private const byte HideRegisterBit = 0x80;
+
+    private static readonly C64CartridgeLines UltimaxLines = new(GameHigh: false, ExromHigh: true);
+
+    private readonly C64BankedRom _roml;
+    private readonly C64BankedRom _romh;
+    private readonly ushort _bankMask;
+    private byte _register;
+    private bool _registerEnabled;
+    private bool _freezeMode;
+    private bool _nmiLineActive;
+
+    public C64FinalCartridgeIIICartridge(
+        C64BankedRom roml,
+        C64BankedRom romh,
+        int bankCount,
+        string name = "The Final Cartridge III")
+    {
+        _roml = roml ?? throw new ArgumentNullException(nameof(roml));
+        _romh = romh ?? throw new ArgumentNullException(nameof(romh));
+        if (bankCount is not (StandardRomBankCount or ExtendedRomBankCount))
+            throw new ArgumentOutOfRangeException(nameof(bankCount), "Final Cartridge III requires 4 or 16 ROM banks.");
+        if (roml.Count != bankCount || romh.Count != bankCount ||
+            roml.HighestBank != bankCount - 1 || romh.HighestBank != bankCount - 1)
+        {
+            throw new ArgumentException("Final Cartridge III ROML and ROMH must contain every bank.");
+        }
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Cartridge name must not be empty.", nameof(name));
+
+        _bankMask = (ushort)(bankCount - 1);
+        Name = name;
+        Reset();
+    }
+
+    public string Name { get; }
+    public byte Register => _register;
+    public ushort CurrentBank => (ushort)(_register & _bankMask);
+    public bool IsRegisterEnabled => _registerEnabled;
+    public bool IsFreezeMode => _freezeMode;
+    public bool NmiLineActive => _nmiLineActive;
+    public C64CartridgeLines Lines
+        => _freezeMode
+            ? UltimaxLines
+            : new C64CartridgeLines(
+                GameHigh: (_register & GameHighBit) != 0,
+                ExromHigh: (_register & ExromHighBit) != 0);
+
+    public event Action? LinesChanged;
+    public event Action? NmiLineChanged;
+
+    public bool HandlesIORead(ushort address)
+        => address is >= IO1StartAddress and <= IO2EndAddress;
+
+    public byte ReadIO(ushort address)
+    {
+        if (address is >= IO1StartAddress and <= IO1EndAddress)
+            return _roml.Read(CurrentBank, (ushort)(IO1RomOffset + (address & 0xFF)));
+        if (address is >= IO2StartAddress and <= IO2EndAddress)
+            return _roml.Read(CurrentBank, (ushort)(IO2RomOffset + (address & 0xFF)));
+
+        throw new InvalidOperationException($"{Name} does not handle I/O reads at 0x{address:X4}.");
+    }
+
+    public bool HandlesIOWrite(ushort address)
+        => address is >= IO2StartAddress and <= IO2EndAddress;
+
+    public void WriteIO(ushort address, byte value)
+    {
+        if (!HandlesIOWrite(address))
+            throw new InvalidOperationException($"{Name} does not handle I/O writes at 0x{address:X4}.");
+        if (address != ControlRegisterAddress || !_registerEnabled)
+            return;
+
+        var previousLines = Lines;
+        var previousNmiLineActive = _nmiLineActive;
+
+        _register = value;
+        _registerEnabled = (value & HideRegisterBit) == 0;
+        _freezeMode = false;
+        _nmiLineActive = (value & NmiReleasedBit) == 0;
+
+        if (previousLines != Lines)
+            LinesChanged?.Invoke();
+        if (previousNmiLineActive != _nmiLineActive)
+            NmiLineChanged?.Invoke();
+    }
+
+    public bool HasROML => Lines != C64CartridgeLines.Released;
+
+    public byte ReadROML(ushort address)
+        => HasROML
+            ? _roml.Read(CurrentBank, address)
+            : throw new InvalidOperationException($"{Name} does not currently provide ROML.");
+
+    public bool HasROMH => !Lines.GameHigh;
+
+    public byte ReadROMH(ushort address)
+        => HasROMH
+            ? _romh.Read(CurrentBank, address)
+            : throw new InvalidOperationException($"{Name} does not currently provide ROMH.");
+
+    public void Freeze()
+    {
+        var previousLines = Lines;
+        _registerEnabled = true;
+        _freezeMode = true;
+        if (previousLines != Lines)
+            LinesChanged?.Invoke();
+    }
+
+    public void Tick(ulong cyclesElapsed = 0)
+    {
+    }
+
+    public void Reset()
+    {
+        var previousLines = Lines;
+        var previousNmiLineActive = _nmiLineActive;
+
+        _register = 0;
+        _registerEnabled = true;
+        _freezeMode = false;
+        _nmiLineActive = false;
+
+        if (previousLines != Lines)
+            LinesChanged?.Invoke();
+        if (previousNmiLineActive != _nmiLineActive)
+            NmiLineChanged?.Invoke();
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64MagicDeskCartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64MagicDeskCartridge.cs
@@ -55,7 +55,7 @@ public sealed class C64MagicDeskCartridge : IC64Cartridge
     public byte ReadROMH(ushort address)
         => throw new InvalidOperationException($"{Name} does not provide ROMH.");
 
-    public void Tick()
+    public void Tick(ulong cyclesElapsed = 0)
     {
     }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64MagicDeskCartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64MagicDeskCartridge.cs
@@ -1,0 +1,90 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+
+/// <summary>
+/// Magic Desk compatible cartridge with banked 8K ROML and a write-only IO1 register.
+/// </summary>
+public sealed class C64MagicDeskCartridge : IC64Cartridge
+{
+    private const ushort IO1StartAddress = 0xDE00;
+    private const ushort IO1EndAddress = 0xDEFF;
+    private const byte DisableBit = 0x80;
+
+    private static readonly C64CartridgeLines EnabledLines = new(GameHigh: true, ExromHigh: false);
+
+    private readonly C64BankedRom _rom;
+    private readonly byte _bankMask;
+    private byte _register;
+
+    public C64MagicDeskCartridge(C64BankedRom rom, string name = "Magic Desk")
+    {
+        _rom = rom ?? throw new ArgumentNullException(nameof(rom));
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Cartridge name must not be empty.", nameof(name));
+
+        Name = name;
+        _bankMask = GetBankMask(rom.HighestBank);
+        Reset();
+    }
+
+    public string Name { get; }
+    public C64CartridgeLines Lines
+        => IsEnabled ? EnabledLines : C64CartridgeLines.Released;
+    public event Action? LinesChanged;
+
+    public ushort CurrentBank => (ushort)(_register & _bankMask);
+    public bool IsEnabled => (_register & DisableBit) == 0;
+
+    public bool HandlesIORead(ushort address) => false;
+    public byte ReadIO(ushort address)
+        => throw new InvalidOperationException($"{Name} has no readable cartridge I/O registers.");
+
+    public bool HandlesIOWrite(ushort address)
+        => address is >= IO1StartAddress and <= IO1EndAddress;
+
+    public void WriteIO(ushort address, byte value)
+    {
+        var wasEnabled = IsEnabled;
+        _register = (byte)(value & (DisableBit | _bankMask));
+        if (wasEnabled != IsEnabled)
+            LinesChanged?.Invoke();
+    }
+
+    public bool HasROML => true;
+    public byte ReadROML(ushort address) => _rom.Read(CurrentBank, address);
+    public bool HasROMH => false;
+    public byte ReadROMH(ushort address)
+        => throw new InvalidOperationException($"{Name} does not provide ROMH.");
+
+    public void Tick()
+    {
+    }
+
+    public void Reset()
+    {
+        var linesChanged = !IsEnabled;
+        _register = 0;
+        if (linesChanged)
+            LinesChanged?.Invoke();
+    }
+
+    public void Dispose()
+    {
+    }
+
+    private static byte GetBankMask(ushort highestBank)
+    {
+        if (highestBank > 127)
+            throw new ArgumentOutOfRangeException(nameof(highestBank), "Magic Desk supports at most 128 ROM banks.");
+        if (highestBank <= 3)
+            return 0x03;
+        if (highestBank <= 7)
+            return 0x07;
+        if (highestBank <= 15)
+            return 0x0F;
+        if (highestBank <= 31)
+            return 0x1F;
+        if (highestBank <= 63)
+            return 0x3F;
+        return 0x7F;
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64OceanCartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64OceanCartridge.cs
@@ -1,0 +1,86 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+
+/// <summary>
+/// Ocean game cartridge with banked 8K ROM and a write-only IO1 bank register.
+/// Smaller cartridges use 16K mode with the selected bank mirrored in ROML and ROMH;
+/// 512K cartridges use 8K ROML-only mode.
+/// </summary>
+public sealed class C64OceanCartridge : IC64Cartridge
+{
+    private const ushort IO1StartAddress = 0xDE00;
+    private const ushort IO1EndAddress = 0xDEFF;
+
+    private static readonly C64CartridgeLines EightKLines = new(GameHigh: true, ExromHigh: false);
+    private static readonly C64CartridgeLines SixteenKLines = new(GameHigh: false, ExromHigh: false);
+
+    private readonly C64BankedRom _rom;
+    private readonly byte _bankMask;
+    private byte _register;
+
+    public C64OceanCartridge(
+        C64BankedRom rom,
+        bool useEightKMode,
+        string name = "Ocean")
+    {
+        _rom = rom ?? throw new ArgumentNullException(nameof(rom));
+        if (rom.Count > 64)
+            throw new ArgumentException("Ocean supports at most 64 ROM banks.", nameof(rom));
+        if (!IsPowerOfTwo(rom.Count))
+            throw new ArgumentException("Ocean ROM bank count must be a power of two.", nameof(rom));
+        if (useEightKMode && rom.Count != 64)
+            throw new ArgumentException("Ocean 8K mode requires exactly 64 ROM banks.", nameof(useEightKMode));
+        if (!useEightKMode && rom.Count == 64)
+            throw new ArgumentException("A 64-bank Ocean cartridge must use 8K mode.", nameof(useEightKMode));
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Cartridge name must not be empty.", nameof(name));
+
+        UseEightKMode = useEightKMode;
+        Name = name;
+        _bankMask = (byte)(rom.Count - 1);
+        Reset();
+    }
+
+    public string Name { get; }
+    public bool UseEightKMode { get; }
+    public C64CartridgeLines Lines => UseEightKMode ? EightKLines : SixteenKLines;
+    public event Action? LinesChanged
+    {
+        add { }
+        remove { }
+    }
+
+    public ushort CurrentBank => (ushort)(_register & _bankMask & 0x3F);
+
+    public bool HandlesIORead(ushort address) => false;
+    public byte ReadIO(ushort address)
+        => throw new InvalidOperationException($"{Name} has no readable cartridge I/O registers.");
+
+    public bool HandlesIOWrite(ushort address)
+        => address is >= IO1StartAddress and <= IO1EndAddress;
+
+    public void WriteIO(ushort address, byte value)
+        => _register = value;
+
+    public bool HasROML => true;
+    public byte ReadROML(ushort address) => _rom.Read(CurrentBank, address);
+
+    public bool HasROMH => !UseEightKMode;
+    public byte ReadROMH(ushort address)
+        => HasROMH
+            ? _rom.Read(CurrentBank, address)
+            : throw new InvalidOperationException($"{Name} does not provide ROMH in 8K mode.");
+
+    public void Tick()
+    {
+    }
+
+    public void Reset()
+        => _register = 0;
+
+    public void Dispose()
+    {
+    }
+
+    private static bool IsPowerOfTwo(int value)
+        => value > 0 && (value & (value - 1)) == 0;
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64OceanCartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64OceanCartridge.cs
@@ -70,7 +70,7 @@ public sealed class C64OceanCartridge : IC64Cartridge
             ? _rom.Read(CurrentBank, address)
             : throw new InvalidOperationException($"{Name} does not provide ROMH in 8K mode.");
 
-    public void Tick()
+    public void Tick(ulong cyclesElapsed = 0)
     {
     }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64RomCartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64RomCartridge.cs
@@ -65,7 +65,7 @@ public sealed class C64RomCartridge : IC64Cartridge
         => _romh?[address & (RomWindowSize - 1)]
             ?? throw new InvalidOperationException($"{Name} does not provide ROMH.");
 
-    public void Tick()
+    public void Tick(ulong cyclesElapsed = 0)
     {
     }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64RomCartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64RomCartridge.cs
@@ -50,8 +50,9 @@ public sealed class C64RomCartridge : IC64Cartridge
         remove { }
     }
 
-    public bool HandlesIOAddress(ushort address) => false;
+    public bool HandlesIORead(ushort address) => false;
     public byte ReadIO(ushort address) => throw new InvalidOperationException($"{Name} does not provide cartridge I/O.");
+    public bool HandlesIOWrite(ushort address) => false;
     public void WriteIO(ushort address, byte value) => throw new InvalidOperationException($"{Name} does not provide cartridge I/O.");
 
     public bool HasROML => _roml != null;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64RomCartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64RomCartridge.cs
@@ -1,0 +1,63 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+
+/// <summary>
+/// A standard fixed 8K or 16K C64 ROM cartridge. Supplying only ROML selects 8K mode;
+/// supplying both ROML and ROMH selects 16K mode.
+/// </summary>
+public sealed class C64RomCartridge : IC64Cartridge
+{
+    public const int RomWindowSize = 0x2000;
+
+    private readonly byte[] _roml;
+    private readonly byte[]? _romh;
+
+    public C64RomCartridge(byte[] roml, byte[]? romh = null, string name = "ROM cartridge")
+    {
+        ArgumentNullException.ThrowIfNull(roml);
+        if (roml.Length != RomWindowSize)
+            throw new ArgumentException($"ROML must be exactly {RomWindowSize} bytes.", nameof(roml));
+        if (romh != null && romh.Length != RomWindowSize)
+            throw new ArgumentException($"ROMH must be exactly {RomWindowSize} bytes.", nameof(romh));
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Cartridge name must not be empty.", nameof(name));
+
+        _roml = roml.ToArray();
+        _romh = romh?.ToArray();
+        Name = name;
+        Lines = romh == null
+            ? new C64CartridgeLines(GameHigh: true, ExromHigh: false)
+            : new C64CartridgeLines(GameHigh: false, ExromHigh: false);
+    }
+
+    public string Name { get; }
+    public C64CartridgeLines Lines { get; }
+    public event Action? LinesChanged
+    {
+        add { }
+        remove { }
+    }
+
+    public bool HandlesIOAddress(ushort address) => false;
+    public byte ReadIO(ushort address) => throw new InvalidOperationException($"{Name} does not provide cartridge I/O.");
+    public void WriteIO(ushort address, byte value) => throw new InvalidOperationException($"{Name} does not provide cartridge I/O.");
+
+    public bool HasROML => true;
+    public byte ReadROML(ushort address) => _roml[address & (RomWindowSize - 1)];
+
+    public bool HasROMH => _romh != null;
+    public byte ReadROMH(ushort address)
+        => _romh?[address & (RomWindowSize - 1)]
+            ?? throw new InvalidOperationException($"{Name} does not provide ROMH.");
+
+    public void Tick()
+    {
+    }
+
+    public void Reset()
+    {
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64RomCartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64RomCartridge.cs
@@ -1,32 +1,45 @@
 namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
 
 /// <summary>
-/// A standard fixed 8K or 16K C64 ROM cartridge. Supplying only ROML selects 8K mode;
-/// supplying both ROML and ROMH selects 16K mode.
+/// A fixed C64 ROM cartridge with explicit ROML/ROMH windows and cartridge lines.
 /// </summary>
 public sealed class C64RomCartridge : IC64Cartridge
 {
     public const int RomWindowSize = 0x2000;
 
-    private readonly byte[] _roml;
+    private readonly byte[]? _roml;
     private readonly byte[]? _romh;
 
     public C64RomCartridge(byte[] roml, byte[]? romh = null, string name = "ROM cartridge")
+        : this(
+            roml,
+            romh,
+            romh == null
+                ? new C64CartridgeLines(GameHigh: true, ExromHigh: false)
+                : new C64CartridgeLines(GameHigh: false, ExromHigh: false),
+            name)
     {
-        ArgumentNullException.ThrowIfNull(roml);
-        if (roml.Length != RomWindowSize)
+    }
+
+    public C64RomCartridge(
+        byte[]? roml,
+        byte[]? romh,
+        C64CartridgeLines lines,
+        string name = "ROM cartridge")
+    {
+        if (roml == null && romh == null)
+            throw new ArgumentException("At least one cartridge ROM window must be supplied.");
+        if (roml != null && roml.Length != RomWindowSize)
             throw new ArgumentException($"ROML must be exactly {RomWindowSize} bytes.", nameof(roml));
         if (romh != null && romh.Length != RomWindowSize)
             throw new ArgumentException($"ROMH must be exactly {RomWindowSize} bytes.", nameof(romh));
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentException("Cartridge name must not be empty.", nameof(name));
 
-        _roml = roml.ToArray();
+        _roml = roml?.ToArray();
         _romh = romh?.ToArray();
         Name = name;
-        Lines = romh == null
-            ? new C64CartridgeLines(GameHigh: true, ExromHigh: false)
-            : new C64CartridgeLines(GameHigh: false, ExromHigh: false);
+        Lines = lines;
     }
 
     public string Name { get; }
@@ -41,8 +54,10 @@ public sealed class C64RomCartridge : IC64Cartridge
     public byte ReadIO(ushort address) => throw new InvalidOperationException($"{Name} does not provide cartridge I/O.");
     public void WriteIO(ushort address, byte value) => throw new InvalidOperationException($"{Name} does not provide cartridge I/O.");
 
-    public bool HasROML => true;
-    public byte ReadROML(ushort address) => _roml[address & (RomWindowSize - 1)];
+    public bool HasROML => _roml != null;
+    public byte ReadROML(ushort address)
+        => _roml?[address & (RomWindowSize - 1)]
+            ?? throw new InvalidOperationException($"{Name} does not provide ROML.");
 
     public bool HasROMH => _romh != null;
     public byte ReadROMH(ushort address)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CartridgeImageAttachResult.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CartridgeImageAttachResult.cs
@@ -1,0 +1,9 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge.Crt;
+
+public sealed record C64CartridgeImageAttachResult(
+    string CartridgeName,
+    ushort HardwareType,
+    byte Subtype,
+    C64CartridgeLines Lines,
+    int ChipCount,
+    string? SourceName);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtCartridgeFactory.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtCartridgeFactory.cs
@@ -12,6 +12,7 @@ public static class C64CrtCartridgeFactory
             (ushort)C64CrtHardwareType.ActionReplay => CreateActionReplay(image),
             (ushort)C64CrtHardwareType.FinalCartridgeIII => CreateFinalCartridgeIII(image),
             (ushort)C64CrtHardwareType.Ocean => CreateOcean(image),
+            (ushort)C64CrtHardwareType.Expert => CreateExpert(image),
             (ushort)C64CrtHardwareType.EpyxFastLoad => CreateEpyxFastLoad(image),
             (ushort)C64CrtHardwareType.MagicDesk => CreateMagicDesk(image),
             _ => throw new C64UnsupportedCrtHardwareException(image.Header.HardwareType),
@@ -152,6 +153,24 @@ public static class C64CrtCartridgeFactory
             rom,
             useEightKMode: bankCount == 64,
             name: string.IsNullOrWhiteSpace(image.Header.Name) ? "Ocean" : image.Header.Name);
+    }
+
+    private static IC64Cartridge CreateExpert(C64CrtImage image)
+    {
+        if (image.Chips.Count != 1)
+            throw new C64CrtImageException("Expert CRT images must contain exactly one CHIP packet.");
+
+        var chip = image.Chips[0];
+        if (chip.Bank != 0)
+            throw new C64CrtImageException("Expert CRT images must use bank 0.");
+        if (chip.LoadAddress != 0x8000)
+            throw new C64CrtImageException("Expert CRT RAM must load at 0x8000.");
+        if (chip.Data.Length != C64ExpertCartridge.RamSize)
+            throw new C64CrtImageException("Expert CRT RAM must contain exactly 8K of data.");
+
+        return new C64ExpertCartridge(
+            chip.Data,
+            string.IsNullOrWhiteSpace(image.Header.Name) ? "Expert Cartridge" : image.Header.Name);
     }
 
     private static IC64Cartridge CreateEpyxFastLoad(C64CrtImage image)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtCartridgeFactory.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtCartridgeFactory.cs
@@ -9,6 +9,7 @@ public static class C64CrtCartridgeFactory
         return image.Header.HardwareType switch
         {
             (ushort)C64CrtHardwareType.Generic => CreateGeneric(image),
+            (ushort)C64CrtHardwareType.Ocean => CreateOcean(image),
             (ushort)C64CrtHardwareType.MagicDesk => CreateMagicDesk(image),
             _ => throw new C64UnsupportedCrtHardwareException(image.Header.HardwareType),
         };
@@ -64,6 +65,51 @@ public static class C64CrtCartridgeFactory
             rom,
             string.IsNullOrWhiteSpace(image.Header.Name) ? "Magic Desk" : image.Header.Name);
     }
+
+    private static IC64Cartridge CreateOcean(C64CrtImage image)
+    {
+        if (image.Chips.Any(chip => chip.Type != C64CrtChipType.Rom))
+            throw new C64CrtImageException("Ocean CRT images support ROM CHIP packets only.");
+
+        var banks = BuildBankedRomChips(image, "Ocean", maximumBank: 63);
+        var bankCount = banks.Count;
+        if (!IsPowerOfTwo(bankCount))
+            throw new C64CrtImageException("Ocean CRT bank count must be a power of two.");
+        for (ushort bank = 0; bank < bankCount; bank++)
+        {
+            if (!banks.ContainsKey(bank))
+                throw new C64CrtImageException($"Ocean CRT bank {bank} is missing.");
+        }
+
+        var rom = new C64BankedRom(banks, maximumBank: 63);
+        return new C64OceanCartridge(
+            rom,
+            useEightKMode: bankCount == 64,
+            name: string.IsNullOrWhiteSpace(image.Header.Name) ? "Ocean" : image.Header.Name);
+    }
+
+    private static Dictionary<ushort, byte[]> BuildBankedRomChips(
+        C64CrtImage image,
+        string hardwareName,
+        ushort maximumBank)
+    {
+        var banks = new Dictionary<ushort, byte[]>(image.Chips.Count);
+        foreach (var chip in image.Chips)
+        {
+            if (chip.Bank > maximumBank)
+                throw new C64CrtImageException($"{hardwareName} CRT bank {chip.Bank} exceeds the supported maximum bank {maximumBank}.");
+            if (chip.LoadAddress is not (0x8000 or 0xA000))
+                throw new C64CrtImageException($"{hardwareName} CRT bank {chip.Bank} must load at 0x8000 or 0xA000.");
+            if (chip.Data.Length != C64BankedRom.BankSize)
+                throw new C64CrtImageException($"{hardwareName} CRT bank {chip.Bank} must contain exactly 8K of ROM data.");
+            if (!banks.TryAdd(chip.Bank, chip.Data))
+                throw new C64CrtImageException($"{hardwareName} CRT bank {chip.Bank} is duplicated.");
+        }
+        return banks;
+    }
+
+    private static bool IsPowerOfTwo(int value)
+        => value > 0 && (value & (value - 1)) == 0;
 
     private static byte[]? BuildWindow(IReadOnlyList<C64CrtChip> chips, ushort baseAddress)
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtCartridgeFactory.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtCartridgeFactory.cs
@@ -9,7 +9,9 @@ public static class C64CrtCartridgeFactory
         return image.Header.HardwareType switch
         {
             (ushort)C64CrtHardwareType.Generic => CreateGeneric(image),
+            (ushort)C64CrtHardwareType.ActionReplay => CreateActionReplay(image),
             (ushort)C64CrtHardwareType.Ocean => CreateOcean(image),
+            (ushort)C64CrtHardwareType.EpyxFastLoad => CreateEpyxFastLoad(image),
             (ushort)C64CrtHardwareType.MagicDesk => CreateMagicDesk(image),
             _ => throw new C64UnsupportedCrtHardwareException(image.Header.HardwareType),
         };
@@ -66,6 +68,26 @@ public static class C64CrtCartridgeFactory
             string.IsNullOrWhiteSpace(image.Header.Name) ? "Magic Desk" : image.Header.Name);
     }
 
+    private static IC64Cartridge CreateActionReplay(C64CrtImage image)
+    {
+        if (image.Chips.Any(chip => chip.Type != C64CrtChipType.Rom))
+            throw new C64CrtImageException("Action Replay CRT images support ROM CHIP packets only.");
+
+        var banks = BuildBankedRomChips(image, "Action Replay", maximumBank: 3);
+        if (banks.Count != C64ActionReplayCartridge.RomBankCount)
+            throw new C64CrtImageException("Action Replay CRT images must contain exactly four ROM banks.");
+        for (ushort bank = 0; bank < C64ActionReplayCartridge.RomBankCount; bank++)
+        {
+            if (!banks.ContainsKey(bank))
+                throw new C64CrtImageException($"Action Replay CRT bank {bank} is missing.");
+        }
+
+        var rom = new C64BankedRom(banks, maximumBank: 3);
+        return new C64ActionReplayCartridge(
+            rom,
+            string.IsNullOrWhiteSpace(image.Header.Name) ? "Action Replay" : image.Header.Name);
+    }
+
     private static IC64Cartridge CreateOcean(C64CrtImage image)
     {
         if (image.Chips.Any(chip => chip.Type != C64CrtChipType.Rom))
@@ -86,6 +108,26 @@ public static class C64CrtCartridgeFactory
             rom,
             useEightKMode: bankCount == 64,
             name: string.IsNullOrWhiteSpace(image.Header.Name) ? "Ocean" : image.Header.Name);
+    }
+
+    private static IC64Cartridge CreateEpyxFastLoad(C64CrtImage image)
+    {
+        if (image.Chips.Count != 1)
+            throw new C64CrtImageException("Epyx FastLoad CRT images must contain exactly one CHIP packet.");
+
+        var chip = image.Chips[0];
+        if (chip.Type != C64CrtChipType.Rom)
+            throw new C64CrtImageException("Epyx FastLoad CRT images support ROM CHIP packets only.");
+        if (chip.Bank != 0)
+            throw new C64CrtImageException("Epyx FastLoad CRT images must use bank 0.");
+        if (chip.LoadAddress != 0x8000)
+            throw new C64CrtImageException("Epyx FastLoad CRT ROM must load at 0x8000.");
+        if (chip.Data.Length != C64EpyxFastLoadCartridge.RomSize)
+            throw new C64CrtImageException("Epyx FastLoad CRT ROM must contain exactly 8K of data.");
+
+        return new C64EpyxFastLoadCartridge(
+            chip.Data,
+            string.IsNullOrWhiteSpace(image.Header.Name) ? "Epyx FastLoad" : image.Header.Name);
     }
 
     private static Dictionary<ushort, byte[]> BuildBankedRomChips(

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtCartridgeFactory.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtCartridgeFactory.cs
@@ -6,9 +6,16 @@ public static class C64CrtCartridgeFactory
     {
         ArgumentNullException.ThrowIfNull(image);
 
-        if (image.Header.HardwareType != (ushort)C64CrtHardwareType.Generic)
-            throw new C64UnsupportedCrtHardwareException(image.Header.HardwareType);
+        return image.Header.HardwareType switch
+        {
+            (ushort)C64CrtHardwareType.Generic => CreateGeneric(image),
+            (ushort)C64CrtHardwareType.MagicDesk => CreateMagicDesk(image),
+            _ => throw new C64UnsupportedCrtHardwareException(image.Header.HardwareType),
+        };
+    }
 
+    private static IC64Cartridge CreateGeneric(C64CrtImage image)
+    {
         if (image.Chips.Any(chip => chip.Type != C64CrtChipType.Rom))
             throw new C64CrtImageException("Generic CRT images currently support ROM CHIP packets only.");
         if (image.Chips.Any(chip => chip.Bank != 0))
@@ -29,6 +36,33 @@ public static class C64CrtCartridgeFactory
             romh,
             lines,
             string.IsNullOrWhiteSpace(image.Header.Name) ? "CRT cartridge" : image.Header.Name);
+    }
+
+    private static IC64Cartridge CreateMagicDesk(C64CrtImage image)
+    {
+        if (image.Chips.Any(chip => chip.Type != C64CrtChipType.Rom))
+            throw new C64CrtImageException("Magic Desk CRT images support ROM CHIP packets only.");
+
+        var banks = new List<KeyValuePair<ushort, byte[]>>(image.Chips.Count);
+        var bankNumbers = new HashSet<ushort>();
+        foreach (var chip in image.Chips)
+        {
+            if (chip.Bank > 127)
+                throw new C64CrtImageException($"Magic Desk CRT bank {chip.Bank} exceeds the supported maximum bank 127.");
+            if (chip.LoadAddress is not (0x8000 or 0xA000))
+                throw new C64CrtImageException($"Magic Desk CRT bank {chip.Bank} must load at 0x8000 or 0xA000.");
+            if (chip.Data.Length != C64BankedRom.BankSize)
+                throw new C64CrtImageException($"Magic Desk CRT bank {chip.Bank} must contain exactly 8K of ROM data.");
+            if (!bankNumbers.Add(chip.Bank))
+                throw new C64CrtImageException($"Magic Desk CRT bank {chip.Bank} is duplicated.");
+
+            banks.Add(new KeyValuePair<ushort, byte[]>(chip.Bank, chip.Data));
+        }
+
+        var rom = new C64BankedRom(banks, maximumBank: 127);
+        return new C64MagicDeskCartridge(
+            rom,
+            string.IsNullOrWhiteSpace(image.Header.Name) ? "Magic Desk" : image.Header.Name);
     }
 
     private static byte[]? BuildWindow(IReadOnlyList<C64CrtChip> chips, ushort baseAddress)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtCartridgeFactory.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtCartridgeFactory.cs
@@ -1,0 +1,142 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge.Crt;
+
+public static class C64CrtCartridgeFactory
+{
+    public static IC64Cartridge Create(C64CrtImage image)
+    {
+        ArgumentNullException.ThrowIfNull(image);
+
+        if (image.Header.HardwareType != (ushort)C64CrtHardwareType.Generic)
+            throw new C64UnsupportedCrtHardwareException(image.Header.HardwareType);
+
+        if (image.Chips.Any(chip => chip.Type != C64CrtChipType.Rom))
+            throw new C64CrtImageException("Generic CRT images currently support ROM CHIP packets only.");
+        if (image.Chips.Any(chip => chip.Bank != 0))
+            throw new C64CrtImageException("Generic CRT images currently support bank 0 only.");
+
+        var lines = new C64CartridgeLines(image.Header.GameHigh, image.Header.ExromHigh);
+        ValidateChipRanges(lines, image.Chips);
+        var roml = BuildWindow(image.Chips, 0x8000);
+        var romhBaseAddress = GetRomhBaseAddress(lines);
+        var romh = romhBaseAddress.HasValue
+            ? BuildWindow(image.Chips, romhBaseAddress.Value)
+            : null;
+
+        ValidateGenericShape(lines, roml, romh);
+
+        return new C64RomCartridge(
+            roml,
+            romh,
+            lines,
+            string.IsNullOrWhiteSpace(image.Header.Name) ? "CRT cartridge" : image.Header.Name);
+    }
+
+    private static byte[]? BuildWindow(IReadOnlyList<C64CrtChip> chips, ushort baseAddress)
+    {
+        var windowStart = (int)baseAddress;
+        var windowEnd = windowStart + C64RomCartridge.RomWindowSize;
+        var matching = chips.Where(chip =>
+        {
+            var chipStart = (int)chip.LoadAddress;
+            var chipEnd = chipStart + chip.Data.Length;
+            return chipStart < windowEnd && chipEnd > windowStart;
+        }).ToArray();
+        if (matching.Length == 0)
+            return null;
+
+        var window = new byte[C64RomCartridge.RomWindowSize];
+        var written = new bool[C64RomCartridge.RomWindowSize];
+        foreach (var chip in matching)
+        {
+            var chipStart = (int)chip.LoadAddress;
+            var copyStart = Math.Max(chipStart, windowStart);
+            var copyEnd = Math.Min(chipStart + chip.Data.Length, windowEnd);
+            for (var address = copyStart; address < copyEnd; address++)
+            {
+                var target = address - windowStart;
+                if (written[target])
+                    throw new C64CrtImageException($"Generic CRT CHIP packets overlap at address 0x{address:X4}.");
+                written[target] = true;
+                window[target] = chip.Data[address - chipStart];
+            }
+        }
+
+        if (written.Any(value => !value))
+            throw new C64CrtImageException($"Generic CRT ROM window at 0x{baseAddress:X4} must contain exactly 8K of ROM data.");
+
+        return window;
+    }
+
+    private static void ValidateChipRanges(
+        C64CartridgeLines lines,
+        IReadOnlyList<C64CrtChip> chips)
+    {
+        (int Start, int End)[] allowedRanges = lines switch
+        {
+            { GameHigh: true, ExromHigh: false } => [(0x8000, 0xA000)],
+            { GameHigh: false, ExromHigh: false } => [(0x8000, 0xC000)],
+            { GameHigh: false, ExromHigh: true } => [(0x8000, 0xA000), (0xE000, 0x10000)],
+            _ => throw new C64CrtImageException("Generic CRT uses an unsupported GAME/EXROM line combination."),
+        };
+
+        foreach (var chip in chips)
+        {
+            var chipStart = (int)chip.LoadAddress;
+            var chipEnd = chipStart + chip.Data.Length;
+            var coveredUntil = chipStart;
+
+            foreach (var range in allowedRanges)
+            {
+                if (coveredUntil < range.Start)
+                    break;
+                if (coveredUntil >= range.End)
+                    continue;
+
+                coveredUntil = Math.Min(chipEnd, range.End);
+                if (coveredUntil == chipEnd)
+                    break;
+            }
+
+            if (coveredUntil != chipEnd)
+            {
+                throw new C64CrtImageException(
+                    $"Generic CRT CHIP at 0x{chip.LoadAddress:X4} contains data outside the cartridge ROM windows selected by GAME/EXROM.");
+            }
+        }
+    }
+
+    private static ushort? GetRomhBaseAddress(C64CartridgeLines lines)
+    {
+        if (lines == new C64CartridgeLines(GameHigh: false, ExromHigh: false))
+            return 0xA000;
+        if (lines == new C64CartridgeLines(GameHigh: false, ExromHigh: true))
+            return 0xE000;
+        return null;
+    }
+
+    private static void ValidateGenericShape(C64CartridgeLines lines, byte[]? roml, byte[]? romh)
+    {
+        if (lines == new C64CartridgeLines(GameHigh: true, ExromHigh: false))
+        {
+            if (roml == null || romh != null)
+                throw new C64CrtImageException("Generic 8K CRT must contain one complete ROML window at 0x8000.");
+            return;
+        }
+
+        if (lines == new C64CartridgeLines(GameHigh: false, ExromHigh: false))
+        {
+            if (roml == null || romh == null)
+                throw new C64CrtImageException("Generic 16K CRT must contain complete ROML and ROMH windows at 0x8000 and 0xA000.");
+            return;
+        }
+
+        if (lines == new C64CartridgeLines(GameHigh: false, ExromHigh: true))
+        {
+            if (romh == null)
+                throw new C64CrtImageException("Generic Ultimax CRT must contain a complete ROMH window at 0xE000.");
+            return;
+        }
+
+        throw new C64CrtImageException("Generic CRT uses an unsupported GAME/EXROM line combination.");
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtCartridgeFactory.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtCartridgeFactory.cs
@@ -10,6 +10,7 @@ public static class C64CrtCartridgeFactory
         {
             (ushort)C64CrtHardwareType.Generic => CreateGeneric(image),
             (ushort)C64CrtHardwareType.ActionReplay => CreateActionReplay(image),
+            (ushort)C64CrtHardwareType.FinalCartridgeIII => CreateFinalCartridgeIII(image),
             (ushort)C64CrtHardwareType.Ocean => CreateOcean(image),
             (ushort)C64CrtHardwareType.EpyxFastLoad => CreateEpyxFastLoad(image),
             (ushort)C64CrtHardwareType.MagicDesk => CreateMagicDesk(image),
@@ -86,6 +87,49 @@ public static class C64CrtCartridgeFactory
         return new C64ActionReplayCartridge(
             rom,
             string.IsNullOrWhiteSpace(image.Header.Name) ? "Action Replay" : image.Header.Name);
+    }
+
+    private static IC64Cartridge CreateFinalCartridgeIII(C64CrtImage image)
+    {
+        if (image.Chips.Any(chip => chip.Type != C64CrtChipType.Rom))
+            throw new C64CrtImageException("Final Cartridge III CRT images support ROM CHIP packets only.");
+        if (image.Chips.Count is not (
+            C64FinalCartridgeIIICartridge.StandardRomBankCount or
+            C64FinalCartridgeIIICartridge.ExtendedRomBankCount))
+        {
+            throw new C64CrtImageException("Final Cartridge III CRT images must contain exactly 4 or 16 ROM banks.");
+        }
+
+        var bankCount = image.Chips.Count;
+        var romlBanks = new Dictionary<ushort, byte[]>(bankCount);
+        var romhBanks = new Dictionary<ushort, byte[]>(bankCount);
+        foreach (var chip in image.Chips)
+        {
+            if (chip.Bank >= bankCount)
+                throw new C64CrtImageException($"Final Cartridge III CRT bank {chip.Bank} exceeds maximum bank {bankCount - 1}.");
+            if (chip.LoadAddress != 0x8000)
+                throw new C64CrtImageException($"Final Cartridge III CRT bank {chip.Bank} must load at 0x8000.");
+            if (chip.Data.Length != C64FinalCartridgeIIICartridge.CrtBankSize)
+                throw new C64CrtImageException($"Final Cartridge III CRT bank {chip.Bank} must contain exactly 16K of ROM data.");
+            if (!romlBanks.TryAdd(chip.Bank, chip.Data[..C64BankedRom.BankSize]))
+                throw new C64CrtImageException($"Final Cartridge III CRT bank {chip.Bank} is duplicated.");
+
+            romhBanks.Add(chip.Bank, chip.Data[C64BankedRom.BankSize..]);
+        }
+
+        for (ushort bank = 0; bank < bankCount; bank++)
+        {
+            if (!romlBanks.ContainsKey(bank))
+                throw new C64CrtImageException($"Final Cartridge III CRT bank {bank} is missing.");
+        }
+
+        return new C64FinalCartridgeIIICartridge(
+            new C64BankedRom(romlBanks, (ushort)(bankCount - 1)),
+            new C64BankedRom(romhBanks, (ushort)(bankCount - 1)),
+            bankCount,
+            string.IsNullOrWhiteSpace(image.Header.Name)
+                ? "The Final Cartridge III"
+                : image.Header.Name);
     }
 
     private static IC64Cartridge CreateOcean(C64CrtImage image)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtChipType.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtChipType.cs
@@ -1,0 +1,8 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge.Crt;
+
+public enum C64CrtChipType : ushort
+{
+    Rom = 0,
+    Ram = 1,
+    Flash = 2,
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtHardwareType.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtHardwareType.cs
@@ -3,6 +3,8 @@ namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge.Crt;
 public enum C64CrtHardwareType : ushort
 {
     Generic = 0,
+    ActionReplay = 1,
     Ocean = 5,
+    EpyxFastLoad = 10,
     MagicDesk = 19,
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtHardwareType.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtHardwareType.cs
@@ -1,0 +1,6 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge.Crt;
+
+public enum C64CrtHardwareType : ushort
+{
+    Generic = 0,
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtHardwareType.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtHardwareType.cs
@@ -3,4 +3,5 @@ namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge.Crt;
 public enum C64CrtHardwareType : ushort
 {
     Generic = 0,
+    MagicDesk = 19,
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtHardwareType.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtHardwareType.cs
@@ -3,5 +3,6 @@ namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge.Crt;
 public enum C64CrtHardwareType : ushort
 {
     Generic = 0,
+    Ocean = 5,
     MagicDesk = 19,
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtHardwareType.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtHardwareType.cs
@@ -6,6 +6,7 @@ public enum C64CrtHardwareType : ushort
     ActionReplay = 1,
     FinalCartridgeIII = 3,
     Ocean = 5,
+    Expert = 6,
     EpyxFastLoad = 10,
     MagicDesk = 19,
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtHardwareType.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtHardwareType.cs
@@ -4,6 +4,7 @@ public enum C64CrtHardwareType : ushort
 {
     Generic = 0,
     ActionReplay = 1,
+    FinalCartridgeIII = 3,
     Ocean = 5,
     EpyxFastLoad = 10,
     MagicDesk = 19,

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtImage.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtImage.cs
@@ -1,0 +1,20 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge.Crt;
+
+public sealed record C64CrtHeader(
+    uint HeaderLength,
+    ushort Version,
+    ushort HardwareType,
+    bool ExromHigh,
+    bool GameHigh,
+    byte Subtype,
+    string Name);
+
+public sealed record C64CrtChip(
+    C64CrtChipType Type,
+    ushort Bank,
+    ushort LoadAddress,
+    byte[] Data);
+
+public sealed record C64CrtImage(
+    C64CrtHeader Header,
+    IReadOnlyList<C64CrtChip> Chips);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtImageException.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtImageException.cs
@@ -1,0 +1,20 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge.Crt;
+
+public class C64CrtImageException : IOException
+{
+    public C64CrtImageException(string message)
+        : base(message)
+    {
+    }
+}
+
+public sealed class C64UnsupportedCrtHardwareException : C64CrtImageException
+{
+    public C64UnsupportedCrtHardwareException(ushort hardwareType)
+        : base($"CRT cartridge hardware type {hardwareType} is not supported.")
+    {
+        HardwareType = hardwareType;
+    }
+
+    public ushort HardwareType { get; }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtParser.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtParser.cs
@@ -51,7 +51,7 @@ public static class C64CrtParser
                 throw new C64CrtImageException($"CRT packet at offset 0x{offset:X} does not contain the CHIP signature.");
 
             var packetLength = ReadUInt32(chipHeader, 4);
-            if (packetLength < ChipHeaderLength || packetLength > data.Length - offset)
+            if (packetLength < ChipHeaderLength)
                 throw new C64CrtImageException($"CRT CHIP packet length {packetLength} at offset 0x{offset:X} is invalid.");
 
             var rawChipType = ReadUInt16(chipHeader, 8);
@@ -61,7 +61,22 @@ public static class C64CrtParser
             var bank = ReadUInt16(chipHeader, 10);
             var loadAddress = ReadUInt16(chipHeader, 12);
             var imageSize = ReadUInt16(chipHeader, 14);
-            if (imageSize > packetLength - ChipHeaderLength)
+            var minimumPacketLength = ChipHeaderLength + imageSize;
+            var remainingLength = data.Length - offset;
+            var effectivePacketLength = packetLength;
+            if (packetLength > remainingLength)
+            {
+                // Some CRT images in the wild have an overstated final CHIP packet length
+                // while the CHIP payload-size field and actual remaining bytes are correct.
+                // Accept only that exact final-packet case; malformed middle packets, truncated
+                // payloads, and trailing garbage still fail.
+                if (minimumPacketLength == remainingLength)
+                    effectivePacketLength = (uint)minimumPacketLength;
+                else
+                    throw new C64CrtImageException($"CRT CHIP packet length {packetLength} at offset 0x{offset:X} is invalid.");
+            }
+
+            if (imageSize > effectivePacketLength - ChipHeaderLength)
                 throw new C64CrtImageException($"CRT CHIP payload size {imageSize} exceeds its packet length at offset 0x{offset:X}.");
             if (loadAddress + (uint)imageSize > 0x10000)
                 throw new C64CrtImageException($"CRT CHIP at offset 0x{offset:X} crosses the 64K address boundary.");
@@ -73,7 +88,7 @@ public static class C64CrtParser
                 loadAddress,
                 data.Slice(payloadStart, imageSize).ToArray()));
 
-            offset += checked((int)packetLength);
+            offset += checked((int)effectivePacketLength);
         }
 
         if (chips.Count == 0)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtParser.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/Crt/C64CrtParser.cs
@@ -1,0 +1,106 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge.Crt;
+
+public static class C64CrtParser
+{
+    private const int MinimumHeaderLength = 0x40;
+    private const int ChipHeaderLength = 0x10;
+    private const string C64Signature = "C64 CARTRIDGE   ";
+    private const string ChipSignature = "CHIP";
+
+    public static C64CrtImage Parse(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        return Parse(data.AsSpan());
+    }
+
+    public static C64CrtImage Parse(ReadOnlySpan<byte> data)
+    {
+        if (data.Length < MinimumHeaderLength)
+            throw new C64CrtImageException("CRT image is shorter than the 64-byte header.");
+
+        if (!data[..16].SequenceEqual(Encoding.ASCII.GetBytes(C64Signature)))
+            throw new C64CrtImageException("CRT image does not contain the C64 CARTRIDGE signature.");
+
+        var headerLength = ReadUInt32(data, 0x10);
+        if (headerLength < MinimumHeaderLength || headerLength > data.Length)
+            throw new C64CrtImageException($"CRT header length {headerLength} is invalid for an image of {data.Length} bytes.");
+        if (data[0x18] > 1 || data[0x19] > 1)
+            throw new C64CrtImageException("CRT EXROM and GAME header values must be 0 or 1.");
+
+        var header = new C64CrtHeader(
+            headerLength,
+            ReadUInt16(data, 0x14),
+            ReadUInt16(data, 0x16),
+            ExromHigh: data[0x18] != 0,
+            GameHigh: data[0x19] != 0,
+            Subtype: data[0x1A],
+            Name: ReadName(data.Slice(0x20, 32)));
+
+        var chips = new List<C64CrtChip>();
+        var offset = checked((int)headerLength);
+        while (offset < data.Length)
+        {
+            if (data.Length - offset < ChipHeaderLength)
+                throw new C64CrtImageException($"CRT CHIP header at offset 0x{offset:X} is truncated.");
+
+            var chipHeader = data.Slice(offset, ChipHeaderLength);
+            if (!chipHeader[..4].SequenceEqual(Encoding.ASCII.GetBytes(ChipSignature)))
+                throw new C64CrtImageException($"CRT packet at offset 0x{offset:X} does not contain the CHIP signature.");
+
+            var packetLength = ReadUInt32(chipHeader, 4);
+            if (packetLength < ChipHeaderLength || packetLength > data.Length - offset)
+                throw new C64CrtImageException($"CRT CHIP packet length {packetLength} at offset 0x{offset:X} is invalid.");
+
+            var rawChipType = ReadUInt16(chipHeader, 8);
+            if (!Enum.IsDefined(typeof(C64CrtChipType), rawChipType))
+                throw new C64CrtImageException($"CRT CHIP type {rawChipType} at offset 0x{offset:X} is invalid.");
+
+            var bank = ReadUInt16(chipHeader, 10);
+            var loadAddress = ReadUInt16(chipHeader, 12);
+            var imageSize = ReadUInt16(chipHeader, 14);
+            if (imageSize > packetLength - ChipHeaderLength)
+                throw new C64CrtImageException($"CRT CHIP payload size {imageSize} exceeds its packet length at offset 0x{offset:X}.");
+            if (loadAddress + (uint)imageSize > 0x10000)
+                throw new C64CrtImageException($"CRT CHIP at offset 0x{offset:X} crosses the 64K address boundary.");
+
+            var payloadStart = offset + ChipHeaderLength;
+            chips.Add(new C64CrtChip(
+                (C64CrtChipType)rawChipType,
+                bank,
+                loadAddress,
+                data.Slice(payloadStart, imageSize).ToArray()));
+
+            offset += checked((int)packetLength);
+        }
+
+        if (chips.Count == 0)
+            throw new C64CrtImageException("CRT image contains no CHIP packets.");
+
+        return new C64CrtImage(header, chips);
+    }
+
+    public static C64CrtImage Parse(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        using var buffer = new MemoryStream();
+        stream.CopyTo(buffer);
+        return Parse(buffer.ToArray());
+    }
+
+    private static ushort ReadUInt16(ReadOnlySpan<byte> data, int offset)
+        => BinaryPrimitives.ReadUInt16BigEndian(data.Slice(offset, sizeof(ushort)));
+
+    private static uint ReadUInt32(ReadOnlySpan<byte> data, int offset)
+        => BinaryPrimitives.ReadUInt32BigEndian(data.Slice(offset, sizeof(uint)));
+
+    private static string ReadName(ReadOnlySpan<byte> data)
+    {
+        var nullIndex = data.IndexOf((byte)0);
+        if (nullIndex >= 0)
+            data = data[..nullIndex];
+        return Encoding.ASCII.GetString(data).Trim();
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64Cartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64Cartridge.cs
@@ -3,7 +3,9 @@ namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
 public interface IC64Cartridge : IDisposable
 {
     string Name { get; }
-    void MapIOLocations(Memory mem);
+    bool HandlesIOAddress(ushort address);
+    byte ReadIO(ushort address);
+    void WriteIO(ushort address, byte value);
     void MapROMLLocations(Memory mem)
     {
     }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64Cartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64Cartridge.cs
@@ -1,9 +1,15 @@
 namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
 
-public interface IC64CartridgeDevice
+public interface IC64Cartridge : IDisposable
 {
     string Name { get; }
     void MapIOLocations(Memory mem);
+    void MapROMLLocations(Memory mem)
+    {
+    }
+    void MapROMHLocations(Memory mem)
+    {
+    }
     void Tick();
     void Reset();
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64Cartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64Cartridge.cs
@@ -8,12 +8,10 @@ public interface IC64Cartridge : IDisposable
     bool HandlesIOAddress(ushort address);
     byte ReadIO(ushort address);
     void WriteIO(ushort address, byte value);
-    void MapROMLLocations(Memory mem)
-    {
-    }
-    void MapROMHLocations(Memory mem)
-    {
-    }
+    bool HasROML { get; }
+    byte ReadROML(ushort address);
+    bool HasROMH { get; }
+    byte ReadROMH(ushort address);
     void Tick();
     void Reset();
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64Cartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64Cartridge.cs
@@ -5,8 +5,9 @@ public interface IC64Cartridge : IDisposable
     string Name { get; }
     C64CartridgeLines Lines { get; }
     event Action? LinesChanged;
-    bool HandlesIOAddress(ushort address);
+    bool HandlesIORead(ushort address);
     byte ReadIO(ushort address);
+    bool HandlesIOWrite(ushort address);
     void WriteIO(ushort address, byte value);
     bool HasROML { get; }
     byte ReadROML(ushort address);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64Cartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64Cartridge.cs
@@ -7,6 +7,7 @@ public interface IC64Cartridge : IDisposable
     event Action? LinesChanged;
     bool HandlesIORead(ushort address);
     byte ReadIO(ushort address);
+    bool ProvidesIOReadValue(ushort address) => HandlesIORead(address);
     bool HandlesIOWrite(ushort address);
     void WriteIO(ushort address, byte value);
     bool HasROML { get; }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64Cartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64Cartridge.cs
@@ -3,6 +3,8 @@ namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
 public interface IC64Cartridge : IDisposable
 {
     string Name { get; }
+    C64CartridgeLines Lines { get; }
+    event Action? LinesChanged;
     bool HandlesIOAddress(ushort address);
     byte ReadIO(ushort address);
     void WriteIO(ushort address, byte value);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64Cartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64Cartridge.cs
@@ -11,8 +11,11 @@ public interface IC64Cartridge : IDisposable
     void WriteIO(ushort address, byte value);
     bool HasROML { get; }
     byte ReadROML(ushort address);
+    bool HandlesROMLWrite => false;
+    void WriteROML(ushort address, byte value)
+        => throw new InvalidOperationException($"{Name} does not provide writable ROML.");
     bool HasROMH { get; }
     byte ReadROMH(ushort address);
-    void Tick();
+    void Tick(ulong cyclesElapsed = 0);
     void Reset();
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64CartridgeNmiAcknowledgeHandler.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64CartridgeNmiAcknowledgeHandler.cs
@@ -1,0 +1,10 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+
+/// <summary>
+/// Optional capability for cartridges that react when the C64 CPU acknowledges
+/// an NMI, before the NMI vector is fetched.
+/// </summary>
+public interface IC64CartridgeNmiAcknowledgeHandler
+{
+    void AcknowledgeNmi();
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64CartridgeNmiSource.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64CartridgeNmiSource.cs
@@ -1,0 +1,10 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+
+/// <summary>
+/// Optional capability for cartridges that can drive the active-low NMI line.
+/// </summary>
+public interface IC64CartridgeNmiSource
+{
+    bool NmiLineActive { get; }
+    event Action? NmiLineChanged;
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64CartridgeNormalMemoryFallback.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64CartridgeNormalMemoryFallback.cs
@@ -1,0 +1,11 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+
+/// <summary>
+/// Optional capability for cartridges that keep the C64 in a cartridge memory
+/// configuration but need selected cartridge-window reads to pass through to
+/// the C64 memory map as if the cartridge lines were released.
+/// </summary>
+public interface IC64CartridgeNormalMemoryFallback
+{
+    bool UsesNormalMemoryFallbackForROMH(ushort address);
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64FreezableCartridge.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64FreezableCartridge.cs
@@ -1,0 +1,6 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+
+public interface IC64FreezableCartridge
+{
+    void Freeze();
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
 
-public sealed class SwiftLinkDevice : IC64CartridgeDevice
+public sealed class SwiftLinkDevice : IC64Cartridge
 {
     private const byte StatusRxFullBit = 1 << 3;
     private const byte StatusTxEmptyBit = 1 << 4;
@@ -408,5 +408,12 @@ public sealed class SwiftLinkDevice : IC64CartridgeDevice
             $"TRANSPORT_CONNECTED={transport?.IsConnected == true}, NMI_DELIVERABLE={CanDeliverNmi?.Invoke()}, " +
             $"NEXT_RX_CYCLE={_nextReceiveCycleAvailable}, STATUS_READS={_statusReadCount}, " +
             $"HISTORY=[{GetDiagnosticHistory()}]";
+    }
+
+    public void Dispose()
+    {
+        ClearIrqPending();
+        Transport?.Dispose();
+        Transport = null;
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
@@ -98,6 +98,11 @@ public sealed class SwiftLinkDevice : IC64Cartridge
         }
     }
 
+    public bool HasROML => false;
+    public byte ReadROML(ushort address) => throw new InvalidOperationException("SwiftLink does not provide ROML.");
+    public bool HasROMH => false;
+    public byte ReadROMH(ushort address) => throw new InvalidOperationException("SwiftLink does not provide ROMH.");
+
     public void Tick()
     {
         UpdateConnectionState();

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
@@ -44,6 +44,12 @@ public sealed class SwiftLinkDevice : IC64Cartridge
     }
 
     public string Name => "SwiftLink";
+    public C64CartridgeLines Lines => C64CartridgeLines.Released;
+    public event Action? LinesChanged
+    {
+        add { }
+        remove { }
+    }
     public ISwiftLinkTransport? Transport { get; set; }
     public CPUInterrupts? CpuInterrupts { get; set; }
     public C64SwiftLinkInterruptMode InterruptMode { get; set; } = C64SwiftLinkInterruptMode.IRQ;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
@@ -106,7 +106,7 @@ public sealed class SwiftLinkDevice : IC64Cartridge
     public bool HasROMH => false;
     public byte ReadROMH(ushort address) => throw new InvalidOperationException("SwiftLink does not provide ROMH.");
 
-    public void Tick()
+    public void Tick(ulong cyclesElapsed = 0)
     {
         UpdateConnectionState();
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
@@ -56,16 +56,40 @@ public sealed class SwiftLinkDevice : IC64Cartridge
     public ulong ReceivePacingCycles { get; set; }
     public ushort BaseAddress => _baseAddress;
 
-    public void MapIOLocations(Memory mem)
+    public bool HandlesIOAddress(ushort address)
+        => address >= _baseAddress && address <= _baseAddress + 0x03;
+
+    public byte ReadIO(ushort address)
     {
-        mem.MapReader((ushort)(_baseAddress + 0x00), DataLoad);
-        mem.MapWriter((ushort)(_baseAddress + 0x00), DataStore);
-        mem.MapReader((ushort)(_baseAddress + 0x01), StatusLoad);
-        mem.MapWriter((ushort)(_baseAddress + 0x01), StatusStore);
-        mem.MapReader((ushort)(_baseAddress + 0x02), CommandLoad);
-        mem.MapWriter((ushort)(_baseAddress + 0x02), CommandStore);
-        mem.MapReader((ushort)(_baseAddress + 0x03), ControlLoad);
-        mem.MapWriter((ushort)(_baseAddress + 0x03), ControlStore);
+        return (ushort)(address - _baseAddress) switch
+        {
+            0x00 => DataLoad(address),
+            0x01 => StatusLoad(address),
+            0x02 => CommandLoad(address),
+            0x03 => ControlLoad(address),
+            _ => throw new ArgumentOutOfRangeException(nameof(address)),
+        };
+    }
+
+    public void WriteIO(ushort address, byte value)
+    {
+        switch ((ushort)(address - _baseAddress))
+        {
+            case 0x00:
+                DataStore(address, value);
+                break;
+            case 0x01:
+                StatusStore(address, value);
+                break;
+            case 0x02:
+                CommandStore(address, value);
+                break;
+            case 0x03:
+                ControlStore(address, value);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(address));
+        }
     }
 
     public void Tick()
@@ -101,7 +125,7 @@ public sealed class SwiftLinkDevice : IC64Cartridge
         Array.Clear(_diagnosticHistory);
         _diagnosticHistoryNextIndex = 0;
         _diagnosticHistoryCount = 0;
-        ClearIrqPending();
+        ClearAllInterruptSources();
         Transport?.Reset();
     }
 
@@ -295,6 +319,13 @@ public sealed class SwiftLinkDevice : IC64Cartridge
             CpuInterrupts?.SetIRQSourceInactive(IrqSourceName);
     }
 
+    private void ClearAllInterruptSources()
+    {
+        _irqPending = false;
+        CpuInterrupts?.SetIRQSourceInactive(IrqSourceName);
+        CpuInterrupts?.SetNMISourceInactive(IrqSourceName);
+    }
+
     private bool IsCarrierDetected => Transport?.IsCarrierDetected == true;
 
     private bool IsDataSetReady => Transport?.IsDataSetReady == true;
@@ -412,7 +443,7 @@ public sealed class SwiftLinkDevice : IC64Cartridge
 
     public void Dispose()
     {
-        ClearIrqPending();
+        ClearAllInterruptSources();
         Transport?.Dispose();
         Transport = null;
     }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
@@ -62,7 +62,10 @@ public sealed class SwiftLinkDevice : IC64Cartridge
     public ulong ReceivePacingCycles { get; set; }
     public ushort BaseAddress => _baseAddress;
 
-    public bool HandlesIOAddress(ushort address)
+    public bool HandlesIORead(ushort address)
+        => address >= _baseAddress && address <= _baseAddress + 0x03;
+
+    public bool HandlesIOWrite(ushort address)
         => address >= _baseAddress && address <= _baseAddress + 0x03;
 
     public byte ReadIO(ushort address)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Models/Vic2Models.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Models/Vic2Models.cs
@@ -119,7 +119,13 @@ public class Vic2ModelPAL : Vic2ModelBase
 
     public override int ConvertRasterLineToScreenLine(int rasterLine)
     {
-        return rasterLine;
+        var screenLine = rasterLine + (GetVisibleScreenStartLine() - FirstRasterLineOfMainScreen);
+        if (screenLine < 0)
+            screenLine += TotalHeight;
+        else if (screenLine >= TotalHeight)
+            screenLine -= TotalHeight;
+
+        return screenLine;
     }
 
 
@@ -196,6 +202,13 @@ public abstract class Vic2ModelBase
     public abstract int VBlankHeight { get; }
 
     public abstract int ConvertRasterLineToScreenLine(int rasterLine);
+
+    protected int GetVisibleScreenStartLine()
+    {
+        var topInvisibleLines = (int)Math.Floor((TotalHeight - MaxVisibleHeight) / 2.0d);
+        var visibleTopBorderHeight = (int)Math.Floor((MaxVisibleHeight - DrawableAreaHeight) / 2.0d);
+        return topInvisibleLines + visibleTopBorderHeight;
+    }
 
     public bool IsRasterLineInMainScreen(int rasterLine)
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/CustomPayload/C64GpuPacketBuilder.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/CustomPayload/C64GpuPacketBuilder.cs
@@ -176,6 +176,10 @@ public static class C64GpuPacketBuilder
         {
             for (var i = 0; i < charsetData.Length; i++)
             {
+                // This builds the legacy GPU renderer's charset cache from the normal
+                // VIC memory view. Actual VIC-II bus fetches in cartridge/Ultimax
+                // contexts must use Vic2.ReadMemory(...) instead, because Vic2Mem
+                // does not include cartridge ROML/ROMH overlays.
                 charsetData[i].CharLine = c64.Vic2.Vic2Mem[(ushort)(charsetManager.CharacterSetAddressInVIC2Bank + i)];
             }
             ;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/Rasterizer/Vic2RasterizerPixelGenerator.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/Rasterizer/Vic2RasterizerPixelGenerator.cs
@@ -248,8 +248,10 @@ public sealed class Vic2RasterizerUintPixelGenerator
             if (posX < _screenLayoutInclNonVisibleLeftBorderStartX || posX > _screenLayoutInclNonVisibleRightBorderEndX)
                 continue;
 
-            // On a new line
-            if (screenLine != _lastScreenLineDataUpdate)
+            var isNewLine = screenLine != _lastScreenLineDataUpdate;
+
+            // On a new line, refresh from the current VIC-II state.
+            if (isNewLine)
             {
                 // Draw border once per line, after normal screen (to cover up any scrolling?). We take data from previous line.
                 if (_lastScreenLineDataUpdate >= 0)
@@ -260,7 +262,6 @@ public sealed class Vic2RasterizerUintPixelGenerator
                     //Array.Clear(PixelArray_Foreground, 0, PixelArray_Foreground.Length);
                     _clearForegroundPixels(0, _width * _height);
 
-                // C64 screen data is updated each line. TODO: For more accurate rendering, this should be done after each instruction (but may be too slow).
                 _vic2VideoMatrixBaseAddress = _c64.Vic2.VideoMatrixBaseAddress;
                 _vic2BitmapBaseAddress = _c64.Vic2.BitmapManager.BitmapAddressInVIC2Bank;
                 _vic2CharacterSetAddressInVIC2Bank = _c64.Vic2.CharsetManager.CharacterSetAddressInVIC2Bank;
@@ -270,7 +271,6 @@ public sealed class Vic2RasterizerUintPixelGenerator
                 _bitmapMode = _c64.Vic2.BitmapMode;
                 _scrollX = _c64.Vic2.GetScrollX();
                 _scrollY = _c64.Vic2.GetScrollY();
-
 
                 _borderColor = _c64.ReadIOStorage(Vic2Addr.BORDER_COLOR);
 
@@ -747,7 +747,7 @@ public sealed class Vic2RasterizerUintPixelGenerator
         var c64BitMapAddress = (ushort)(_vic2BitmapBaseAddress + characterRow * _vic2ScreenTextCols * 8 + col * 8 + characterLine);
 
         // Determine character code at current position from video matrix
-        var characterCode = c64.Vic2.Vic2Mem[characterAddress];
+        var characterCode = c64.Vic2.ReadMemory(characterAddress);
         var colorRamCode = c64.ReadIOStorage(colorRamAddress);
 
         uint[] eightPixels;
@@ -784,7 +784,7 @@ public sealed class Vic2RasterizerUintPixelGenerator
             var characterSetLineAddress = (ushort)(_vic2CharacterSetAddressInVIC2Bank
                 + characterCode * _vic2ScreenCharacterHeight
                 + characterLine);
-            var lineData = c64.Vic2.Vic2Mem[characterSetLineAddress];
+            var lineData = c64.Vic2.ReadMemory(characterSetLineAddress);
 
             // Get pre-calculated 8 pixels that should be drawn on the bitmap, with correct colors for foreground and background
             if (characterMode == CharMode.Standard || characterMode == CharMode.Extended)
@@ -824,7 +824,7 @@ public sealed class Vic2RasterizerUintPixelGenerator
             // Assume bitmap mode
 
             // 8 bits of bitmap data for the current line, at the current column
-            var bitmapLineData = c64.Vic2.Vic2Mem[c64BitMapAddress];
+            var bitmapLineData = c64.Vic2.ReadMemory(c64BitMapAddress);
 
             // Bg color is picked from text screen, low 4 bits.
             var bitmapBgColorCode = (byte)(characterCode & 0b00001111);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Sharing/C64ShareLinkBuilder.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Sharing/C64ShareLinkBuilder.cs
@@ -27,6 +27,8 @@ public static class C64ShareLinkBuilder
         public const string LoadPrgUrl = "loadPrgUrl";
         public const string LoadD64Url = "loadD64Url";
         public const string LoadCrtUrl = "loadCrtUrl";
+        public const string LoadD64ZipEntry = "loadD64ZipEntry";
+        public const string LoadCrtZipEntry = "loadCrtZipEntry";
         public const string D64Program = "d64Program";
         public const string DiskMount = "diskMount";
         public const string RunLoadedProgram = "runLoadedProgram";
@@ -121,6 +123,8 @@ public static class C64ShareLinkBuilder
             // .d64 / .d64-in-zip: the automation path content-sniffs the bytes. Direct-load a
             // named PRG when one is given (incl. "*" = first file), otherwise mount the disk.
             pairs.Add((QueryKeys.LoadD64Url, request.DownloadUrl));
+            if (!string.IsNullOrWhiteSpace(request.D64ZipEntry))
+                pairs.Add((QueryKeys.LoadD64ZipEntry, request.D64ZipEntry));
             if (!string.IsNullOrEmpty(request.DirectLoadPRGName))
                 pairs.Add((QueryKeys.D64Program, request.DirectLoadPRGName));
             else
@@ -137,6 +141,8 @@ public static class C64ShareLinkBuilder
             throw new ArgumentException("CartridgeImage share mode requires CartridgeUrl.", nameof(request));
 
         pairs.Add((QueryKeys.LoadCrtUrl, request.CartridgeUrl));
+        if (!string.IsNullOrWhiteSpace(request.CartridgeZipEntry))
+            pairs.Add((QueryKeys.LoadCrtZipEntry, request.CartridgeZipEntry));
     }
 
     private static void AddSettingsParams(List<(string, string)> pairs, C64ShareLinkRequest request)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Sharing/C64ShareLinkBuilder.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Sharing/C64ShareLinkBuilder.cs
@@ -26,6 +26,7 @@ public static class C64ShareLinkBuilder
         public const string RunBasic = "runBasic";
         public const string LoadPrgUrl = "loadPrgUrl";
         public const string LoadD64Url = "loadD64Url";
+        public const string LoadCrtUrl = "loadCrtUrl";
         public const string D64Program = "d64Program";
         public const string DiskMount = "diskMount";
         public const string RunLoadedProgram = "runLoadedProgram";
@@ -61,9 +62,12 @@ public static class C64ShareLinkBuilder
         if (!string.IsNullOrWhiteSpace(request.SystemVariant))
             pairs.Add((QueryKeys.SystemVariant, request.SystemVariant));
 
-        // Every share mode starts the system and waits for BASIC to be ready.
+        // Every share mode starts the system. BASIC/PRG/D64 flows also wait for BASIC to be ready.
+        // Cartridge images reset/boot the machine when attached, so they intentionally do not
+        // require waitForSystemReady.
         pairs.Add((QueryKeys.Start, "1"));
-        pairs.Add((QueryKeys.WaitForSystemReady, "1"));
+        if (request.Mode != C64ShareMode.CartridgeImage)
+            pairs.Add((QueryKeys.WaitForSystemReady, "1"));
 
         switch (request.Mode)
         {
@@ -72,6 +76,9 @@ public static class C64ShareLinkBuilder
                 break;
             case C64ShareMode.DownloadProgram:
                 AddDownloadProgramParams(pairs, request);
+                break;
+            case C64ShareMode.CartridgeImage:
+                AddCartridgeImageParams(pairs, request);
                 break;
             default:
                 throw new ArgumentException($"Unknown share mode '{request.Mode}'.", nameof(request));
@@ -122,6 +129,14 @@ public static class C64ShareLinkBuilder
 
         if (request.AutoRun)
             pairs.Add((QueryKeys.RunLoadedProgram, "1"));
+    }
+
+    private static void AddCartridgeImageParams(List<(string, string)> pairs, C64ShareLinkRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.CartridgeUrl))
+            throw new ArgumentException("CartridgeImage share mode requires CartridgeUrl.", nameof(request));
+
+        pairs.Add((QueryKeys.LoadCrtUrl, request.CartridgeUrl));
     }
 
     private static void AddSettingsParams(List<(string, string)> pairs, C64ShareLinkRequest request)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Sharing/C64ShareLinkRequest.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Sharing/C64ShareLinkRequest.cs
@@ -58,8 +58,14 @@ public sealed record C64ShareLinkRequest
     /// <summary>Direct-load this PRG from the .d64 (incl. <c>*</c> = first file); null = mount disk.</summary>
     public string? DirectLoadPRGName { get; init; }
 
+    /// <summary>Optional exact ZIP entry name to extract for a zipped .d64 download.</summary>
+    public string? D64ZipEntry { get; init; }
+
     // --- CartridgeImage mode ---
 
     /// <summary>Clean remote .crt cartridge-image URL — never proxied (CartridgeImage mode).</summary>
     public string? CartridgeUrl { get; init; }
+
+    /// <summary>Optional exact ZIP entry name to extract for a zipped .crt download.</summary>
+    public string? CartridgeZipEntry { get; init; }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Sharing/C64ShareLinkRequest.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Sharing/C64ShareLinkRequest.cs
@@ -10,6 +10,9 @@ public enum C64ShareMode
 
     /// <summary>Download &amp; run a program from a remote URL (.prg or .d64/.d64-in-zip).</summary>
     DownloadProgram,
+
+    /// <summary>Download &amp; attach a .crt cartridge image from a remote URL.</summary>
+    CartridgeImage,
 }
 
 /// <summary>
@@ -54,4 +57,9 @@ public sealed record C64ShareLinkRequest
 
     /// <summary>Direct-load this PRG from the .d64 (incl. <c>*</c> = first file); null = mount disk.</summary>
     public string? DirectLoadPRGName { get; init; }
+
+    // --- CartridgeImage mode ---
+
+    /// <summary>Clean remote .crt cartridge-image URL — never proxied (CartridgeImage mode).</summary>
+    public string? CartridgeUrl { get; init; }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/Cia1.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/Cia1.cs
@@ -28,58 +28,42 @@ public class Cia1 : CiaBase
     public override void MapIOLocations(Memory c64mem)
     {
         // CIA #1 DataPort A
-        c64mem.MapReader(CiaAddr.CIA1_DATAA, DataALoad);
-        c64mem.MapWriter(CiaAddr.CIA1_DATAA, DataAStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA1_DATAA, DataALoad, DataAStore);
 
         // CIA #1 DataPort B
-        c64mem.MapReader(CiaAddr.CIA1_DATAB, DataBLoad);
-        c64mem.MapWriter(CiaAddr.CIA1_DATAB, DataBStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA1_DATAB, DataBLoad, DataBStore);
 
         // CIA #1 Timer A (using base class methods)
-        c64mem.MapReader(CiaAddr.CIA1_TIMAHI, TimerAHILoad);
-        c64mem.MapWriter(CiaAddr.CIA1_TIMAHI, TimerAHIStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA1_TIMAHI, TimerAHILoad, TimerAHIStore);
 
-        c64mem.MapReader(CiaAddr.CIA1_TIMALO, TimerALOLoad);
-        c64mem.MapWriter(CiaAddr.CIA1_TIMALO, TimerALOStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA1_TIMALO, TimerALOLoad, TimerALOStore);
 
         // CIA #1 Timer B (using base class methods)
-        c64mem.MapReader(CiaAddr.CIA1_TIMBHI, TimerBHILoad);
-        c64mem.MapWriter(CiaAddr.CIA1_TIMBHI, TimerBHIStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA1_TIMBHI, TimerBHILoad, TimerBHIStore);
 
-        c64mem.MapReader(CiaAddr.CIA1_TIMBLO, TimerBLOLoad);
-        c64mem.MapWriter(CiaAddr.CIA1_TIMBLO, TimerBLOStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA1_TIMBLO, TimerBLOLoad, TimerBLOStore);
 
         // CIA #1 Interrupt Control Register (using base class methods)
-        c64mem.MapReader(CiaAddr.CIA1_CIAICR, InterruptControlLoad);
-        c64mem.MapWriter(CiaAddr.CIA1_CIAICR, InterruptControlStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA1_CIAICR, InterruptControlLoad, InterruptControlStore);
 
         // CIA #1 Control Register A (using base class methods)
-        c64mem.MapReader(CiaAddr.CIA1_CIACRA, TimerAControlLoad);
-        c64mem.MapWriter(CiaAddr.CIA1_CIACRA, TimerAControlStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA1_CIACRA, TimerAControlLoad, TimerAControlStore);
 
         // CIA #1 Control Register B (using base class methods)
-        c64mem.MapReader(CiaAddr.CIA1_CIACRB, TimerBControlLoad);
-        c64mem.MapWriter(CiaAddr.CIA1_CIACRB, TimerBControlStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA1_CIACRB, TimerBControlLoad, TimerBControlStore);
 
         // CIA #1 Time Of Day registers (temporary debug implementation)
-        c64mem.MapReader(CiaAddr.CIA1_TOD10THS, DebugLoad);
-        c64mem.MapWriter(CiaAddr.CIA1_TOD10THS, DebugStore);
-        c64mem.MapReader(CiaAddr.CIA1_TODSEC, DebugLoad);
-        c64mem.MapWriter(CiaAddr.CIA1_TODSEC, DebugStore);
-        c64mem.MapReader(CiaAddr.CIA1_TODMIN, DebugLoad);
-        c64mem.MapWriter(CiaAddr.CIA1_TODMIN, DebugStore);
-        c64mem.MapReader(CiaAddr.CIA1_TODHR, DebugLoad);
-        c64mem.MapWriter(CiaAddr.CIA1_TODHR, DebugStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA1_TOD10THS, DebugLoad, DebugStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA1_TODSEC, DebugLoad, DebugStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA1_TODMIN, DebugLoad, DebugStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA1_TODHR, DebugLoad, DebugStore);
 
         // CIA #1 Serial Data Register (temporary debug implementation)
-        c64mem.MapReader(CiaAddr.CIA1_SDR, DebugLoad);
-        c64mem.MapWriter(CiaAddr.CIA1_SDR, DebugStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA1_SDR, DebugLoad, DebugStore);
 
         // CIA #1 Data Direction Registers
-        c64mem.MapReader(CiaAddr.CIA1_DDRA, DDRARead);
-        c64mem.MapWriter(CiaAddr.CIA1_DDRA, DDRAWrite);
-        c64mem.MapReader(CiaAddr.CIA1_DDRB, DDRBRead);
-        c64mem.MapWriter(CiaAddr.CIA1_DDRB, DDRBWrite);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA1_DDRA, DDRARead, DDRAWrite);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA1_DDRB, DDRBRead, DDRBWrite);
     }
 
     /// <summary>

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/Cia2.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/Cia2.cs
@@ -18,58 +18,42 @@ public class Cia2 : CiaBase
     public override void MapIOLocations(Memory c64mem)
     {
         // CIA #2 DataPort A (VIC2 bank, serial bus, etc)
-        c64mem.MapReader(CiaAddr.CIA2_DATAA, DataALoad);
-        c64mem.MapWriter(CiaAddr.CIA2_DATAA, DataAStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA2_DATAA, DataALoad, DataAStore);
 
         // CIA #2 DataPort B 
-        c64mem.MapReader(CiaAddr.CIA2_DATAB, DataBLoad);
-        c64mem.MapWriter(CiaAddr.CIA2_DATAB, DataBStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA2_DATAB, DataBLoad, DataBStore);
 
         // CIA #2 Timer A (using base class methods)
-        c64mem.MapReader(CiaAddr.CIA2_TIMAHI, TimerAHILoad);
-        c64mem.MapWriter(CiaAddr.CIA2_TIMAHI, TimerAHIStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA2_TIMAHI, TimerAHILoad, TimerAHIStore);
 
-        c64mem.MapReader(CiaAddr.CIA2_TIMALO, TimerALOLoad);
-        c64mem.MapWriter(CiaAddr.CIA2_TIMALO, TimerALOStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA2_TIMALO, TimerALOLoad, TimerALOStore);
 
         // CIA #2 Timer B (using base class methods)
-        c64mem.MapReader(CiaAddr.CIA2_TIMBHI, TimerBHILoad);
-        c64mem.MapWriter(CiaAddr.CIA2_TIMBHI, TimerBHIStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA2_TIMBHI, TimerBHILoad, TimerBHIStore);
 
-        c64mem.MapReader(CiaAddr.CIA2_TIMBLO, TimerBLOLoad);
-        c64mem.MapWriter(CiaAddr.CIA2_TIMBLO, TimerBLOStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA2_TIMBLO, TimerBLOLoad, TimerBLOStore);
 
         // CIA #2 Interrupt Control Register (using base class methods)
-        c64mem.MapReader(CiaAddr.CIA2_CIAICR, InterruptControlLoad);
-        c64mem.MapWriter(CiaAddr.CIA2_CIAICR, InterruptControlStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA2_CIAICR, InterruptControlLoad, InterruptControlStore);
 
         // CIA #2 Control Register A (using base class methods)
-        c64mem.MapReader(CiaAddr.CIA2_CIACRA, TimerAControlLoad);
-        c64mem.MapWriter(CiaAddr.CIA2_CIACRA, TimerAControlStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA2_CIACRA, TimerAControlLoad, TimerAControlStore);
 
         // CIA #2 Control Register B (using base class methods)
-        c64mem.MapReader(CiaAddr.CIA2_CIACRB, TimerBControlLoad);
-        c64mem.MapWriter(CiaAddr.CIA2_CIACRB, TimerBControlStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA2_CIACRB, TimerBControlLoad, TimerBControlStore);
 
         // CIA #2 Time Of Day registers (temporary debug implementation)
-        c64mem.MapReader(CiaAddr.CIA2_TOD10THS, DebugLoad);
-        c64mem.MapWriter(CiaAddr.CIA2_TOD10THS, DebugStore);
-        c64mem.MapReader(CiaAddr.CIA2_TODSEC, DebugLoad);
-        c64mem.MapWriter(CiaAddr.CIA2_TODSEC, DebugStore);
-        c64mem.MapReader(CiaAddr.CIA2_TODMIN, DebugLoad);
-        c64mem.MapWriter(CiaAddr.CIA2_TODMIN, DebugStore);
-        c64mem.MapReader(CiaAddr.CIA2_TODHR, DebugLoad);
-        c64mem.MapWriter(CiaAddr.CIA2_TODHR, DebugStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA2_TOD10THS, DebugLoad, DebugStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA2_TODSEC, DebugLoad, DebugStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA2_TODMIN, DebugLoad, DebugStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA2_TODHR, DebugLoad, DebugStore);
 
         // CIA #2 Serial Data Register (temporary debug implementation)
-        c64mem.MapReader(CiaAddr.CIA2_SDR, DebugLoad);
-        c64mem.MapWriter(CiaAddr.CIA2_SDR, DebugStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA2_SDR, DebugLoad, DebugStore);
 
         // CIA #2 Data Direction Registers (temporary debug implementation)
-        c64mem.MapReader(CiaAddr.CIA2_DDRA, DebugLoad);
-        c64mem.MapWriter(CiaAddr.CIA2_DDRA, DebugStore);
-        c64mem.MapReader(CiaAddr.CIA2_DDRB, DebugLoad);
-        c64mem.MapWriter(CiaAddr.CIA2_DDRB, DebugStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA2_DDRA, DebugLoad, DebugStore);
+        MapRegisterMirrors(c64mem, CiaAddr.CIA2_DDRB, DebugLoad, DebugStore);
     }
 
     /// <summary>

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaBase.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaBase.cs
@@ -123,6 +123,7 @@ public abstract class CiaBase
 
         // If this address is read, it's contents is automatically cleared ( = all IRQ states are cleared).
         _ciaIRQ.ConditionClearAll();
+        _ciaIRQ.Acknowledge(_c64.CPU);
 
         return value;
     }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaBase.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaBase.cs
@@ -62,12 +62,18 @@ public abstract class CiaBase
         Memory.LoadByte reader,
         Memory.StoreByte writer)
     {
+        c64mem.MapReader(registerAddress, reader);
+        c64mem.MapWriter(registerAddress, writer);
+
         var pageStart = registerAddress & 0xFF00;
         var registerOffset = registerAddress & 0x000F;
 
         for (var offset = registerOffset; offset <= 0x00FF; offset += 0x10)
         {
             var mirrorAddress = (ushort)(pageStart + offset);
+            if (mirrorAddress == registerAddress)
+                continue;
+
             c64mem.MapReader(mirrorAddress, _ => reader(registerAddress));
             c64mem.MapWriter(mirrorAddress, (_, value) => writer(registerAddress, value));
         }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaBase.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaBase.cs
@@ -52,6 +52,28 @@ public abstract class CiaBase
     public abstract void MapIOLocations(Memory c64mem);
 
     /// <summary>
+    /// Map one CIA register and all of its mirrors across the chip's 256-byte I/O page.
+    /// The MOS 6526 only decodes the low 4 address bits, so $DC0D is also visible at
+    /// $DC1D, $DC2D, ..., $DCFD (and likewise for CIA #2 at $DDxx).
+    /// </summary>
+    protected static void MapRegisterMirrors(
+        Memory c64mem,
+        ushort registerAddress,
+        Memory.LoadByte reader,
+        Memory.StoreByte writer)
+    {
+        var pageStart = registerAddress & 0xFF00;
+        var registerOffset = registerAddress & 0x000F;
+
+        for (var offset = registerOffset; offset <= 0x00FF; offset += 0x10)
+        {
+            var mirrorAddress = (ushort)(pageStart + offset);
+            c64mem.MapReader(mirrorAddress, _ => reader(registerAddress));
+            c64mem.MapWriter(mirrorAddress, (_, value) => writer(registerAddress, value));
+        }
+    }
+
+    /// <summary>
     /// Common timer high byte load functionality
     /// </summary>
     protected byte TimerHILoad(CiaTimerType timerType) => _ciaTimers[timerType].InternalTimer.Highbyte();

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaBase.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaBase.cs
@@ -145,8 +145,10 @@ public abstract class CiaBase
         if (_ciaIRQ.IsConditionSet(IRQSource.TimerB))
             value.SetBit((int)IRQSource.TimerB);
 
-        // If any IRQ source is set, also set bit 7.
-        if (value != 0)
+        // Bit 7 is the interrupt-request latch. A CIA source condition can be set
+        // while its mask is disabled; in that case the source bit is reported, but
+        // bit 7 must stay clear because the CIA did not actually drive IRQ/NMI.
+        if (_ciaIRQ.IsConditionSet(IRQSource.Any))
             value.SetBit((int)IRQSource.Any);
 
         // If this address is read, it's contents is automatically cleared ( = all IRQ states are cleared).

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaIRQ.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaIRQ.cs
@@ -63,6 +63,20 @@ public class CiaIRQ
             ConditionClear(source);
         }
     }
+
+    public void Acknowledge(CPU cpu)
+    {
+        foreach (IRQSource source in Enum.GetValues(typeof(IRQSource)))
+        {
+            if (source == IRQSource.Any)
+                continue;
+
+            if (_useNMI)
+                cpu.CPUInterrupts.SetNMISourceInactive(source.ToString());
+            else
+                cpu.CPUInterrupts.SetIRQSourceInactive(source.ToString());
+        }
+    }
 }
 
 /// <summary>

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaIRQ.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaIRQ.cs
@@ -18,6 +18,8 @@ public class CiaIRQ
 
     public void Trigger(IRQSource source, CPU cpu)
     {
+        _sourceConditionStatus[IRQSource.Any] = true;
+
         if (_useNMI)
         {
             // Raise NMI (Non-Maskable Interrupt)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaIRQ.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaIRQ.cs
@@ -2,6 +2,20 @@ namespace Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
 
 public class CiaIRQ
 {
+    // Indexed by IRQSource enum value, which is the corresponding bit position in the CIA interrupt control register.
+    // Bits 5 and 6 are unused in the CIA register, so those entries are intentionally empty and should never be used.
+    private static readonly string[] s_interruptSourceNames =
+    [
+        "CIA.TimerA",
+        "CIA.TimerB",
+        "CIA.TimeOfDayAlarm",
+        "CIA.SerialShiftRegister",
+        "CIA.FlagLine",
+        "",
+        "",
+        "CIA.Any",
+    ];
+
     private readonly bool _useNMI;
     private readonly Dictionary<IRQSource, bool> _sourceEnableStatus = new();
     private readonly Dictionary<IRQSource, bool> _sourceConditionStatus = new();
@@ -19,18 +33,22 @@ public class CiaIRQ
     public void Trigger(IRQSource source, CPU cpu)
     {
         _sourceConditionStatus[IRQSource.Any] = true;
+        var interruptSourceName = GetInterruptSourceName(source);
 
         if (_useNMI)
         {
             // Raise NMI (Non-Maskable Interrupt)
-            cpu.CPUInterrupts.SetNMISourceActive(source.ToString());
+            cpu.CPUInterrupts.SetNMISourceActive(interruptSourceName);
         }
         else
         {
             // Raise IRQ (Interrupt Request)
-            cpu.CPUInterrupts.SetIRQSourceActive(source.ToString(), autoAcknowledge: true);
+            cpu.CPUInterrupts.SetIRQSourceActive(interruptSourceName, autoAcknowledge: true);
         }
     }
+
+    public static string GetInterruptSourceName(IRQSource source)
+        => s_interruptSourceNames[(int)source];
 
     public bool IsEnabled(IRQSource source)
     {
@@ -73,10 +91,11 @@ public class CiaIRQ
             if (source == IRQSource.Any)
                 continue;
 
+            var interruptSourceName = GetInterruptSourceName(source);
             if (_useNMI)
-                cpu.CPUInterrupts.SetNMISourceInactive(source.ToString());
+                cpu.CPUInterrupts.SetNMISourceInactive(interruptSourceName);
             else
-                cpu.CPUInterrupts.SetIRQSourceInactive(source.ToString());
+                cpu.CPUInterrupts.SetIRQSourceInactive(interruptSourceName);
         }
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaTimer.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaTimer.cs
@@ -76,15 +76,22 @@ public class CiaTimer
 
     public void ProcessTimer(ulong cyclesExecuted)
     {
-        if (TimerControl.IsBitSet(_timerControlStartBit) && _timerIsRunning)
-        {
-            if (InternalTimer >= cyclesExecuted)
-                InternalTimer -= (ushort)cyclesExecuted;
-            else
-                InternalTimer = 0;
+        if (!TimerControl.IsBitSet(_timerControlStartBit) || !_timerIsRunning || cyclesExecuted == 0)
+            return;
 
-            if (InternalTimer == 0)
-                _ciaIRQ.ConditionSet(_iRQSource);
+        var cyclesRemaining = cyclesExecuted;
+        while (cyclesRemaining > 0 && TimerControl.IsBitSet(_timerControlStartBit) && _timerIsRunning)
+        {
+            var cyclesUntilUnderflow = GetCyclesUntilUnderflow();
+            if (cyclesRemaining < cyclesUntilUnderflow)
+            {
+                InternalTimer = (ushort)(cyclesUntilUnderflow - cyclesRemaining - 1);
+                return;
+            }
+
+            cyclesRemaining -= cyclesUntilUnderflow;
+            InternalTimer = 0xffff;
+            _ciaIRQ.ConditionSet(_iRQSource);
 
             if (_ciaIRQ.IsConditionSet(_iRQSource))
             {
@@ -95,7 +102,7 @@ public class CiaTimer
                 // Check if timer should be reloaded from latch. If Timer A RunMode bit is clear, timer should be continously reloaded from latch.
                 if (!TimerControl.IsBitSet(_timerControlRunModeBit))
                 {
-                    ResetTimerValue();
+                    ReloadTimerValue();
                 }
                 else
                 {
@@ -105,10 +112,21 @@ public class CiaTimer
         }
     }
 
+    private ulong GetCyclesUntilUnderflow()
+        => InternalTimer == 0
+            ? 0x10000UL
+            : (ulong)InternalTimer + 1;
+
     private void ResetTimerValue()
     {
         InternalTimer = _internalTimer_Latch;
         StartTimer();
+    }
+
+    private void ReloadTimerValue()
+    {
+        InternalTimer = _internalTimer_Latch;
+        _timerIsRunning = true;
     }
 
     public void StartTimer()

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/DiskDrive/D64/Download/D64ZipExtractor.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/DiskDrive/D64/Download/D64ZipExtractor.cs
@@ -1,4 +1,4 @@
-using System.IO.Compression;
+using Highbyte.DotNet6502.Systems.Commodore64.Utils;
 using Microsoft.Extensions.Logging;
 
 namespace Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.DiskDrive.D64.Download;
@@ -15,52 +15,38 @@ namespace Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.DiskDrive.D
 /// </remarks>
 public static class D64ZipExtractor
 {
-    // Local file header signature for a ZIP archive: "PK\x03\x04".
-    private static readonly byte[] ZipLocalFileHeaderSignature = { 0x50, 0x4B, 0x03, 0x04 };
-
     /// <summary>True if the buffer starts with the ZIP local-file-header magic bytes.</summary>
     public static bool LooksLikeZip(ReadOnlySpan<byte> bytes)
-        => bytes.Length >= ZipLocalFileHeaderSignature.Length
-           && bytes[..ZipLocalFileHeaderSignature.Length].SequenceEqual(ZipLocalFileHeaderSignature);
+        => ZipImageExtractor.LooksLikeZip(bytes);
 
     /// <summary>
     /// Returns raw .d64 bytes from <paramref name="bytes"/>: if the buffer is a ZIP archive, the
     /// first .d64 entry is extracted; otherwise the buffer is assumed to already be a .d64 and is
     /// returned unchanged.
     /// </summary>
-    public static byte[] EnsureD64Bytes(byte[] bytes, ILogger? logger = null)
-    {
-        if (!LooksLikeZip(bytes))
-            return bytes;
-
-        logger?.LogInformation("Downloaded bytes are a ZIP archive ({ByteCount} bytes); extracting .d64.", bytes.Length);
-        return ExtractFirstD64FromZip(bytes, logger);
-    }
+    public static byte[] EnsureD64Bytes(byte[] bytes, ILogger? logger = null, string? entryName = null)
+        => ZipImageExtractor.EnsureImageBytes(
+            bytes,
+            ".d64",
+            ZipImageMultipleMatchBehavior.UseFirst,
+            logger,
+            entryName);
 
     /// <summary>Extracts the first <c>.d64</c> entry from an in-memory ZIP archive.</summary>
-    public static byte[] ExtractFirstD64FromZip(byte[] zipBytes, ILogger? logger = null)
-    {
-        using var zipStream = new MemoryStream(zipBytes, writable: false);
-        return ExtractFirstD64FromZip(zipStream, logger);
-    }
+    public static byte[] ExtractFirstD64FromZip(byte[] zipBytes, ILogger? logger = null, string? entryName = null)
+        => ZipImageExtractor.ExtractImageFromZip(
+            zipBytes,
+            ".d64",
+            ZipImageMultipleMatchBehavior.UseFirst,
+            logger,
+            entryName);
 
     /// <summary>Extracts the first <c>.d64</c> entry from a ZIP archive stream.</summary>
-    public static byte[] ExtractFirstD64FromZip(Stream zipStream, ILogger? logger = null)
-    {
-        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
-
-        var d64Entry = archive.Entries.FirstOrDefault(
-                entry => entry.Name.EndsWith(".d64", StringComparison.OrdinalIgnoreCase))
-            ?? throw new InvalidOperationException("No .d64 file found in the ZIP archive");
-
-        logger?.LogInformation("Found .d64 file in ZIP: {EntryName}, size: {ByteCount} bytes", d64Entry.Name, d64Entry.Length);
-
-        // Pre-allocate with the exact uncompressed size and read the entry fully.
-        var d64Bytes = new byte[d64Entry.Length];
-        using var entryStream = d64Entry.Open();
-        entryStream.ReadExactly(d64Bytes);
-
-        logger?.LogInformation("Extracted .d64 file: {ByteCount} bytes", d64Bytes.Length);
-        return d64Bytes;
-    }
+    public static byte[] ExtractFirstD64FromZip(Stream zipStream, ILogger? logger = null, string? entryName = null)
+        => ZipImageExtractor.ExtractImageFromZip(
+            zipStream,
+            ".d64",
+            ZipImageMultipleMatchBehavior.UseFirst,
+            logger,
+            entryName);
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Utils/ZipImageExtractor.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Utils/ZipImageExtractor.cs
@@ -1,0 +1,188 @@
+using System.IO.Compression;
+using Microsoft.Extensions.Logging;
+
+namespace Highbyte.DotNet6502.Systems.Commodore64.Utils;
+
+/// <summary>
+/// Controls what to do when a ZIP archive contains more than one entry matching the requested
+/// image-file extension.
+/// </summary>
+public enum ZipImageMultipleMatchBehavior
+{
+    /// <summary>Extract the first matching entry in the ZIP archive's entry order.</summary>
+    UseFirst,
+
+    /// <summary>Reject the ZIP archive as ambiguous.</summary>
+    Throw,
+}
+
+/// <summary>
+/// Helpers for turning downloaded bytes into raw image bytes, transparently handling the case
+/// where the bytes are actually a ZIP archive containing a matching image file.
+/// </summary>
+public static class ZipImageExtractor
+{
+    // Local file header signature for a ZIP archive: "PK\x03\x04".
+    private static readonly byte[] ZipLocalFileHeaderSignature = { 0x50, 0x4B, 0x03, 0x04 };
+
+    /// <summary>True if the buffer starts with the ZIP local-file-header magic bytes.</summary>
+    public static bool LooksLikeZip(ReadOnlySpan<byte> bytes)
+        => bytes.Length >= ZipLocalFileHeaderSignature.Length
+           && bytes[..ZipLocalFileHeaderSignature.Length].SequenceEqual(ZipLocalFileHeaderSignature);
+
+    /// <summary>
+    /// Returns raw image bytes from <paramref name="bytes"/>: if the buffer is a ZIP archive, a
+    /// matching entry is extracted; otherwise the buffer is assumed to already be the image and is
+    /// returned unchanged.
+    /// </summary>
+    public static byte[] EnsureImageBytes(
+        byte[] bytes,
+        string extension,
+        ZipImageMultipleMatchBehavior multipleMatchBehavior,
+        ILogger? logger = null,
+        string? entryName = null)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        if (!LooksLikeZip(bytes))
+        {
+            if (!string.IsNullOrWhiteSpace(entryName))
+                throw new InvalidOperationException("A ZIP entry was specified, but the supplied bytes are not a ZIP archive.");
+            return bytes;
+        }
+
+        var normalizedExtension = NormalizeExtension(extension);
+        logger?.LogInformation(
+            "Image bytes are a ZIP archive ({ByteCount} bytes); extracting {Extension}.",
+            bytes.Length,
+            normalizedExtension);
+
+        return ExtractImageFromZip(bytes, normalizedExtension, multipleMatchBehavior, logger, entryName);
+    }
+
+    /// <summary>Extracts a matching image entry from an in-memory ZIP archive.</summary>
+    public static byte[] ExtractImageFromZip(
+        byte[] zipBytes,
+        string extension,
+        ZipImageMultipleMatchBehavior multipleMatchBehavior,
+        ILogger? logger = null,
+        string? entryName = null)
+    {
+        ArgumentNullException.ThrowIfNull(zipBytes);
+
+        using var zipStream = new MemoryStream(zipBytes, writable: false);
+        return ExtractImageFromZip(zipStream, extension, multipleMatchBehavior, logger, entryName);
+    }
+
+    /// <summary>Extracts a matching image entry from a ZIP archive stream.</summary>
+    public static byte[] ExtractImageFromZip(
+        Stream zipStream,
+        string extension,
+        ZipImageMultipleMatchBehavior multipleMatchBehavior,
+        ILogger? logger = null,
+        string? entryName = null)
+    {
+        ArgumentNullException.ThrowIfNull(zipStream);
+
+        var normalizedExtension = NormalizeExtension(extension);
+        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+
+        var (imageEntry, matchCount) = string.IsNullOrWhiteSpace(entryName)
+            ? FindEntryByExtension(archive, normalizedExtension, multipleMatchBehavior)
+            : FindEntryByName(archive, normalizedExtension, entryName);
+
+        if (imageEntry.Length > int.MaxValue)
+            throw new InvalidOperationException(
+                $"The ZIP entry '{imageEntry.FullName}' is too large to extract into memory ({imageEntry.Length} bytes).");
+
+        if (matchCount > 1)
+        {
+            logger?.LogInformation(
+                "Found {MatchCount} {Extension} files in ZIP; using first entry: {EntryName}.",
+                matchCount,
+                normalizedExtension,
+                imageEntry.FullName);
+        }
+        else
+        {
+            logger?.LogInformation(
+                "Found {Extension} file in ZIP: {EntryName}, size: {ByteCount} bytes.",
+                normalizedExtension,
+                imageEntry.FullName,
+                imageEntry.Length);
+        }
+
+        // Pre-allocate with the exact uncompressed size and read the entry fully.
+        var imageBytes = new byte[imageEntry.Length];
+        using var entryStream = imageEntry.Open();
+        entryStream.ReadExactly(imageBytes);
+
+        logger?.LogInformation(
+            "Extracted {Extension} file: {ByteCount} bytes.",
+            normalizedExtension,
+            imageBytes.Length);
+        return imageBytes;
+    }
+
+    private static (ZipArchiveEntry Entry, int MatchCount) FindEntryByExtension(
+        ZipArchive archive,
+        string normalizedExtension,
+        ZipImageMultipleMatchBehavior multipleMatchBehavior)
+    {
+        var matches = archive.Entries
+            .Where(entry => entry.Name.EndsWith(normalizedExtension, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (matches.Count == 0)
+            throw new InvalidOperationException($"No {normalizedExtension} file found in the ZIP archive");
+
+        if (matches.Count > 1 && multipleMatchBehavior == ZipImageMultipleMatchBehavior.Throw)
+        {
+            var names = string.Join(", ", matches.Select(entry => entry.FullName));
+            throw new InvalidOperationException(
+                $"Multiple {normalizedExtension} files found in the ZIP archive; refusing to choose automatically: {names}");
+        }
+
+        return (matches[0], matches.Count);
+    }
+
+    private static (ZipArchiveEntry Entry, int MatchCount) FindEntryByName(
+        ZipArchive archive,
+        string normalizedExtension,
+        string entryName)
+    {
+        var normalizedEntryName = NormalizeEntryName(entryName);
+        if (!normalizedEntryName.EndsWith(normalizedExtension, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"ZIP entry '{normalizedEntryName}' must be a {normalizedExtension} file.");
+        }
+
+        var entry = archive.GetEntry(normalizedEntryName)
+            ?? throw new InvalidOperationException($"ZIP entry '{normalizedEntryName}' was not found in the archive.");
+
+        if (string.IsNullOrEmpty(entry.Name))
+            throw new InvalidOperationException($"ZIP entry '{normalizedEntryName}' is a directory, not a file.");
+
+        return (entry, 1);
+    }
+
+    private static string NormalizeExtension(string extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+            throw new ArgumentException("Image extension must be supplied.", nameof(extension));
+
+        extension = extension.Trim();
+        return extension.StartsWith(".", StringComparison.Ordinal)
+            ? extension
+            : "." + extension;
+    }
+
+    private static string NormalizeEntryName(string entryName)
+    {
+        if (string.IsNullOrWhiteSpace(entryName))
+            throw new ArgumentException("ZIP entry name must be supplied.", nameof(entryName));
+
+        return entryName.Trim().Replace('\\', '/').TrimStart('/');
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2.cs
@@ -110,8 +110,8 @@ public class Vic2
         public byte SpriteMultiColor1;
         public int ScrollX;
         public int ScrollY;
-        public bool ColMode40;
-        public bool RowMode25;
+        public bool ColMode40 = true;
+        public bool RowMode25 = true;
 
         public object Clone()
         {
@@ -169,74 +169,78 @@ public class Vic2
         // TODO: Make common init like this that covers all IO locations, not only VIC2: SID, CIA, etc.
         //       Then all that need specific logic writes special mapping below (will overwrite above).
 
+        // Addresses 0xd000 - 0xd00f: Sprite X/Y coordinates.
+        for (ushort address = Vic2Addr.SPRITE_0_X; address <= Vic2Addr.SPRITE_7_Y; address++)
+        {
+            MapRegisterMirrors(c64Mem, address, C64.ReadIOStorage, C64.WriteIOStorage);
+        }
+
+        // Address 0xd010: Sprite X position MSB.
+        MapRegisterMirrors(c64Mem, Vic2Addr.SPRITE_MSB_X, C64.ReadIOStorage, C64.WriteIOStorage);
+
         // Address 0xd011: "Vertical Fine Scrollling and Screen Control Register"
-        c64Mem.MapReader(Vic2Addr.SCROLL_Y_AND_SCREEN_CONTROL_REGISTER, ScrCtrlReg1Load);
-        c64Mem.MapWriter(Vic2Addr.SCROLL_Y_AND_SCREEN_CONTROL_REGISTER, ScrCtrlReg1Store);
+        MapRegisterMirrors(c64Mem, Vic2Addr.SCROLL_Y_AND_SCREEN_CONTROL_REGISTER, ScrCtrlReg1Load, ScrCtrlReg1Store);
 
         // Address 0xd012: "Current Raster Line"
-        c64Mem.MapReader(Vic2Addr.CURRENT_RASTER_LINE, RasterLoad);
-        c64Mem.MapWriter(Vic2Addr.CURRENT_RASTER_LINE, RasterStore);
+        MapRegisterMirrors(c64Mem, Vic2Addr.CURRENT_RASTER_LINE, RasterLoad, RasterStore);
+
+        // Addresses 0xd013 - 0xd014: Light pen X/Y latches.
+        MapRegisterMirrors(c64Mem, 0xD013, C64.ReadIOStorage, C64.WriteIOStorage);
+        MapRegisterMirrors(c64Mem, 0xD014, C64.ReadIOStorage, C64.WriteIOStorage);
 
         // Address 0xd015: "Sprite enable"
-        c64Mem.MapReader(Vic2Addr.SPRITE_ENABLE, SpriteEnableLoad);
-        c64Mem.MapWriter(Vic2Addr.SPRITE_ENABLE, SpriteEnableStore);
+        MapRegisterMirrors(c64Mem, Vic2Addr.SPRITE_ENABLE, SpriteEnableLoad, SpriteEnableStore);
 
         // Address 0xd016: "Horizontal Fine Scrolling and Screen Control Register"
-        c64Mem.MapReader(Vic2Addr.SCROLL_X_AND_SCREEN_CONTROL_REGISTER, ScrollXLoad);
-        c64Mem.MapWriter(Vic2Addr.SCROLL_X_AND_SCREEN_CONTROL_REGISTER, ScrollXStore);
+        MapRegisterMirrors(c64Mem, Vic2Addr.SCROLL_X_AND_SCREEN_CONTROL_REGISTER, ScrollXLoad, ScrollXStore);
+
+        // Address 0xd017: Sprite Y expansion.
+        MapRegisterMirrors(c64Mem, Vic2Addr.SPRITE_Y_EXPAND, C64.ReadIOStorage, C64.WriteIOStorage);
 
         // Address 0xd018: "Memory setup" (VIC2 pointer for charset/bitmap & screen memory)
-        c64Mem.MapReader(Vic2Addr.MEMORY_SETUP, MemorySetupLoad);
-        c64Mem.MapWriter(Vic2Addr.MEMORY_SETUP, MemorySetupStore);
+        MapRegisterMirrors(c64Mem, Vic2Addr.MEMORY_SETUP, MemorySetupLoad, MemorySetupStore);
 
         // Address 0xd019: "VIC Interrupt Flag Register"
-        c64Mem.MapReader(Vic2Addr.VIC_IRQ, VICIRQLoad);
-        c64Mem.MapWriter(Vic2Addr.VIC_IRQ, VICIRQStore);
+        MapRegisterMirrors(c64Mem, Vic2Addr.VIC_IRQ, VICIRQLoad, VICIRQStore);
 
         // Address 0xd01a: "IRQ Mask Register"
-        c64Mem.MapReader(Vic2Addr.IRQ_MASK, IRQMASKLoad);
-        c64Mem.MapWriter(Vic2Addr.IRQ_MASK, IRQMASKStore);
+        MapRegisterMirrors(c64Mem, Vic2Addr.IRQ_MASK, IRQMASKLoad, IRQMASKStore);
+
+        // Address 0xd01b: Sprite/background priority.
+        MapRegisterMirrors(c64Mem, Vic2Addr.SPRITE_FOREGROUND_PRIO, C64.ReadIOStorage, C64.WriteIOStorage);
 
         // Address 0xd01c: "Sprite multi-color enable"
-        c64Mem.MapReader(Vic2Addr.SPRITE_MULTICOLOR_ENABLE, SpriteMultiColorEnableLoad);
-        c64Mem.MapWriter(Vic2Addr.SPRITE_MULTICOLOR_ENABLE, SpriteMultiColorEnableStore);
+        MapRegisterMirrors(c64Mem, Vic2Addr.SPRITE_MULTICOLOR_ENABLE, SpriteMultiColorEnableLoad, SpriteMultiColorEnableStore);
+
+        // Address 0xd01d: Sprite X expansion.
+        MapRegisterMirrors(c64Mem, Vic2Addr.SPRITE_X_EXPAND, C64.ReadIOStorage, C64.WriteIOStorage);
 
         // Address 0xd01e: "Sprite-to-sprite collision"
-        c64Mem.MapReader(Vic2Addr.SPRITE_TO_SPRITE_COLLISION, SpriteToSpriteCollisionLoad);
-        c64Mem.MapWriter(Vic2Addr.SPRITE_TO_SPRITE_COLLISION, SpriteToSpriteCollisionStore);
+        MapRegisterMirrors(c64Mem, Vic2Addr.SPRITE_TO_SPRITE_COLLISION, SpriteToSpriteCollisionLoad, SpriteToSpriteCollisionStore);
 
         // Address 0xd01f: "Sprite-to-background collision"
-        c64Mem.MapReader(Vic2Addr.SPRITE_TO_BACKGROUND_COLLISION, SpriteToBackgroundCollisionLoad);
-        c64Mem.MapWriter(Vic2Addr.SPRITE_TO_BACKGROUND_COLLISION, SpriteToBackgroundCollisionStore);
+        MapRegisterMirrors(c64Mem, Vic2Addr.SPRITE_TO_BACKGROUND_COLLISION, SpriteToBackgroundCollisionLoad, SpriteToBackgroundCollisionStore);
 
         // Address 0xd020: Border color
-        c64Mem.MapReader(Vic2Addr.BORDER_COLOR, BorderColorLoad);
-        c64Mem.MapWriter(Vic2Addr.BORDER_COLOR, BorderColorStore);
+        MapRegisterMirrors(c64Mem, Vic2Addr.BORDER_COLOR, BorderColorLoad, BorderColorStore);
         // Address 0xd021: Background color 0
-        c64Mem.MapReader(Vic2Addr.BACKGROUND_COLOR_0, BackgroundColorLoad);
-        c64Mem.MapWriter(Vic2Addr.BACKGROUND_COLOR_0, BackgroundColorStore);
+        MapRegisterMirrors(c64Mem, Vic2Addr.BACKGROUND_COLOR_0, BackgroundColorLoad, BackgroundColorStore);
         // Address 0xd022: Background color 1
-        c64Mem.MapReader(Vic2Addr.BACKGROUND_COLOR_1, BackgroundColorLoad);
-        c64Mem.MapWriter(Vic2Addr.BACKGROUND_COLOR_1, BackgroundColorStore);
+        MapRegisterMirrors(c64Mem, Vic2Addr.BACKGROUND_COLOR_1, BackgroundColorLoad, BackgroundColorStore);
         // Address 0xd023: Background color 2
-        c64Mem.MapReader(Vic2Addr.BACKGROUND_COLOR_2, BackgroundColorLoad);
-        c64Mem.MapWriter(Vic2Addr.BACKGROUND_COLOR_2, BackgroundColorStore);
+        MapRegisterMirrors(c64Mem, Vic2Addr.BACKGROUND_COLOR_2, BackgroundColorLoad, BackgroundColorStore);
         // Address 0xd024: Background color 3
-        c64Mem.MapReader(Vic2Addr.BACKGROUND_COLOR_3, BackgroundColorLoad);
-        c64Mem.MapWriter(Vic2Addr.BACKGROUND_COLOR_3, BackgroundColorStore);
+        MapRegisterMirrors(c64Mem, Vic2Addr.BACKGROUND_COLOR_3, BackgroundColorLoad, BackgroundColorStore);
 
         // Address 0xd025: Sprite multi-color 0
-        c64Mem.MapReader(Vic2Addr.SPRITE_MULTI_COLOR_0, SpriteMultiColor0Load);
-        c64Mem.MapWriter(Vic2Addr.SPRITE_MULTI_COLOR_0, SpriteMultiColor0Store);
+        MapRegisterMirrors(c64Mem, Vic2Addr.SPRITE_MULTI_COLOR_0, SpriteMultiColor0Load, SpriteMultiColor0Store);
         // Address 0xd026: Sprite multi-color 1
-        c64Mem.MapReader(Vic2Addr.SPRITE_MULTI_COLOR_1, SpriteMultiColor1Load);
-        c64Mem.MapWriter(Vic2Addr.SPRITE_MULTI_COLOR_1, SpriteMultiColor1Store);
+        MapRegisterMirrors(c64Mem, Vic2Addr.SPRITE_MULTI_COLOR_1, SpriteMultiColor1Load, SpriteMultiColor1Store);
 
         // Addresses 0xd027 - 0xd02e: Sprite colors
         for (ushort address = Vic2Addr.SPRITE_0_COLOR; address <= Vic2Addr.SPRITE_7_COLOR; address++)
         {
-            c64Mem.MapReader(address, SpriteColorLoad);
-            c64Mem.MapWriter(address, SpriteColorStore);
+            MapRegisterMirrors(c64Mem, address, SpriteColorLoad, SpriteColorStore);
         }
 
         // Addresses 0xd800 - 0xdbe7:  Color RAM is always at fixed location. 1 byte per character in screen ram = 0x03e8 (1000) bytes)
@@ -244,6 +248,31 @@ public class Vic2
         {
             c64Mem.MapReader(address, ColorRAMLoad);
             c64Mem.MapWriter(address, ColorRAMStore);
+        }
+    }
+
+    private void MapRegisterMirrors(
+        Memory c64Mem,
+        ushort registerAddress,
+        Memory.LoadByte reader,
+        Memory.StoreByte writer)
+    {
+        c64Mem.MapReader(registerAddress, reader);
+        c64Mem.MapWriter(registerAddress, writer);
+
+        var registerOffset = registerAddress & 0x003F;
+
+        for (var offset = registerOffset; offset <= 0x03FF; offset += 0x40)
+        {
+            var mirrorAddress = (ushort)(0xD000 + offset);
+            if (mirrorAddress == registerAddress)
+                continue;
+
+            c64Mem.MapReader(mirrorAddress, _ => reader(registerAddress));
+            c64Mem.MapWriter(mirrorAddress, (_, value) =>
+            {
+                writer(registerAddress, value);
+            });
         }
     }
 
@@ -578,6 +607,103 @@ public class Vic2
             CharsetManager.NotifyCharsetAddressChanged();
             SpriteManager.SetAllChanged(Vic2SpriteChangeType.Data);
         }
+    }
+
+    /// <summary>
+    /// Reads memory as the VIC-II sees it on its video bus.
+    /// </summary>
+    /// <remarks>
+    /// Use this for all actual VIC-II fetches: screen matrix bytes, character/bitmap
+    /// graphics bytes, sprite pointers, and sprite data. Those fetches are not always
+    /// equivalent to <see cref="Vic2Mem"/> reads.
+    ///
+    /// The common path still uses <see cref="Vic2Mem"/>, which models normal 16 KB
+    /// VIC bank selection plus chargen shadows and is kept in sync by
+    /// <see cref="SetVIC2Bank(byte)"/>. The slower cartridge-aware path is only used
+    /// when a cartridge is attached and the current memory configuration can expose
+    /// cartridge ROM to the VIC-II. In Ultimax/MAX mode, freezer cartridges such as
+    /// Final Cartridge III can expose ROML/ROMH to the VIC-II; their freezer menu may
+    /// fetch graphics/sprite data from cartridge ROM instead of the underlying C64
+    /// RAM.
+    ///
+    /// Direct <see cref="Vic2Mem"/> access is still useful for non-bus purposes such
+    /// as maintaining the legacy banked memory view or tests that intentionally inspect
+    /// underlying RAM/chargen mapping, but renderer fetch paths should prefer this
+    /// method.
+    /// </remarks>
+    public byte ReadMemory(ushort vic2Address)
+    {
+        // Hot path: most frames run without a cartridge, and many attached cartridges
+        // are not visible to the VIC-II in the current memory mode. In those cases,
+        // the old banked Vic2Mem lookup is still the correct and cheapest fetch.
+        // Current renderer/sprite callers are expected to pass 14-bit VIC-II
+        // addresses ($0000-$3fff), as they did when accessing Vic2Mem directly.
+        if (C64.CartridgeSlot.AttachedCartridge == null)
+            return Vic2Mem[vic2Address];
+        if (!IsCartridgeMemoryVisibleToVic())
+            return Vic2Mem[vic2Address];
+
+        return ReadMemoryWithCartridge(CurrentVIC2Bank, vic2Address);
+    }
+
+    private byte ReadMemoryWithCartridge(byte vic2Bank, ushort vic2Address)
+    {
+        vic2Address &= 0x3FFF;
+        var c64RamAddress = ResolveC64RamAddress(vic2Bank, vic2Address);
+        if (c64RamAddress.HasValue && TryReadCartridgeMemoryForVic(c64RamAddress.Value, out var cartridgeValue))
+            return cartridgeValue;
+
+        return vic2Bank switch
+        {
+            0 => vic2Address is >= 0x1000 and < 0x2000
+                ? C64.ROMData[C64SystemConfig.CHARGEN_ROM_NAME][vic2Address - 0x1000]
+                : C64.RAM[vic2Address],
+            1 => C64.RAM[0x4000 + vic2Address],
+            2 => vic2Address is >= 0x1000 and < 0x2000
+                ? C64.ROMData[C64SystemConfig.CHARGEN_ROM_NAME][vic2Address - 0x1000]
+                : C64.RAM[0x8000 + vic2Address],
+            3 => C64.RAM[0xC000 + vic2Address],
+            _ => throw new ArgumentOutOfRangeException(nameof(vic2Bank), vic2Bank, "VIC-II bank must be 0-3.")
+        };
+    }
+
+    private bool IsCartridgeMemoryVisibleToVic()
+        => (C64.CurrentBank & 0x18) == 0x10;
+
+    private bool TryReadCartridgeMemoryForVic(ushort c64Address, out byte value)
+    {
+        value = 0;
+
+        var cartridge = C64.CartridgeSlot.AttachedCartridge;
+        if (cartridge == null)
+            return false;
+
+        if (c64Address is >= 0x8000 and <= 0x9FFF && cartridge.HasROML)
+        {
+            value = cartridge.ReadROML(c64Address);
+            return true;
+        }
+
+        if (c64Address >= 0xE000 && cartridge.HasROMH)
+        {
+            value = cartridge.ReadROMH(c64Address);
+            return true;
+        }
+
+        return false;
+    }
+
+    public ushort? ResolveC64RamAddress(byte vic2Bank, ushort vic2Address)
+    {
+        vic2Address &= 0x3FFF;
+        return vic2Bank switch
+        {
+            0 => vic2Address is >= 0x1000 and < 0x2000 ? null : vic2Address,
+            1 => (ushort)(0x4000 + vic2Address),
+            2 => vic2Address is >= 0x1000 and < 0x2000 ? null : (ushort)(0x8000 + vic2Address),
+            3 => (ushort)(0xC000 + vic2Address),
+            _ => throw new ArgumentOutOfRangeException(nameof(vic2Bank), vic2Bank, "VIC-II bank must be 0-3.")
+        };
     }
 
     public void ScrCtrlReg1Store(ushort address, byte value)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2.cs
@@ -644,7 +644,7 @@ public class Vic2
                 if (source == IRQSource.Any)
                     continue;
                 // Clear all individual latches.
-                if (Vic2IRQ.IsTriggered(source, C64.CPU))
+                if (Vic2IRQ.IsTriggered(source))
                     Vic2IRQ.ClearTrigger(source, C64.CPU);
             }
         }
@@ -657,7 +657,7 @@ public class Vic2
                 if (source == IRQSource.Any)
                     continue;
                 // Clear individual latch.
-                if (value.IsBitSet((int)source) && Vic2IRQ.IsTriggered(source, C64.CPU))
+                if (value.IsBitSet((int)source) && Vic2IRQ.IsTriggered(source))
                     Vic2IRQ.ClearTrigger(source, C64.CPU);
             }
         }
@@ -667,21 +667,22 @@ public class Vic2
     {
         byte value = 0b01110000;    // Bits 4-7 are unused and always set to 1.
 
-        bool anyIRQSourceTriggered = false;
+        bool irqLineAsserted = false;
         // Set bit 0-3 based on which IRQ sources have been triggered
         foreach (IRQSource source in Enum.GetValues(typeof(IRQSource)))
         {
             // "Any" flag does not have a separate trigger.
             if (source == IRQSource.Any)
                 continue;
-            if (Vic2IRQ.IsTriggered(source, C64.CPU))
+            if (Vic2IRQ.IsTriggered(source))
             {
                 value.SetBit((int)source);
-                anyIRQSourceTriggered = true;
+                if (Vic2IRQ.IsEnabled(source))
+                    irqLineAsserted = true;
             }
         }
-        // If any of the individual IRQ flags are set, also set the "Any" flag (bit 7)
-        if (anyIRQSourceTriggered)
+        // Bit 7 reflects the IRQ output, so a latched source must also be enabled.
+        if (irqLineAsserted)
             value.SetBit((int)IRQSource.Any);
         else
             value.ClearBit((int)IRQSource.Any);
@@ -696,9 +697,9 @@ public class Vic2
             if (source == IRQSource.Any)
                 continue;
             if (value.IsBitSet((int)source))
-                Vic2IRQ.Enable(source);
+                Vic2IRQ.Enable(source, C64.CPU);
             else
-                Vic2IRQ.Disable(source);
+                Vic2IRQ.Disable(source, C64.CPU);
         }
     }
     public byte IRQMASKLoad(ushort _)
@@ -766,8 +767,7 @@ public class Vic2
         var source = IRQSource.RasterCompare;
         if ((_currentRasterLineInternal == Vic2IRQ.ConfiguredIRQRasterLine
             || (!Vic2IRQ.ConfiguredIRQRasterLine.HasValue & _currentRasterLineInternal >= Vic2Model.TotalHeight))
-            && Vic2IRQ.IsEnabled(source)
-            && !Vic2IRQ.IsTriggered(source, C64.CPU))
+            && !Vic2IRQ.IsTriggered(source))
         {
             Vic2IRQ.Trigger(source, cpu);
         }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2IRQ.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2IRQ.cs
@@ -2,6 +2,20 @@ namespace Highbyte.DotNet6502.Systems.Commodore64.Video;
 
 public class Vic2IRQ
 {
+    // Indexed by IRQSource enum value, which is the corresponding bit position in the VIC-II interrupt register.
+    // Bits 4, 5 and 6 are unused in the VIC-II register, so those entries are intentionally empty and should never be used.
+    private static readonly string[] s_interruptSourceNames =
+    [
+        "VIC2.RasterCompare",
+        "VIC2.SpriteToSpriteCollision",
+        "VIC2.SpriteToBackgroundCollision",
+        "VIC2.LightPenTrigger",
+        "",
+        "",
+        "",
+        "VIC2.Any",
+    ];
+
     // ConfiguredIRQRasterLine = null means not configured yet, and raster IRQ should occur when raster line wraps around from it's max (defined by C64/VIC2 model) to 0.
     public ushort? ConfiguredIRQRasterLine { get; set; } = null;
 
@@ -25,12 +39,12 @@ public class Vic2IRQ
     {
         _sourceEnableStatus[source] = true;
         if (_sourceTriggerStatus[source])
-            cpu.CPUInterrupts.SetIRQSourceActive(source.ToString(), autoAcknowledge: false);
+            cpu.CPUInterrupts.SetIRQSourceActive(GetInterruptSourceName(source), autoAcknowledge: false);
     }
     public void Disable(IRQSource source, CPU cpu)
     {
         _sourceEnableStatus[source] = false;
-        cpu.CPUInterrupts.SetIRQSourceInactive(source.ToString());
+        cpu.CPUInterrupts.SetIRQSourceInactive(GetInterruptSourceName(source));
     }
 
     public bool IsTriggered(IRQSource source)
@@ -42,13 +56,16 @@ public class Vic2IRQ
     {
         _sourceTriggerStatus[source] = true;
         if (_sourceEnableStatus[source])
-            cpu.CPUInterrupts.SetIRQSourceActive(source.ToString(), autoAcknowledge: false);
+            cpu.CPUInterrupts.SetIRQSourceActive(GetInterruptSourceName(source), autoAcknowledge: false);
     }
     public void ClearTrigger(IRQSource source, CPU cpu)
     {
         _sourceTriggerStatus[source] = false;
-        cpu.CPUInterrupts.SetIRQSourceInactive(source.ToString());
+        cpu.CPUInterrupts.SetIRQSourceInactive(GetInterruptSourceName(source));
     }
+
+    public static string GetInterruptSourceName(IRQSource source)
+        => s_interruptSourceNames[(int)source];
 }
 
 /// <summary>

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2IRQ.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2IRQ.cs
@@ -6,12 +6,14 @@ public class Vic2IRQ
     public ushort? ConfiguredIRQRasterLine { get; set; } = null;
 
     private readonly Dictionary<IRQSource, bool> _sourceEnableStatus = new();
+    private readonly Dictionary<IRQSource, bool> _sourceTriggerStatus = new();
 
     public Vic2IRQ()
     {
         foreach (IRQSource source in Enum.GetValues(typeof(IRQSource)))
         {
             _sourceEnableStatus.Add(source, false);
+            _sourceTriggerStatus.Add(source, false);
         }
     }
 
@@ -19,26 +21,32 @@ public class Vic2IRQ
     {
         return _sourceEnableStatus[source];
     }
-    public void Enable(IRQSource source)
+    public void Enable(IRQSource source, CPU cpu)
     {
         _sourceEnableStatus[source] = true;
+        if (_sourceTriggerStatus[source])
+            cpu.CPUInterrupts.SetIRQSourceActive(source.ToString(), autoAcknowledge: false);
     }
-    public void Disable(IRQSource source)
+    public void Disable(IRQSource source, CPU cpu)
     {
         _sourceEnableStatus[source] = false;
+        cpu.CPUInterrupts.SetIRQSourceInactive(source.ToString());
     }
 
-    public bool IsTriggered(IRQSource source, CPU cpu)
+    public bool IsTriggered(IRQSource source)
     {
-        return cpu.CPUInterrupts.IsIRQSourceActive(source.ToString());
+        return _sourceTriggerStatus[source];
     }
 
     public void Trigger(IRQSource source, CPU cpu)
     {
-        cpu.CPUInterrupts.SetIRQSourceActive(source.ToString(), autoAcknowledge: false);
+        _sourceTriggerStatus[source] = true;
+        if (_sourceEnableStatus[source])
+            cpu.CPUInterrupts.SetIRQSourceActive(source.ToString(), autoAcknowledge: false);
     }
     public void ClearTrigger(IRQSource source, CPU cpu)
     {
+        _sourceTriggerStatus[source] = false;
         cpu.CPUInterrupts.SetIRQSourceInactive(source.ToString());
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2Sprite.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2Sprite.cs
@@ -65,7 +65,7 @@ public class Vic2Sprite
 
     private void BuildSpriteData()
     {
-        var spritePointer = _vic2.Vic2Mem[(ushort)(_spriteManager.SpritePointerStartAddress + SpriteNumber)];
+        var spritePointer = _vic2.ReadMemory((ushort)(_spriteManager.SpritePointerStartAddress + SpriteNumber));
         var spritePointerAddress = (ushort)(spritePointer * 64);
 
         var bytesPerRow = DEFAULT_WIDTH / 8;
@@ -76,7 +76,7 @@ public class Vic2Sprite
             for (int rowByte = 0; rowByte < bytesPerRow; rowByte++)
             {
                 var byteAddr = spritePointerAddress + (row * bytesPerRow) + rowByte;
-                var spriteRowByte = _vic2.Vic2Mem[(ushort)(byteAddr)];
+                var spriteRowByte = _vic2.ReadMemory((ushort)byteAddr);
                 _data.Rows[row].Bytes[rowByte] = spriteRowByte;
                 rowHasPixels |= spriteRowByte != 0;
             }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2SpriteManager.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2SpriteManager.cs
@@ -98,7 +98,7 @@ public class Vic2SpriteManager : IVic2SpriteManager
         if (((SpriteToSpriteCollisionStore != 0 && !SpriteToSpriteCollisionIRQBlock)
             || (SpriteToBackgroundCollisionStore != 0 && !SpriteToBackgroundCollisionIRQBlock))
             && Vic2.Vic2IRQ.IsEnabled(source)
-            && !Vic2.Vic2IRQ.IsTriggered(source, Vic2.C64.CPU))
+            && !Vic2.Vic2IRQ.IsTriggered(source))
         {
             Vic2.Vic2IRQ.Trigger(source, Vic2.C64.CPU);
             if (SpriteToSpriteCollisionStore != 0)

--- a/src/libraries/Highbyte.DotNet6502/CPU.cs
+++ b/src/libraries/Highbyte.DotNet6502/CPU.cs
@@ -124,6 +124,19 @@ public class CPU
         handler?.Invoke(this, e);
     }
 
+    /// <summary>
+    /// Raised when the CPU is about to service a pending hardware NMI, before the
+    /// vector at $FFFA/$FFFB is read. Some C64 expansion-port hardware changes
+    /// memory mapping as part of NMI acknowledgement, so system integrations can
+    /// use this boundary to expose the vector that the real machine would see.
+    /// </summary>
+    public event EventHandler? NmiAcknowledging;
+    protected virtual void OnNmiAcknowledging()
+    {
+        var handler = NmiAcknowledging;
+        handler?.Invoke(this, EventArgs.Empty);
+    }
+
     // Per-instruction event-firing helpers. Each snapshots the delegate first to avoid
     // the standard event-race (subscriber detaches between null check and invocation)
     // and skips the EventArgs allocation when no subscriber is attached -- a measurable
@@ -330,6 +343,7 @@ public class CPU
 
         if (CPUInterrupts.NMIPending)
         {
+            OnNmiAcknowledging();
             ushort nmiVector = FetchWord(mem, CPU.NonMaskableIRQHandlerVector);
             _logger.LogDebug(
                 "Servicing NMI. PC={PC:X4}, Vector={Vector:X4}, ActiveSources=[{Sources}]",

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Audio/SidPotRegisterTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Audio/SidPotRegisterTests.cs
@@ -1,0 +1,24 @@
+using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Audio;
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64.Audio;
+
+public class SidPotRegisterTests
+{
+    [Theory]
+    [InlineData(SidAddr.POTX)]
+    [InlineData(SidAddr.POTY)]
+    public void Pot_Registers_Return_Idle_Value_When_No_Paddle_Or_Mouse_Is_Connected(ushort address)
+    {
+        var c64 = C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            C64Model = "C64PAL",
+            Vic2Model = "PAL"
+        }, NullLoggerFactory.Instance);
+
+        Assert.Equal(0xff, c64.Mem.Read(address));
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64CpuPortTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64CpuPortTests.cs
@@ -125,6 +125,10 @@ public class C64CpuPortTests
         public bool HandlesIOAddress(ushort address) => false;
         public byte ReadIO(ushort address) => throw new InvalidOperationException();
         public void WriteIO(ushort address, byte value) => throw new InvalidOperationException();
+        public bool HasROML => false;
+        public byte ReadROML(ushort address) => throw new InvalidOperationException();
+        public bool HasROMH => false;
+        public byte ReadROMH(ushort address) => throw new InvalidOperationException();
         public void Tick() { }
         public void Reset() { }
         public void Dispose() { }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64CpuPortTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64CpuPortTests.cs
@@ -130,7 +130,7 @@ public class C64CpuPortTests
         public byte ReadROML(ushort address) => throw new InvalidOperationException();
         public bool HasROMH => false;
         public byte ReadROMH(ushort address) => throw new InvalidOperationException();
-        public void Tick() { }
+        public void Tick(ulong cyclesElapsed = 0) { }
         public void Reset() { }
         public void Dispose() { }
     }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64CpuPortTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64CpuPortTests.cs
@@ -122,8 +122,9 @@ public class C64CpuPortTests
             LinesChanged?.Invoke();
         }
 
-        public bool HandlesIOAddress(ushort address) => false;
+        public bool HandlesIORead(ushort address) => false;
         public byte ReadIO(ushort address) => throw new InvalidOperationException();
+        public bool HandlesIOWrite(ushort address) => false;
         public void WriteIO(ushort address, byte value) => throw new InvalidOperationException();
         public bool HasROML => false;
         public byte ReadROML(ushort address) => throw new InvalidOperationException();

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64CpuPortTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64CpuPortTests.cs
@@ -1,4 +1,5 @@
 using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -57,6 +58,42 @@ public class C64CpuPortTests
         Assert.Equal(0x42, c64.Mem.Read(KernalProbeAddress));
     }
 
+    [Theory]
+    [InlineData(true, true, 31)]
+    [InlineData(true, false, 15)]
+    [InlineData(false, false, 7)]
+    [InlineData(false, true, 23)]
+    public void Cartridge_Lines_And_Cpu_Port_Derive_The_Memory_Configuration(
+        bool gameHigh,
+        bool exromHigh,
+        byte expectedBank)
+    {
+        var c64 = BuildC64();
+
+        c64.AttachCartridge(new LineStateCartridge(new C64CartridgeLines(gameHigh, exromHigh)));
+
+        Assert.Equal(expectedBank, c64.CurrentBank);
+        Assert.Equal(expectedBank, c64.Mem.CurrentConfiguration);
+    }
+
+    [Fact]
+    public void Cartridge_Line_Changes_And_Detach_Recompute_The_Memory_Configuration()
+    {
+        var c64 = BuildC64();
+        var cartridge = new LineStateCartridge(C64CartridgeLines.Released);
+        c64.AttachCartridge(cartridge);
+
+        cartridge.SetLines(new C64CartridgeLines(GameHigh: false, ExromHigh: false));
+        Assert.Equal(7, c64.CurrentBank);
+
+        c64.Mem.Write(0x0001, 0x06);
+        Assert.Equal(6, c64.CurrentBank);
+
+        c64.DetachCartridge();
+        Assert.Equal(30, c64.CurrentBank);
+        Assert.Equal(30, c64.Mem.CurrentConfiguration);
+    }
+
     private static C64 BuildC64()
     {
         return C64.BuildC64(new C64Config
@@ -71,5 +108,25 @@ public class C64CpuPortTests
     {
         c64.ROMData[C64SystemConfig.KERNAL_ROM_NAME][KernalProbeAddress - 0xE000] = kernalValue;
         c64.RAM[KernalProbeAddress] = ramValue;
+    }
+
+    private sealed class LineStateCartridge(C64CartridgeLines lines) : IC64Cartridge
+    {
+        public string Name => "Line state test cartridge";
+        public C64CartridgeLines Lines { get; private set; } = lines;
+        public event Action? LinesChanged;
+
+        public void SetLines(C64CartridgeLines lines)
+        {
+            Lines = lines;
+            LinesChanged?.Invoke();
+        }
+
+        public bool HandlesIOAddress(ushort address) => false;
+        public byte ReadIO(ushort address) => throw new InvalidOperationException();
+        public void WriteIO(ushort address, byte value) => throw new InvalidOperationException();
+        public void Tick() { }
+        public void Reset() { }
+        public void Dispose() { }
     }
 }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64CpuPortTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64CpuPortTests.cs
@@ -21,6 +21,19 @@ public class C64CpuPortTests
     }
 
     [Fact]
+    public void Hard_Reset_Clears_Stale_IO_Register_Storage()
+    {
+        var c64 = BuildC64();
+        c64.WriteIOStorage(0xD011, 0x7F);
+        c64.WriteIOStorage(0xDC0D, 0x81);
+
+        c64.HardReset();
+
+        Assert.Equal(0, c64.ReadIOStorage(0xD011));
+        Assert.Equal(0, c64.ReadIOStorage(0xDC0D));
+    }
+
+    [Fact]
     public void Kernal_Rom_Stays_Visible_When_Bank_Lines_Are_Configured_As_Inputs()
     {
         var c64 = BuildC64();

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64ShareLinkBuilderTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64ShareLinkBuilderTests.cs
@@ -147,6 +147,28 @@ public class C64ShareLinkBuilderTests
     }
 
     [Fact]
+    public void Build_CartridgeImage_Emits_LoadCrtUrl_Without_WaitForSystemReady()
+    {
+        var request = new C64ShareLinkRequest
+        {
+            Mode = C64ShareMode.CartridgeImage,
+            SystemVariant = "C64PAL",
+            CartridgeUrl = "https://example.com/fc3.crt",
+        };
+
+        var q = ParseQuery(C64ShareLinkBuilder.Build(BaseUrl, request));
+
+        Assert.Equal("C64", q["system"]);
+        Assert.Equal("C64PAL", q["systemVariant"]);
+        Assert.Equal("1", q["start"]);
+        Assert.Equal("https://example.com/fc3.crt", q["loadCrtUrl"]);
+        Assert.False(q.ContainsKey("waitForSystemReady"));
+        Assert.False(q.ContainsKey("runLoadedProgram"));
+        Assert.False(q.ContainsKey("loadPrgUrl"));
+        Assert.False(q.ContainsKey("loadD64Url"));
+    }
+
+    [Fact]
     public void Build_With_IncludeSettings_Enabled_Emits_All_Runtime_Knobs()
     {
         var request = new C64ShareLinkRequest
@@ -228,6 +250,18 @@ public class C64ShareLinkBuilderTests
             Mode = C64ShareMode.DownloadProgram,
             SystemVariant = "C64NTSC",
             DownloadType = C64DownloadProgramType.Prg,
+        };
+
+        Assert.Throws<ArgumentException>(() => C64ShareLinkBuilder.Build(BaseUrl, request));
+    }
+
+    [Fact]
+    public void Build_CartridgeImage_Without_Url_Throws()
+    {
+        var request = new C64ShareLinkRequest
+        {
+            Mode = C64ShareMode.CartridgeImage,
+            SystemVariant = "C64NTSC",
         };
 
         Assert.Throws<ArgumentException>(() => C64ShareLinkBuilder.Build(BaseUrl, request));

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64ShareLinkBuilderTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64ShareLinkBuilderTests.cs
@@ -117,12 +117,14 @@ public class C64ShareLinkBuilderTests
             AutoRun = true,
             DownloadUrl = "https://csdb.dk/release/download.php?id=70413",
             DownloadType = C64DownloadProgramType.D64Zip,
+            D64ZipEntry = "side-b/elite.d64",
             DirectLoadPRGName = "*",
         };
 
         var q = ParseQuery(C64ShareLinkBuilder.Build(BaseUrl, request));
 
         Assert.Equal("https://csdb.dk/release/download.php?id=70413", q["loadD64Url"]);
+        Assert.Equal("side-b/elite.d64", q["loadD64ZipEntry"]);
         Assert.Equal("*", q["d64Program"]);
         Assert.False(q.ContainsKey("diskMount"));
         Assert.Equal("1", q["runLoadedProgram"]);
@@ -154,6 +156,7 @@ public class C64ShareLinkBuilderTests
             Mode = C64ShareMode.CartridgeImage,
             SystemVariant = "C64PAL",
             CartridgeUrl = "https://example.com/fc3.crt",
+            CartridgeZipEntry = "carts/fc3.crt",
         };
 
         var q = ParseQuery(C64ShareLinkBuilder.Build(BaseUrl, request));
@@ -162,6 +165,7 @@ public class C64ShareLinkBuilderTests
         Assert.Equal("C64PAL", q["systemVariant"]);
         Assert.Equal("1", q["start"]);
         Assert.Equal("https://example.com/fc3.crt", q["loadCrtUrl"]);
+        Assert.Equal("carts/fc3.crt", q["loadCrtZipEntry"]);
         Assert.False(q.ContainsKey("waitForSystemReady"));
         Assert.False(q.ContainsKey("runLoadedProgram"));
         Assert.False(q.ContainsKey("loadPrgUrl"));

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CartridgeSlotTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CartridgeSlotTests.cs
@@ -43,16 +43,12 @@ public class C64CartridgeSlotTests
 
         memory.Write(0xDE00, 0x42);
         var value = memory.Read(0xDE00);
-        slot.MapROMLLocations(memory);
-        slot.MapROMHLocations(memory);
         slot.Tick();
         slot.Reset();
 
         Assert.Equal(0x42, value);
         Assert.Equal(1, cartridge.WriteIOCalls);
         Assert.Equal(1, cartridge.ReadIOCalls);
-        Assert.Equal(1, cartridge.MapROMLCalls);
-        Assert.Equal(1, cartridge.MapROMHCalls);
         Assert.Equal(1, cartridge.TickCalls);
         Assert.Equal(2, cartridge.ResetCalls);
     }
@@ -83,8 +79,6 @@ public class C64CartridgeSlotTests
         private byte _ioValue;
         public int ReadIOCalls { get; private set; }
         public int WriteIOCalls { get; private set; }
-        public int MapROMLCalls { get; private set; }
-        public int MapROMHCalls { get; private set; }
         public int TickCalls { get; private set; }
         public int ResetCalls { get; private set; }
         public int DisposeCalls { get; private set; }
@@ -100,8 +94,10 @@ public class C64CartridgeSlotTests
             WriteIOCalls++;
             _ioValue = value;
         }
-        public void MapROMLLocations(Memory mem) => MapROMLCalls++;
-        public void MapROMHLocations(Memory mem) => MapROMHCalls++;
+        public bool HasROML => false;
+        public byte ReadROML(ushort address) => throw new InvalidOperationException();
+        public bool HasROMH => false;
+        public byte ReadROMH(ushort address) => throw new InvalidOperationException();
         public void Tick() => TickCalls++;
         public void Reset() => ResetCalls++;
         public void Dispose() => DisposeCalls++;

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CartridgeSlotTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CartridgeSlotTests.cs
@@ -105,13 +105,36 @@ public class C64CartridgeSlotTests
         Assert.Equal(1, replacement.ResetCalls);
     }
 
+    [Fact]
+    public void Slot_Tracks_Only_The_Attached_Cartridge_Nmi_Line()
+    {
+        var slot = new C64CartridgeSlot();
+        var previous = new TestCartridge("Previous");
+        var replacement = new TestCartridge("Replacement");
+        var nmiChanges = 0;
+        slot.NmiLineChanged += () => nmiChanges++;
+
+        slot.Attach(previous);
+        previous.SetNmiLine(active: true);
+        slot.Replace(replacement);
+        previous.SetNmiLine(active: false);
+        replacement.SetNmiLine(active: true);
+        slot.Detach();
+        replacement.SetNmiLine(active: false);
+
+        Assert.False(slot.NmiLineActive);
+        Assert.Equal(5, nmiChanges);
+    }
+
     private sealed class TestCartridge(
         string name = "Test",
-        bool throwOnReset = false) : IC64Cartridge
+        bool throwOnReset = false) : IC64Cartridge, IC64CartridgeNmiSource
     {
         public string Name { get; } = name;
         public C64CartridgeLines Lines => C64CartridgeLines.Released;
         public event Action? LinesChanged;
+        public bool NmiLineActive { get; private set; }
+        public event Action? NmiLineChanged;
         private byte _ioValue;
         public int ReadIOCalls { get; private set; }
         public int WriteIOCalls { get; private set; }
@@ -149,5 +172,10 @@ public class C64CartridgeSlotTests
         }
         public void Dispose() => DisposeCalls++;
         public void RaiseLinesChanged() => LinesChanged?.Invoke();
+        public void SetNmiLine(bool active)
+        {
+            NmiLineActive = active;
+            NmiLineChanged?.Invoke();
+        }
     }
 }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CartridgeSlotTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CartridgeSlotTests.cs
@@ -118,7 +118,8 @@ public class C64CartridgeSlotTests
         public int ResetCalls { get; private set; }
         public int DisposeCalls { get; private set; }
 
-        public bool HandlesIOAddress(ushort address) => address == 0xDE00;
+        public bool HandlesIORead(ushort address) => address == 0xDE00;
+        public bool HandlesIOWrite(ushort address) => address == 0xDE00;
         public byte ReadIO(ushort address)
         {
             ReadIOCalls++;

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CartridgeSlotTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CartridgeSlotTests.cs
@@ -74,6 +74,12 @@ public class C64CartridgeSlotTests
     private sealed class TestCartridge(string name = "Test") : IC64Cartridge
     {
         public string Name { get; } = name;
+        public C64CartridgeLines Lines => C64CartridgeLines.Released;
+        public event Action? LinesChanged
+        {
+            add { }
+            remove { }
+        }
         private byte _ioValue;
         public int ReadIOCalls { get; private set; }
         public int WriteIOCalls { get; private set; }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CartridgeSlotTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CartridgeSlotTests.cs
@@ -1,0 +1,82 @@
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64.Cartridge;
+
+public class C64CartridgeSlotTests
+{
+    [Fact]
+    public void Attach_Exposes_The_Attached_Cartridge()
+    {
+        var slot = new C64CartridgeSlot();
+        var cartridge = new TestCartridge();
+
+        slot.Attach(cartridge);
+
+        Assert.Same(cartridge, slot.AttachedCartridge);
+        Assert.Same(cartridge, slot.GetCartridge<TestCartridge>());
+    }
+
+    [Fact]
+    public void Attach_Rejects_A_Second_Cartridge()
+    {
+        var slot = new C64CartridgeSlot();
+        slot.Attach(new TestCartridge("First"));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => slot.Attach(new TestCartridge("Second")));
+
+        Assert.Equal("Cartridge 'First' is already attached.", exception.Message);
+    }
+
+    [Fact]
+    public void Slot_Routes_Mapping_Tick_And_Reset_To_The_Attached_Cartridge()
+    {
+        var slot = new C64CartridgeSlot();
+        var cartridge = new TestCartridge();
+        var memory = new Memory();
+        slot.Attach(cartridge);
+
+        slot.MapIOLocations(memory);
+        slot.MapROMLLocations(memory);
+        slot.MapROMHLocations(memory);
+        slot.Tick();
+        slot.Reset();
+
+        Assert.Equal(1, cartridge.MapIOCalls);
+        Assert.Equal(1, cartridge.MapROMLCalls);
+        Assert.Equal(1, cartridge.MapROMHCalls);
+        Assert.Equal(1, cartridge.TickCalls);
+        Assert.Equal(1, cartridge.ResetCalls);
+    }
+
+    [Fact]
+    public void Detach_Disposes_And_Removes_The_Attached_Cartridge()
+    {
+        var slot = new C64CartridgeSlot();
+        var cartridge = new TestCartridge();
+        slot.Attach(cartridge);
+
+        slot.Detach();
+
+        Assert.Null(slot.AttachedCartridge);
+        Assert.Equal(1, cartridge.DisposeCalls);
+    }
+
+    private sealed class TestCartridge(string name = "Test") : IC64Cartridge
+    {
+        public string Name { get; } = name;
+        public int MapIOCalls { get; private set; }
+        public int MapROMLCalls { get; private set; }
+        public int MapROMHCalls { get; private set; }
+        public int TickCalls { get; private set; }
+        public int ResetCalls { get; private set; }
+        public int DisposeCalls { get; private set; }
+
+        public void MapIOLocations(Memory mem) => MapIOCalls++;
+        public void MapROMLLocations(Memory mem) => MapROMLCalls++;
+        public void MapROMHLocations(Memory mem) => MapROMHCalls++;
+        public void Tick() => TickCalls++;
+        public void Reset() => ResetCalls++;
+        public void Dispose() => DisposeCalls++;
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CartridgeSlotTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CartridgeSlotTests.cs
@@ -34,19 +34,27 @@ public class C64CartridgeSlotTests
         var slot = new C64CartridgeSlot();
         var cartridge = new TestCartridge();
         var memory = new Memory();
+        var io = new byte[0x200];
+        slot.MapIOLocations(
+            memory,
+            address => io[address - 0xDE00],
+            (address, value) => io[address - 0xDE00] = value);
         slot.Attach(cartridge);
 
-        slot.MapIOLocations(memory);
+        memory.Write(0xDE00, 0x42);
+        var value = memory.Read(0xDE00);
         slot.MapROMLLocations(memory);
         slot.MapROMHLocations(memory);
         slot.Tick();
         slot.Reset();
 
-        Assert.Equal(1, cartridge.MapIOCalls);
+        Assert.Equal(0x42, value);
+        Assert.Equal(1, cartridge.WriteIOCalls);
+        Assert.Equal(1, cartridge.ReadIOCalls);
         Assert.Equal(1, cartridge.MapROMLCalls);
         Assert.Equal(1, cartridge.MapROMHCalls);
         Assert.Equal(1, cartridge.TickCalls);
-        Assert.Equal(1, cartridge.ResetCalls);
+        Assert.Equal(2, cartridge.ResetCalls);
     }
 
     [Fact]
@@ -59,20 +67,33 @@ public class C64CartridgeSlotTests
         slot.Detach();
 
         Assert.Null(slot.AttachedCartridge);
+        Assert.Equal(2, cartridge.ResetCalls);
         Assert.Equal(1, cartridge.DisposeCalls);
     }
 
     private sealed class TestCartridge(string name = "Test") : IC64Cartridge
     {
         public string Name { get; } = name;
-        public int MapIOCalls { get; private set; }
+        private byte _ioValue;
+        public int ReadIOCalls { get; private set; }
+        public int WriteIOCalls { get; private set; }
         public int MapROMLCalls { get; private set; }
         public int MapROMHCalls { get; private set; }
         public int TickCalls { get; private set; }
         public int ResetCalls { get; private set; }
         public int DisposeCalls { get; private set; }
 
-        public void MapIOLocations(Memory mem) => MapIOCalls++;
+        public bool HandlesIOAddress(ushort address) => address == 0xDE00;
+        public byte ReadIO(ushort address)
+        {
+            ReadIOCalls++;
+            return _ioValue;
+        }
+        public void WriteIO(ushort address, byte value)
+        {
+            WriteIOCalls++;
+            _ioValue = value;
+        }
         public void MapROMLLocations(Memory mem) => MapROMLCalls++;
         public void MapROMHLocations(Memory mem) => MapROMHCalls++;
         public void Tick() => TickCalls++;

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CartridgeSlotTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CartridgeSlotTests.cs
@@ -67,15 +67,50 @@ public class C64CartridgeSlotTests
         Assert.Equal(1, cartridge.DisposeCalls);
     }
 
-    private sealed class TestCartridge(string name = "Test") : IC64Cartridge
+    [Fact]
+    public void Replace_Activates_New_Cartridge_And_Disposes_Previous_Cartridge()
+    {
+        var slot = new C64CartridgeSlot();
+        var previous = new TestCartridge("Previous");
+        var replacement = new TestCartridge("Replacement");
+        var lineChanges = 0;
+        slot.LinesChanged += () => lineChanges++;
+        slot.Attach(previous);
+
+        slot.Replace(replacement);
+        previous.RaiseLinesChanged();
+        replacement.RaiseLinesChanged();
+
+        Assert.Same(replacement, slot.AttachedCartridge);
+        Assert.Equal(2, previous.ResetCalls);
+        Assert.Equal(1, previous.DisposeCalls);
+        Assert.Equal(1, replacement.ResetCalls);
+        Assert.Equal(3, lineChanges);
+    }
+
+    [Fact]
+    public void Replace_Preserves_Previous_Cartridge_When_Replacement_Reset_Fails()
+    {
+        var slot = new C64CartridgeSlot();
+        var previous = new TestCartridge("Previous");
+        var replacement = new TestCartridge("Replacement", throwOnReset: true);
+        slot.Attach(previous);
+
+        Assert.Throws<InvalidOperationException>(() => slot.Replace(replacement));
+
+        Assert.Same(previous, slot.AttachedCartridge);
+        Assert.Equal(1, previous.ResetCalls);
+        Assert.Equal(0, previous.DisposeCalls);
+        Assert.Equal(1, replacement.ResetCalls);
+    }
+
+    private sealed class TestCartridge(
+        string name = "Test",
+        bool throwOnReset = false) : IC64Cartridge
     {
         public string Name { get; } = name;
         public C64CartridgeLines Lines => C64CartridgeLines.Released;
-        public event Action? LinesChanged
-        {
-            add { }
-            remove { }
-        }
+        public event Action? LinesChanged;
         private byte _ioValue;
         public int ReadIOCalls { get; private set; }
         public int WriteIOCalls { get; private set; }
@@ -99,7 +134,13 @@ public class C64CartridgeSlotTests
         public bool HasROMH => false;
         public byte ReadROMH(ushort address) => throw new InvalidOperationException();
         public void Tick() => TickCalls++;
-        public void Reset() => ResetCalls++;
+        public void Reset()
+        {
+            ResetCalls++;
+            if (throwOnReset)
+                throw new InvalidOperationException("Reset failed.");
+        }
         public void Dispose() => DisposeCalls++;
+        public void RaiseLinesChanged() => LinesChanged?.Invoke();
     }
 }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CartridgeSlotTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CartridgeSlotTests.cs
@@ -43,13 +43,14 @@ public class C64CartridgeSlotTests
 
         memory.Write(0xDE00, 0x42);
         var value = memory.Read(0xDE00);
-        slot.Tick();
+        slot.Tick(37);
         slot.Reset();
 
         Assert.Equal(0x42, value);
         Assert.Equal(1, cartridge.WriteIOCalls);
         Assert.Equal(1, cartridge.ReadIOCalls);
         Assert.Equal(1, cartridge.TickCalls);
+        Assert.Equal((ulong)37, cartridge.LastTickCycles);
         Assert.Equal(2, cartridge.ResetCalls);
     }
 
@@ -115,6 +116,7 @@ public class C64CartridgeSlotTests
         public int ReadIOCalls { get; private set; }
         public int WriteIOCalls { get; private set; }
         public int TickCalls { get; private set; }
+        public ulong LastTickCycles { get; private set; }
         public int ResetCalls { get; private set; }
         public int DisposeCalls { get; private set; }
 
@@ -134,7 +136,11 @@ public class C64CartridgeSlotTests
         public byte ReadROML(ushort address) => throw new InvalidOperationException();
         public bool HasROMH => false;
         public byte ReadROMH(ushort address) => throw new InvalidOperationException();
-        public void Tick() => TickCalls++;
+        public void Tick(ulong cyclesElapsed = 0)
+        {
+            TickCalls++;
+            LastTickCycles = cyclesElapsed;
+        }
         public void Reset()
         {
             ResetCalls++;

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CrtTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CrtTests.cs
@@ -1,0 +1,239 @@
+using System.Buffers.Binary;
+using System.Text;
+using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.Crt;
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64.Cartridge;
+
+public class C64CrtTests
+{
+    [Fact]
+    public void Parser_Reads_Header_And_Chip_Fields()
+    {
+        var bytes = BuildCrt(
+            hardwareType: 0,
+            exromHigh: false,
+            gameHigh: true,
+            name: "TEST CART",
+            headerLength: 0x50,
+            chips: [new Chip(0, 0x8000, Filled(0x2000, 0x42))]);
+
+        var image = C64CrtParser.Parse(bytes);
+
+        Assert.Equal((uint)0x50, image.Header.HeaderLength);
+        Assert.Equal((ushort)0x0100, image.Header.Version);
+        Assert.Equal((ushort)0, image.Header.HardwareType);
+        Assert.False(image.Header.ExromHigh);
+        Assert.True(image.Header.GameHigh);
+        Assert.Equal("TEST CART", image.Header.Name);
+        var chip = Assert.Single(image.Chips);
+        Assert.Equal(C64CrtChipType.Rom, chip.Type);
+        Assert.Equal((ushort)0, chip.Bank);
+        Assert.Equal((ushort)0x8000, chip.LoadAddress);
+        Assert.Equal(0x2000, chip.Data.Length);
+        Assert.Equal(0x42, chip.Data[0]);
+    }
+
+    [Theory]
+    [InlineData("bad-signature")]
+    [InlineData("truncated-chip")]
+    [InlineData("bad-packet-length")]
+    [InlineData("bad-chip-type")]
+    public void Parser_Rejects_Malformed_Images(string corruption)
+    {
+        var bytes = BuildCrt(
+            hardwareType: 0,
+            exromHigh: false,
+            gameHigh: true,
+            chips: [new Chip(0, 0x8000, Filled(0x2000, 0x42))]);
+
+        switch (corruption)
+        {
+            case "bad-signature":
+                bytes[0] = (byte)'X';
+                break;
+            case "truncated-chip":
+                Array.Resize(ref bytes, bytes.Length - 1);
+                break;
+            case "bad-packet-length":
+                BinaryPrimitives.WriteUInt32BigEndian(bytes.AsSpan(0x44, 4), 8);
+                break;
+            case "bad-chip-type":
+                BinaryPrimitives.WriteUInt16BigEndian(bytes.AsSpan(0x48, 2), 99);
+                break;
+        }
+
+        Assert.Throws<C64CrtImageException>(() => C64CrtParser.Parse(bytes));
+    }
+
+    [Fact]
+    public void Factory_Creates_Generic_8K_Cartridge()
+    {
+        var image = C64CrtParser.Parse(BuildCrt(
+            hardwareType: 0,
+            exromHigh: false,
+            gameHigh: true,
+            chips: [new Chip(0, 0x8000, Filled(0x2000, 0x42))]));
+
+        var cartridge = C64CrtCartridgeFactory.Create(image);
+
+        Assert.Equal(new C64CartridgeLines(GameHigh: true, ExromHigh: false), cartridge.Lines);
+        Assert.True(cartridge.HasROML);
+        Assert.False(cartridge.HasROMH);
+        Assert.Equal(0x42, cartridge.ReadROML(0x8000));
+    }
+
+    [Fact]
+    public void Factory_Creates_Generic_16K_From_One_Combined_Chip()
+    {
+        var data = Filled(0x4000, 0x42);
+        Array.Fill(data, (byte)0x84, 0x2000, 0x2000);
+        var image = C64CrtParser.Parse(BuildCrt(
+            hardwareType: 0,
+            exromHigh: false,
+            gameHigh: false,
+            chips: [new Chip(0, 0x8000, data)]));
+
+        var cartridge = C64CrtCartridgeFactory.Create(image);
+
+        Assert.Equal(0x42, cartridge.ReadROML(0x8000));
+        Assert.Equal(0x84, cartridge.ReadROMH(0xA000));
+    }
+
+    [Fact]
+    public void Factory_Creates_Generic_Ultimax_Cartridge()
+    {
+        var image = C64CrtParser.Parse(BuildCrt(
+            hardwareType: 0,
+            exromHigh: true,
+            gameHigh: false,
+            chips:
+            [
+                new Chip(0, 0x8000, Filled(0x2000, 0x42)),
+                new Chip(0, 0xE000, Filled(0x2000, 0x84)),
+            ]));
+
+        var cartridge = C64CrtCartridgeFactory.Create(image);
+
+        Assert.Equal(new C64CartridgeLines(GameHigh: false, ExromHigh: true), cartridge.Lines);
+        Assert.Equal(0x42, cartridge.ReadROML(0x8000));
+        Assert.Equal(0x84, cartridge.ReadROMH(0xE000));
+    }
+
+    [Fact]
+    public void Factory_Rejects_Chip_Data_Outside_Selected_Rom_Windows()
+    {
+        var image = C64CrtParser.Parse(BuildCrt(
+            hardwareType: 0,
+            exromHigh: false,
+            gameHigh: true,
+            chips:
+            [
+                new Chip(0, 0x8000, Filled(0x2000, 0x42)),
+                new Chip(0, 0xA000, Filled(0x2000, 0x84)),
+            ]));
+
+        var exception = Assert.Throws<C64CrtImageException>(
+            () => C64CrtCartridgeFactory.Create(image));
+
+        Assert.Contains("outside the cartridge ROM windows", exception.Message);
+    }
+
+    [Fact]
+    public void Unsupported_Hardware_Type_Does_Not_Replace_Current_Cartridge()
+    {
+        var c64 = BuildC64();
+        var current = new C64RomCartridge(Filled(0x2000, 0x11), name: "Current");
+        c64.AttachCartridge(current);
+        var unsupported = BuildCrt(
+            hardwareType: 32,
+            exromHigh: false,
+            gameHigh: true,
+            chips: [new Chip(0, 0x8000, Filled(0x2000, 0x42))]);
+
+        Assert.Throws<C64UnsupportedCrtHardwareException>(
+            () => c64.AttachCrtImage(unsupported, "unsupported.crt"));
+
+        Assert.Same(current, c64.CartridgeSlot.AttachedCartridge);
+    }
+
+    [Fact]
+    public void AttachCrtImage_Replaces_Cartridge_And_Hard_Resets_From_Cartridge_Vector()
+    {
+        var c64 = BuildC64();
+        var romh = Filled(0x2000, 0x84);
+        romh[0x1FFC] = 0x34;
+        romh[0x1FFD] = 0x12;
+        var crt = BuildCrt(
+            hardwareType: 0,
+            exromHigh: true,
+            gameHigh: false,
+            name: "ULTIMAX TEST",
+            chips:
+            [
+                new Chip(0, 0x8000, Filled(0x2000, 0x42)),
+                new Chip(0, 0xE000, romh),
+            ]);
+
+        var result = c64.AttachCrtImage(crt, "test.crt");
+
+        Assert.Equal("ULTIMAX TEST", result.CartridgeName);
+        Assert.Equal("test.crt", result.SourceName);
+        Assert.Equal((ushort)0x1234, c64.CPU.PC);
+        Assert.Equal(0x84, c64.Mem.Read(0xE000));
+        Assert.Same(result, c64.AttachedCartridgeImage);
+    }
+
+    private static C64 BuildC64()
+        => C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            C64Model = "C64PAL",
+            Vic2Model = "PAL",
+        }, NullLoggerFactory.Instance);
+
+    private static byte[] BuildCrt(
+        ushort hardwareType,
+        bool exromHigh,
+        bool gameHigh,
+        Chip[] chips,
+        string name = "TEST",
+        int headerLength = 0x40)
+    {
+        var size = headerLength + chips.Sum(chip => 0x10 + chip.Data.Length);
+        var bytes = new byte[size];
+        Encoding.ASCII.GetBytes("C64 CARTRIDGE   ").CopyTo(bytes, 0);
+        BinaryPrimitives.WriteUInt32BigEndian(bytes.AsSpan(0x10, 4), (uint)headerLength);
+        BinaryPrimitives.WriteUInt16BigEndian(bytes.AsSpan(0x14, 2), 0x0100);
+        BinaryPrimitives.WriteUInt16BigEndian(bytes.AsSpan(0x16, 2), hardwareType);
+        bytes[0x18] = exromHigh ? (byte)1 : (byte)0;
+        bytes[0x19] = gameHigh ? (byte)1 : (byte)0;
+        Encoding.ASCII.GetBytes(name).CopyTo(bytes, 0x20);
+
+        var offset = headerLength;
+        foreach (var chip in chips)
+        {
+            Encoding.ASCII.GetBytes("CHIP").CopyTo(bytes, offset);
+            BinaryPrimitives.WriteUInt32BigEndian(bytes.AsSpan(offset + 4, 4), (uint)(0x10 + chip.Data.Length));
+            BinaryPrimitives.WriteUInt16BigEndian(bytes.AsSpan(offset + 8, 2), (ushort)C64CrtChipType.Rom);
+            BinaryPrimitives.WriteUInt16BigEndian(bytes.AsSpan(offset + 10, 2), chip.Bank);
+            BinaryPrimitives.WriteUInt16BigEndian(bytes.AsSpan(offset + 12, 2), chip.Address);
+            BinaryPrimitives.WriteUInt16BigEndian(bytes.AsSpan(offset + 14, 2), (ushort)chip.Data.Length);
+            chip.Data.CopyTo(bytes, offset + 0x10);
+            offset += 0x10 + chip.Data.Length;
+        }
+        return bytes;
+    }
+
+    private static byte[] Filled(int length, byte value)
+    {
+        var data = new byte[length];
+        Array.Fill(data, value);
+        return data;
+    }
+
+    private sealed record Chip(ushort Bank, ushort Address, byte[] Data);
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CrtTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CrtTests.cs
@@ -351,6 +351,241 @@ public class C64CrtTests
     }
 
     [Fact]
+    public void Factory_Creates_EpyxFastLoad_Cartridge_With_Timed_Rom_And_IO2_Page()
+    {
+        var rom = Filled(0x2000, 0x42);
+        rom[0x1F34] = 0x84;
+        var image = C64CrtParser.Parse(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.EpyxFastLoad,
+            exromHigh: false,
+            gameHigh: true,
+            name: "EPYX FASTLOAD TEST",
+            chips: [new Chip(0, 0x8000, rom)]));
+
+        var cartridge = Assert.IsType<C64EpyxFastLoadCartridge>(
+            C64CrtCartridgeFactory.Create(image));
+
+        Assert.Equal("EPYX FASTLOAD TEST", cartridge.Name);
+        Assert.True(cartridge.IsRomEnabled);
+        Assert.Equal(new C64CartridgeLines(GameHigh: true, ExromHigh: false), cartridge.Lines);
+        Assert.Equal(0x42, cartridge.ReadROML(0x8000));
+        Assert.Equal(C64EpyxFastLoadCartridge.RomEnableCycles, cartridge.CyclesUntilDisabled);
+        Assert.Equal(0x84, cartridge.ReadIO(0xDF34));
+
+        cartridge.Tick(C64EpyxFastLoadCartridge.RomEnableCycles - 1);
+
+        Assert.True(cartridge.IsRomEnabled);
+
+        cartridge.Tick(1);
+
+        Assert.False(cartridge.IsRomEnabled);
+        Assert.Equal(C64CartridgeLines.Released, cartridge.Lines);
+        Assert.Equal(0x84, cartridge.ReadIO(0xDF34));
+
+        Assert.Equal(0, cartridge.ReadIO(0xDE00));
+        Assert.True(cartridge.IsRomEnabled);
+        Assert.Equal(C64EpyxFastLoadCartridge.RomEnableCycles, cartridge.CyclesUntilDisabled);
+    }
+
+    [Theory]
+    [InlineData("multiple-chips")]
+    [InlineData("wrong-bank")]
+    [InlineData("wrong-address")]
+    [InlineData("wrong-size")]
+    public void Factory_Rejects_Invalid_EpyxFastLoad_Images(string invalidShape)
+    {
+        Chip[] chips = invalidShape switch
+        {
+            "multiple-chips" =>
+            [
+                new Chip(0, 0x8000, Filled(0x2000, 0x10)),
+                new Chip(0, 0x8000, Filled(0x2000, 0x11)),
+            ],
+            "wrong-bank" => [new Chip(1, 0x8000, Filled(0x2000, 0x10))],
+            "wrong-address" => [new Chip(0, 0xA000, Filled(0x2000, 0x10))],
+            "wrong-size" => [new Chip(0, 0x8000, Filled(0x1000, 0x10))],
+            _ => throw new ArgumentOutOfRangeException(nameof(invalidShape)),
+        };
+        var image = C64CrtParser.Parse(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.EpyxFastLoad,
+            exromHigh: false,
+            gameHigh: true,
+            chips: chips));
+
+        Assert.Throws<C64CrtImageException>(
+            () => C64CrtCartridgeFactory.Create(image));
+    }
+
+    [Fact]
+    public void EpyxFastLoad_Attach_Times_Out_And_IO1_Read_Reenables_Rom()
+    {
+        var c64 = BuildC64();
+        c64.RAM[0x8000] = 0x44;
+        var rom = Filled(0x2000, 0x42);
+        rom[0x1F34] = 0x84;
+        var crt = BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.EpyxFastLoad,
+            exromHigh: false,
+            gameHigh: true,
+            name: "EPYX FASTLOAD TEST",
+            chips: [new Chip(0, 0x8000, rom)]);
+
+        var result = c64.AttachCrtImage(crt, "epyx-fastload.crt");
+
+        Assert.Equal((ushort)C64CrtHardwareType.EpyxFastLoad, result.HardwareType);
+        Assert.Equal(0x42, c64.Mem.Read(0x8000));
+
+        c64.CartridgeSlot.Tick(C64EpyxFastLoadCartridge.RomEnableCycles);
+
+        Assert.Equal(C64CartridgeLines.Released, c64.CartridgeSlot.Lines);
+        Assert.Equal(0x44, c64.Mem.Read(0x8000));
+        Assert.Equal(0x84, c64.Mem.Read(0xDF34));
+
+        Assert.Equal(0, c64.Mem.Read(0xDE00));
+
+        Assert.Equal(new C64CartridgeLines(GameHigh: true, ExromHigh: false), c64.CartridgeSlot.Lines);
+        Assert.Equal(0x42, c64.Mem.Read(0x8000));
+    }
+
+    [Fact]
+    public void Factory_Creates_ActionReplay_With_Banked_Rom_And_Exported_Ram()
+    {
+        var image = C64CrtParser.Parse(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.ActionReplay,
+            exromHigh: false,
+            gameHigh: true,
+            name: "ACTION REPLAY TEST",
+            chips: CreateBankChips(4)));
+
+        var cartridge = Assert.IsType<C64ActionReplayCartridge>(
+            C64CrtCartridgeFactory.Create(image));
+
+        Assert.Equal("ACTION REPLAY TEST", cartridge.Name);
+        Assert.Equal(new C64CartridgeLines(GameHigh: true, ExromHigh: false), cartridge.Lines);
+        Assert.Equal((ushort)0, cartridge.CurrentBank);
+        Assert.Equal(0x10, cartridge.ReadROML(0x8000));
+
+        cartridge.WriteIO(0xDE00, 0x11);
+
+        Assert.Equal((ushort)2, cartridge.CurrentBank);
+        Assert.Equal(new C64CartridgeLines(GameHigh: false, ExromHigh: false), cartridge.Lines);
+        Assert.Equal(0x12, cartridge.ReadROML(0x8000));
+        Assert.Equal(0x12, cartridge.ReadROMH(0xA000));
+        Assert.Equal(0x12, cartridge.ReadIO(0xDF34));
+
+        cartridge.WriteIO(0xDE00, 0x21);
+        cartridge.WriteROML(0x8123, 0x42);
+        cartridge.WriteIO(0xDF34, 0x84);
+
+        Assert.True(cartridge.IsRamExported);
+        Assert.Equal(0x42, cartridge.ReadROML(0x8123));
+        Assert.Equal(0x84, cartridge.ReadIO(0xDF34));
+        Assert.Equal(0x84, cartridge.ReadRam(0x1F34));
+    }
+
+    [Theory]
+    [InlineData("missing-bank")]
+    [InlineData("duplicate-bank")]
+    [InlineData("wrong-address")]
+    [InlineData("wrong-size")]
+    [InlineData("bank-too-high")]
+    public void Factory_Rejects_Invalid_ActionReplay_Images(string invalidShape)
+    {
+        Chip[] chips = invalidShape switch
+        {
+            "missing-bank" => CreateBankChips(3),
+            "duplicate-bank" =>
+            [
+                new Chip(0, 0x8000, Filled(0x2000, 0x10)),
+                new Chip(1, 0x8000, Filled(0x2000, 0x11)),
+                new Chip(2, 0x8000, Filled(0x2000, 0x12)),
+                new Chip(2, 0x8000, Filled(0x2000, 0x13)),
+            ],
+            "wrong-address" =>
+            [
+                new Chip(0, 0x9000, Filled(0x2000, 0x10)),
+                .. CreateBankChips(4)[1..],
+            ],
+            "wrong-size" =>
+            [
+                new Chip(0, 0x8000, Filled(0x1000, 0x10)),
+                .. CreateBankChips(4)[1..],
+            ],
+            "bank-too-high" =>
+            [
+                .. CreateBankChips(3),
+                new Chip(4, 0x8000, Filled(0x2000, 0x14)),
+            ],
+            _ => throw new ArgumentOutOfRangeException(nameof(invalidShape)),
+        };
+        var image = C64CrtParser.Parse(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.ActionReplay,
+            exromHigh: false,
+            gameHigh: true,
+            chips: chips));
+
+        Assert.Throws<C64CrtImageException>(
+            () => C64CrtCartridgeFactory.Create(image));
+    }
+
+    [Fact]
+    public void ActionReplay_Attach_Maps_Writable_Ram_And_Can_Disable()
+    {
+        var c64 = BuildC64();
+        c64.RAM[0x8000] = 0x44;
+        var crt = BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.ActionReplay,
+            exromHigh: false,
+            gameHigh: true,
+            name: "ACTION REPLAY TEST",
+            chips: CreateBankChips(4));
+
+        var result = c64.AttachCrtImage(crt, "action-replay.crt");
+
+        Assert.Equal((ushort)C64CrtHardwareType.ActionReplay, result.HardwareType);
+        Assert.Equal(0x10, c64.Mem.Read(0x8000));
+
+        c64.Mem.Write(0xDE00, 0x20);
+        c64.Mem.Write(0x8123, 0x42);
+        c64.Mem.Write(0xDF34, 0x84);
+
+        Assert.Equal(0x42, c64.Mem.Read(0x8123));
+        Assert.Equal(0x84, c64.Mem.Read(0xDF34));
+
+        c64.Mem.Write(0xDE00, 0x04);
+
+        Assert.Equal(C64CartridgeLines.Released, c64.CartridgeSlot.Lines);
+        Assert.Equal(0x44, c64.Mem.Read(0x8000));
+    }
+
+    [Fact]
+    public void ActionReplay_Freeze_Enters_Ultimax_And_Services_Nmi_From_Cartridge()
+    {
+        var c64 = BuildC64();
+        var banks = CreateBankChips(4);
+        banks[0].Data[0x1FFA] = 0x34;
+        banks[0].Data[0x1FFB] = 0x12;
+        var crt = BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.ActionReplay,
+            exromHigh: false,
+            gameHigh: true,
+            chips: banks);
+        c64.AttachCrtImage(crt, "action-replay.crt");
+        c64.Mem.Write(0xDE00, 0x1C); // Select bank 3 and disable, like exiting to BASIC.
+
+        var frozen = c64.FreezeAttachedCartridge();
+
+        var cartridge = Assert.IsType<C64ActionReplayCartridge>(
+            c64.CartridgeSlot.AttachedCartridge);
+        Assert.True(frozen);
+        Assert.True(cartridge.IsFreezeMode);
+        Assert.True(cartridge.IsRamExported);
+        Assert.Equal((ushort)0, cartridge.CurrentBank);
+        Assert.Equal(new C64CartridgeLines(GameHigh: false, ExromHigh: true), cartridge.Lines);
+        Assert.Equal((ushort)0x1234, c64.CPU.PC);
+    }
+
+    [Fact]
     public void Unsupported_Hardware_Type_Does_Not_Replace_Current_Cartridge()
     {
         var c64 = BuildC64();

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CrtTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CrtTests.cs
@@ -208,7 +208,6 @@ public class C64CrtTests
     {
         var c64 = BuildC64();
         c64.RAM[0x8000] = 0x44;
-        c64.IO[0x0E00] = 0x5A;
         var crt = BuildCrt(
             hardwareType: (ushort)C64CrtHardwareType.MagicDesk,
             exromHigh: false,
@@ -226,6 +225,7 @@ public class C64CrtTests
 
         Assert.Equal((ushort)C64CrtHardwareType.MagicDesk, result.HardwareType);
         Assert.Equal(0x10, c64.Mem.Read(0x8000));
+        c64.IO[0x0E00] = 0x5A;
         Assert.Equal(0x5A, c64.Mem.Read(0xDE00));
 
         c64.Mem.Write(0xDE00, 2);
@@ -329,7 +329,6 @@ public class C64CrtTests
     public void Ocean_Attach_Maps_And_Switches_Mirrored_Rom_Banks()
     {
         var c64 = BuildC64();
-        c64.IO[0x0E00] = 0x5A;
         var crt = BuildCrt(
             hardwareType: (ushort)C64CrtHardwareType.Ocean,
             exromHigh: false,
@@ -342,6 +341,7 @@ public class C64CrtTests
         Assert.Equal((ushort)C64CrtHardwareType.Ocean, result.HardwareType);
         Assert.Equal(0x10, c64.Mem.Read(0x8000));
         Assert.Equal(0x10, c64.Mem.Read(0xA000));
+        c64.IO[0x0E00] = 0x5A;
         Assert.Equal(0x5A, c64.Mem.Read(0xDE00));
 
         c64.Mem.Write(0xDE00, 3);
@@ -586,6 +586,175 @@ public class C64CrtTests
     }
 
     [Fact]
+    public void Factory_Creates_FinalCartridgeIII_With_Banked_Rom_And_IO_Mirrors()
+    {
+        var image = C64CrtParser.Parse(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.FinalCartridgeIII,
+            exromHigh: false,
+            gameHigh: false,
+            name: "FINAL CARTRIDGE III TEST",
+            chips: CreateFinalCartridgeIIIBankChips(4)));
+
+        var cartridge = Assert.IsType<C64FinalCartridgeIIICartridge>(
+            C64CrtCartridgeFactory.Create(image));
+
+        Assert.Equal("FINAL CARTRIDGE III TEST", cartridge.Name);
+        Assert.Equal(new C64CartridgeLines(GameHigh: false, ExromHigh: false), cartridge.Lines);
+        Assert.Equal((ushort)0, cartridge.CurrentBank);
+        Assert.Equal(0x10, cartridge.ReadROML(0x8000));
+        Assert.Equal(0x20, cartridge.ReadROMH(0xA000));
+        Assert.Equal(0x10, cartridge.ReadIO(0xDE34));
+        Assert.Equal(0x10, cartridge.ReadIO(0xDF34));
+
+        cartridge.WriteIO(0xDFFF, 0x62); // Bank 2, 8K mode, NMI released.
+
+        Assert.Equal((ushort)2, cartridge.CurrentBank);
+        Assert.Equal(new C64CartridgeLines(GameHigh: true, ExromHigh: false), cartridge.Lines);
+        Assert.Equal(0x12, cartridge.ReadROML(0x8000));
+        Assert.False(cartridge.HasROMH);
+        Assert.Equal(0x12, cartridge.ReadIO(0xDE34));
+        Assert.Equal(0x12, cartridge.ReadIO(0xDF34));
+    }
+
+    [Fact]
+    public void Factory_Creates_Sixteen_Bank_FinalCartridgeIIIPlus()
+    {
+        var image = C64CrtParser.Parse(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.FinalCartridgeIII,
+            exromHigh: false,
+            gameHigh: false,
+            chips: CreateFinalCartridgeIIIBankChips(16)));
+        var cartridge = Assert.IsType<C64FinalCartridgeIIICartridge>(
+            C64CrtCartridgeFactory.Create(image));
+
+        cartridge.WriteIO(0xDFFF, 0x4F); // Bank 15, 16K mode, NMI released.
+
+        Assert.Equal((ushort)15, cartridge.CurrentBank);
+        Assert.Equal(0x1F, cartridge.ReadROML(0x8000));
+        Assert.Equal(0x2F, cartridge.ReadROMH(0xA000));
+    }
+
+    [Theory]
+    [InlineData("wrong-count")]
+    [InlineData("duplicate-bank")]
+    [InlineData("wrong-address")]
+    [InlineData("wrong-size")]
+    [InlineData("bank-too-high")]
+    public void Factory_Rejects_Invalid_FinalCartridgeIII_Images(string invalidShape)
+    {
+        Chip[] chips = invalidShape switch
+        {
+            "wrong-count" => CreateFinalCartridgeIIIBankChips(3),
+            "duplicate-bank" =>
+            [
+                .. CreateFinalCartridgeIIIBankChips(3),
+                CreateFinalCartridgeIIIBankChips(4)[2],
+            ],
+            "wrong-address" =>
+            [
+                new Chip(0, 0xA000, Filled(0x4000, 0x10)),
+                .. CreateFinalCartridgeIIIBankChips(4)[1..],
+            ],
+            "wrong-size" =>
+            [
+                new Chip(0, 0x8000, Filled(0x2000, 0x10)),
+                .. CreateFinalCartridgeIIIBankChips(4)[1..],
+            ],
+            "bank-too-high" =>
+            [
+                .. CreateFinalCartridgeIIIBankChips(3),
+                new Chip(4, 0x8000, Filled(0x4000, 0x14)),
+            ],
+            _ => throw new ArgumentOutOfRangeException(nameof(invalidShape)),
+        };
+        var image = C64CrtParser.Parse(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.FinalCartridgeIII,
+            exromHigh: false,
+            gameHigh: false,
+            chips: chips));
+
+        Assert.Throws<C64CrtImageException>(
+            () => C64CrtCartridgeFactory.Create(image));
+    }
+
+    [Fact]
+    public void FinalCartridgeIII_Hidden_Register_Ignores_Writes_Until_Freeze()
+    {
+        var cartridge = Assert.IsType<C64FinalCartridgeIIICartridge>(
+            C64CrtCartridgeFactory.Create(C64CrtParser.Parse(BuildCrt(
+                hardwareType: (ushort)C64CrtHardwareType.FinalCartridgeIII,
+                exromHigh: false,
+                gameHigh: false,
+                chips: CreateFinalCartridgeIIIBankChips(4)))));
+
+        cartridge.WriteIO(0xDFFF, 0xF3); // Bank 3, released mode, hide register.
+        cartridge.WriteIO(0xDFFF, 0x40);
+
+        Assert.False(cartridge.IsRegisterEnabled);
+        Assert.Equal((ushort)3, cartridge.CurrentBank);
+        Assert.Equal(C64CartridgeLines.Released, cartridge.Lines);
+
+        cartridge.Freeze();
+        cartridge.WriteIO(0xDFFF, 0x40);
+
+        Assert.True(cartridge.IsRegisterEnabled);
+        Assert.False(cartridge.IsFreezeMode);
+        Assert.Equal((ushort)0, cartridge.CurrentBank);
+        Assert.Equal(new C64CartridgeLines(GameHigh: false, ExromHigh: false), cartridge.Lines);
+    }
+
+    [Fact]
+    public void FinalCartridgeIII_Control_Register_Drives_The_Cartridge_Nmi_Line()
+    {
+        var c64 = BuildC64();
+        var chips = CreateFinalCartridgeIIIBankChips(4);
+        chips[1].Data[0x3FFA] = 0x78;
+        chips[1].Data[0x3FFB] = 0x56;
+        c64.AttachCrtImage(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.FinalCartridgeIII,
+            exromHigh: false,
+            gameHigh: false,
+            chips: chips));
+
+        c64.Mem.Write(0xDFFF, 0x11); // Bank 1, Ultimax, assert NMI.
+
+        Assert.True(c64.CartridgeSlot.NmiLineActive);
+        Assert.True(c64.CPU.CPUInterrupts.NMIPending);
+        c64.CPU.ProcessPendingInterrupts(c64.Mem);
+        Assert.Equal((ushort)0x5678, c64.CPU.PC);
+
+        c64.Mem.Write(0xDFFF, 0x51); // Keep mapping and bank, release NMI.
+
+        Assert.False(c64.CartridgeSlot.NmiLineActive);
+    }
+
+    [Fact]
+    public void FinalCartridgeIII_Freeze_Preserves_Bank_And_Services_Its_Nmi_Vector()
+    {
+        var c64 = BuildC64();
+        var chips = CreateFinalCartridgeIIIBankChips(4);
+        chips[2].Data[0x3FFA] = 0x34;
+        chips[2].Data[0x3FFB] = 0x12;
+        c64.AttachCrtImage(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.FinalCartridgeIII,
+            exromHigh: false,
+            gameHigh: false,
+            chips: chips));
+        c64.Mem.Write(0xDFFF, 0xF2); // Bank 2, released mode, hide register.
+
+        var frozen = c64.FreezeAttachedCartridge();
+
+        var cartridge = Assert.IsType<C64FinalCartridgeIIICartridge>(
+            c64.CartridgeSlot.AttachedCartridge);
+        Assert.True(frozen);
+        Assert.True(cartridge.IsFreezeMode);
+        Assert.True(cartridge.IsRegisterEnabled);
+        Assert.Equal((ushort)2, cartridge.CurrentBank);
+        Assert.Equal(new C64CartridgeLines(GameHigh: false, ExromHigh: true), cartridge.Lines);
+        Assert.Equal((ushort)0x1234, c64.CPU.PC);
+    }
+
+    [Fact]
     public void Unsupported_Hardware_Type_Does_Not_Replace_Current_Cartridge()
     {
         var c64 = BuildC64();
@@ -684,6 +853,17 @@ public class C64CrtTests
                 (ushort)bank,
                 0x8000,
                 Filled(0x2000, (byte)(0x10 + bank))))
+            .ToArray();
+
+    private static Chip[] CreateFinalCartridgeIIIBankChips(int count)
+        => Enumerable.Range(0, count)
+            .Select(bank => new Chip(
+                (ushort)bank,
+                0x8000,
+                [
+                    .. Filled(0x2000, (byte)(0x10 + bank)),
+                    .. Filled(0x2000, (byte)(0x20 + bank)),
+                ]))
             .ToArray();
 
     private sealed record Chip(ushort Bank, ushort Address, byte[] Data);

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CrtTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CrtTests.cs
@@ -729,10 +729,11 @@ public class C64CrtTests
     }
 
     [Fact]
-    public void FinalCartridgeIII_Freeze_Preserves_Bank_And_Services_Its_Nmi_Vector()
+    public void FinalCartridgeIII_Freeze_Keeps_Selected_Bank_And_Services_Its_Nmi_Vector()
     {
         var c64 = BuildC64();
         var chips = CreateFinalCartridgeIIIBankChips(4);
+        chips[2].Data[0x1FE0] = 0x8E; // IO2 mirror at $DFE0 should come from the selected bank.
         chips[2].Data[0x3FFA] = 0x34;
         chips[2].Data[0x3FFB] = 0x12;
         c64.AttachCrtImage(BuildCrt(
@@ -740,7 +741,7 @@ public class C64CrtTests
             exromHigh: false,
             gameHigh: false,
             chips: chips));
-        c64.Mem.Write(0xDFFF, 0xF2); // Bank 2, released mode, hide register.
+        c64.Mem.Write(0xDFFF, 0x72); // Bank 2, released mode.
 
         var frozen = c64.FreezeAttachedCartridge();
 
@@ -751,7 +752,181 @@ public class C64CrtTests
         Assert.True(cartridge.IsRegisterEnabled);
         Assert.Equal((ushort)2, cartridge.CurrentBank);
         Assert.Equal(new C64CartridgeLines(GameHigh: false, ExromHigh: true), cartridge.Lines);
+        Assert.Equal(0x8E, c64.Mem.Read(0xDFE0));
         Assert.Equal((ushort)0x1234, c64.CPU.PC);
+    }
+
+    [Fact]
+    public void FinalCartridgeIII_Freeze_Writes_To_Ram_Under_ROMH_For_VIC_Bank_Three()
+    {
+        var c64 = BuildC64();
+        var chips = CreateFinalCartridgeIIIBankChips(4);
+        chips[3].Data[0x3FFA] = 0x34;
+        chips[3].Data[0x3FFB] = 0x12;
+        c64.AttachCrtImage(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.FinalCartridgeIII,
+            exromHigh: false,
+            gameHigh: false,
+            chips: chips));
+        c64.Mem.Write(0xDFFF, 0x73); // Bank 3, released mode.
+        c64.FreezeAttachedCartridge();
+        c64.Vic2.SetVIC2Bank(0x00); // VIC bank 3: C64 $C000-$FFFF.
+
+        c64.Mem.Write(0xE123, 0x5A);
+
+        Assert.Equal(0x5A, c64.RAM[0xE123]);
+        Assert.Equal(0x5A, c64.Vic2.Vic2Mem[0x2123]);
+        Assert.NotEqual(0x5A, c64.Mem.Read(0xE123)); // CPU still reads ROMH while RAM is hidden behind it.
+    }
+
+    [Fact]
+    public void FinalCartridgeIII_Ultimax_Exposes_ROMH_To_VIC()
+    {
+        var c64 = BuildC64();
+        var chips = CreateFinalCartridgeIIIBankChips(4);
+        chips[3].Data[0x2000 + 0x1140] = 0xA5; // ROMH byte visible to VIC bank 3 at C64 $F140.
+        c64.RAM[0xF140] = 0x00;
+        c64.AttachCrtImage(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.FinalCartridgeIII,
+            exromHigh: false,
+            gameHigh: false,
+            chips: chips));
+
+        c64.Mem.Write(0xDFFF, 0x13); // Bank 3, Ultimax, assert cartridge NMI line.
+        c64.Vic2.SetVIC2Bank(0x00); // VIC bank 3: C64 $C000-$FFFF.
+
+        Assert.Equal(23, c64.CurrentBank);
+        Assert.Equal(0xA5, c64.Vic2.ReadMemory(0x3140));
+        Assert.Equal(0x00, c64.RAM[0xF140]);
+    }
+
+    [Fact]
+    public void FinalCartridgeIII_Ultimax_Sprite_Data_Can_Come_From_ROMH()
+    {
+        var c64 = BuildC64();
+        var chips = CreateFinalCartridgeIIIBankChips(4);
+        chips[3].Data[0x2000 + 0x1140] = 0x80; // Sprite pointer $C5 starts at VIC $3140 / C64 $F140.
+        c64.RAM[0xC7FA] = 0xC5; // Sprite 2 pointer in VIC bank 3, default screen matrix $0400.
+        c64.RAM[0xF140] = 0x00;
+        c64.AttachCrtImage(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.FinalCartridgeIII,
+            exromHigh: false,
+            gameHigh: false,
+            chips: chips));
+        c64.RAM[0xC7FA] = 0xC5;
+        c64.RAM[0xF140] = 0x00;
+        c64.Vic2.SetVIC2Bank(0x00); // VIC bank 3: C64 $C000-$FFFF.
+        c64.Vic2.MemorySetupStore(0xD018, 0x10); // Screen matrix $0400; sprite pointers at $07F8.
+        c64.Mem.Write(0xDFFF, 0x73); // Bank 3, released mode: sprite data comes from underlying RAM.
+
+        Assert.Equal(0x00, c64.Vic2.SpriteManager.Sprites[2].Data.Rows[0].Bytes[0]);
+
+        c64.Mem.Write(0xDFFF, 0x13); // Bank 3, Ultimax, assert cartridge NMI line.
+
+        var spriteData = c64.Vic2.SpriteManager.Sprites[2].Data;
+
+        Assert.Equal(0x80, spriteData.Rows[0].Bytes[0]);
+        Assert.Equal(0x00, c64.RAM[0xF140]);
+    }
+
+    [Fact]
+    public void FinalCartridgeIII_Freeze_Holds_Nmi_Line_Until_Control_Register_Releases_It()
+    {
+        var c64 = BuildC64();
+        var chips = CreateFinalCartridgeIIIBankChips(4);
+        chips[0].Data[0x3FFA] = 0x34;
+        chips[0].Data[0x3FFB] = 0x12;
+        c64.AttachCrtImage(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.FinalCartridgeIII,
+            exromHigh: false,
+            gameHigh: false,
+            chips: chips));
+
+        var frozen = c64.FreezeAttachedCartridge();
+
+        var cartridge = Assert.IsType<C64FinalCartridgeIIICartridge>(
+            c64.CartridgeSlot.AttachedCartridge);
+        Assert.True(frozen);
+        Assert.True(cartridge.NmiLineActive);
+        Assert.True(c64.CPU.CPUInterrupts.IsNMISourceActive("CartridgeNmi"));
+        Assert.False(c64.CPU.NMI);
+        Assert.Equal((ushort)0x1234, c64.CPU.PC);
+
+        c64.Mem.Write(0xDFFF, 0x40);
+
+        Assert.False(cartridge.NmiLineActive);
+        Assert.False(c64.CPU.CPUInterrupts.IsNMISourceActive("CartridgeNmi"));
+    }
+
+    [Fact]
+    public void FinalCartridgeIII_Control_Register_Releases_Nmi_Line()
+    {
+        var c64 = BuildC64();
+        var chips = CreateFinalCartridgeIIIBankChips(4);
+        c64.AttachCrtImage(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.FinalCartridgeIII,
+            exromHigh: false,
+            gameHigh: false,
+            chips: chips));
+
+        c64.Mem.Write(0xDFFF, 0x00);
+
+        var cartridge = Assert.IsType<C64FinalCartridgeIIICartridge>(
+            c64.CartridgeSlot.AttachedCartridge);
+        Assert.True(cartridge.NmiLineActive);
+        Assert.True(c64.CPU.CPUInterrupts.IsNMISourceActive("CartridgeNmi"));
+
+        c64.Mem.Write(0xDFFF, 0x40);
+
+        Assert.False(cartridge.NmiLineActive);
+        Assert.False(c64.CPU.CPUInterrupts.IsNMISourceActive("CartridgeNmi"));
+    }
+
+    [Fact]
+    public void FinalCartridgeIII_Control_Register_Does_Not_Retrigger_Nmi_While_Line_Is_Active()
+    {
+        var c64 = BuildC64();
+        var chips = CreateFinalCartridgeIIIBankChips(4);
+        c64.AttachCrtImage(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.FinalCartridgeIII,
+            exromHigh: false,
+            gameHigh: false,
+            chips: chips));
+        c64.FreezeAttachedCartridge();
+        c64.CPU.ProcessPendingInterrupts(c64.Mem);
+
+        Assert.True(c64.CartridgeSlot.NmiLineActive);
+        Assert.False(c64.CPU.NMI);
+
+        c64.Mem.Write(0xDFFF, 0x03);
+
+        var cartridge = Assert.IsType<C64FinalCartridgeIIICartridge>(
+            c64.CartridgeSlot.AttachedCartridge);
+        Assert.True(cartridge.NmiLineActive);
+        Assert.False(c64.CPU.NMI);
+        Assert.True(c64.CPU.CPUInterrupts.IsNMISourceActive("CartridgeNmi"));
+    }
+
+    [Fact]
+    public void FinalCartridgeIII_Repeated_Active_Nmi_Register_Write_Does_Not_Retrigger_Nmi()
+    {
+        var c64 = BuildC64();
+        var chips = CreateFinalCartridgeIIIBankChips(4);
+        c64.AttachCrtImage(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.FinalCartridgeIII,
+            exromHigh: false,
+            gameHigh: false,
+            chips: chips));
+
+        c64.Mem.Write(0xDFFF, 0x03);
+        c64.CPU.ProcessPendingInterrupts(c64.Mem);
+
+        Assert.False(c64.CPU.NMI);
+
+        c64.Mem.Write(0xDFFF, 0x03);
+
+        Assert.False(c64.CPU.NMI);
+        Assert.True(c64.CPU.CPUInterrupts.IsNMISourceActive("CartridgeNmi"));
     }
 
     [Fact]

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CrtTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CrtTests.cs
@@ -70,6 +70,25 @@ public class C64CrtTests
     }
 
     [Fact]
+    public void Parser_Accepts_Final_Chip_With_Overstated_Packet_Length_When_Payload_Fits()
+    {
+        var bytes = BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.Expert,
+            exromHigh: false,
+            gameHigh: false,
+            chips: [new Chip(0, 0x8000, Filled(0x2000, 0x42), C64CrtChipType.Flash)]);
+        BinaryPrimitives.WriteUInt32BigEndian(bytes.AsSpan(0x44, 4), 0x4010);
+
+        var image = C64CrtParser.Parse(bytes);
+
+        Assert.Equal((ushort)C64CrtHardwareType.Expert, image.Header.HardwareType);
+        var chip = Assert.Single(image.Chips);
+        Assert.Equal(C64CrtChipType.Flash, chip.Type);
+        Assert.Equal(0x2000, chip.Data.Length);
+        Assert.Equal(0x42, chip.Data[0]);
+    }
+
+    [Fact]
     public void Factory_Creates_Generic_8K_Cartridge()
     {
         var image = C64CrtParser.Parse(BuildCrt(
@@ -930,6 +949,196 @@ public class C64CrtTests
     }
 
     [Fact]
+    public void Factory_Creates_Expert_Cartridge_From_Saved_Ram_Image()
+    {
+        var ram = Filled(0x2000, 0x42);
+        ram[0x1FFC] = 0x34;
+        ram[0x1FFD] = 0x12;
+        var image = C64CrtParser.Parse(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.Expert,
+            exromHigh: false,
+            gameHigh: false,
+            name: "EXPERT TEST",
+            chips: [new Chip(0, 0x8000, ram, C64CrtChipType.Flash)]));
+
+        var cartridge = Assert.IsType<C64ExpertCartridge>(
+            C64CrtCartridgeFactory.Create(image));
+
+        Assert.Equal("EXPERT TEST", cartridge.Name);
+        Assert.Equal(C64ExpertMode.On, cartridge.Mode);
+        Assert.Equal(new C64CartridgeLines(GameHigh: false, ExromHigh: true), cartridge.Lines);
+        Assert.True(cartridge.HasROML);
+        Assert.True(cartridge.HasROMH);
+        Assert.True(cartridge.HandlesROMLWrite);
+        Assert.Equal(0x42, cartridge.ReadROML(0x8000));
+        Assert.Equal(0x34, cartridge.ReadROMH(0xFFFC));
+    }
+
+    [Theory]
+    [InlineData("wrong-count")]
+    [InlineData("wrong-bank")]
+    [InlineData("wrong-address")]
+    [InlineData("wrong-size")]
+    public void Factory_Rejects_Invalid_Expert_Images(string invalidShape)
+    {
+        Chip[] chips = invalidShape switch
+        {
+            "wrong-count" =>
+            [
+                new Chip(0, 0x8000, Filled(0x2000, 0x10), C64CrtChipType.Flash),
+                new Chip(1, 0x8000, Filled(0x2000, 0x11), C64CrtChipType.Flash),
+            ],
+            "wrong-bank" => [new Chip(1, 0x8000, Filled(0x2000, 0x10), C64CrtChipType.Flash)],
+            "wrong-address" => [new Chip(0, 0xA000, Filled(0x2000, 0x10), C64CrtChipType.Flash)],
+            "wrong-size" => [new Chip(0, 0x8000, Filled(0x1000, 0x10), C64CrtChipType.Flash)],
+            _ => throw new ArgumentOutOfRangeException(nameof(invalidShape)),
+        };
+        var image = C64CrtParser.Parse(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.Expert,
+            exromHigh: false,
+            gameHigh: false,
+            chips: chips));
+
+        Assert.Throws<C64CrtImageException>(
+            () => C64CrtCartridgeFactory.Create(image));
+    }
+
+    [Fact]
+    public void Expert_Attach_Resets_From_Cartridge_Ram_Vector_And_Allows_Roml_Writes()
+    {
+        var c64 = BuildC64();
+        var ram = Filled(0x2000, 0x42);
+        ram[0x1FFC] = 0x34;
+        ram[0x1FFD] = 0x12;
+        var crt = BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.Expert,
+            exromHigh: false,
+            gameHigh: false,
+            name: "EXPERT TEST",
+            chips: [new Chip(0, 0x8000, ram, C64CrtChipType.Flash)]);
+
+        var result = c64.AttachCrtImage(crt, "expert.crt");
+
+        var cartridge = Assert.IsType<C64ExpertCartridge>(c64.CartridgeSlot.AttachedCartridge);
+        Assert.Equal("EXPERT TEST", result.CartridgeName);
+        Assert.Equal((ushort)0x1234, c64.CPU.PC);
+        Assert.Equal(0x42, c64.Mem.Read(0x8000));
+
+        c64.Mem.Write(0x8000, 0x99);
+
+        Assert.Equal(0x99, cartridge.ReadRam(0));
+        Assert.Equal(0x99, c64.Mem.Read(0x8000));
+    }
+
+    [Fact]
+    public void Expert_IO1_Access_Toggles_Ram_Visibility_And_Disables_Cartridge_Ram_Writes()
+    {
+        var c64 = BuildC64();
+        c64.RAM[0x8000] = 0x55;
+        var ram = Filled(0x2000, 0x42);
+        ram[0x1FFC] = 0x34;
+        ram[0x1FFD] = 0x12;
+        c64.AttachCrtImage(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.Expert,
+            exromHigh: false,
+            gameHigh: false,
+            chips: [new Chip(0, 0x8000, ram, C64CrtChipType.Flash)]));
+        var cartridge = Assert.IsType<C64ExpertCartridge>(c64.CartridgeSlot.AttachedCartridge);
+        c64.WriteIOStorage(0xDE00, 0xA5);
+
+        var ioValue = c64.Mem.Read(0xDE00);
+
+        Assert.Equal(0xA5, ioValue);
+        Assert.False(cartridge.IsRamVisible);
+        Assert.Equal(new C64CartridgeLines(GameHigh: false, ExromHigh: true), cartridge.Lines);
+        Assert.Equal(23, c64.CurrentBank);
+        Assert.False(cartridge.HandlesROMLWrite);
+        Assert.Equal(0x55, c64.Mem.Read(0x8000));
+
+        c64.Mem.Write(0x8000, 0x77);
+
+        Assert.Equal(0x42, cartridge.ReadRam(0));
+        Assert.Equal(0x77, c64.RAM[0x8000]);
+    }
+
+    [Fact]
+    public void Expert_Hidden_Romh_Falls_Back_To_Normal_C64_Memory_While_Keeping_Ultimax_Lines()
+    {
+        var c64 = BuildC64();
+        c64.ROMData[C64SystemConfig.KERNAL_ROM_NAME][0x1DBD] = 0x85;
+        c64.RAM[0xFDBD] = 0x42;
+        var ram = Filled(0x2000, 0x99);
+        ram[0x1FFC] = 0x34;
+        ram[0x1FFD] = 0x12;
+        c64.AttachCrtImage(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.Expert,
+            exromHigh: false,
+            gameHigh: false,
+            chips: [new Chip(0, 0x8000, ram, C64CrtChipType.Flash)]));
+        var cartridge = Assert.IsType<C64ExpertCartridge>(c64.CartridgeSlot.AttachedCartridge);
+
+        Assert.Equal(0x99, c64.Mem.Read(0xFDBD));
+
+        c64.Mem.Write(0x01, 0x37);
+        c64.Mem.Read(0xDE00);
+
+        Assert.False(cartridge.IsRamVisible);
+        Assert.Equal(new C64CartridgeLines(GameHigh: false, ExromHigh: true), cartridge.Lines);
+        Assert.Equal(23, c64.CurrentBank);
+        Assert.Equal(0x85, c64.Mem.Read(0xFDBD));
+
+        c64.Mem.Write(0x01, 0x35);
+
+        Assert.Equal(0x42, c64.Mem.Read(0xFDBD));
+    }
+
+    [Fact]
+    public void Expert_Freeze_In_On_Mode_Remaps_Writable_Ram()
+    {
+        var c64 = BuildC64();
+        c64.AttachCrtImage(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.Expert,
+            exromHigh: false,
+            gameHigh: false,
+            chips: [new Chip(0, 0x8000, Filled(0x2000, 0x42), C64CrtChipType.Flash)]));
+        var cartridge = Assert.IsType<C64ExpertCartridge>(c64.CartridgeSlot.AttachedCartridge);
+        c64.Mem.Read(0xDE00);
+
+        var frozen = c64.FreezeAttachedCartridge();
+
+        Assert.True(frozen);
+        Assert.True(cartridge.IsRamVisible);
+        Assert.True(cartridge.HandlesROMLWrite);
+        Assert.Equal(0x42, c64.Mem.Read(0x8000));
+    }
+
+    [Fact]
+    public void Expert_Maps_Writable_Ram_When_Any_Nmi_Is_Acknowledged()
+    {
+        var c64 = BuildC64();
+        var ram = Filled(0x2000, 0x42);
+        ram[0x1FFA] = 0x78;
+        ram[0x1FFB] = 0x56;
+        ram[0x1FFC] = 0x34;
+        ram[0x1FFD] = 0x12;
+        c64.AttachCrtImage(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.Expert,
+            exromHigh: false,
+            gameHigh: false,
+            chips: [new Chip(0, 0x8000, ram, C64CrtChipType.Flash)]));
+        var cartridge = Assert.IsType<C64ExpertCartridge>(c64.CartridgeSlot.AttachedCartridge);
+        c64.Mem.Read(0xDE00);
+        Assert.False(cartridge.IsRamVisible);
+
+        c64.CPU.CPUInterrupts.SetNMISourceActive("test");
+        c64.CPU.ProcessPendingInterrupts(c64.Mem);
+
+        Assert.True(cartridge.IsRamVisible);
+        Assert.True(cartridge.HandlesROMLWrite);
+        Assert.Equal((ushort)0x5678, c64.CPU.PC);
+    }
+
+    [Fact]
     public void Unsupported_Hardware_Type_Does_Not_Replace_Current_Cartridge()
     {
         var c64 = BuildC64();
@@ -1005,7 +1214,7 @@ public class C64CrtTests
         {
             Encoding.ASCII.GetBytes("CHIP").CopyTo(bytes, offset);
             BinaryPrimitives.WriteUInt32BigEndian(bytes.AsSpan(offset + 4, 4), (uint)(0x10 + chip.Data.Length));
-            BinaryPrimitives.WriteUInt16BigEndian(bytes.AsSpan(offset + 8, 2), (ushort)C64CrtChipType.Rom);
+            BinaryPrimitives.WriteUInt16BigEndian(bytes.AsSpan(offset + 8, 2), (ushort)chip.Type);
             BinaryPrimitives.WriteUInt16BigEndian(bytes.AsSpan(offset + 10, 2), chip.Bank);
             BinaryPrimitives.WriteUInt16BigEndian(bytes.AsSpan(offset + 12, 2), chip.Address);
             BinaryPrimitives.WriteUInt16BigEndian(bytes.AsSpan(offset + 14, 2), (ushort)chip.Data.Length);
@@ -1041,5 +1250,9 @@ public class C64CrtTests
                 ]))
             .ToArray();
 
-    private sealed record Chip(ushort Bank, ushort Address, byte[] Data);
+    private sealed record Chip(
+        ushort Bank,
+        ushort Address,
+        byte[] Data,
+        C64CrtChipType Type = C64CrtChipType.Rom);
 }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CrtTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CrtTests.cs
@@ -143,6 +143,107 @@ public class C64CrtTests
     }
 
     [Fact]
+    public void Factory_Creates_MagicDesk_Cartridge_With_Banked_Rom()
+    {
+        var image = C64CrtParser.Parse(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.MagicDesk,
+            exromHigh: false,
+            gameHigh: true,
+            name: "MAGIC DESK TEST",
+            chips:
+            [
+                new Chip(0, 0x8000, Filled(0x2000, 0x10)),
+                new Chip(1, 0x8000, Filled(0x2000, 0x11)),
+                new Chip(2, 0x8000, Filled(0x2000, 0x12)),
+                new Chip(3, 0x8000, Filled(0x2000, 0x13)),
+            ]));
+
+        var cartridge = Assert.IsType<C64MagicDeskCartridge>(
+            C64CrtCartridgeFactory.Create(image));
+
+        Assert.Equal("MAGIC DESK TEST", cartridge.Name);
+        Assert.Equal(new C64CartridgeLines(GameHigh: true, ExromHigh: false), cartridge.Lines);
+        Assert.Equal((ushort)0, cartridge.CurrentBank);
+        Assert.Equal(0x10, cartridge.ReadROML(0x8000));
+        Assert.False(cartridge.HandlesIORead(0xDE00));
+        Assert.True(cartridge.HandlesIOWrite(0xDE00));
+
+        cartridge.WriteIO(0xDE00, 2);
+
+        Assert.Equal((ushort)2, cartridge.CurrentBank);
+        Assert.Equal(0x12, cartridge.ReadROML(0x8000));
+    }
+
+    [Theory]
+    [InlineData("duplicate-bank")]
+    [InlineData("invalid-address")]
+    [InlineData("invalid-size")]
+    [InlineData("bank-too-high")]
+    public void Factory_Rejects_Invalid_MagicDesk_Images(string invalidShape)
+    {
+        Chip[] chips = invalidShape switch
+        {
+            "duplicate-bank" =>
+            [
+                new Chip(0, 0x8000, Filled(0x2000, 0x10)),
+                new Chip(0, 0x8000, Filled(0x2000, 0x11)),
+            ],
+            "invalid-address" => [new Chip(0, 0x9000, Filled(0x2000, 0x10))],
+            "invalid-size" => [new Chip(0, 0x8000, Filled(0x1000, 0x10))],
+            "bank-too-high" => [new Chip(128, 0x8000, Filled(0x2000, 0x10))],
+            _ => throw new ArgumentOutOfRangeException(nameof(invalidShape)),
+        };
+        var image = C64CrtParser.Parse(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.MagicDesk,
+            exromHigh: false,
+            gameHigh: true,
+            chips: chips));
+
+        Assert.Throws<C64CrtImageException>(
+            () => C64CrtCartridgeFactory.Create(image));
+    }
+
+    [Fact]
+    public void MagicDesk_Attach_Switches_Banks_And_Can_Disable_And_Reenable_Itself()
+    {
+        var c64 = BuildC64();
+        c64.RAM[0x8000] = 0x44;
+        c64.IO[0x0E00] = 0x5A;
+        var crt = BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.MagicDesk,
+            exromHigh: false,
+            gameHigh: true,
+            name: "MAGIC DESK TEST",
+            chips:
+            [
+                new Chip(0, 0x8000, Filled(0x2000, 0x10)),
+                new Chip(1, 0x8000, Filled(0x2000, 0x11)),
+                new Chip(2, 0x8000, Filled(0x2000, 0x12)),
+                new Chip(3, 0x8000, Filled(0x2000, 0x13)),
+            ]);
+
+        var result = c64.AttachCrtImage(crt, "magic-desk.crt");
+
+        Assert.Equal((ushort)C64CrtHardwareType.MagicDesk, result.HardwareType);
+        Assert.Equal(0x10, c64.Mem.Read(0x8000));
+        Assert.Equal(0x5A, c64.Mem.Read(0xDE00));
+
+        c64.Mem.Write(0xDE00, 2);
+
+        Assert.Equal(0x12, c64.Mem.Read(0x8000));
+
+        c64.Mem.Write(0xDE00, 0x80);
+
+        Assert.Equal(C64CartridgeLines.Released, c64.CartridgeSlot.Lines);
+        Assert.Equal(0x44, c64.Mem.Read(0x8000));
+
+        c64.Mem.Write(0xDE00, 1);
+
+        Assert.Equal(new C64CartridgeLines(GameHigh: true, ExromHigh: false), c64.CartridgeSlot.Lines);
+        Assert.Equal(0x11, c64.Mem.Read(0x8000));
+    }
+
+    [Fact]
     public void Unsupported_Hardware_Type_Does_Not_Replace_Current_Cartridge()
     {
         var c64 = BuildC64();

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CrtTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64CrtTests.cs
@@ -244,6 +244,113 @@ public class C64CrtTests
     }
 
     [Fact]
+    public void Factory_Creates_Ocean_16K_Cartridge_With_Mirrored_Banked_Rom()
+    {
+        var image = C64CrtParser.Parse(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.Ocean,
+            exromHigh: false,
+            gameHigh: false,
+            name: "OCEAN TEST",
+            chips: CreateBankChips(4)));
+
+        var cartridge = Assert.IsType<C64OceanCartridge>(
+            C64CrtCartridgeFactory.Create(image));
+
+        Assert.False(cartridge.UseEightKMode);
+        Assert.Equal(new C64CartridgeLines(GameHigh: false, ExromHigh: false), cartridge.Lines);
+        Assert.True(cartridge.HasROML);
+        Assert.True(cartridge.HasROMH);
+        Assert.False(cartridge.HandlesIORead(0xDE00));
+        Assert.True(cartridge.HandlesIOWrite(0xDE00));
+        Assert.Equal(0x10, cartridge.ReadROML(0x8000));
+        Assert.Equal(0x10, cartridge.ReadROMH(0xA000));
+
+        cartridge.WriteIO(0xDE00, 0x82);
+
+        Assert.Equal((ushort)2, cartridge.CurrentBank);
+        Assert.Equal(0x12, cartridge.ReadROML(0x8000));
+        Assert.Equal(0x12, cartridge.ReadROMH(0xA000));
+    }
+
+    [Fact]
+    public void Factory_Creates_Ocean_512K_Cartridge_In_8K_Mode()
+    {
+        var image = C64CrtParser.Parse(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.Ocean,
+            exromHigh: false,
+            gameHigh: true,
+            chips: CreateBankChips(64)));
+
+        var cartridge = Assert.IsType<C64OceanCartridge>(
+            C64CrtCartridgeFactory.Create(image));
+
+        Assert.True(cartridge.UseEightKMode);
+        Assert.Equal(new C64CartridgeLines(GameHigh: true, ExromHigh: false), cartridge.Lines);
+        Assert.False(cartridge.HasROMH);
+
+        cartridge.WriteIO(0xDE00, 63);
+
+        Assert.Equal((ushort)63, cartridge.CurrentBank);
+        Assert.Equal(0x4F, cartridge.ReadROML(0x8000));
+    }
+
+    [Theory]
+    [InlineData("missing-bank")]
+    [InlineData("non-power-of-two")]
+    [InlineData("invalid-address")]
+    [InlineData("invalid-size")]
+    [InlineData("bank-too-high")]
+    public void Factory_Rejects_Invalid_Ocean_Images(string invalidShape)
+    {
+        Chip[] chips = invalidShape switch
+        {
+            "missing-bank" =>
+            [
+                new Chip(0, 0x8000, Filled(0x2000, 0x10)),
+                new Chip(2, 0x8000, Filled(0x2000, 0x12)),
+            ],
+            "non-power-of-two" => CreateBankChips(3),
+            "invalid-address" => [new Chip(0, 0x9000, Filled(0x2000, 0x10))],
+            "invalid-size" => [new Chip(0, 0x8000, Filled(0x1000, 0x10))],
+            "bank-too-high" => [new Chip(64, 0x8000, Filled(0x2000, 0x10))],
+            _ => throw new ArgumentOutOfRangeException(nameof(invalidShape)),
+        };
+        var image = C64CrtParser.Parse(BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.Ocean,
+            exromHigh: false,
+            gameHigh: false,
+            chips: chips));
+
+        Assert.Throws<C64CrtImageException>(
+            () => C64CrtCartridgeFactory.Create(image));
+    }
+
+    [Fact]
+    public void Ocean_Attach_Maps_And_Switches_Mirrored_Rom_Banks()
+    {
+        var c64 = BuildC64();
+        c64.IO[0x0E00] = 0x5A;
+        var crt = BuildCrt(
+            hardwareType: (ushort)C64CrtHardwareType.Ocean,
+            exromHigh: false,
+            gameHigh: false,
+            name: "OCEAN TEST",
+            chips: CreateBankChips(4));
+
+        var result = c64.AttachCrtImage(crt, "ocean.crt");
+
+        Assert.Equal((ushort)C64CrtHardwareType.Ocean, result.HardwareType);
+        Assert.Equal(0x10, c64.Mem.Read(0x8000));
+        Assert.Equal(0x10, c64.Mem.Read(0xA000));
+        Assert.Equal(0x5A, c64.Mem.Read(0xDE00));
+
+        c64.Mem.Write(0xDE00, 3);
+
+        Assert.Equal(0x13, c64.Mem.Read(0x8000));
+        Assert.Equal(0x13, c64.Mem.Read(0xA000));
+    }
+
+    [Fact]
     public void Unsupported_Hardware_Type_Does_Not_Replace_Current_Cartridge()
     {
         var c64 = BuildC64();
@@ -335,6 +442,14 @@ public class C64CrtTests
         Array.Fill(data, value);
         return data;
     }
+
+    private static Chip[] CreateBankChips(int count)
+        => Enumerable.Range(0, count)
+            .Select(bank => new Chip(
+                (ushort)bank,
+                0x8000,
+                Filled(0x2000, (byte)(0x10 + bank))))
+            .ToArray();
 
     private sealed record Chip(ushort Bank, ushort Address, byte[] Data);
 }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64RomCartridgeTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/C64RomCartridgeTests.cs
@@ -1,0 +1,92 @@
+using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64.Cartridge;
+
+public class C64RomCartridgeTests
+{
+    [Fact]
+    public void EightK_Cartridge_Maps_ROML_And_Writes_Through_To_Underlying_RAM()
+    {
+        var c64 = BuildC64();
+        c64.RAM[0x8000] = 0x11;
+        var roml = CreateRom(0x42);
+
+        c64.AttachCartridge(new C64RomCartridge(roml, name: "8K test"));
+
+        Assert.Equal(15, c64.CurrentBank);
+        Assert.Equal(0x42, c64.Mem.Read(0x8000));
+
+        c64.Mem.Write(0x8000, 0x77);
+
+        Assert.Equal(0x77, c64.RAM[0x8000]);
+        Assert.Equal(0x42, c64.Mem.Read(0x8000));
+
+        c64.DetachCartridge();
+
+        Assert.Equal(31, c64.CurrentBank);
+        Assert.Equal(0x77, c64.Mem.Read(0x8000));
+    }
+
+    [Fact]
+    public void SixteenK_Cartridge_Maps_ROML_And_ROMH()
+    {
+        var c64 = BuildC64();
+        var roml = CreateRom(0x42);
+        var romh = CreateRom(0x84);
+
+        c64.AttachCartridge(new C64RomCartridge(roml, romh, "16K test"));
+
+        Assert.Equal(7, c64.CurrentBank);
+        Assert.Equal(0x42, c64.Mem.Read(0x8000));
+        Assert.Equal(0x84, c64.Mem.Read(0xA000));
+        Assert.Equal(0x42, c64.Mem.Read(0x9FFF));
+        Assert.Equal(0x84, c64.Mem.Read(0xBFFF));
+    }
+
+    [Fact]
+    public void SixteenK_Cartridge_Respects_Cpu_Port_Control_Of_Rom_Windows()
+    {
+        var c64 = BuildC64();
+        c64.RAM[0x8000] = 0x11;
+        c64.RAM[0xA000] = 0x22;
+        c64.AttachCartridge(new C64RomCartridge(CreateRom(0x42), CreateRom(0x84)));
+
+        c64.Mem.Write(0x0001, 0x06);
+
+        Assert.Equal(6, c64.CurrentBank);
+        Assert.Equal(0x11, c64.Mem.Read(0x8000));
+        Assert.Equal(0x84, c64.Mem.Read(0xA000));
+    }
+
+    [Theory]
+    [InlineData(0x1FFF, false)]
+    [InlineData(0x2000, true)]
+    [InlineData(0x2001, false)]
+    public void Cartridge_Validates_Rom_Window_Size(int size, bool isValid)
+    {
+        var roml = new byte[size];
+
+        if (isValid)
+            _ = new C64RomCartridge(roml);
+        else
+            Assert.Throws<ArgumentException>(() => new C64RomCartridge(roml));
+    }
+
+    private static C64 BuildC64()
+        => C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            C64Model = "C64PAL",
+            Vic2Model = "PAL",
+        }, NullLoggerFactory.Instance);
+
+    private static byte[] CreateRom(byte value)
+    {
+        var rom = new byte[C64RomCartridge.RomWindowSize];
+        Array.Fill(rom, value);
+        return rom;
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
@@ -310,6 +310,8 @@ public class SwiftLinkDeviceTests
         Assert.Same(c64.CPU.CPUInterrupts, swiftLink.CpuInterrupts);
         Assert.Equal(C64SwiftLinkInterruptMode.IRQ, swiftLink.InterruptMode);
         Assert.Equal(C64SwiftLinkReceiveMode.Compatible, swiftLink.ReceiveMode);
+        Assert.Equal(C64CartridgeLines.Released, swiftLink.Lines);
+        Assert.Equal(31, c64.CurrentBank);
 
         c64.Mem.Write(0xDF02, 0x01);
         Assert.Equal(0x01, c64.Mem.Read(0xDF02));

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
@@ -315,11 +315,16 @@ public class SwiftLinkDeviceTests
             },
         }, new NullLoggerFactory());
 
-        Assert.NotNull(c64.SwiftLink);
-        Assert.Equal((ushort)0xDF00, c64.SwiftLink!.BaseAddress);
-        Assert.Same(c64.CPU.CPUInterrupts, c64.SwiftLink.CpuInterrupts);
-        Assert.Equal(C64SwiftLinkInterruptMode.IRQ, c64.SwiftLink.InterruptMode);
-        Assert.Equal(C64SwiftLinkReceiveMode.Compatible, c64.SwiftLink.ReceiveMode);
+        var swiftLink = c64.CartridgeSlot.GetCartridge<SwiftLinkDevice>();
+
+        Assert.NotNull(swiftLink);
+        Assert.Equal((ushort)0xDF00, swiftLink!.BaseAddress);
+        Assert.Same(c64.CPU.CPUInterrupts, swiftLink.CpuInterrupts);
+        Assert.Equal(C64SwiftLinkInterruptMode.IRQ, swiftLink.InterruptMode);
+        Assert.Equal(C64SwiftLinkReceiveMode.Compatible, swiftLink.ReceiveMode);
+
+        c64.Mem.Write(0xDF02, 0x01);
+        Assert.Equal(0x01, c64.Mem.Read(0xDF02));
     }
 
     [Fact]
@@ -334,7 +339,28 @@ public class SwiftLinkDeviceTests
             },
         }, new NullLoggerFactory());
 
-        Assert.Null(c64.SwiftLink);
+        Assert.Null(c64.CartridgeSlot.AttachedCartridge);
+    }
+
+    [Fact]
+    public void Cleanup_Detaches_SwiftLink_And_Disposes_Its_Transport()
+    {
+        var c64 = C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            SwiftLink =
+            {
+                Enabled = true,
+            },
+        }, new NullLoggerFactory());
+        var swiftLink = c64.CartridgeSlot.GetCartridge<SwiftLinkDevice>()!;
+        var transport = new PendingSendTransport();
+        swiftLink.Transport = transport;
+
+        c64.Cleanup();
+
+        Assert.Null(c64.CartridgeSlot.AttachedCartridge);
+        Assert.Equal(1, transport.DisposeCalls);
     }
 
     private static bool IsRxFull(byte status)
@@ -359,6 +385,7 @@ public class SwiftLinkDeviceTests
         public bool IsConnected => true;
         public bool IsCarrierDetected => true;
         public bool IsDataSetReady => true;
+        public int DisposeCalls { get; private set; }
 
         public ValueTask ConnectAsync(CancellationToken cancellationToken = default)
             => ValueTask.CompletedTask;
@@ -382,6 +409,7 @@ public class SwiftLinkDeviceTests
 
         public void Dispose()
         {
+            DisposeCalls++;
         }
 
         public void CompletePendingSend()

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
@@ -21,8 +21,7 @@ public class SwiftLinkDeviceTests
         await transport.ConnectAsync();
         device.Transport = transport;
 
-        var mem = new Memory();
-        device.MapIOLocations(mem);
+        var mem = MapDevice(device);
 
         await transport.SendAsync(0x41);
         device.Tick();
@@ -41,8 +40,7 @@ public class SwiftLinkDeviceTests
             Transport = transport
         };
 
-        var mem = new Memory();
-        device.MapIOLocations(mem);
+        var mem = MapDevice(device);
 
         mem.Write(0xDE00, 0x42);
         Assert.False(IsTxEmpty(mem.Read(0xDE01)));
@@ -59,8 +57,7 @@ public class SwiftLinkDeviceTests
     public void Device_Maps_At_Configured_Base_Address(C64CartridgeIOAddress cartridgeIOAddress, ushort expectedBaseAddress)
     {
         var device = new SwiftLinkDevice(cartridgeIOAddress, NullLogger<SwiftLinkDevice>.Instance);
-        var mem = new Memory();
-        device.MapIOLocations(mem);
+        var mem = MapDevice(device);
 
         mem.Write((ushort)(expectedBaseAddress + 0x02), 0x77);
 
@@ -75,8 +72,7 @@ public class SwiftLinkDeviceTests
         await transport.ConnectAsync();
         device.Transport = transport;
 
-        var mem = new Memory();
-        device.MapIOLocations(mem);
+        var mem = MapDevice(device);
 
         mem.Write(0xDE02, 0x12);
         mem.Write(0xDE03, 0x34);
@@ -104,8 +100,7 @@ public class SwiftLinkDeviceTests
         await transport.ConnectAsync();
         device.Transport = transport;
 
-        var mem = new Memory();
-        device.MapIOLocations(mem);
+        var mem = MapDevice(device);
         mem.Write(0xDE02, ReceiveIrqEnabledCommand);
 
         await transport.SendAsync(0x41);
@@ -134,8 +129,7 @@ public class SwiftLinkDeviceTests
         await transport.ConnectAsync();
         device.Transport = transport;
 
-        var mem = new Memory();
-        device.MapIOLocations(mem);
+        var mem = MapDevice(device);
         mem.Write(0xDE02, ReceiveIrqEnabledCommand);
 
         await transport.SendAsync(0x41);
@@ -159,8 +153,7 @@ public class SwiftLinkDeviceTests
             CpuInterrupts = interrupts
         };
 
-        var mem = new Memory();
-        device.MapIOLocations(mem);
+        var mem = MapDevice(device);
         mem.Write(0xDE02, TransmitIrqEnabledCommand);
 
         mem.Write(0xDE00, 0x42);
@@ -184,8 +177,7 @@ public class SwiftLinkDeviceTests
         await transport.ConnectAsync();
         device.Transport = transport;
 
-        var mem = new Memory();
-        device.MapIOLocations(mem);
+        var mem = MapDevice(device);
 
         await transport.SendAsync(0x41);
         await transport.SendAsync(0x42);
@@ -213,8 +205,7 @@ public class SwiftLinkDeviceTests
         await transport.ConnectAsync();
         device.Transport = transport;
 
-        var mem = new Memory();
-        device.MapIOLocations(mem);
+        var mem = MapDevice(device);
 
         await transport.SendAsync(0x41);
         await transport.SendAsync(0x42);
@@ -246,8 +237,7 @@ public class SwiftLinkDeviceTests
         await transport.ConnectAsync();
         device.Transport = transport;
 
-        var mem = new Memory();
-        device.MapIOLocations(mem);
+        var mem = MapDevice(device);
 
         mem.Read(0xDE01);
         device.Tick();
@@ -271,8 +261,7 @@ public class SwiftLinkDeviceTests
         await transport.ConnectAsync();
         device.Transport = transport;
 
-        var mem = new Memory();
-        device.MapIOLocations(mem);
+        var mem = MapDevice(device);
 
         await transport.SendAsync(0x41);
         device.Tick();
@@ -289,8 +278,7 @@ public class SwiftLinkDeviceTests
         var transport = new LoopbackTransport();
         device.Transport = transport;
 
-        var mem = new Memory();
-        device.MapIOLocations(mem);
+        var mem = MapDevice(device);
 
         Assert.False(IsDcdHigh(mem.Read(0xDE01)));
         Assert.True(IsDsrHigh(mem.Read(0xDE01)));
@@ -363,8 +351,83 @@ public class SwiftLinkDeviceTests
         Assert.Equal(1, transport.DisposeCalls);
     }
 
+    [Fact]
+    public void SwiftLink_Can_Be_Attached_And_Detached_After_C64_Memory_Is_Created()
+    {
+        var c64 = C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            SwiftLink =
+            {
+                Enabled = false,
+            },
+        }, new NullLoggerFactory());
+        c64.Mem.Write(0xDE02, 0x5A);
+        var swiftLink = new SwiftLinkDevice(
+            C64CartridgeIOAddress.DE00,
+            NullLogger<SwiftLinkDevice>.Instance)
+        {
+            CpuInterrupts = c64.CPU.CPUInterrupts,
+        };
+
+        c64.AttachCartridge(swiftLink);
+        c64.Mem.Write(0xDE02, 0x77);
+
+        Assert.Equal(0x77, c64.Mem.Read(0xDE02));
+
+        c64.DetachCartridge();
+
+        Assert.Null(c64.CartridgeSlot.AttachedCartridge);
+        Assert.Equal(0x5A, c64.Mem.Read(0xDE02));
+    }
+
+    [Fact]
+    public async Task Detaching_SwiftLink_Clears_Its_Interrupt_Line()
+    {
+        var c64 = C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            SwiftLink =
+            {
+                Enabled = false,
+            },
+        }, new NullLoggerFactory());
+        var swiftLink = new SwiftLinkDevice(
+            C64CartridgeIOAddress.DE00,
+            NullLogger<SwiftLinkDevice>.Instance)
+        {
+            CpuInterrupts = c64.CPU.CPUInterrupts,
+        };
+        c64.AttachCartridge(swiftLink);
+        var transport = new LoopbackTransport();
+        await transport.ConnectAsync();
+        swiftLink.Transport = transport;
+        c64.Mem.Write(0xDE02, ReceiveIrqEnabledCommand);
+        await transport.SendAsync(0x41);
+        c64.CartridgeSlot.Tick();
+        Assert.True(c64.CPU.CPUInterrupts.IRQLineEnabled);
+
+        c64.DetachCartridge();
+
+        Assert.False(c64.CPU.CPUInterrupts.IRQLineEnabled);
+        Assert.False(transport.IsConnected);
+    }
+
     private static bool IsRxFull(byte status)
         => (status & (1 << 3)) != 0;
+
+    private static Memory MapDevice(SwiftLinkDevice device)
+    {
+        var memory = new Memory();
+        var io = new byte[0x200];
+        var slot = new C64CartridgeSlot();
+        slot.MapIOLocations(
+            memory,
+            address => io[address - 0xDE00],
+            (address, value) => io[address - 0xDE00] = value);
+        slot.Attach(device);
+        return memory;
+    }
 
     private static bool IsTxEmpty(byte status)
         => (status & (1 << 4)) != 0;

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/D64ZipExtractorTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/D64ZipExtractorTests.cs
@@ -60,6 +60,30 @@ public class D64ZipExtractorTests
     }
 
     [Fact]
+    public void EnsureD64Bytes_Uses_First_D64_When_Zip_Contains_Multiple_D64_Files()
+    {
+        var first = new byte[] { 0x01, 0x02 };
+        var second = new byte[] { 0x03, 0x04 };
+        var zip = BuildZipWith(("disk1.d64", first), ("disk2.d64", second));
+
+        var result = D64ZipExtractor.EnsureD64Bytes(zip);
+
+        Assert.Equal(first, result);
+    }
+
+    [Fact]
+    public void EnsureD64Bytes_Extracts_Explicit_Zip_Entry()
+    {
+        var first = new byte[] { 0x01, 0x02 };
+        var second = new byte[] { 0x03, 0x04 };
+        var zip = BuildZipWith(("disk1.d64", first), ("side-b/disk2.d64", second));
+
+        var result = D64ZipExtractor.EnsureD64Bytes(zip, entryName: "side-b/disk2.d64");
+
+        Assert.Equal(second, result);
+    }
+
+    [Fact]
     public void ExtractFirstD64FromZip_Throws_When_No_D64_Entry()
     {
         var zip = BuildZipWith(("readme.txt", new byte[] { 1 }), ("game.prg", new byte[] { 2 }));

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Render/Vic2RasterizerPixelGeneratorTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Render/Vic2RasterizerPixelGeneratorTests.cs
@@ -45,13 +45,44 @@ public class Vic2RasterizerPixelGeneratorTests
         Assert.Equal(visibleMainScreenArea.Screen.Start.Y + 2, row);
     }
 
+    [Theory]
+    [InlineData("C64PAL", "PAL")]
+    [InlineData("C64NTSC", "NTSC")]
+    public void ConvertRasterLineToScreenLine_aligns_first_display_raster_line_with_visible_layout(string c64Model, string vic2Model)
+    {
+        var c64 = BuildC64(c64Model, vic2Model);
+        var visibleMainScreenArea = c64.Vic2.ScreenLayouts.GetLayout(Vic2ScreenLayouts.LayoutType.Visible, for24RowMode: false, for38ColMode: false);
+
+        var screenLine = c64.Vic2.Vic2Model.ConvertRasterLineToScreenLine(c64.Vic2.Vic2Model.FirstRasterLineOfMainScreen);
+
+        Assert.Equal(visibleMainScreenArea.Screen.Start.Y, screenLine);
+    }
+
+    [Fact]
+    public void Vic2_register_mirrors_update_display_state_used_by_raster_timed_cartridge_code()
+    {
+        var c64 = BuildC64();
+
+        c64.Mem.Write(0xD051, 0x3B); // Mirror of $D011.
+        c64.Mem.Write(0xD058, 0xCD); // Mirror of $D018.
+
+        Assert.Equal(Vic2.DispMode.Bitmap, c64.Vic2.DisplayMode);
+        Assert.Equal(0x3000, c64.Vic2.VideoMatrixBaseAddress);
+        Assert.Equal(0x2000, c64.Vic2.BitmapManager.BitmapAddressInVIC2Bank);
+    }
+
     private static C64 BuildC64()
+    {
+        return BuildC64("C64PAL", "PAL");
+    }
+
+    private static C64 BuildC64(string c64Model, string vic2Model)
     {
         return C64.BuildC64(new C64Config
         {
             LoadROMs = false,
-            C64Model = "C64PAL",
-            Vic2Model = "PAL"
+            C64Model = c64Model,
+            Vic2Model = vic2Model
         }, NullLoggerFactory.Instance);
     }
 

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/TimerAndPeripheral/CiaInterruptTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/TimerAndPeripheral/CiaInterruptTests.cs
@@ -1,0 +1,39 @@
+using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64.TimerAndPeripheral;
+
+public class CiaInterruptTests
+{
+    [Fact]
+    public void Reading_Cia2_Interrupt_Control_Register_Allows_Nmi_To_Retrigger()
+    {
+        var c64 = C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            C64Model = "C64PAL",
+            Vic2Model = "PAL",
+        }, NullLoggerFactory.Instance);
+
+        c64.Cia2.TimerBLOStore(0, 1);
+        c64.Cia2.TimerBHIStore(0, 0);
+        c64.Cia2.InterruptControlStore(0, 0x82);
+        c64.Cia2.TimerBControlStore(0, 0x11);
+
+        c64.Cia2.ProcessTimers(2);
+
+        Assert.True(c64.CPU.CPUInterrupts.NMIPending);
+        Assert.Contains("TimerB", c64.CPU.CPUInterrupts.ActiveNMISources);
+
+        c64.CPU.CPUInterrupts.ClearPendingNMI();
+        c64.Cia2.InterruptControlLoad(0);
+
+        Assert.DoesNotContain("TimerB", c64.CPU.CPUInterrupts.ActiveNMISources);
+
+        c64.Cia2.ProcessTimers(2);
+
+        Assert.True(c64.CPU.CPUInterrupts.NMIPending);
+        Assert.Contains("TimerB", c64.CPU.CPUInterrupts.ActiveNMISources);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/TimerAndPeripheral/CiaInterruptTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/TimerAndPeripheral/CiaInterruptTests.cs
@@ -36,4 +36,89 @@ public class CiaInterruptTests
         Assert.True(c64.CPU.CPUInterrupts.NMIPending);
         Assert.Contains("TimerB", c64.CPU.CPUInterrupts.ActiveNMISources);
     }
+
+    [Fact]
+    public void Cia2_TimerB_Latch_Zero_Does_Not_Immediately_Underflow()
+    {
+        var c64 = C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            C64Model = "C64PAL",
+            Vic2Model = "PAL",
+        }, NullLoggerFactory.Instance);
+
+        c64.Cia2.TimerBLOStore(0, 0);
+        c64.Cia2.TimerBHIStore(0, 0);
+        c64.Cia2.InterruptControlStore(0, 0x82);
+        c64.Cia2.TimerBControlStore(0, 0x11);
+
+        c64.Cia2.ProcessTimers(2);
+
+        Assert.False(c64.CPU.CPUInterrupts.NMIPending);
+        Assert.DoesNotContain("TimerB", c64.CPU.CPUInterrupts.ActiveNMISources);
+    }
+
+    [Fact]
+    public void Cia2_TimerB_Continuous_Underflow_Remains_Visible_Until_Icr_Read()
+    {
+        var c64 = C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            C64Model = "C64PAL",
+            Vic2Model = "PAL",
+        }, NullLoggerFactory.Instance);
+
+        c64.Cia2.TimerBLOStore(0, 1);
+        c64.Cia2.TimerBHIStore(0, 0);
+        c64.Cia2.InterruptControlStore(0, 0x82);
+        c64.Cia2.TimerBControlStore(0, 0x11);
+
+        c64.Cia2.ProcessTimers(2);
+
+        Assert.Equal(0x82, c64.Cia2.InterruptControlLoad(0));
+        Assert.DoesNotContain("TimerB", c64.CPU.CPUInterrupts.ActiveNMISources);
+    }
+
+    [Fact]
+    public void Cia2_TimerB_Underflow_While_Disabled_Does_Not_Set_Any_Interrupt_Bit()
+    {
+        var c64 = C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            C64Model = "C64PAL",
+            Vic2Model = "PAL",
+        }, NullLoggerFactory.Instance);
+
+        c64.Cia2.TimerBLOStore(0, 1);
+        c64.Cia2.TimerBHIStore(0, 0);
+        c64.Cia2.TimerBControlStore(0, 0x11);
+
+        c64.Cia2.ProcessTimers(2);
+
+        Assert.False(c64.CPU.CPUInterrupts.NMIPending);
+        Assert.DoesNotContain("TimerB", c64.CPU.CPUInterrupts.ActiveNMISources);
+        Assert.Equal(0x02, c64.Cia2.InterruptControlLoad(0));
+    }
+
+    [Fact]
+    public void Cia2_TimerB_Triggered_Interrupt_Keeps_Any_Bit_When_Disabled_Before_Read()
+    {
+        var c64 = C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            C64Model = "C64PAL",
+            Vic2Model = "PAL",
+        }, NullLoggerFactory.Instance);
+
+        c64.Cia2.TimerBLOStore(0, 1);
+        c64.Cia2.TimerBHIStore(0, 0);
+        c64.Cia2.InterruptControlStore(0, 0x82);
+        c64.Cia2.TimerBControlStore(0, 0x11);
+
+        c64.Cia2.ProcessTimers(2);
+        c64.Cia2.InterruptControlStore(0, 0x7f);
+
+        Assert.Equal(0x82, c64.Cia2.InterruptControlLoad(0));
+        Assert.DoesNotContain("TimerB", c64.CPU.CPUInterrupts.ActiveNMISources);
+    }
 }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/TimerAndPeripheral/CiaInterruptTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/TimerAndPeripheral/CiaInterruptTests.cs
@@ -1,11 +1,14 @@
 using Highbyte.DotNet6502.Systems.Commodore64;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Highbyte.DotNet6502.Systems.Tests.Commodore64.TimerAndPeripheral;
 
 public class CiaInterruptTests
 {
+    private static readonly string TimerBNmiSource = CiaIRQ.GetInterruptSourceName(IRQSource.TimerB);
+
     [Fact]
     public void Reading_Cia2_Interrupt_Control_Register_Allows_Nmi_To_Retrigger()
     {
@@ -24,17 +27,17 @@ public class CiaInterruptTests
         c64.Cia2.ProcessTimers(2);
 
         Assert.True(c64.CPU.CPUInterrupts.NMIPending);
-        Assert.Contains("TimerB", c64.CPU.CPUInterrupts.ActiveNMISources);
+        Assert.Contains(TimerBNmiSource, c64.CPU.CPUInterrupts.ActiveNMISources);
 
         c64.CPU.CPUInterrupts.ClearPendingNMI();
         c64.Cia2.InterruptControlLoad(0);
 
-        Assert.DoesNotContain("TimerB", c64.CPU.CPUInterrupts.ActiveNMISources);
+        Assert.DoesNotContain(TimerBNmiSource, c64.CPU.CPUInterrupts.ActiveNMISources);
 
         c64.Cia2.ProcessTimers(2);
 
         Assert.True(c64.CPU.CPUInterrupts.NMIPending);
-        Assert.Contains("TimerB", c64.CPU.CPUInterrupts.ActiveNMISources);
+        Assert.Contains(TimerBNmiSource, c64.CPU.CPUInterrupts.ActiveNMISources);
     }
 
     [Fact]
@@ -55,7 +58,7 @@ public class CiaInterruptTests
         c64.Cia2.ProcessTimers(2);
 
         Assert.False(c64.CPU.CPUInterrupts.NMIPending);
-        Assert.DoesNotContain("TimerB", c64.CPU.CPUInterrupts.ActiveNMISources);
+        Assert.DoesNotContain(TimerBNmiSource, c64.CPU.CPUInterrupts.ActiveNMISources);
     }
 
     [Fact]
@@ -76,7 +79,7 @@ public class CiaInterruptTests
         c64.Cia2.ProcessTimers(2);
 
         Assert.Equal(0x82, c64.Cia2.InterruptControlLoad(0));
-        Assert.DoesNotContain("TimerB", c64.CPU.CPUInterrupts.ActiveNMISources);
+        Assert.DoesNotContain(TimerBNmiSource, c64.CPU.CPUInterrupts.ActiveNMISources);
     }
 
     [Fact]
@@ -96,7 +99,7 @@ public class CiaInterruptTests
         c64.Cia2.ProcessTimers(2);
 
         Assert.False(c64.CPU.CPUInterrupts.NMIPending);
-        Assert.DoesNotContain("TimerB", c64.CPU.CPUInterrupts.ActiveNMISources);
+        Assert.DoesNotContain(TimerBNmiSource, c64.CPU.CPUInterrupts.ActiveNMISources);
         Assert.Equal(0x02, c64.Cia2.InterruptControlLoad(0));
     }
 
@@ -119,6 +122,6 @@ public class CiaInterruptTests
         c64.Cia2.InterruptControlStore(0, 0x7f);
 
         Assert.Equal(0x82, c64.Cia2.InterruptControlLoad(0));
-        Assert.DoesNotContain("TimerB", c64.CPU.CPUInterrupts.ActiveNMISources);
+        Assert.DoesNotContain(TimerBNmiSource, c64.CPU.CPUInterrupts.ActiveNMISources);
     }
 }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/TimerAndPeripheral/CiaMirroringTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/TimerAndPeripheral/CiaMirroringTests.cs
@@ -1,0 +1,56 @@
+using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64.TimerAndPeripheral;
+
+public class CiaMirroringTests
+{
+    [Fact]
+    public void Cia1_Interrupt_Control_Register_Is_Mirrored_To_Dcfd()
+    {
+        var c64 = BuildC64();
+        c64.Cia1.TimerBLOStore(0, 1);
+        c64.Cia1.TimerBHIStore(0, 0);
+        c64.Cia1.InterruptControlStore(0, 0x82);
+        c64.Cia1.TimerBControlStore(0, 0x19);
+
+        c64.Cia1.ProcessTimers(2);
+
+        Assert.Equal(0x82, c64.Mem.Read(0xDCFD));
+        Assert.Equal(0x00, c64.Mem.Read(CiaAddr.CIA1_CIAICR));
+    }
+
+    [Fact]
+    public void Cia1_Data_Direction_Register_Writes_Are_Mirrored()
+    {
+        var c64 = BuildC64();
+
+        c64.Mem.Write(0xDCF2, 0xA5);
+
+        Assert.Equal(0xA5, c64.Mem.Read(CiaAddr.CIA1_DDRA));
+        Assert.Equal(0xA5, c64.Mem.Read(0xDCF2));
+    }
+
+    [Fact]
+    public void Cia2_Data_Port_Writes_Are_Mirrored()
+    {
+        var c64 = BuildC64();
+
+        c64.Mem.Write(0xDDF0, 0x03);
+
+        Assert.Equal(0xC3, c64.Mem.Read(CiaAddr.CIA2_DATAA));
+        Assert.Equal(0xC3, c64.Mem.Read(0xDDF0));
+    }
+
+    private static C64 BuildC64()
+    {
+        return C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            C64Model = "C64PAL",
+            Vic2Model = "PAL"
+        }, NullLoggerFactory.Instance);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Video/Vic2IrqTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Video/Vic2IrqTests.cs
@@ -1,0 +1,49 @@
+using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Systems.Commodore64.Video;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64.Video;
+
+public class Vic2IrqTests
+{
+    [Fact]
+    public void Raster_Event_Is_Latched_When_Irq_Mask_Is_Disabled()
+    {
+        var c64 = BuildC64();
+        c64.Mem.Write(Vic2Addr.CURRENT_RASTER_LINE, 1);
+        c64.Mem.Write(Vic2Addr.IRQ_MASK, 0);
+
+        c64.Vic2.AdvanceRaster(c64.Vic2.Vic2Model.CyclesPerLine);
+
+        Assert.Equal(0x01, c64.Mem.Read(Vic2Addr.VIC_IRQ) & 0x81);
+        Assert.False(c64.CPU.CPUInterrupts.IsIRQSourceActive(IRQSource.RasterCompare.ToString()));
+    }
+
+    [Fact]
+    public void Enabling_And_Disabling_A_Latched_Source_Controls_The_Cpu_Irq_Line()
+    {
+        var c64 = BuildC64();
+        c64.Mem.Write(Vic2Addr.CURRENT_RASTER_LINE, 1);
+        c64.Mem.Write(Vic2Addr.IRQ_MASK, 0);
+        c64.Vic2.AdvanceRaster(c64.Vic2.Vic2Model.CyclesPerLine);
+
+        c64.Mem.Write(Vic2Addr.IRQ_MASK, 1);
+        Assert.True(c64.CPU.CPUInterrupts.IsIRQSourceActive(IRQSource.RasterCompare.ToString()));
+        Assert.Equal(0x81, c64.Mem.Read(Vic2Addr.VIC_IRQ) & 0x81);
+
+        c64.Mem.Write(Vic2Addr.IRQ_MASK, 0);
+        Assert.False(c64.CPU.CPUInterrupts.IsIRQSourceActive(IRQSource.RasterCompare.ToString()));
+        Assert.Equal(0x01, c64.Mem.Read(Vic2Addr.VIC_IRQ) & 0x81);
+    }
+
+    private static C64 BuildC64()
+    {
+        return C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            C64Model = "C64PAL",
+            Vic2Model = "PAL"
+        }, NullLoggerFactory.Instance);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Video/Vic2IrqTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Video/Vic2IrqTests.cs
@@ -7,6 +7,8 @@ namespace Highbyte.DotNet6502.Systems.Tests.Commodore64.Video;
 
 public class Vic2IrqTests
 {
+    private static readonly string RasterCompareIrqSource = Vic2IRQ.GetInterruptSourceName(IRQSource.RasterCompare);
+
     [Fact]
     public void Raster_Event_Is_Latched_When_Irq_Mask_Is_Disabled()
     {
@@ -17,7 +19,7 @@ public class Vic2IrqTests
         c64.Vic2.AdvanceRaster(c64.Vic2.Vic2Model.CyclesPerLine);
 
         Assert.Equal(0x01, c64.Mem.Read(Vic2Addr.VIC_IRQ) & 0x81);
-        Assert.False(c64.CPU.CPUInterrupts.IsIRQSourceActive(IRQSource.RasterCompare.ToString()));
+        Assert.False(c64.CPU.CPUInterrupts.IsIRQSourceActive(RasterCompareIrqSource));
     }
 
     [Fact]
@@ -29,11 +31,11 @@ public class Vic2IrqTests
         c64.Vic2.AdvanceRaster(c64.Vic2.Vic2Model.CyclesPerLine);
 
         c64.Mem.Write(Vic2Addr.IRQ_MASK, 1);
-        Assert.True(c64.CPU.CPUInterrupts.IsIRQSourceActive(IRQSource.RasterCompare.ToString()));
+        Assert.True(c64.CPU.CPUInterrupts.IsIRQSourceActive(RasterCompareIrqSource));
         Assert.Equal(0x81, c64.Mem.Read(Vic2Addr.VIC_IRQ) & 0x81);
 
         c64.Mem.Write(Vic2Addr.IRQ_MASK, 0);
-        Assert.False(c64.CPU.CPUInterrupts.IsIRQSourceActive(IRQSource.RasterCompare.ToString()));
+        Assert.False(c64.CPU.CPUInterrupts.IsIRQSourceActive(RasterCompareIrqSource));
         Assert.Equal(0x01, c64.Mem.Read(Vic2Addr.VIC_IRQ) & 0x81);
     }
 

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/ZipImageExtractorTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/ZipImageExtractorTests.cs
@@ -1,0 +1,182 @@
+using System.IO.Compression;
+using Highbyte.DotNet6502.Systems.Commodore64.Utils;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64;
+
+public class ZipImageExtractorTests
+{
+    private static byte[] BuildZipWith(params (string name, byte[] content)[] entries)
+    {
+        using var ms = new MemoryStream();
+        using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (name, content) in entries)
+            {
+                var entry = archive.CreateEntry(name);
+                using var entryStream = entry.Open();
+                entryStream.Write(content, 0, content.Length);
+            }
+        }
+        return ms.ToArray();
+    }
+
+    [Fact]
+    public void EnsureImageBytes_Returns_Raw_Bytes_Unchanged()
+    {
+        var raw = new byte[] { 0x10, 0x20, 0x30 };
+
+        var result = ZipImageExtractor.EnsureImageBytes(
+            raw,
+            ".crt",
+            ZipImageMultipleMatchBehavior.Throw);
+
+        Assert.Same(raw, result);
+    }
+
+    [Fact]
+    public void EnsureImageBytes_Extracts_Matching_Extension_From_Zip()
+    {
+        var crtContent = new byte[] { 0x43, 0x36, 0x34 };
+        var zip = BuildZipWith(("readme.txt", new byte[] { 1 }), ("fc3.crt", crtContent));
+
+        var result = ZipImageExtractor.EnsureImageBytes(
+            zip,
+            ".crt",
+            ZipImageMultipleMatchBehavior.Throw);
+
+        Assert.Equal(crtContent, result);
+    }
+
+    [Fact]
+    public void EnsureImageBytes_Normalizes_Extension()
+    {
+        var crtContent = new byte[] { 0x01 };
+        var zip = BuildZipWith(("fc3.crt", crtContent));
+
+        var result = ZipImageExtractor.EnsureImageBytes(
+            zip,
+            "crt",
+            ZipImageMultipleMatchBehavior.Throw);
+
+        Assert.Equal(crtContent, result);
+    }
+
+    [Fact]
+    public void EnsureImageBytes_Throws_When_Multiple_Matches_Are_Ambiguous()
+    {
+        var zip = BuildZipWith(
+            ("fc3.crt", new byte[] { 0x01 }),
+            ("expert.crt", new byte[] { 0x02 }));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ZipImageExtractor.EnsureImageBytes(
+                zip,
+                ".crt",
+                ZipImageMultipleMatchBehavior.Throw));
+
+        Assert.Contains("Multiple .crt files", exception.Message);
+    }
+
+    [Fact]
+    public void EnsureImageBytes_Uses_First_Match_When_Configured()
+    {
+        var first = new byte[] { 0x01 };
+        var second = new byte[] { 0x02 };
+        var zip = BuildZipWith(("fc3.crt", first), ("expert.crt", second));
+
+        var result = ZipImageExtractor.EnsureImageBytes(
+            zip,
+            ".crt",
+            ZipImageMultipleMatchBehavior.UseFirst);
+
+        Assert.Equal(first, result);
+    }
+
+    [Fact]
+    public void EnsureImageBytes_Extracts_Explicit_Zip_Entry()
+    {
+        var first = new byte[] { 0x01 };
+        var second = new byte[] { 0x02 };
+        var zip = BuildZipWith(("fc3.crt", first), ("side-b/expert.crt", second));
+
+        var result = ZipImageExtractor.EnsureImageBytes(
+            zip,
+            ".crt",
+            ZipImageMultipleMatchBehavior.Throw,
+            entryName: "side-b/expert.crt");
+
+        Assert.Equal(second, result);
+    }
+
+    [Fact]
+    public void EnsureImageBytes_Normalizes_Explicit_Zip_Entry_Slashes()
+    {
+        var crtContent = new byte[] { 0x01 };
+        var zip = BuildZipWith(("carts/fc3.crt", crtContent));
+
+        var result = ZipImageExtractor.EnsureImageBytes(
+            zip,
+            ".crt",
+            ZipImageMultipleMatchBehavior.Throw,
+            entryName: @"\carts\fc3.crt");
+
+        Assert.Equal(crtContent, result);
+    }
+
+    [Fact]
+    public void EnsureImageBytes_Throws_When_Explicit_Zip_Entry_Has_Wrong_Extension()
+    {
+        var zip = BuildZipWith(("readme.txt", new byte[] { 0x01 }));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ZipImageExtractor.EnsureImageBytes(
+                zip,
+                ".crt",
+                ZipImageMultipleMatchBehavior.Throw,
+                entryName: "readme.txt"));
+
+        Assert.Contains("must be a .crt file", exception.Message);
+    }
+
+    [Fact]
+    public void EnsureImageBytes_Throws_When_Explicit_Zip_Entry_Is_Missing()
+    {
+        var zip = BuildZipWith(("fc3.crt", new byte[] { 0x01 }));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ZipImageExtractor.EnsureImageBytes(
+                zip,
+                ".crt",
+                ZipImageMultipleMatchBehavior.Throw,
+                entryName: "expert.crt"));
+
+        Assert.Contains("was not found", exception.Message);
+    }
+
+    [Fact]
+    public void EnsureImageBytes_Throws_When_Explicit_Zip_Entry_Is_Supplied_For_Raw_Bytes()
+    {
+        var raw = new byte[] { 0x10, 0x20, 0x30 };
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ZipImageExtractor.EnsureImageBytes(
+                raw,
+                ".crt",
+                ZipImageMultipleMatchBehavior.Throw,
+                entryName: "fc3.crt"));
+
+        Assert.Contains("not a ZIP archive", exception.Message);
+    }
+
+    [Fact]
+    public void ExtractImageFromZip_Throws_When_No_Matching_Entry()
+    {
+        var zip = BuildZipWith(("readme.txt", new byte[] { 1 }));
+
+        Assert.Throws<InvalidOperationException>(
+            () => ZipImageExtractor.ExtractImageFromZip(
+                zip,
+                ".crt",
+                ZipImageMultipleMatchBehavior.Throw));
+    }
+}


### PR DESCRIPTION
## Summary
- Add C64 cartridge loading and CRT parsing support, including banked ROM handling and cartridge line/device plumbing.
- Update the Commodore 64 system, CPU, CIA, VIC-II, SID, and share-link paths to reflect the new cartridge-aware behavior.
- Expand the Avalonia shell and startup configuration to expose C64 cartridge options in desktop and browser apps.
- Refresh documentation for C64 systems, host apps, and startup parameters.
- Add and update tests covering cartridges, CIA interrupts/mirroring, VIC-II IRQs, rasterization, share links, CPU port behavior, and SID pot registers.

## Testing
- Added and updated automated tests across the Commodore 64 subsystem, including cartridge, timing, audio, video, and interrupt coverage.
- Benchmarks and app entry points were updated to align with the new C64 configuration flow.