### PR TITLE
Unify Avalonia open file picking

### DIFF
--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/BrowserScripting.js
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/BrowserScripting.js
@@ -8,6 +8,91 @@ export function getLocalStorageKeys(prefix) {
     return JSON.stringify(keys);
 }
 
+export function pickLocalFilesAsBase64(accept, allowMultiple) {
+    return new Promise((resolve) => {
+        const input = document.createElement("input");
+        input.type = "file";
+        input.multiple = !!allowMultiple;
+        input.style.position = "fixed";
+        input.style.left = "-10000px";
+        input.style.top = "-10000px";
+
+        if (accept)
+            input.accept = accept;
+
+        let settled = false;
+
+        const finish = (value) => {
+            if (settled)
+                return;
+
+            settled = true;
+            window.removeEventListener("focus", onFocus, true);
+            input.removeEventListener("change", onChange);
+            input.removeEventListener("cancel", onCancel);
+            input.remove();
+            resolve(value ?? "");
+        };
+
+        const supportsCancelEvent = "oncancel" in input;
+
+        const onCancel = () => finish("");
+
+        const onFocus = () => {
+            if (supportsCancelEvent)
+                return;
+
+            // Some browsers do not fire a cancel event for file inputs. When the OS file picker
+            // closes without a selected file, focus returns to the window. Delay long enough for
+            // browsers that restore focus before dispatching the "change" event on real selection;
+            // otherwise a valid file pick can race with this fallback and be reported as cancel.
+            setTimeout(() => {
+                if (!settled && (!input.files || input.files.length === 0))
+                    finish("");
+            }, 1000);
+        };
+
+        const onChange = async () => {
+            if (!input.files || input.files.length === 0) {
+                finish("");
+                return;
+            }
+
+            try {
+                const files = await Promise.all(Array.from(input.files).map(async file => {
+                    const bytes = new Uint8Array(await file.arrayBuffer());
+                    return {
+                        name: file.name,
+                        base64: bytesToBase64(bytes)
+                    };
+                }));
+                finish(JSON.stringify(files));
+            } catch (error) {
+                console.error("Failed to read local file", error);
+                finish("");
+            }
+        };
+
+        input.addEventListener("change", onChange);
+        if (supportsCancelEvent)
+            input.addEventListener("cancel", onCancel);
+        else
+            window.addEventListener("focus", onFocus, true);
+        document.body.appendChild(input);
+        input.click();
+    });
+}
+
+function bytesToBase64(bytes) {
+    const chunkSize = 0x8000;
+    let binary = "";
+
+    for (let i = 0; i < bytes.length; i += chunkSize)
+        binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+
+    return btoa(binary);
+}
+
 export function getScriptsFromLocalStorage(prefix) {
     const results = [];
     for (let i = 0; i < localStorage.length; i++) {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/Program.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/Program.cs
@@ -5,8 +5,10 @@ using System.Text.Json;
 using AvaloniaBrowserApp = Highbyte.DotNet6502.App.Avalonia.Core.App;
 using Avalonia;
 using Avalonia.Browser;
+using Avalonia.Controls;
 using Avalonia.Threading;
 using Highbyte.DotNet6502.App.Avalonia.Core;
+using Highbyte.DotNet6502.App.Avalonia.Core.Services;
 using Highbyte.DotNet6502.Impl.Avalonia.Input;
 using Highbyte.DotNet6502.Impl.Avalonia.Logging;
 using Highbyte.DotNet6502.Impl.Browser.Input;
@@ -1182,6 +1184,39 @@ internal sealed partial class Program
         // emulator's later audio output is allowed to play.
         [JSImport("unlockAudio", "BrowserScripting")]
         public static partial void UnlockAudio();
+
+        [JSImport("pickLocalFilesAsBase64", "BrowserScripting")]
+        public static partial Task<string?> PickLocalFilesAsBase64Async(string accept, bool allowMultiple);
+    }
+
+    private sealed class BrowserAppFilePicker : IAppFilePicker
+    {
+        public async Task<AppPickedFile?> OpenFileAsync(Control owner, AppFilePickerOpenOptions options)
+        {
+            var files = await OpenFilesAsync(owner, options with { AllowMultiple = false });
+            return files.Count == 0 ? null : files[0];
+        }
+
+        public async Task<IReadOnlyList<AppPickedFile>> OpenFilesAsync(Control owner, AppFilePickerOpenOptions options)
+        {
+            var fileJson = await JSInterop.PickLocalFilesAsBase64Async(
+                options.ToBrowserAccept(),
+                options.AllowMultiple);
+            if (string.IsNullOrWhiteSpace(fileJson))
+                return [];
+
+            using var jsonDocument = JsonDocument.Parse(fileJson);
+            var files = new List<AppPickedFile>();
+            foreach (var fileElement in jsonDocument.RootElement.EnumerateArray())
+            {
+                var name = fileElement.GetProperty("name").GetString() ?? string.Empty;
+                var base64 = fileElement.GetProperty("base64").GetString();
+                if (!string.IsNullOrEmpty(base64))
+                    files.Add(new AppPickedFile(name, Convert.FromBase64String(base64)));
+            }
+
+            return files;
+        }
     }
 
     private static async Task SeedExampleScriptsAsync(Action<string, string> saveScript)
@@ -1365,7 +1400,8 @@ internal sealed partial class Program
                                 saveScript: saveScript,
                                 deleteScript: deleteScript,
                                 loadExamples: loadExamples,
-                                automatedStartupRunner: automatedStartupRunner
+                                automatedStartupRunner: automatedStartupRunner,
+                                appFilePicker: new BrowserAppFilePicker()
                             );
         })
         .AfterSetup(_ =>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/App.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/App.axaml.cs
@@ -9,6 +9,7 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
 using Highbyte.DotNet6502.DebugAdapter;
 using Highbyte.DotNet6502.Remoting;
+using Highbyte.DotNet6502.App.Avalonia.Core.Services;
 using Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
 using Highbyte.DotNet6502.App.Avalonia.Core.Views;
 using Highbyte.DotNet6502.Impl.Avalonia.Input;
@@ -46,6 +47,7 @@ public partial class App : Application
     private readonly Action<string>? _deleteScript;
     private readonly Func<Task>? _loadExamples;
     private readonly Func<IHostApp, Task>? _automatedStartupRunner;
+    private readonly IAppFilePicker? _appFilePicker;
     private AvaloniaHostApp _hostApp = default!;
     private IServiceProvider _serviceProvider = default!;
 
@@ -132,7 +134,8 @@ public partial class App : Application
         Action<string, string>? saveScript = null,
         Action<string>? deleteScript = null,
         Func<Task>? loadExamples = null,
-        Func<IHostApp, Task>? automatedStartupRunner = null)
+        Func<IHostApp, Task>? automatedStartupRunner = null,
+        IAppFilePicker? appFilePicker = null)
     {
         WriteBootstrapLog("App constructor called");
 
@@ -150,6 +153,7 @@ public partial class App : Application
         _deleteScript = deleteScript;
         _loadExamples = loadExamples;
         _automatedStartupRunner = automatedStartupRunner;
+        _appFilePicker = appFilePicker;
 
         // Set static reference for external access (e.g., debug adapter)
         Current = this;
@@ -309,6 +313,7 @@ public partial class App : Application
         services.AddSingleton(_configuration);
         services.AddSingleton(_loggerFactory);
         services.AddSingleton(new CustomConfigPersistence(_saveCustomConfigString));
+        services.AddSingleton<IAppFilePicker>(_appFilePicker ?? new AvaloniaStorageAppFilePicker());
         if (_logStore != null)
             services.AddSingleton(_logStore);
         if (_logConfig != null)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Services/IAppFilePicker.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Services/IAppFilePicker.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Platform.Storage;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Core.Services;
+
+public sealed record AppPickedFile(string Name, byte[] Bytes);
+
+public sealed record AppFilePickerFileType(string Name, IReadOnlyList<string> Patterns)
+{
+    public static AppFilePickerFileType AllFiles { get; } = new("All Files", ["*"]);
+}
+
+public sealed record AppFilePickerOpenOptions(
+    string Title,
+    bool AllowMultiple,
+    IReadOnlyList<AppFilePickerFileType> FileTypes)
+{
+    public string ToBrowserAccept()
+    {
+        return string.Join(
+            ",",
+            FileTypes
+                .SelectMany(fileType => fileType.Patterns)
+                .Select(ToBrowserAcceptPattern)
+                .Where(pattern => !string.IsNullOrWhiteSpace(pattern))
+                .Distinct(StringComparer.OrdinalIgnoreCase));
+    }
+
+    private static string ToBrowserAcceptPattern(string pattern)
+    {
+        if (string.IsNullOrWhiteSpace(pattern) || pattern == "*")
+            return string.Empty;
+
+        return pattern.StartsWith("*.", StringComparison.Ordinal)
+            ? pattern[1..]
+            : pattern;
+    }
+}
+
+/// <summary>
+/// App-level open-file picker used by Avalonia views that need local file bytes.
+/// </summary>
+/// <remarks>
+/// File dialogs are UI/platform interactions, so ViewModels should request files from their Views
+/// instead of opening Avalonia dialogs directly. This abstraction keeps that boundary while avoiding
+/// scattered direct StorageProvider calls. It also lets the Browser host replace Avalonia's browser
+/// StorageProvider open-file path: in practice, cancelled browser file dialogs can fail to complete
+/// awaited command flows, leaving ReactiveCommand-backed buttons disabled. Centralizing the picker
+/// gives every open-file UI the same cancel semantics on Desktop and Browser.
+/// </remarks>
+public interface IAppFilePicker
+{
+    Task<AppPickedFile?> OpenFileAsync(Control owner, AppFilePickerOpenOptions options);
+    Task<IReadOnlyList<AppPickedFile>> OpenFilesAsync(Control owner, AppFilePickerOpenOptions options);
+}
+
+/// <summary>
+/// Default Desktop-capable implementation backed by Avalonia's StorageProvider.
+/// </summary>
+public sealed class AvaloniaStorageAppFilePicker : IAppFilePicker
+{
+    public async Task<AppPickedFile?> OpenFileAsync(Control owner, AppFilePickerOpenOptions options)
+    {
+        var files = await OpenFilesAsync(owner, options with { AllowMultiple = false });
+        return files.Count == 0 ? null : files[0];
+    }
+
+    public async Task<IReadOnlyList<AppPickedFile>> OpenFilesAsync(Control owner, AppFilePickerOpenOptions options)
+    {
+        if (TopLevel.GetTopLevel(owner) is not { } topLevel ||
+            !topLevel.StorageProvider.CanOpen)
+        {
+            return [];
+        }
+
+        try
+        {
+            var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            {
+                Title = options.Title,
+                AllowMultiple = options.AllowMultiple,
+                FileTypeFilter = options.FileTypes
+                    .Select(ToAvaloniaFileType)
+                    .ToArray()
+            });
+
+            var pickedFiles = new List<AppPickedFile>(files.Count);
+            foreach (var file in files)
+            {
+                await using var stream = await file.OpenReadAsync();
+                using var buffer = new MemoryStream();
+                await stream.CopyToAsync(buffer);
+                pickedFiles.Add(new AppPickedFile(file.Name, buffer.ToArray()));
+            }
+
+            return pickedFiles;
+        }
+        catch (OperationCanceledException)
+        {
+            return [];
+        }
+    }
+
+    private static FilePickerFileType ToAvaloniaFileType(AppFilePickerFileType fileType)
+    {
+        if (fileType.Patterns.Count == 1 && fileType.Patterns[0] == "*")
+            return FilePickerFileTypes.All;
+
+        return new FilePickerFileType(fileType.Name)
+        {
+            Patterns = fileType.Patterns
+        };
+    }
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
@@ -1251,7 +1251,8 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
         if (AttachCartridgeImageRequested == null)
             return null;
 
-        var tcs = new TaskCompletionSource<SelectedBinaryFile?>();
+        var tcs = new TaskCompletionSource<SelectedBinaryFile?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         AttachCartridgeImageRequested.Invoke(this, tcs);
         return await tcs.Task;
     }
@@ -1368,7 +1369,8 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
         if (AttachDiskImageRequested == null)
             return;
 
-        var tcs = new TaskCompletionSource<byte[]?>();
+        var tcs = new TaskCompletionSource<byte[]?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         AttachDiskImageRequested.Invoke(this, tcs);
         var fileBuffer = await tcs.Task;
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64ConfigUserControl.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64ConfigUserControl.axaml.cs
@@ -7,10 +7,10 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
-using Avalonia.Platform.Storage;
 using Avalonia.VisualTree;
 using AvaloniaApp = Highbyte.DotNet6502.App.Avalonia.Core.App;
 using Highbyte.DotNet6502.App.Avalonia.Core;
+using Highbyte.DotNet6502.App.Avalonia.Core.Services;
 using Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -105,36 +105,28 @@ public partial class C64ConfigUserControl : UserControl
 
     private async Task LoadRomsAsync()
     {
-        if (TopLevel.GetTopLevel(this)?.StorageProvider == null)
+        var serviceProvider = (Application.Current as AvaloniaApp)?.GetServiceProvider();
+        var filePicker = serviceProvider?.GetService<IAppFilePicker>();
+        if (filePicker == null)
             return;
-        var storageProvider = TopLevel.GetTopLevel(this)!.StorageProvider;
 
-        var options = new FilePickerOpenOptions
-        {
-            Title = "Select C64 ROM files",
-            AllowMultiple = true,
-            FileTypeFilter = new List<FilePickerFileType>
-            {
-                new FilePickerFileType("ROM files")
-                {
-                    Patterns = new[] { "*.bin", "*.rom" }
-                },
-                FilePickerFileTypes.All
-            }
-        };
-
-        var files = await storageProvider.OpenFilePickerAsync(options);
-        if (files != null && files.Count > 0)
+        var files = await filePicker.OpenFilesAsync(
+            this,
+            new AppFilePickerOpenOptions(
+                "Select C64 ROM files",
+                AllowMultiple: true,
+                [
+                    new AppFilePickerFileType("ROM files", ["*.bin", "*.rom"]),
+                    AppFilePickerFileType.AllFiles
+                ]));
+        if (files.Count > 0)
         {
             var romDataList = new List<(string fileName, byte[] data)>();
             foreach (var file in files)
             {
                 try
                 {
-                    using var stream = await file.OpenReadAsync();
-                    var data = new byte[stream.Length];
-                    await stream.ReadExactlyAsync(data);
-                    romDataList.Add((file.Name, data));
+                    romDataList.Add((file.Name, file.Bytes));
                 }
                 catch (Exception ex)
                 {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml.cs
@@ -11,6 +11,7 @@ using Avalonia.Media;
 using Avalonia.Platform.Storage;
 using AvaloniaApp = Highbyte.DotNet6502.App.Avalonia.Core.App;
 using Highbyte.DotNet6502.App.Avalonia.Core;
+using Highbyte.DotNet6502.App.Avalonia.Core.Services;
 using Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64.ViewModels;
 using Highbyte.DotNet6502.Impl.Avalonia;
 using Highbyte.DotNet6502.Impl.Avalonia.Commodore64;
@@ -125,34 +126,14 @@ public partial class C64MenuView : UserControl
         {
             try
             {
-                if (TopLevel.GetTopLevel(this) is not { } topLevel ||
-                    !topLevel.StorageProvider.CanOpen)
-                {
-                    tcs.TrySetResult(null);
-                    return;
-                }
-
-                var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
-                {
-                    Title = "Select C64 CRT Cartridge Image",
-                    AllowMultiple = false,
-                    FileTypeFilter =
-                    [
-                        new FilePickerFileType("C64 CRT Cartridge Images") { Patterns = ["*.crt"] },
-                        new FilePickerFileType("All Files") { Patterns = ["*"] },
-                    ],
-                });
-
-                if (files.Count == 0)
-                {
-                    tcs.TrySetResult(null);
-                    return;
-                }
-
-                await using var stream = await files[0].OpenReadAsync();
-                using var buffer = new MemoryStream();
-                await stream.CopyToAsync(buffer);
-                tcs.TrySetResult(new SelectedBinaryFile(files[0].Name, buffer.ToArray()));
+                tcs.TrySetResult(await OpenLocalFileAsync(
+                    "Select C64 CRT Cartridge Image",
+                    "C64 CRT Cartridge Images",
+                    "*.crt"));
+            }
+            catch (OperationCanceledException)
+            {
+                tcs.TrySetResult(null);
             }
             catch (Exception ex)
             {
@@ -191,47 +172,21 @@ public partial class C64MenuView : UserControl
     private void OnAttachDiskImageRequested(object? sender, TaskCompletionSource<byte[]?> tcs)
         => SafeAsyncHelper.Execute(async () =>
         {
-            if (TopLevel.GetTopLevel(this) is not { } topLevel)
+            try
+            {
+                var selectedFile = await OpenLocalFileAsync(
+                    "Select D64 Disk Image",
+                    "D64 Disk Images",
+                    "*.d64");
+                tcs.TrySetResult(selectedFile?.Bytes);
+            }
+            catch (OperationCanceledException)
             {
                 tcs.TrySetResult(null);
-                return;
             }
-
-            var storageProvider = topLevel.StorageProvider;
-            if (!storageProvider.CanOpen)
+            catch (Exception ex)
             {
-                tcs.TrySetResult(null);
-                return;
-            }
-
-            var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
-            {
-                Title = "Select D64 Disk Image",
-                AllowMultiple = false,
-                FileTypeFilter = new[]
-                {
-                    new FilePickerFileType("D64 Disk Images") { Patterns = new[] { "*.d64" } },
-                    new FilePickerFileType("All Files") { Patterns = new[] { "*" } }
-                }
-            });
-
-            if (files.Count > 0)
-            {
-                try
-                {
-                    await using var stream = await files[0].OpenReadAsync();
-                    var fileBuffer = new byte[stream.Length];
-                    await stream.ReadExactlyAsync(fileBuffer);
-                    tcs.TrySetResult(fileBuffer);
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError(ex, "Error reading disk image file");
-                    tcs.TrySetResult(null);
-                }
-            }
-            else
-            {
+                Logger.LogError(ex, "Error reading disk image file");
                 tcs.TrySetResult(null);
             }
         });
@@ -627,33 +582,16 @@ public partial class C64MenuView : UserControl
     private void LoadBasicFile_Click(object? sender, RoutedEventArgs e)
         => SafeAsyncHelper.Execute(async () =>
         {
-            if (TopLevel.GetTopLevel(this) is not { } topLevel)
-                return;
-            var storageProvider = topLevel.StorageProvider;
-            if (!storageProvider.CanOpen)
-                return;
-
-            var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
-            {
-                Title = "Load Basic PRG File",
-                AllowMultiple = false,
-                FileTypeFilter = new[]
-                {
-                    new FilePickerFileType("PRG Files") { Patterns = new[] { "*.prg" } },
-                    new FilePickerFileType("All Files") { Patterns = new[] { "*" } }
-                }
-            });
-
-            if (files.Count > 0)
+            var selectedFile = await OpenLocalFileAsync(
+                "Load Basic PRG File",
+                "PRG Files",
+                "*.prg");
+            if (selectedFile != null)
             {
                 try
                 {
-                    await using var stream = await files[0].OpenReadAsync();
-                    var fileBuffer = new byte[stream.Length];
-                    await stream.ReadExactlyAsync(fileBuffer);
-
                     // Fire and forget - let the ReactiveCommand handle scheduling and execution. This works in WebAssembly because we're not subscribing to the observable
-                    _ = ViewModel!.LoadBasicFileCommand.Execute(fileBuffer);
+                    _ = ViewModel!.LoadBasicFileCommand.Execute(selectedFile.Bytes);
                 }
                 catch (Exception ex)
                 {
@@ -661,6 +599,30 @@ public partial class C64MenuView : UserControl
                 }
             }
         });
+
+    private async Task<SelectedBinaryFile?> OpenLocalFileAsync(
+        string title,
+        string fileTypeName,
+        params string[] patterns)
+    {
+        var serviceProvider = (Application.Current as AvaloniaApp)?.GetServiceProvider();
+        var filePicker = serviceProvider?.GetService<IAppFilePicker>();
+        var file = filePicker == null
+            ? null
+            : await filePicker.OpenFileAsync(
+                this,
+                new AppFilePickerOpenOptions(
+                    title,
+                    AllowMultiple: false,
+                    [
+                        new AppFilePickerFileType(fileTypeName, patterns),
+                        AppFilePickerFileType.AllFiles
+                    ]));
+
+        return file == null
+            ? null
+            : new SelectedBinaryFile(file.Name, file.Bytes);
+    }
 
     private void SaveBasicFile_Click(object? sender, RoutedEventArgs e)
         => SafeAsyncHelper.Execute(async () =>
@@ -703,33 +665,16 @@ public partial class C64MenuView : UserControl
     private void LoadBinaryFile_Click(object? sender, RoutedEventArgs e)
         => SafeAsyncHelper.Execute(async () =>
         {
-            if (TopLevel.GetTopLevel(this) is not { } topLevel)
-                return;
-            var storageProvider = topLevel.StorageProvider;
-            if (!storageProvider.CanOpen)
-                return;
-
-            var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
-            {
-                Title = "Load & Start Binary PRG File",
-                AllowMultiple = false,
-                FileTypeFilter = new[]
-                {
-                    new FilePickerFileType("PRG Files") { Patterns = new[] { "*.prg" } },
-                    new FilePickerFileType("All Files") { Patterns = new[] { "*" } }
-                }
-            });
-
-            if (files.Count > 0)
+            var selectedFile = await OpenLocalFileAsync(
+                "Load & Start Binary PRG File",
+                "PRG Files",
+                "*.prg");
+            if (selectedFile != null)
             {
                 try
                 {
-                    await using var stream = await files[0].OpenReadAsync();
-                    var fileBuffer = new byte[stream.Length];
-                    await stream.ReadExactlyAsync(fileBuffer);
-
                     // Fire and forget - let the ReactiveCommand handle scheduling and execution. This works in WebAssembly because we're not subscribing to the observable
-                    _ = ViewModel!.LoadBinaryFileCommand.Execute(fileBuffer);
+                    _ = ViewModel!.LoadBinaryFileCommand.Execute(selectedFile.Bytes);
                 }
                 catch (Exception ex)
                 {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20ConfigDialogView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20ConfigDialogView.axaml.cs
@@ -6,8 +6,8 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
-using Avalonia.Platform.Storage;
 using Highbyte.DotNet6502.App.Avalonia.Core;
+using Highbyte.DotNet6502.App.Avalonia.Core.Services;
 using Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -88,26 +88,21 @@ public partial class Vic20ConfigDialogView : UserControl
 
     private async Task LoadRomsAsync()
     {
-        if (TopLevel.GetTopLevel(this)?.StorageProvider == null)
+        var serviceProvider = (Application.Current as AvaloniaApp)?.GetServiceProvider();
+        var filePicker = serviceProvider?.GetService<IAppFilePicker>();
+        if (filePicker == null)
             return;
-        var storageProvider = TopLevel.GetTopLevel(this)!.StorageProvider;
 
-        var options = new FilePickerOpenOptions
-        {
-            Title = "Select VIC-20 ROM files",
-            AllowMultiple = true,
-            FileTypeFilter = new List<FilePickerFileType>
-            {
-                new("ROM files")
-                {
-                    Patterns = new[] { "*.bin", "*.rom" }
-                },
-                FilePickerFileTypes.All
-            }
-        };
-
-        var files = await storageProvider.OpenFilePickerAsync(options);
-        if (files == null || files.Count == 0)
+        var files = await filePicker.OpenFilesAsync(
+            this,
+            new AppFilePickerOpenOptions(
+                "Select VIC-20 ROM files",
+                AllowMultiple: true,
+                [
+                    new AppFilePickerFileType("ROM files", ["*.bin", "*.rom"]),
+                    AppFilePickerFileType.AllFiles
+                ]));
+        if (files.Count == 0)
             return;
 
         var romDataList = new List<(string fileName, byte[] data)>();
@@ -115,10 +110,7 @@ public partial class Vic20ConfigDialogView : UserControl
         {
             try
             {
-                using var stream = await file.OpenReadAsync();
-                var data = new byte[stream.Length];
-                await stream.ReadExactlyAsync(data);
-                romDataList.Add((file.Name, data));
+                romDataList.Add((file.Name, file.Bytes));
             }
             catch (Exception ex)
             {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20MenuView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20MenuView.axaml.cs
@@ -9,6 +9,7 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Platform.Storage;
 using Highbyte.DotNet6502.App.Avalonia.Core;
+using Highbyte.DotNet6502.App.Avalonia.Core.Services;
 using Highbyte.DotNet6502.App.Avalonia.Shell.Vic20.ViewModels;
 using Highbyte.DotNet6502.Impl.Avalonia;
 using Highbyte.DotNet6502.Impl.Avalonia.Vic20;
@@ -187,32 +188,15 @@ public partial class Vic20MenuView : UserControl
     private void LoadBasicFile_Click(object? sender, RoutedEventArgs e)
         => SafeAsyncHelper.Execute(async () =>
         {
-            if (TopLevel.GetTopLevel(this) is not { } topLevel)
-                return;
-            var storageProvider = topLevel.StorageProvider;
-            if (!storageProvider.CanOpen)
-                return;
-
-            var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
-            {
-                Title = "Load Basic PRG File",
-                AllowMultiple = false,
-                FileTypeFilter = new[]
-                {
-                    new FilePickerFileType("PRG Files") { Patterns = new[] { "*.prg" } },
-                    new FilePickerFileType("All Files") { Patterns = new[] { "*" } }
-                }
-            });
-
-            if (files.Count > 0)
+            var selectedFile = await OpenLocalFileAsync(
+                "Load Basic PRG File",
+                "PRG Files",
+                "*.prg");
+            if (selectedFile != null)
             {
                 try
                 {
-                    await using var stream = await files[0].OpenReadAsync();
-                    var fileBuffer = new byte[stream.Length];
-                    await stream.ReadExactlyAsync(fileBuffer);
-
-                    _ = ViewModel!.LoadBasicFileCommand.Execute(fileBuffer);
+                    _ = ViewModel!.LoadBasicFileCommand.Execute(selectedFile.Bytes);
                 }
                 catch (Exception ex)
                 {
@@ -261,32 +245,15 @@ public partial class Vic20MenuView : UserControl
     private void LoadBinaryFile_Click(object? sender, RoutedEventArgs e)
         => SafeAsyncHelper.Execute(async () =>
         {
-            if (TopLevel.GetTopLevel(this) is not { } topLevel)
-                return;
-            var storageProvider = topLevel.StorageProvider;
-            if (!storageProvider.CanOpen)
-                return;
-
-            var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
-            {
-                Title = "Load & Start Binary PRG File",
-                AllowMultiple = false,
-                FileTypeFilter = new[]
-                {
-                    new FilePickerFileType("PRG Files") { Patterns = new[] { "*.prg" } },
-                    new FilePickerFileType("All Files") { Patterns = new[] { "*" } }
-                }
-            });
-
-            if (files.Count > 0)
+            var selectedFile = await OpenLocalFileAsync(
+                "Load & Start Binary PRG File",
+                "PRG Files",
+                "*.prg");
+            if (selectedFile != null)
             {
                 try
                 {
-                    await using var stream = await files[0].OpenReadAsync();
-                    var fileBuffer = new byte[stream.Length];
-                    await stream.ReadExactlyAsync(fileBuffer);
-
-                    _ = ViewModel!.LoadBinaryFileCommand.Execute(fileBuffer);
+                    _ = ViewModel!.LoadBinaryFileCommand.Execute(selectedFile.Bytes);
                 }
                 catch (Exception ex)
                 {
@@ -294,6 +261,26 @@ public partial class Vic20MenuView : UserControl
                 }
             }
         });
+
+    private async Task<AppPickedFile?> OpenLocalFileAsync(
+        string title,
+        string fileTypeName,
+        params string[] patterns)
+    {
+        var serviceProvider = (Application.Current as AvaloniaApp)?.GetServiceProvider();
+        var filePicker = serviceProvider?.GetService<IAppFilePicker>();
+        return filePicker == null
+            ? null
+            : await filePicker.OpenFileAsync(
+                this,
+                new AppFilePickerOpenOptions(
+                    title,
+                    AllowMultiple: false,
+                    [
+                        new AppFilePickerFileType(fileTypeName, patterns),
+                        AppFilePickerFileType.AllFiles
+                    ]));
+    }
 
     private void OpenVic20Config_Click(object? sender, RoutedEventArgs e)
         => SafeAsyncHelper.Execute(async () =>


### PR DESCRIPTION
Adds a shared app-level file picker abstraction for local file bytes. Uses a Browser-specific implementation to avoid stuck cancel flows. Routes C64/VIC-20 PRG, ROM, D64 and CRT open-file actions through it.