### PR TITLE
Interrupt integration: CPU boundary tests + SwiftLink cartridge-line refactor

### DIFF
--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -30,6 +30,7 @@ namespace Highbyte.DotNet6502.Systems.Commodore64;
 public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
 {
     private const string CartridgeNmiSource = "CartridgeNmi";
+    private const string CartridgeIrqSource = "CartridgeIrq";
     private const byte CpuPortBankBitsMask = 0x07;
     private const byte CpuPortDataDirectionResetValue = 0x2F;
     private const byte CpuPortDataResetValue = 0x37;
@@ -258,6 +259,16 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
             else
                 CPU.CPUInterrupts.SetNMISourceInactive(CartridgeNmiSource);
         };
+        CartridgeSlot.IrqLineChanged += () =>
+        {
+            if (CPU is null)
+                return;
+
+            if (CartridgeSlot.IrqLineActive)
+                CPU.CPUInterrupts.SetIRQSourceActive(CartridgeIrqSource, autoAcknowledge: false);
+            else
+                CPU.CPUInterrupts.SetIRQSourceInactive(CartridgeIrqSource);
+        };
         _spriteCollisionStat = Instrumentations.Add($"{StatsCategory}-SpriteCollision", new ElapsedMillisecondsTimedStatSystem(this));
 
         _audioProviderPerInstructionStat = Instrumentations.Add($"{StatsCategoryAudioProvider}-Instruction", new ElapsedMillisecondsTimedStatSystem(this));
@@ -329,7 +340,6 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
                 c64Config.SwiftLink.CartridgeIOAddress,
                 loggerFactory.CreateLogger(nameof(SwiftLinkDevice)))
             {
-                CpuInterrupts = cpu.CPUInterrupts,
                 InterruptMode = c64Config.SwiftLink.InterruptMode,
                 ReceiveMode = c64Config.SwiftLink.ReceiveMode,
                 GetCurrentCycleCount = () => cpu.ExecState.CyclesConsumed,

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/C64CartridgeSlot.cs
@@ -11,8 +11,11 @@ public sealed class C64CartridgeSlot : IDisposable
     public C64CartridgeLines Lines => AttachedCartridge?.Lines ?? C64CartridgeLines.Released;
     public bool NmiLineActive
         => AttachedCartridge is IC64CartridgeNmiSource { NmiLineActive: true };
+    public bool IrqLineActive
+        => AttachedCartridge is IC64CartridgeIrqSource { IrqLineActive: true };
     public event Action? LinesChanged;
     public event Action? NmiLineChanged;
+    public event Action? IrqLineChanged;
 
     public void Attach(IC64Cartridge cartridge)
     {
@@ -25,9 +28,12 @@ public sealed class C64CartridgeSlot : IDisposable
         AttachedCartridge = cartridge;
         cartridge.LinesChanged += OnCartridgeLinesChanged;
         SubscribeToNmiSource(cartridge);
+        SubscribeToIrqSource(cartridge);
         LinesChanged?.Invoke();
         if (cartridge is IC64CartridgeNmiSource)
             NmiLineChanged?.Invoke();
+        if (cartridge is IC64CartridgeIrqSource)
+            IrqLineChanged?.Invoke();
     }
 
     public void Replace(IC64Cartridge cartridge)
@@ -40,14 +46,18 @@ public sealed class C64CartridgeSlot : IDisposable
         {
             previous.LinesChanged -= OnCartridgeLinesChanged;
             UnsubscribeFromNmiSource(previous);
+            UnsubscribeFromIrqSource(previous);
         }
 
         AttachedCartridge = cartridge;
         cartridge.LinesChanged += OnCartridgeLinesChanged;
         SubscribeToNmiSource(cartridge);
+        SubscribeToIrqSource(cartridge);
         LinesChanged?.Invoke();
         if (previous is IC64CartridgeNmiSource || cartridge is IC64CartridgeNmiSource)
             NmiLineChanged?.Invoke();
+        if (previous is IC64CartridgeIrqSource || cartridge is IC64CartridgeIrqSource)
+            IrqLineChanged?.Invoke();
 
         if (previous != null)
         {
@@ -66,8 +76,11 @@ public sealed class C64CartridgeSlot : IDisposable
         LinesChanged?.Invoke();
         if (cartridge is IC64CartridgeNmiSource)
             NmiLineChanged?.Invoke();
+        if (cartridge is IC64CartridgeIrqSource)
+            IrqLineChanged?.Invoke();
         cartridge.LinesChanged -= OnCartridgeLinesChanged;
         UnsubscribeFromNmiSource(cartridge);
+        UnsubscribeFromIrqSource(cartridge);
         cartridge.Reset();
         cartridge.Dispose();
     }
@@ -188,6 +201,9 @@ public sealed class C64CartridgeSlot : IDisposable
     private void OnCartridgeNmiLineChanged()
         => NmiLineChanged?.Invoke();
 
+    private void OnCartridgeIrqLineChanged()
+        => IrqLineChanged?.Invoke();
+
     private void SubscribeToNmiSource(IC64Cartridge cartridge)
     {
         if (cartridge is IC64CartridgeNmiSource nmiSource)
@@ -198,6 +214,18 @@ public sealed class C64CartridgeSlot : IDisposable
     {
         if (cartridge is IC64CartridgeNmiSource nmiSource)
             nmiSource.NmiLineChanged -= OnCartridgeNmiLineChanged;
+    }
+
+    private void SubscribeToIrqSource(IC64Cartridge cartridge)
+    {
+        if (cartridge is IC64CartridgeIrqSource irqSource)
+            irqSource.IrqLineChanged += OnCartridgeIrqLineChanged;
+    }
+
+    private void UnsubscribeFromIrqSource(IC64Cartridge cartridge)
+    {
+        if (cartridge is IC64CartridgeIrqSource irqSource)
+            irqSource.IrqLineChanged -= OnCartridgeIrqLineChanged;
     }
 
     private byte ReadIO(ushort address, Func<ushort, byte> fallbackReader)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64CartridgeIrqSource.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/IC64CartridgeIrqSource.cs
@@ -1,0 +1,12 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
+
+/// <summary>
+/// Optional capability for cartridges that can drive the active-low IRQ line.
+/// Mirrors <see cref="IC64CartridgeNmiSource"/>; the system translates line state into
+/// a CPU IRQ source so cartridges never touch <see cref="CPUInterrupts"/> directly.
+/// </summary>
+public interface IC64CartridgeIrqSource
+{
+    bool IrqLineActive { get; }
+    event Action? IrqLineChanged;
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Cartridge/SwiftLinkDevice.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Highbyte.DotNet6502.Systems.Commodore64.Cartridge;
 
-public sealed class SwiftLinkDevice : IC64Cartridge
+public sealed class SwiftLinkDevice : IC64Cartridge, IC64CartridgeNmiSource, IC64CartridgeIrqSource
 {
     private const byte StatusRxFullBit = 1 << 3;
     private const byte StatusTxEmptyBit = 1 << 4;
@@ -16,7 +16,6 @@ public sealed class SwiftLinkDevice : IC64Cartridge
     private const byte CommandReceiverIrqDisableBit = 1 << 1;
     private const byte CommandTransmitterControlMask = 0b0000_1100;
     private const byte CommandTransmitterIrqControl = 0b0000_0100;
-    private const string IrqSourceName = "SwiftLink";
     private const int DiagnosticHistorySize = 24;
 
     private readonly ILogger _logger;
@@ -26,6 +25,9 @@ public sealed class SwiftLinkDevice : IC64Cartridge
     private bool _rxFull;
     private bool _txEmpty = true;
     private bool _irqPending;
+    private bool _nmiLineActive;
+    private bool _irqLineActive;
+    private bool _nmiDeferred;
     private byte _commandRegister;
     private byte _controlRegister;
     private Task? _pendingSendTask;
@@ -51,13 +53,22 @@ public sealed class SwiftLinkDevice : IC64Cartridge
         remove { }
     }
     public ISwiftLinkTransport? Transport { get; set; }
-    public CPUInterrupts? CpuInterrupts { get; set; }
+
+    // Interrupt participation goes through the cartridge line abstractions: SwiftLink drives
+    // its active-low IRQ/NMI lines and the C64 slot wiring translates them into CPU interrupt
+    // sources. The device never touches CPUInterrupts directly.
+    public bool NmiLineActive => _nmiLineActive;
+    public event Action? NmiLineChanged;
+    public bool IrqLineActive => _irqLineActive;
+    public event Action? IrqLineChanged;
+
     public C64SwiftLinkInterruptMode InterruptMode { get; set; } = C64SwiftLinkInterruptMode.IRQ;
     public C64SwiftLinkReceiveMode ReceiveMode { get; set; } = C64SwiftLinkReceiveMode.Compatible;
     public Func<ulong>? GetCurrentCycleCount { get; set; }
-    // Optional device-specific compatibility hook. When unset, NMI is asserted as soon as
-    // SwiftLink marks its receive interrupt pending. C64 currently uses this for software
-    // that temporarily banks out the mapped NMI vector area.
+    // Optional device-specific compatibility policy. When unset, the NMI line is driven as
+    // soon as SwiftLink marks its receive interrupt pending. When set and it returns false,
+    // SwiftLink holds the NMI line released (see RefreshInterruptLines) -- C64 uses this for
+    // software that temporarily banks out the mapped NMI vector area.
     public Func<bool>? CanDeliverNmi { get; set; }
     public ulong ReceivePacingCycles { get; set; }
     public ushort BaseAddress => _baseAddress;
@@ -115,7 +126,9 @@ public sealed class SwiftLinkDevice : IC64Cartridge
             CompletePendingSend();
         }
 
-        TryAssertDeferredNmi();
+        // Re-evaluate the interrupt lines each tick so a deferred NMI is asserted once the
+        // mapped NMI vector becomes usable again (see RefreshInterruptLines).
+        RefreshInterruptLines();
 
         if (_rxFull)
             return;
@@ -139,7 +152,10 @@ public sealed class SwiftLinkDevice : IC64Cartridge
         Array.Clear(_diagnosticHistory);
         _diagnosticHistoryNextIndex = 0;
         _diagnosticHistoryCount = 0;
-        ClearAllInterruptSources();
+        _nmiDeferred = false;
+        // _irqPending was cleared above; refreshing releases both lines (and fires the line
+        // changed events so the C64 slot wiring clears any active CPU interrupt source).
+        RefreshInterruptLines();
         Transport?.Reset();
     }
 
@@ -316,10 +332,7 @@ public sealed class SwiftLinkDevice : IC64Cartridge
             _rxFull,
             _txEmpty);
         RecordDiagnosticEvent($"IRQ set mode={InterruptMode} rx={_rxFull} tx={_txEmpty}");
-        if (InterruptMode == C64SwiftLinkInterruptMode.NMI)
-            TryAssertDeferredNmi();
-        else
-            CpuInterrupts?.SetIRQSourceActive(IrqSourceName, autoAcknowledge: false);
+        RefreshInterruptLines();
     }
 
     private void ClearIrqPending()
@@ -327,42 +340,51 @@ public sealed class SwiftLinkDevice : IC64Cartridge
         _irqPending = false;
         _logger.LogDebug("SwiftLink {InterruptMode} pending cleared.", InterruptMode);
         RecordDiagnosticEvent($"IRQ clear mode={InterruptMode}");
-        if (InterruptMode == C64SwiftLinkInterruptMode.NMI)
-            CpuInterrupts?.SetNMISourceInactive(IrqSourceName);
-        else
-            CpuInterrupts?.SetIRQSourceInactive(IrqSourceName);
+        RefreshInterruptLines();
     }
 
-    private void ClearAllInterruptSources()
+    /// <summary>
+    /// Drives the cartridge IRQ/NMI lines from the current pending state and interrupt mode,
+    /// firing the line-changed events only on transitions. The C64 slot wiring turns those
+    /// lines into CPU interrupt sources, so SwiftLink never touches CPUInterrupts directly.
+    ///
+    /// NMI mode additionally honors the optional <see cref="CanDeliverNmi"/> policy: while the
+    /// mapped NMI vector is unusable (some modem software temporarily banks it out) the NMI
+    /// line is held released and re-evaluated on each Tick instead of asserting into a bad
+    /// vector. This device-local deferral is the SwiftLink compatibility behavior.
+    /// </summary>
+    private void RefreshInterruptLines()
     {
-        _irqPending = false;
-        CpuInterrupts?.SetIRQSourceInactive(IrqSourceName);
-        CpuInterrupts?.SetNMISourceInactive(IrqSourceName);
+        var nmiMode = InterruptMode == C64SwiftLinkInterruptMode.NMI;
+        var desiredIrqLine = _irqPending && !nmiMode;
+
+        var wantsNmi = _irqPending && nmiMode;
+        var nmiDeliverable = !wantsNmi || CanDeliverNmi?.Invoke() != false;
+        var desiredNmiLine = wantsNmi && nmiDeliverable;
+
+        var deferred = wantsNmi && !nmiDeliverable;
+        if (deferred && !_nmiDeferred)
+            RecordDiagnosticEvent("NMI deferred");
+        _nmiDeferred = deferred;
+
+        if (_irqLineActive != desiredIrqLine)
+        {
+            _irqLineActive = desiredIrqLine;
+            IrqLineChanged?.Invoke();
+        }
+
+        if (_nmiLineActive != desiredNmiLine)
+        {
+            _nmiLineActive = desiredNmiLine;
+            if (desiredNmiLine)
+                RecordDiagnosticEvent("NMI asserted");
+            NmiLineChanged?.Invoke();
+        }
     }
 
     private bool IsCarrierDetected => Transport?.IsCarrierDetected == true;
 
     private bool IsDataSetReady => Transport?.IsDataSetReady == true;
-
-    private void TryAssertDeferredNmi()
-    {
-        if (!_irqPending || InterruptMode != C64SwiftLinkInterruptMode.NMI)
-            return;
-
-        if (CpuInterrupts?.IsNMISourceActive(IrqSourceName) == true)
-            return;
-
-        if (CanDeliverNmi?.Invoke() == false)
-        {
-            // SwiftLink-specific compatibility behavior: keep the pending receive state but
-            // avoid asserting the NMI source until the mapped NMI vector is usable again.
-            RecordDiagnosticEvent("NMI deferred");
-            return;
-        }
-
-        CpuInterrupts?.SetNMISourceActive(IrqSourceName);
-        RecordDiagnosticEvent("NMI asserted");
-    }
 
     private void TryLatchReceivedByte()
     {
@@ -457,7 +479,9 @@ public sealed class SwiftLinkDevice : IC64Cartridge
 
     public void Dispose()
     {
-        ClearAllInterruptSources();
+        _irqPending = false;
+        _nmiDeferred = false;
+        RefreshInterruptLines();
         Transport?.Dispose();
         Transport = null;
     }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Cartridge/SwiftLinkDeviceTests.cs
@@ -91,11 +91,7 @@ public class SwiftLinkDeviceTests
     [Fact]
     public async Task Receive_Irq_Is_Raised_When_Rx_Full_Transitions_And_Cleared_On_Status_Read()
     {
-        var interrupts = new CPUInterrupts();
-        var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance)
-        {
-            CpuInterrupts = interrupts
-        };
+        var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance);
         var transport = new LoopbackTransport();
         await transport.ConnectAsync();
         device.Transport = transport;
@@ -106,11 +102,11 @@ public class SwiftLinkDeviceTests
         await transport.SendAsync(0x41);
         device.Tick();
 
-        Assert.True(interrupts.IRQLineEnabled);
+        Assert.True(device.IrqLineActive);
         var status = mem.Read(0xDE01);
         Assert.True(IsRxFull(status));
         Assert.True(IsIrqPending(status));
-        Assert.False(interrupts.IRQLineEnabled);
+        Assert.False(device.IrqLineActive);
 
         Assert.Equal(0x41, mem.Read(0xDE00));
         Assert.False(IsIrqPending(mem.Read(0xDE01)));
@@ -119,10 +115,8 @@ public class SwiftLinkDeviceTests
     [Fact]
     public async Task Receive_Nmi_Is_Raised_When_Configured_And_Cleared_On_Status_Read()
     {
-        var interrupts = new CPUInterrupts();
         var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance)
         {
-            CpuInterrupts = interrupts,
             InterruptMode = C64SwiftLinkInterruptMode.NMI
         };
         var transport = new LoopbackTransport();
@@ -135,38 +129,71 @@ public class SwiftLinkDeviceTests
         await transport.SendAsync(0x41);
         device.Tick();
 
-        Assert.True(interrupts.NMILineEnabled);
+        Assert.True(device.NmiLineActive);
         var status = mem.Read(0xDE01);
         Assert.True(IsRxFull(status));
         Assert.True(IsIrqPending(status));
-        Assert.False(interrupts.NMILineEnabled);
+        Assert.False(device.NmiLineActive);
+    }
+
+    [Fact]
+    public async Task Nmi_Line_Is_Deferred_While_Vector_Not_Deliverable_Then_Asserted()
+    {
+        // SwiftLink compatibility policy: in NMI mode the device must not drive the NMI line
+        // while the mapped NMI vector is unusable; it re-evaluates each Tick and asserts once
+        // the vector becomes deliverable. With the line abstraction this is expressed purely
+        // as the device's own line state -- the C64 slot wiring stays generic.
+        var canDeliver = false;
+        var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance)
+        {
+            InterruptMode = C64SwiftLinkInterruptMode.NMI,
+            CanDeliverNmi = () => canDeliver,
+        };
+        var transport = new LoopbackTransport();
+        await transport.ConnectAsync();
+        device.Transport = transport;
+
+        var mem = MapDevice(device);
+        mem.Write(0xDE02, ReceiveIrqEnabledCommand);
+
+        await transport.SendAsync(0x41);
+        device.Tick();
+
+        // The receive interrupt is pending, but the NMI line is held released while the vector
+        // is undeliverable. (Avoid reading the status register here -- that would clear the
+        // pending interrupt per 6551 semantics.)
+        Assert.False(device.NmiLineActive);
+
+        canDeliver = true;
+        device.Tick();
+
+        // Re-evaluated on Tick: now deliverable, so the still-pending interrupt asserts NMI.
+        Assert.True(device.NmiLineActive);
     }
 
     [Fact]
     public void Transmit_Irq_Is_Raised_When_Send_Completes_And_Cleared_On_Status_Read()
     {
-        var interrupts = new CPUInterrupts();
         var transport = new PendingSendTransport();
         var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance)
         {
-            Transport = transport,
-            CpuInterrupts = interrupts
+            Transport = transport
         };
 
         var mem = MapDevice(device);
         mem.Write(0xDE02, TransmitIrqEnabledCommand);
 
         mem.Write(0xDE00, 0x42);
-        Assert.False(interrupts.IRQLineEnabled);
+        Assert.False(device.IrqLineActive);
 
         transport.CompletePendingSend();
         device.Tick();
 
-        Assert.True(interrupts.IRQLineEnabled);
+        Assert.True(device.IrqLineActive);
         var status = mem.Read(0xDE01);
         Assert.True(IsTxEmpty(status));
         Assert.True(IsIrqPending(status));
-        Assert.False(interrupts.IRQLineEnabled);
+        Assert.False(device.IrqLineActive);
     }
 
     [Fact]
@@ -252,11 +279,7 @@ public class SwiftLinkDeviceTests
     [Fact]
     public async Task Receive_Irq_Is_Not_Raised_When_Disabled()
     {
-        var interrupts = new CPUInterrupts();
-        var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance)
-        {
-            CpuInterrupts = interrupts
-        };
+        var device = new SwiftLinkDevice(C64CartridgeIOAddress.DE00, NullLogger<SwiftLinkDevice>.Instance);
         var transport = new LoopbackTransport();
         await transport.ConnectAsync();
         device.Transport = transport;
@@ -266,7 +289,7 @@ public class SwiftLinkDeviceTests
         await transport.SendAsync(0x41);
         device.Tick();
 
-        Assert.False(interrupts.IRQLineEnabled);
+        Assert.False(device.IrqLineActive);
         Assert.True(IsRxFull(mem.Read(0xDE01)));
         Assert.False(IsIrqPending(mem.Read(0xDE01)));
     }
@@ -307,7 +330,6 @@ public class SwiftLinkDeviceTests
 
         Assert.NotNull(swiftLink);
         Assert.Equal((ushort)0xDF00, swiftLink!.BaseAddress);
-        Assert.Same(c64.CPU.CPUInterrupts, swiftLink.CpuInterrupts);
         Assert.Equal(C64SwiftLinkInterruptMode.IRQ, swiftLink.InterruptMode);
         Assert.Equal(C64SwiftLinkReceiveMode.Compatible, swiftLink.ReceiveMode);
         Assert.Equal(C64CartridgeLines.Released, swiftLink.Lines);
@@ -367,10 +389,7 @@ public class SwiftLinkDeviceTests
         c64.Mem.Write(0xDE02, 0x5A);
         var swiftLink = new SwiftLinkDevice(
             C64CartridgeIOAddress.DE00,
-            NullLogger<SwiftLinkDevice>.Instance)
-        {
-            CpuInterrupts = c64.CPU.CPUInterrupts,
-        };
+            NullLogger<SwiftLinkDevice>.Instance);
 
         c64.AttachCartridge(swiftLink);
         c64.Mem.Write(0xDE02, 0x77);
@@ -396,10 +415,7 @@ public class SwiftLinkDeviceTests
         }, new NullLoggerFactory());
         var swiftLink = new SwiftLinkDevice(
             C64CartridgeIOAddress.DE00,
-            NullLogger<SwiftLinkDevice>.Instance)
-        {
-            CpuInterrupts = c64.CPU.CPUInterrupts,
-        };
+            NullLogger<SwiftLinkDevice>.Instance);
         c64.AttachCartridge(swiftLink);
         var transport = new LoopbackTransport();
         await transport.ConnectAsync();

--- a/tests/Highbyte.DotNet6502.Tests/CPUInterruptBoundaryTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/CPUInterruptBoundaryTests.cs
@@ -1,0 +1,183 @@
+using Highbyte.DotNet6502.Utils;
+
+namespace Highbyte.DotNet6502.Tests;
+
+/// <summary>
+/// System-independent tests for the CPU interrupt-boundary contract that systems rely on
+/// when they tick devices after an instruction and then flush newly raised hardware
+/// interrupts via <see cref="CPU.ProcessPendingInterrupts(Memory)"/>.
+///
+/// These cover the universal 6502 semantics (edge-triggered NMI, level-triggered IRQ,
+/// NMI &gt; IRQ priority) plus the post-device-tick servicing point and the
+/// <see cref="CPU.NmiAcknowledging"/> boundary that C64 expansion-port hardware depends on.
+/// They are intentionally not tied to any emulated system.
+/// </summary>
+public class CPUInterruptBoundaryTests
+{
+    // Helper: place a NOP at the given address so the only PC change in a test comes from
+    // interrupt servicing, not from a multi-byte/branching instruction.
+    private static (CPU cpu, Memory mem) NewCpuAt(ushort pc)
+    {
+        var cpu = new CPU();
+        var mem = new Memory();
+        mem[pc] = (byte)OpCodeId.NOP;
+        cpu.PC = pc;
+        cpu.SP = 0xFF;
+        return (cpu, mem);
+    }
+
+    [Fact]
+    public void Interrupt_Raised_By_PostInstruction_DeviceTick_Is_Serviced_On_The_Next_Boundary()
+    {
+        // Models the C64 pipeline: execute one instruction, then a device tick raises an
+        // IRQ, then the system flushes pending interrupts. The IRQ must land here -- before
+        // the instruction after the NOP runs -- not one instruction late.
+        var (cpu, mem) = NewCpuAt(0x1000);
+        cpu.ProcessorStatus.InterruptDisable = false;
+        mem.WriteWord(CPU.BrkIRQHandlerVector, 0x4000);
+
+        // Put a distinctive instruction right after the NOP. If the IRQ were serviced one
+        // instruction late, this would execute and advance PC past 0x1001 first.
+        mem[0x1001] = (byte)OpCodeId.NOP;
+
+        cpu.ExecuteOneInstructionMinimal(mem);   // NOP at 0x1000 -> PC = 0x1001
+        Assert.Equal((ushort)0x1001, cpu.PC);
+
+        cpu.CPUInterrupts.SetIRQSourceActive("device", autoAcknowledge: true); // device tick
+        cpu.ProcessPendingInterrupts(mem);
+
+        // PC is the IRQ handler, so the next instruction fetched is the handler -- the
+        // instruction at 0x1001 was not executed.
+        Assert.Equal((ushort)0x4000, cpu.PC);
+        Assert.False(cpu.IRQ); // auto-acknowledged source cleared
+    }
+
+    [Fact]
+    public void IRQ_Raised_Between_Instructions_Is_Serviced_By_ProcessPendingInterrupts()
+    {
+        var (cpu, mem) = NewCpuAt(0x1000);
+        cpu.ProcessorStatus.InterruptDisable = false;
+        mem.WriteWord(CPU.BrkIRQHandlerVector, 0x4000);
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+        Assert.Equal((ushort)0x1001, cpu.PC);
+
+        cpu.CPUInterrupts.SetIRQSourceActive("dummy", autoAcknowledge: true);
+        cpu.ProcessPendingInterrupts(mem);
+
+        Assert.Equal((ushort)0x4000, cpu.PC);
+
+        // The pre-interrupt PC (0x1001) was pushed so RTI returns to it.
+        var pcOnStackAddress = (ushort)(CPU.StackBaseAddress + (byte)(cpu.SP + 2));
+        var pcOnStack = ByteHelpers.ToLittleEndianWord(
+            new[] { mem[pcOnStackAddress], mem[(ushort)(pcOnStackAddress + 1)] });
+        Assert.Equal((ushort)0x1001, pcOnStack);
+    }
+
+    [Fact]
+    public void IRQ_Raised_Between_Instructions_Is_Held_Off_While_InterruptDisable_Is_Set()
+    {
+        // IRQ is level-triggered and masked by the I flag: a source raised between
+        // instructions must not be serviced until the I flag is cleared, and then it is
+        // serviced on the next flush because the line is still held active.
+        var (cpu, mem) = NewCpuAt(0x1000);
+        cpu.ProcessorStatus.InterruptDisable = true;
+        mem.WriteWord(CPU.BrkIRQHandlerVector, 0x4000);
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+        cpu.CPUInterrupts.SetIRQSourceActive("dummy", autoAcknowledge: false);
+        cpu.ProcessPendingInterrupts(mem);
+
+        Assert.Equal((ushort)0x1001, cpu.PC);   // masked -> not serviced
+        Assert.True(cpu.IRQ);                    // line still held active
+
+        cpu.ProcessorStatus.InterruptDisable = false;
+        cpu.ProcessPendingInterrupts(mem);
+
+        Assert.Equal((ushort)0x4000, cpu.PC);    // serviced once unmasked
+    }
+
+    [Fact]
+    public void NmiAcknowledging_Fires_Before_The_Nmi_Vector_Is_Read()
+    {
+        // C64 expansion-port hardware (e.g. Final Cartridge III / Expert) changes memory
+        // mapping as part of NMI acknowledgement so the correct vector becomes visible. The
+        // CPU exposes NmiAcknowledging precisely so a system can remap before the vector is
+        // fetched. Proven here by swapping the vector inside the handler and confirming the
+        // CPU jumps to the swapped value.
+        var (cpu, mem) = NewCpuAt(0x1000);
+        mem.WriteWord(CPU.NonMaskableIRQHandlerVector, 0x1111);
+
+        int fireCount = 0;
+        cpu.NmiAcknowledging += (_, _) =>
+        {
+            fireCount++;
+            mem.WriteWord(CPU.NonMaskableIRQHandlerVector, 0x2222);
+        };
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+        cpu.CPUInterrupts.SetNMISourceActive("cart");
+        cpu.ProcessPendingInterrupts(mem);
+
+        Assert.Equal(1, fireCount);
+        Assert.Equal((ushort)0x2222, cpu.PC); // jumped to the vector exposed during acknowledge
+    }
+
+    [Fact]
+    public void NmiAcknowledging_Does_Not_Fire_When_No_Nmi_Is_Pending()
+    {
+        var (cpu, mem) = NewCpuAt(0x1000);
+
+        int fireCount = 0;
+        cpu.NmiAcknowledging += (_, _) => fireCount++;
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+        cpu.ProcessPendingInterrupts(mem); // nothing pending
+
+        Assert.Equal(0, fireCount);
+    }
+
+    [Fact]
+    public void NMI_Is_Edge_Triggered_And_Does_Not_Retrigger_While_Source_Stays_Active()
+    {
+        // A held-low NMI line must fire exactly once. Re-asserting an already-active source
+        // does not produce a new edge; the source must be released and re-asserted.
+        var (cpu, mem) = NewCpuAt(0x1000);
+        mem.WriteWord(CPU.NonMaskableIRQHandlerVector, 0x4000);
+
+        cpu.CPUInterrupts.SetNMISourceActive("cart");
+        cpu.ProcessPendingInterrupts(mem);
+        Assert.Equal((ushort)0x4000, cpu.PC);
+        Assert.False(cpu.NMI); // pending edge consumed
+
+        // Source is still active, but no new falling edge -> no second NMI.
+        cpu.PC = 0x2000;
+        cpu.CPUInterrupts.SetNMISourceActive("cart"); // re-assert already-active source: no edge
+        cpu.ProcessPendingInterrupts(mem);
+        Assert.Equal((ushort)0x2000, cpu.PC);
+        Assert.False(cpu.NMI);
+
+        // Release then re-assert -> new edge -> serviced again.
+        cpu.CPUInterrupts.SetNMISourceInactive("cart");
+        cpu.CPUInterrupts.SetNMISourceActive("cart");
+        Assert.True(cpu.NMI);
+        cpu.ProcessPendingInterrupts(mem);
+        Assert.Equal((ushort)0x4000, cpu.PC);
+    }
+
+    [Fact]
+    public void NMI_Takes_Priority_Over_IRQ_When_Both_Are_Pending()
+    {
+        var (cpu, mem) = NewCpuAt(0x1000);
+        cpu.ProcessorStatus.InterruptDisable = false;
+        mem.WriteWord(CPU.BrkIRQHandlerVector, 0x4000);
+        mem.WriteWord(CPU.NonMaskableIRQHandlerVector, 0x5000);
+
+        cpu.CPUInterrupts.SetIRQSourceActive("irq", autoAcknowledge: true);
+        cpu.CPUInterrupts.SetNMISourceActive("nmi");
+        cpu.ProcessPendingInterrupts(mem);
+
+        Assert.Equal((ushort)0x5000, cpu.PC); // NMI handler, not IRQ handler
+        Assert.True(cpu.IRQ);                  // IRQ still pending, serviced on a later flush
+    }
+}


### PR DESCRIPTION
Follows up on the interrupt/NMI work from #234, addressing remaining items from the `6502-nmi-integration-abstraction` design note: generic CPU-level interrupt-boundary coverage, and moving SwiftLink onto the cartridge interrupt-line abstractions.

## CPU interrupt boundary tests
New `CPUInterruptBoundaryTests.cs` adds system-independent coverage of the interrupt-boundary contract introduced in #234, which previously only had indirect/C64-level coverage:
- interrupt raised by a post-instruction device tick is serviced on the **next** boundary (not one instruction late)
- IRQ raised between instructions serviced via `ProcessPendingInterrupts`, and held off while the I flag is set (level-trigger + masking)
- `NmiAcknowledging` fires **before** the NMI vector is read (and not when no NMI is pending) — the boundary C64 expansion-port hardware depends on
- NMI edge-trigger (no retrigger while a source stays active) and NMI > IRQ priority

No production code change in this commit — pure regression coverage.

## SwiftLink cartridge-line refactor
SwiftLink previously held a direct `CPUInterrupts` reference and asserted IRQ/NMI sources itself, with a bespoke `CanDeliverNmi` deferral living in the generic interrupt path. It now participates through the same line-based model the C64 cartridges already use (design direction: isolate device-specific compatibility policy from generic interrupt plumbing).

- Add `IC64CartridgeIrqSource`, mirroring `IC64CartridgeNmiSource`, so a cartridge's active-low IRQ line is routed through the slot instead of touching `CPUInterrupts` directly.
- `C64CartridgeSlot` exposes `IrqLineActive`/`IrqLineChanged` and subscribes/unsubscribes symmetrically with the NMI line on attach/replace/detach.
- `C64` translates the slot IRQ line into a `CartridgeIrq` CPU source, paralleling the existing `CartridgeNmi` wiring; SwiftLink no longer receives a `CPUInterrupts` reference.
- `SwiftLinkDevice` implements both line-source interfaces and derives line state in a single `RefreshInterruptLines()`. The `CanDeliverNmi` deferral is preserved but is now device-local line policy: while the mapped NMI vector is unusable the NMI line is held released and re-evaluated each `Tick`.

Behavior is unchanged (deferral, manual-ack-on-status-read, transmit/receive IRQ, detach-clears-line).

## Testing
- `SwiftLinkDeviceTests` updated to assert the line-based surface, plus a new test covering the NMI deferral through the line model.
- Full suites green: cartridge 107/107, Systems 407/407, core CPU 727/727; full solution builds clean.
- Manually verified with Compunet Reborn (SwiftLink NMI path) — still works.