### PR TITLE
Validate CLI-arg paths in swiftlink smoke scripts (fix Sonar S8707)

### DIFF
--- a/tests/swiftlink-smoke/_safe_path.py
+++ b/tests/swiftlink-smoke/_safe_path.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Shared path validation for the swiftlink smoke-test helper scripts.
+
+Sonar rule pythonsecurity:S8707 flags filesystem paths that are built from
+CLI arguments and then used as write targets without validation. These
+helpers only ever need to write artifacts into the system temp directory
+(the run-*.sh smoke runners create their working dir with `mktemp` under
+``$TMPDIR``/``/tmp``) or into the current working directory.
+
+``safe_path`` resolves the candidate and confirms it stays within one of
+those allowed roots before any filesystem access, rejecting path-traversal
+escapes from faulty/hostile CLI arguments.
+"""
+import pathlib
+import tempfile
+
+
+def safe_path(candidate: str) -> pathlib.Path:
+    """Resolve ``candidate`` and ensure it stays within an allowed root.
+
+    Allowed roots are the system temp directory and the current working
+    directory. Raises ``ValueError`` if the resolved path escapes them.
+    """
+    resolved = pathlib.Path(candidate).resolve()
+    allowed_roots = (
+        pathlib.Path(tempfile.gettempdir()).resolve(),
+        pathlib.Path.cwd().resolve(),
+    )
+    if any(resolved == root or root in resolved.parents for root in allowed_roots):
+        return resolved
+    raise ValueError(
+        f"refusing to access path outside allowed temp/working directories: {candidate}"
+    )

--- a/tests/swiftlink-smoke/tcp_burst_server.py
+++ b/tests/swiftlink-smoke/tcp_burst_server.py
@@ -6,6 +6,8 @@ import sys
 import time
 from typing import Optional
 
+from _safe_path import safe_path
+
 
 def wait_for_trigger(trigger_file: Optional[str]) -> None:
     if not trigger_file:
@@ -28,7 +30,7 @@ def main() -> int:
     args = parser.parse_args()
 
     payload = bytes((args.start_byte + i) & 0xFF for i in range(args.count))
-    log_path = pathlib.Path(args.log_file) if args.log_file else None
+    log_path = safe_path(args.log_file) if args.log_file else None
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
         server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -37,7 +39,7 @@ def main() -> int:
 
         actual_port = server.getsockname()[1]
         if args.port_file:
-            pathlib.Path(args.port_file).write_text(f"{actual_port}\n", encoding="utf-8")
+            safe_path(args.port_file).write_text(f"{actual_port}\n", encoding="utf-8")
 
         print(f"listening {args.host}:{actual_port}", flush=True)
 

--- a/tests/swiftlink-smoke/tcp_echo_server.py
+++ b/tests/swiftlink-smoke/tcp_echo_server.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 import argparse
-import pathlib
 import socket
 import sys
+
+from _safe_path import safe_path
 
 
 def main() -> int:
@@ -13,7 +14,7 @@ def main() -> int:
     parser.add_argument("--log-file")
     args = parser.parse_args()
 
-    log_path = pathlib.Path(args.log_file) if args.log_file else None
+    log_path = safe_path(args.log_file) if args.log_file else None
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
         server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -22,7 +23,7 @@ def main() -> int:
 
         actual_port = server.getsockname()[1]
         if args.port_file:
-            pathlib.Path(args.port_file).write_text(f"{actual_port}\n", encoding="utf-8")
+            safe_path(args.port_file).write_text(f"{actual_port}\n", encoding="utf-8")
 
         print(f"listening {args.host}:{actual_port}", flush=True)
 

--- a/tests/swiftlink-smoke/write_irq_smoke_prg.py
+++ b/tests/swiftlink-smoke/write_irq_smoke_prg.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-import pathlib
 import sys
+
+from _safe_path import safe_path
 
 
 LOAD_ADDRESS = 0xC000
@@ -176,7 +177,7 @@ def main() -> int:
         print("usage: write_irq_smoke_prg.py <output.prg>", file=sys.stderr)
         return 2
 
-    output_path = pathlib.Path(sys.argv[1])
+    output_path = safe_path(sys.argv[1])
     output_path.write_bytes(build_program())
     return 0
 

--- a/tests/swiftlink-smoke/write_smoke_prg.py
+++ b/tests/swiftlink-smoke/write_smoke_prg.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-import pathlib
 import sys
+
+from _safe_path import safe_path
 
 
 PROGRAM_BYTES = bytes(
@@ -37,7 +38,7 @@ def main() -> int:
         print("usage: write_smoke_prg.py <output.prg>", file=sys.stderr)
         return 2
 
-    output_path = pathlib.Path(sys.argv[1])
+    output_path = safe_path(sys.argv[1])
     output_path.write_bytes(PROGRAM_BYTES)
     return 0
 


### PR DESCRIPTION
## Summary

Fixes the 6 high-severity (security) SonarCloud issues on `master`, all the same rule — `pythonsecurity:S8707` (path injection from CLI arguments) — in the four swiftlink smoke-test helper scripts.

Each script built a filesystem write target directly from a CLI argument and used it without validation.

## Changes

- Add shared helper `tests/swiftlink-smoke/_safe_path.py` with `safe_path()`, which resolves the candidate path and confirms it stays within an allowed root (system temp dir or cwd) before any filesystem access, raising `ValueError` on a traversal escape.
- Route every flagged write through it:
  - `tcp_burst_server.py` — `--port-file`, `--log-file`
  - `tcp_echo_server.py` — `--port-file`, `--log-file`
  - `write_irq_smoke_prg.py` / `write_smoke_prg.py` — output `.prg`
- Drop the now-unused `import pathlib` where it was only used at the sink.

The `run-*.sh` runners only ever write into a `mktemp` dir under `$TMPDIR`/`/tmp`, so the legitimate use case is unaffected. A single shared helper (rather than duplicating the check in 4 files) also avoids copy/paste duplication.

## Verification

- All five files `py_compile` cleanly.
- Functional run of both `write_*_prg.py` into a `mktemp` dir succeeds.
- Helper allows temp + cwd paths and rejects `/etc/passwd` with a clear error.