### PR TITLE
Fix sprite collisions triggering a raster IRQ instead of a collision IRQ

### DIFF
--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2SpriteManager.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2SpriteManager.cs
@@ -93,18 +93,28 @@ public class Vic2SpriteManager : IVic2SpriteManager
         var spriteToBackgroundCollision = GetSpriteToBackgroundCollision();
         SpriteToBackgroundCollisionStore = (byte)(SpriteToBackgroundCollisionStore | spriteToBackgroundCollision);
 
-        // Raise IRQ if any collision detected, and it's enabled, and not currently blocked (cleared by reading from collision registers)
-        var source = IRQSource.RasterCompare;
-        if (((SpriteToSpriteCollisionStore != 0 && !SpriteToSpriteCollisionIRQBlock)
-            || (SpriteToBackgroundCollisionStore != 0 && !SpriteToBackgroundCollisionIRQBlock))
-            && Vic2.Vic2IRQ.IsEnabled(source)
-            && !Vic2.Vic2IRQ.IsTriggered(source))
+        // Raise IRQ if a collision is detected, the corresponding source is enabled, and it's not
+        // currently blocked (block is cleared when the game reads the collision IO register).
+        //
+        // Sprite-to-sprite and sprite-to-background collisions are their own VIC-II interrupt
+        // sources ($D019 bits 1 and 2), each enabled independently via $D01A. They must NOT be
+        // raised as a raster-compare IRQ ($D019 bit 0): doing so makes a sprite collision look
+        // like a raster interrupt, so games that drive raster splits (e.g. Giana Sisters) service
+        // the collision as a spurious extra raster IRQ, displacing their split chain.
+        if (SpriteToSpriteCollisionStore != 0 && !SpriteToSpriteCollisionIRQBlock
+            && Vic2.Vic2IRQ.IsEnabled(IRQSource.SpriteToSpriteCollision)
+            && !Vic2.Vic2IRQ.IsTriggered(IRQSource.SpriteToSpriteCollision))
         {
-            Vic2.Vic2IRQ.Trigger(source, Vic2.C64.CPU);
-            if (SpriteToSpriteCollisionStore != 0)
-                SpriteToSpriteCollisionIRQBlock = true;
-            if (SpriteToBackgroundCollisionStore != 0)
-                SpriteToBackgroundCollisionIRQBlock = true;
+            Vic2.Vic2IRQ.Trigger(IRQSource.SpriteToSpriteCollision, Vic2.C64.CPU);
+            SpriteToSpriteCollisionIRQBlock = true;
+        }
+
+        if (SpriteToBackgroundCollisionStore != 0 && !SpriteToBackgroundCollisionIRQBlock
+            && Vic2.Vic2IRQ.IsEnabled(IRQSource.SpriteToBackgroundCollision)
+            && !Vic2.Vic2IRQ.IsTriggered(IRQSource.SpriteToBackgroundCollision))
+        {
+            Vic2.Vic2IRQ.Trigger(IRQSource.SpriteToBackgroundCollision, Vic2.C64.CPU);
+            SpriteToBackgroundCollisionIRQBlock = true;
         }
     }
 

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Video/Vic2SpriteManagerTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Video/Vic2SpriteManagerTests.cs
@@ -7,6 +7,9 @@ namespace Highbyte.DotNet6502.Systems.Tests.Commodore64.Video;
 
 public class Vic2SpriteManagerTests
 {
+    private static readonly string RasterCompareIrqSource = Vic2IRQ.GetInterruptSourceName(IRQSource.RasterCompare);
+    private static readonly string SpriteToSpriteCollisionIrqSource = Vic2IRQ.GetInterruptSourceName(IRQSource.SpriteToSpriteCollision);
+
     [Fact]
     public void GetSpriteToSpriteCollision_returns_zero_for_non_overlapping_visible_sprites()
     {
@@ -41,6 +44,43 @@ public class Vic2SpriteManagerTests
         var collision = c64.Vic2.SpriteManager.GetSpriteToSpriteCollision();
 
         Assert.Equal(0b0000_0011, collision);
+    }
+
+    [Fact]
+    public void Sprite_to_sprite_collision_raises_collision_irq_and_not_raster_irq()
+    {
+        var c64 = BuildC64();
+
+        // A game using raster splits has the raster IRQ enabled; enable the sprite-to-sprite
+        // collision IRQ too ($D01A bit 0 = raster-compare, bit 1 = sprite-to-sprite collision).
+        c64.Mem.Write(Vic2Addr.IRQ_MASK, 0b0000_0011);
+
+        CreateVisibleSolidSprite(c64, spriteNumber: 0, x: 10, y: 10, spritePointer: 192);
+        CreateVisibleSolidSprite(c64, spriteNumber: 1, x: 20, y: 15, spritePointer: 193);
+
+        c64.Vic2.SpriteManager.SetCollitionDetectionStatesAndIRQ();
+
+        // A collision must raise its own collision IRQ source ($D019 bit 1)...
+        Assert.True(c64.CPU.CPUInterrupts.IsIRQSourceActive(SpriteToSpriteCollisionIrqSource));
+        // ...and must never raise the raster-compare IRQ source ($D019 bit 0).
+        Assert.False(c64.CPU.CPUInterrupts.IsIRQSourceActive(RasterCompareIrqSource));
+    }
+
+    [Fact]
+    public void Sprite_collision_does_not_raise_raster_irq_when_only_raster_irq_enabled()
+    {
+        // Regression for the Great Giana Sisters status-panel jitter: the game enables the
+        // raster IRQ (for screen splits) but not the collision IRQ. A sprite collision must
+        // not raise a spurious raster-compare IRQ that the game would service as an extra split.
+        var c64 = BuildC64();
+        c64.Mem.Write(Vic2Addr.IRQ_MASK, 0b0000_0001); // enable raster-compare only
+
+        CreateVisibleSolidSprite(c64, spriteNumber: 0, x: 10, y: 10, spritePointer: 192);
+        CreateVisibleSolidSprite(c64, spriteNumber: 1, x: 20, y: 15, spritePointer: 193);
+
+        c64.Vic2.SpriteManager.SetCollitionDetectionStatesAndIRQ();
+
+        Assert.False(c64.CPU.CPUInterrupts.IsIRQSourceActive(RasterCompareIrqSource));
     }
 
     private static C64 BuildC64()


### PR DESCRIPTION
Vic2SpriteManager.SetCollitionDetectionStatesAndIRQ raised
IRQSource.RasterCompare ($D019 bit 0) for sprite-to-sprite and
sprite-to-background collisions, instead of their own collision IRQ
sources (bits 1 and 2). Each collision type now raises its own source,
gated on its own $D01A enable bit and block flag.

Effect: a game that drives raster-split IRQs and also produces sprite
collisions during play (e.g. The Great Giana Sisters) no longer receives
a spurious raster IRQ on every collision frame, which was being serviced
as an extra raster split and caused the status-panel score row to jitter
horizontally while scrolling.

Add regression tests asserting a sprite collision raises the collision
IRQ source and never the raster-compare source.

Bug present since sprite support was added (0bcb9fb7).
