### PR TITLE
Fix stale cached version after in-app Update on browser app

### DIFF
--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/wwwroot/index.html
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/wwwroot/index.html
@@ -51,13 +51,31 @@ function showUpdateNotification() {
     document.body.appendChild(notification);
 }
 
-// Force refresh with cache clearing
-function forceRefresh() {
-    // Clear localStorage version
+// Force refresh with cache clearing.
+// Note: window.location.reload(true) does NOT bypass the cache — the boolean
+// argument is non-standard and ignored by modern browsers. Instead we
+// explicitly clear any service worker / Cache Storage and force-revalidate the
+// stable-named loader files (index.html -> main.js -> dotnet.js ->
+// blazor.boot.json) so the fresh boot manifest, and thus the new fingerprinted
+// assemblies, are loaded after the reload.
+async function forceRefresh() {
     localStorage.removeItem('app-version');
-    
-    // Force reload bypassing all caches
-    window.location.reload(true);
+    try {
+        if ('serviceWorker' in navigator) {
+            const regs = await navigator.serviceWorker.getRegistrations();
+            await Promise.all(regs.map(r => r.unregister()));
+        }
+        if (self.caches) {
+            const keys = await caches.keys();
+            await Promise.all(keys.map(k => caches.delete(k)));
+        }
+        // Overwrite the HTTP-cached, non-fingerprinted entry files with fresh copies.
+        const entryFiles = ['.', './main.js', './_framework/dotnet.js', './_framework/blazor.boot.json'];
+        await Promise.all(entryFiles.map(u => fetch(u, { cache: 'reload' }).catch(() => {})));
+    } catch (e) {
+        console.warn('Cache clear before update failed', e);
+    }
+    window.location.reload();
 }
 
 // Dismiss update notification

--- a/tools/cloudflare/app-sec-headers/README.md
+++ b/tools/cloudflare/app-sec-headers/README.md
@@ -1,7 +1,8 @@
-# dotnet-6502 app cross-origin isolation headers
+# dotnet-6502 app cross-origin isolation + cache-control headers
 
-Cloudflare Worker that adds cross-origin isolation headers to the dotnet-6502
-emulator browser apps served from GitHub Pages behind Cloudflare.
+Cloudflare Worker that adds cross-origin isolation headers and cache-control
+headers to the dotnet-6502 emulator browser apps served from GitHub Pages
+behind Cloudflare.
 
 ## What it does
 
@@ -9,8 +10,29 @@ emulator browser apps served from GitHub Pages behind Cloudflare.
 - Stamps these headers on emulator **app** paths only (`/dotnet-6502/app*`):
   - `Cross-Origin-Opener-Policy: same-origin`
   - `Cross-Origin-Embedder-Policy: require-corp`
+- Sets `Cache-Control: no-cache` on the stable-named loader/entry files within
+  an app path, forcing the browser to revalidate them every load:
+  - the app document (`/` / `index.html`)
+  - `main.js`
+  - `_framework/dotnet.js` (and `dotnet.boot.js`)
+  - `_framework/blazor.boot.json`
 - Passes every other `/dotnet-6502/*` request (the docs site, etc.) through
-  unchanged.
+  unchanged, and leaves the fingerprinted `*.wasm`/`*.dll` assemblies on their
+  long-lived upstream cache headers.
+
+## Why `no-cache` on the loader files
+
+The .NET WebAssembly publish content-fingerprints every assembly
+(e.g. `Foo.ab12cd34.wasm`), so those are safe to cache forever — a new version
+changes their filenames. But the loader chain that *selects* which fingerprints
+to load keeps stable filenames:
+`index.html` → `main.js` → `_framework/dotnet.js` → `_framework/blazor.boot.json`.
+GitHub Pages serves these with `max-age=600..14400`, so within that window a
+normal reload (including the in-app "Update" button) serves the **old**
+`blazor.boot.json` from the browser cache → old fingerprints → old app version,
+until a manual hard refresh. Marking the loader files `no-cache` makes the
+browser revalidate them on every load (cheap 304 when unchanged), so a new
+deploy is picked up immediately.
 
 ## Why
 
@@ -82,7 +104,15 @@ curl -sI https://highbyte.se/dotnet-6502/app2/ | grep -i cross-origin
 ```
 
 Both `cross-origin-opener-policy` and `cross-origin-embedder-policy` should be
-present. In the live app's devtools console:
+present. The loader files should report `cache-control: no-cache`, while a
+fingerprinted assembly keeps its long-lived cache:
+
+```sh
+curl -sI https://highbyte.se/dotnet-6502/app2/_framework/blazor.boot.json | grep -i cache-control  # no-cache
+curl -sI https://highbyte.se/dotnet-6502/app2/_framework/dotnet.js         | grep -i cache-control  # no-cache
+```
+
+In the live app's devtools console:
 
 ```js
 crossOriginIsolated        // true

--- a/tools/cloudflare/app-sec-headers/src/index.ts
+++ b/tools/cloudflare/app-sec-headers/src/index.ts
@@ -1,18 +1,40 @@
 /**
- * Cross-origin isolation headers for the dotnet-6502 emulator browser apps.
+ * Cross-origin isolation + cache-control headers for the dotnet-6502 emulator
+ * browser apps.
  *
  * Routed on `highbyte.se/dotnet-6502/*` (a single worker so newly deployed
  * emulator apps are covered automatically). It only stamps headers on the
  * emulator *app* paths (`/dotnet-6502/app*`) and passes everything else
  * (e.g. the docs site at `/dotnet-6502/...`) through unchanged.
  *
- * The COOP/COEP pair makes the app page `crossOriginIsolated`, which is
- * required for `SharedArrayBuffer` and the low-latency AudioWorklet SID path.
+ * Two header concerns are handled:
+ *
+ * 1. COOP/COEP — makes the app page `crossOriginIsolated`, required for
+ *    `SharedArrayBuffer` and the low-latency AudioWorklet SID path.
+ *
+ * 2. Cache-Control — forces revalidation of the few *stable-named* entry files
+ *    that gate which app version loads. The .NET WebAssembly publish
+ *    fingerprints every assembly (e.g. `Foo.ab12cd34.wasm`), so those are safe
+ *    to cache long-term — a new version changes their filenames. But the loader
+ *    chain that *selects* those fingerprints keeps stable names
+ *    (`index.html` -> `main.js` -> `_framework/dotnet.js` ->
+ *    `_framework/blazor.boot.json`). GitHub Pages serves them with
+ *    `max-age=600..14400`, so within that window a normal reload serves the old
+ *    boot manifest from the browser cache -> old fingerprints -> old version,
+ *    even after the in-app "Update" button. Marking these `no-cache` makes the
+ *    browser revalidate them on every load (304 when unchanged), so a new
+ *    deploy is picked up immediately.
  */
 
 // Matches the emulator app deployments: app, app2, app2-test, future app3, ...
 // Anchored so only `/dotnet-6502/app...` paths are isolated, not the docs site.
 const APP_PATH_PATTERN = /^\/dotnet-6502\/app[^/]*(\/|$)/;
+
+// Stable-named loader/entry files within an app path. Everything else under the
+// app path (the fingerprinted `*.wasm`/`*.dll` assemblies, images, etc.) keeps
+// its upstream long-lived cache headers.
+const NO_CACHE_PATTERN =
+	/(\/|\/index\.html|\/main\.js|\/_framework\/dotnet\.js|\/_framework\/dotnet\.boot\.js|\/_framework\/blazor\.boot\.json)$/;
 
 export default {
 	async fetch(request: Request): Promise<Response> {
@@ -28,6 +50,12 @@ export default {
 		const response = new Response(upstream.body, upstream);
 		response.headers.set("Cross-Origin-Opener-Policy", "same-origin");
 		response.headers.set("Cross-Origin-Embedder-Policy", "require-corp");
+
+		if (NO_CACHE_PATTERN.test(path)) {
+			// Must revalidate on every load so a new deploy is seen immediately.
+			response.headers.set("Cache-Control", "no-cache");
+		}
+
 		return response;
 	},
 };


### PR DESCRIPTION
The Avalonia Browser app's "Update Now" button did not reliably load a newly published version; the app kept showing the cached version until a manual hard refresh.

Two causes:
- forceRefresh() used window.location.reload(true), whose boolean argument is non-standard and ignored by modern browsers, so it never bypassed the cache.
- The stable-named loader chain (index.html -> main.js -> dotnet.js -> blazor.boot.json) was served by GitHub Pages with max-age=600..14400, so a normal reload reused the old blazor.boot.json -> old fingerprinted assemblies -> old version.

Fixes:
- app-sec-headers worker: set Cache-Control: no-cache on the loader/entry files under /dotnet-6502/app*, leaving fingerprinted assemblies on their long-lived cache.
- index.html: rewrite forceRefresh() to unregister service workers, clear Cache Storage, and force-revalidate the entry files before reloading.