### PR TITLE
Feature/c64 vic2 fixes

### DIFF
--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -322,7 +322,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup
         };
 
         var cpu = CreateC64CPU(loggerFactory, c64Config.CpuCompatibilityProfile);
-        var vic2 = Vic2.BuildVic2(vic2Model, c64);
+        var vic2 = Vic2.BuildVic2(vic2Model, c64, loggerFactory);
         var sid = Sid.BuildSid(c64);
 
         var cia1 = new Cia1(c64, c64Config, loggerFactory);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/Rasterizer/Vic2RasterizerPixelGenerator.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/Rasterizer/Vic2RasterizerPixelGenerator.cs
@@ -84,12 +84,11 @@ public sealed class Vic2RasterizerUintPixelGenerator
     private CharMode _characterMode;
     private BitmMode _bitmapMode;
     private bool _invalidMode; // ECM combined with BMM/MCM: VIC-II outputs black for the display area.
-    private bool _prevInvalidMode; // invalid-mode state of the previous line, to detect when display resumes.
-    // Character-grid vertical phase offset (0-7). Normally 0 (grid locked to the screen-top
-    // drawLine/8 grid). When the display resumes after an invalid-mode band the grid is re-phased so
-    // the resuming line starts at character-line 0 - mimicking the VIC-II row counter restart and
-    // preventing the band from splitting a character row (which clips e.g. a status line's text top).
-    private int _charGridYOffset;
+    // Invalid-mode lines render black and don't advance the character-row counter, so rows below a
+    // band are pushed down past it (VIC-II "flexible line distance" effect). Normally 0 - identical
+    // to baseline rendering for ordinary screens.
+    private int _charGridYOffset;   // grid snap (0-7) after an invalid-mode band; 0 for normal screens.
+    private bool _prevInvalidMode;  // invalid-mode state of the previous line (to detect band end).
     private int _scrollX;
     private int _scrollY;
 
@@ -337,7 +336,7 @@ public sealed class Vic2RasterizerUintPixelGenerator
                     //Array.Clear(PixelArray_Foreground, 0, PixelArray_Foreground.Length);
                     _clearForegroundPixels(0, _width * _height);
 
-                    // New frame: character grid starts locked to the screen top.
+                    // New frame: character grid locked to the screen top.
                     _charGridYOffset = 0;
                     _prevInvalidMode = false;
 
@@ -359,22 +358,22 @@ public sealed class Vic2RasterizerUintPixelGenerator
                 _bitmapMode = _c64.Vic2.BitmapMode;
                 _invalidMode = _c64.Vic2.IsInvalidVideoMode;
 
-                // When the display resumes after an invalid-mode band, re-phase the character grid so
-                // the resuming line is character-line 0 (VIC-II row-counter restart). This keeps the
-                // same screen-RAM row (characterRow is unchanged at the resume line) but shifts its
-                // 8 character-lines down so the band can't clip the row's top. Only ever non-zero
-                // after an invalid band, so normal (non-split) screens are unaffected.
+                // Invalid-mode (ECM+BMM/MCM) lines render black and DO NOT advance the character-row
+                // counter - matching the VIC-II "flexible line distance" effect a program produces by
+                // suppressing bad lines during the band. The character grid for the lines below the
+                // band is therefore pushed down by the number of invalid lines, so a row that would
+                // otherwise straddle the band (clipping e.g. a title's text) lands cleanly after it.
+                // For normal screens (no invalid lines) this stays 0, identical to baseline rendering.
+                // When the display resumes after an invalid-mode band, snap the character grid to the
+                // next character-row boundary so the resuming row starts cleanly *after* the band
+                // (the band absorbs the partial separator row it overlapped). This is the minimal
+                // downward shift needed to clear the band - pushing by the full band height would
+                // over-shift and drop the rows below off the bottom border. Only ever non-zero after
+                // an invalid band, so normal (non-split) screens are unaffected.
                 if (_prevInvalidMode && !_invalidMode)
                 {
-                    // Align the resumed character grid to the VIC-II bad-line phase: character-line 0
-                    // (row-counter reset) falls on raster lines where (raster & 7) == yscroll. Anchored
-                    // to the bad-line grid (not the resume line) so the shift is the minimal amount the
-                    // hardware would apply - a fixed per-screen offset would over-shift text that sits
-                    // far from the band (e.g. a title screen's lines near the bottom border).
                     var resumeDrawLine = screenLine - _screenLayoutInclNonVisibleScreenStartY;
-                    var rasterAtDrawLine0 = rasterLine - resumeDrawLine; // raster line of drawLine 0 (constant)
-                    var yscroll = _c64.Vic2.GetScrollY();
-                    _charGridYOffset = (((yscroll - rasterAtDrawLine0) % 8) + 8) % 8;
+                    _charGridYOffset = ((resumeDrawLine % 8) + 8) % 8;
                 }
                 _prevInvalidMode = _invalidMode;
 
@@ -1002,8 +1001,8 @@ public sealed class Vic2RasterizerUintPixelGenerator
             return;
         }
 
-        // Re-phase the character grid after an invalid-mode band (see _charGridYOffset). Normally 0,
-        // so this is identical to drawLine/8 and drawLine%8 for ordinary screens.
+        // Snap the character grid to the row boundary after an invalid-mode band (see _charGridYOffset).
+        // Normally 0, so this is identical to drawLine/8 and drawLine%8 for ordinary screens.
         var gridLine = drawLine - _charGridYOffset;
         var characterRow = gridLine / 8;
         var characterLine = (ushort)(gridLine % 8);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/Rasterizer/Vic2RasterizerPixelGenerator.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/Rasterizer/Vic2RasterizerPixelGenerator.cs
@@ -996,6 +996,7 @@ public sealed class Vic2RasterizerUintPixelGenerator
         // than painting black keeps the foreground transparent so sprites still composite normally.
         if (_invalidMode)
         {
+            // Clear pixels
             WriteToPixelArray(_oneLineSameColorPixels[(byte)C64Colors.Black], foreground: false, drawLine, col * 8, fnLength: 8, fnAdjustForScrollX: false, fnAdjustForScrollY: false);
             WriteToPixelArray(_oneLineTransparentPixels, foreground: true, drawLine, col * 8, fnLength: 8, fnAdjustForScrollX: false, fnAdjustForScrollY: false);
             return;
@@ -1003,6 +1004,7 @@ public sealed class Vic2RasterizerUintPixelGenerator
 
         // Snap the character grid to the row boundary after an invalid-mode band (see _charGridYOffset).
         // Normally 0, so this is identical to drawLine/8 and drawLine%8 for ordinary screens.
+        // This is adjusted again when the actual pixels are drawn to pixel buffer in WriteToPixelArray. 
         var gridLine = drawLine - _charGridYOffset;
         var characterRow = gridLine / 8;
         var characterLine = (ushort)(gridLine % 8);
@@ -1073,7 +1075,7 @@ public sealed class Vic2RasterizerUintPixelGenerator
                         throw new DotNet6502Exception("Invalid background color number.");
                 }
             }
-            else // Asume text multicolor mode
+            else // Assume text multicolor mode
             {
                 // Text multicolor mode color usage (8 bits, 4 pixel pairs)
                 // Transparent background = the color of pixel-pair 00
@@ -1134,6 +1136,10 @@ public sealed class Vic2RasterizerUintPixelGenerator
             if (fnAdjustForScrollY)
                 fnMainScreenY += _scrollY;
             var ypos = _screenStartY + fnMainScreenY;
+
+            // Adjust for invalid mode lines offset
+            ypos -= _charGridYOffset;
+
             if (ypos <= _topBorderEndYAdjusted || ypos >= _bottomBorderStartYAdjusted)
                 return;
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/Rasterizer/Vic2RasterizerPixelGenerator.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/Rasterizer/Vic2RasterizerPixelGenerator.cs
@@ -21,6 +21,7 @@ public sealed class Vic2RasterizerUintPixelGenerator
 
     // Pre-calculated pixel arrays
     private uint[][] _oneLineSameColorPixels; // pixelArray
+    private uint[] _oneLineTransparentPixels = default!; // a line of the transparent color, used to clear the foreground layer
 
     // Text standard mode: 8-bit patterns mapped to 8 pixels (1 pixel = 1 uint rgba).
     // 1 maps to the color in the lookup table, and 0 maps to a predefined "background" color that will be replaced in shader.
@@ -82,6 +83,13 @@ public sealed class Vic2RasterizerUintPixelGenerator
     private bool _isTextMode;
     private CharMode _characterMode;
     private BitmMode _bitmapMode;
+    private bool _invalidMode; // ECM combined with BMM/MCM: VIC-II outputs black for the display area.
+    private bool _prevInvalidMode; // invalid-mode state of the previous line, to detect when display resumes.
+    // Character-grid vertical phase offset (0-7). Normally 0 (grid locked to the screen-top
+    // drawLine/8 grid). When the display resumes after an invalid-mode band the grid is re-phased so
+    // the resuming line starts at character-line 0 - mimicking the VIC-II row counter restart and
+    // preventing the band from splitting a character row (which clips e.g. a status line's text top).
+    private int _charGridYOffset;
     private int _scrollX;
     private int _scrollY;
 
@@ -329,6 +337,10 @@ public sealed class Vic2RasterizerUintPixelGenerator
                     //Array.Clear(PixelArray_Foreground, 0, PixelArray_Foreground.Length);
                     _clearForegroundPixels(0, _width * _height);
 
+                    // New frame: character grid starts locked to the screen top.
+                    _charGridYOffset = 0;
+                    _prevInvalidMode = false;
+
                     // New frame: reset the sprite display latch so no sprite carries over.
                     if (_perLineSprites)
                     {
@@ -345,6 +357,27 @@ public sealed class Vic2RasterizerUintPixelGenerator
                 _isTextMode = _c64.Vic2.DisplayMode == DispMode.Text;
                 _characterMode = _c64.Vic2.CharacterMode;
                 _bitmapMode = _c64.Vic2.BitmapMode;
+                _invalidMode = _c64.Vic2.IsInvalidVideoMode;
+
+                // When the display resumes after an invalid-mode band, re-phase the character grid so
+                // the resuming line is character-line 0 (VIC-II row-counter restart). This keeps the
+                // same screen-RAM row (characterRow is unchanged at the resume line) but shifts its
+                // 8 character-lines down so the band can't clip the row's top. Only ever non-zero
+                // after an invalid band, so normal (non-split) screens are unaffected.
+                if (_prevInvalidMode && !_invalidMode)
+                {
+                    // Align the resumed character grid to the VIC-II bad-line phase: character-line 0
+                    // (row-counter reset) falls on raster lines where (raster & 7) == yscroll. Anchored
+                    // to the bad-line grid (not the resume line) so the shift is the minimal amount the
+                    // hardware would apply - a fixed per-screen offset would over-shift text that sits
+                    // far from the band (e.g. a title screen's lines near the bottom border).
+                    var resumeDrawLine = screenLine - _screenLayoutInclNonVisibleScreenStartY;
+                    var rasterAtDrawLine0 = rasterLine - resumeDrawLine; // raster line of drawLine 0 (constant)
+                    var yscroll = _c64.Vic2.GetScrollY();
+                    _charGridYOffset = (((yscroll - rasterAtDrawLine0) % 8) + 8) % 8;
+                }
+                _prevInvalidMode = _invalidMode;
+
                 _scrollX = _c64.Vic2.GetScrollX();
                 _scrollY = _c64.Vic2.GetScrollY();
 
@@ -699,6 +732,11 @@ public sealed class Vic2RasterizerUintPixelGenerator
 
         var transparentColorVal = TransparentColor;
 
+        // A single line of the transparent color. Used to clear the foreground layer (e.g. invalid mode).
+        _oneLineTransparentPixels = new uint[width];
+        for (var i = 0; i < _oneLineTransparentPixels.Length; i++)
+            _oneLineTransparentPixels[i] = transparentColorVal;
+
         // Text (normal) & bitmap (standard "HiRes") mode with one foreground color with a single "transparent" color as background color
         // 8 bits => 8 pixels
         _eightPixelsOneColorAndBackground = new uint[256 * 16][];
@@ -949,8 +987,26 @@ public sealed class Vic2RasterizerUintPixelGenerator
 
     private void DrawTextAndBitmapPixels(C64 c64, int drawLine, int col)
     {
-        var characterRow = drawLine / 8;
-        var characterLine = (ushort)(drawLine % 8);
+        // Invalid VIC-II mode (ECM combined with BMM/MCM): the pixel sequencer is disabled and the
+        // display area outputs black at the physical raster line, regardless of screen/char/bitmap
+        // memory. (Without this, the BMM bit alone makes us render garbage bitmap data - the cause of
+        // the garbled band seen in e.g. Commando, which toggles this mode on for a few raster lines.)
+        // Fill the background layer black, and clear the foreground layer at the *unshifted* raster
+        // position: fine-scroll writes foreground from neighbouring lines shifted by ScrollY, which
+        // would otherwise bleed scrolled content (e.g. trees) into the black band. Clearing rather
+        // than painting black keeps the foreground transparent so sprites still composite normally.
+        if (_invalidMode)
+        {
+            WriteToPixelArray(_oneLineSameColorPixels[(byte)C64Colors.Black], foreground: false, drawLine, col * 8, fnLength: 8, fnAdjustForScrollX: false, fnAdjustForScrollY: false);
+            WriteToPixelArray(_oneLineTransparentPixels, foreground: true, drawLine, col * 8, fnLength: 8, fnAdjustForScrollX: false, fnAdjustForScrollY: false);
+            return;
+        }
+
+        // Re-phase the character grid after an invalid-mode band (see _charGridYOffset). Normally 0,
+        // so this is identical to drawLine/8 and drawLine%8 for ordinary screens.
+        var gridLine = drawLine - _charGridYOffset;
+        var characterRow = gridLine / 8;
+        var characterLine = (ushort)(gridLine % 8);
         var backgroundIsPrefilled = _isTextMode && _characterMode == CharMode.Standard;
 
         var characterAddress = (ushort)(_vic2VideoMatrixBaseAddress + characterRow * _vic2ScreenTextCols + col);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2.cs
@@ -2,6 +2,7 @@ using Highbyte.DotNet6502.Systems.Commodore64.Config;
 using Highbyte.DotNet6502.Systems.Commodore64.Models;
 using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
 using Highbyte.DotNet6502.Utils;
+using Microsoft.Extensions.Logging;
 using static Highbyte.DotNet6502.Systems.Commodore64.Video.Vic2Sprite;
 
 namespace Highbyte.DotNet6502.Systems.Commodore64.Video;
@@ -26,6 +27,8 @@ public class Vic2
     public Memory Vic2Mem { get; private set; } = default!;
 
     public Vic2IRQ Vic2IRQ { get; private set; } = default!;
+
+    private ILogger _logger = default!;
 
     public ulong CyclesConsumedCurrentVblank { get; private set; } = 0;
 
@@ -68,6 +71,24 @@ public class Vic2
     }
 
     public enum CharMode { Standard = 0, Extended = 1, MultiColor = 2 };
+
+    /// <summary>
+    /// True when the VIC-II mode bits select an invalid combination: ECM (bit 6 of $D011) set
+    /// together with BMM (bit 5 of $D011) and/or MCM (bit 4 of $D016). On real hardware the pixel
+    /// sequencer is disabled for these modes and the display area outputs black. Some games (e.g.
+    /// Commando) toggle this on for a few raster lines to draw a black separator band.
+    /// </summary>
+    public bool IsInvalidVideoMode
+    {
+        get
+        {
+            if (!C64.ReadIOStorage(Vic2Addr.SCROLL_Y_AND_SCREEN_CONTROL_REGISTER).IsBitSet(6)) // ECM
+                return false;
+            var bmm = C64.ReadIOStorage(Vic2Addr.SCROLL_Y_AND_SCREEN_CONTROL_REGISTER).IsBitSet(5);
+            var mcm = C64.ReadIOStorage(Vic2Addr.SCROLL_X_AND_SCREEN_CONTROL_REGISTER).IsBitSet(4);
+            return bmm || mcm;
+        }
+    }
 
     private ushort _currentRasterLineInternal = ushort.MaxValue;
     public ushort CurrentRasterLine => _currentRasterLineInternal;
@@ -128,7 +149,7 @@ public class Vic2
 
     private Vic2() { }
 
-    public static Vic2 BuildVic2(Vic2ModelBase vic2Model, C64 c64)
+    public static Vic2 BuildVic2(Vic2ModelBase vic2Model, C64 c64, ILoggerFactory loggerFactory)
     {
         var vic2Mem = CreateVic2Memory(c64);
 
@@ -143,6 +164,7 @@ public class Vic2
             Vic2Model = vic2Model,
             Vic2IRQ = vic2IRQ,
             ScreenLineIORegisterValues = screenLineData,
+            _logger = loggerFactory.CreateLogger(nameof(Vic2)),
         };
 
         var vic2Screen = new Vic2Screen(vic2Model, c64.CpuFrequencyHz);
@@ -726,11 +748,12 @@ public class Vic2
 
         }
 
-#if DEBUG
+        // A program is allowed to set a raster IRQ compare line beyond the model's visible/total line count.
+        // On real hardware the compare simply never matches that line (the IRQ won't fire) until reprogrammed.
+        // This happens e.g. when bit 7 of SCRCTRL1 ($D011) is set while the low 8 bits ($D012) hold a value
+        // that combines to more lines than the model has. Just log it instead of treating it as an error.
         if (Vic2IRQ.ConfiguredIRQRasterLine > Vic2Model.TotalHeight)
-            throw new DotNet6502Exception($"Internal error. Setting unreachable scan line for IRQ: {Vic2IRQ.ConfiguredIRQRasterLine}. Incorrect ROM for Vic2 model: {Vic2Model.Name} ?");
-#endif
-
+            _logger.LogDebug("Raster IRQ compare line {IRQLine} is beyond the {Model} model's total height ({TotalHeight}); IRQ will not fire for this line until reprogrammed.", Vic2IRQ.ConfiguredIRQRasterLine, Vic2Model.Name, Vic2Model.TotalHeight);
     }
 
     public byte ScrCtrlReg1Load(ushort address)


### PR DESCRIPTION
Fixes several C64 VIC-II rendering issues seen with games that use a mid-screen raster split (and a related cartridge crash).

## Fixed

- **Garbled band at raster splits** (Commando, Ghosts 'n Goblins, PAL): these games briefly select the illegal VIC-II mode **ECM+BMM** (a black separator). The mode decoder only checked BMM, so the rasterizer drew garbage bitmap data. Now detected via `Vic2.IsInvalidVideoMode` and rendered **black**, matching real hardware.
- **Scrolled content bleeding past the playfield**: the foreground layer is now cleared across the invalid band, so fine-scrolled pixels no longer leak into it. Sprites still composite normally.
- **Text clipped below the band**: the character grid is re-aligned to the next row boundary after an invalid band (`_charGridYOffset`), applied to **both** the character fetch and the output Y position, so rows below the band land at the correct vertical position.
- **Terminator 2 (PAL) DEBUG crash on start**: writing an out-of-range raster-IRQ compare value (legal on hardware — the IRQ simply never matches) no longer trips a `#if DEBUG` assertion; it logs instead.

## Notes

- Changes are scoped to the rasterizer's invalid-mode handling; normal (non-split) screens are unaffected.
- Verified visually in the Avalonia desktop app (PAL): Commando title + in-game, Ghosts 'n Goblins in-game, Terminator 2 boot-to-game.