### PR TITLE
Fix VIC-II raster split rendering and 38 column sprite clipping

### DIFF
--- a/docs/tools/remote-control/examples.md
+++ b/docs/tools/remote-control/examples.md
@@ -100,7 +100,7 @@ dotnet-6502-remote emu.loadsnapshot --path /tmp/state.d6502snap
 # Advance exactly one frame and render it (rejected if the emulator is Running)
 dotnet-6502-remote emu.runframes --count 1
 
-# Capture the rendered frame (Avalonia hosts only — headless has no renderer)
+# Capture the rendered frame (works on both Avalonia and headless hosts)
 dotnet-6502-remote screenshot --output /tmp/result.png
 ```
 

--- a/docs/tools/remote-control/overview.md
+++ b/docs/tools/remote-control/overview.md
@@ -81,7 +81,6 @@ By default the server binds to `127.0.0.1`, so it is only reachable from the sam
 - **`emu.loadsnapshot` leaves the emulator paused**, and **`emu.runframes` requires the emulator to be stopped/paused** (it is rejected while `Running`, since the real-time run loop would make the frame step non-deterministic). The typical automation flow is `emu.loadsnapshot` → `emu.runframes` → `screenshot`. `emu.savesnapshot` / `emu.loadsnapshot` paths are resolved on the **server** (the machine the emulator runs on), not the client.
 - **One client at a time.** A second connection attempt is accepted only after the first client disconnects.
 - **`emu.quit` is disabled in Avalonia Desktop** by default. It is available in headless mode when `--allow-remote-quit` is passed.
-- **`screenshot` returns an error in headless mode** because no renderer is active.
 - **Loopback by default.** The server binds to `127.0.0.1` unless `--remote-bind-address` (or the **Bind** field in the Debug & Remoting tab) is set to a different interface. The wire protocol is unauthenticated — only bind to non-loopback addresses on trusted networks.
 - **`keyboard.press` holds a key until `keyboard.release` or `keyboard.releaseall`.** The client controls press duration by choosing when to release. Keys are applied at frame boundary and remain held until released.
 - **`joystick.press` holds joystick actions until `joystick.release` or `joystick.releaseall`.** Use this for ergonomic hold/release remote control.

--- a/docs/tools/remote-control/tcp-protocol.md
+++ b/docs/tools/remote-control/tcp-protocol.md
@@ -585,7 +585,7 @@ Call `keyboard.getall` at runtime for the authoritative list. Common C64 key nam
 
 ### `screenshot`
 
-Captures the current display as a Base64-encoded PNG. Returns an error in headless mode (no renderer).
+Captures the current display as a Base64-encoded PNG. Works in both Avalonia and headless hosts (composited from the current system's render frame); returns an error if no system is running.
 
 ```json
 {"id": 19, "cmd": "screenshot"}

--- a/src/apps/Highbyte.DotNet6502.App.Headless/HeadlessHostApp.cs
+++ b/src/apps/Highbyte.DotNet6502.App.Headless/HeadlessHostApp.cs
@@ -1,10 +1,14 @@
+using System.Runtime.InteropServices;
 using Highbyte.DotNet6502.DebugAdapter;
 using Highbyte.DotNet6502.Remoting;
 using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Audio;
 using Highbyte.DotNet6502.Systems.Input;
+using Highbyte.DotNet6502.Systems.Rendering.VideoFrameProvider;
 using Highbyte.DotNet6502.Systems.Timing;
 using Microsoft.Extensions.Logging;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace Highbyte.DotNet6502.App.Headless;
 
@@ -220,6 +224,38 @@ public class HeadlessHostApp : HostApp, IDebuggableHostApp, IRemotableHostApp
         }
     }
 
-    // IRemotableHostApp — no rendering in headless
-    public byte[]? CaptureScreenshotPng() => null;
+    // IRemotableHostApp — screenshot capture.
+    // Headless has no bitmap render target, so composite the current frame's layers directly
+    // (same technique as LuaScreenshotProxy's emu.screenshot(), duplicated here to avoid pulling
+    // an ImageSharp dependency into the shared Systems library).
+    public byte[]? CaptureScreenshotPng()
+    {
+        var layerProvider = CurrentSystemRunner?.System.RenderProvider as IVideoFrameLayerProvider;
+        if (layerProvider == null) return null;
+
+        var layers = layerProvider.Layers;
+        if (layers.Count == 0) return null;
+
+        var size = layers[0].Size;
+        int width = size.Width;
+        int height = size.Height;
+
+        var frontBuffers = layerProvider.CurrentFrontLayerBuffers;
+        var byteSrcs = new List<ReadOnlyMemory<byte>>(frontBuffers.Count);
+        foreach (var mem in frontBuffers)
+        {
+            var byteSpan = MemoryMarshal.AsBytes(mem.Span);
+            byteSrcs.Add(byteSpan.ToArray());
+        }
+
+        int dstStride = width * 4;
+        var dst = new byte[height * dstStride];
+        SoftwareLayerCompositor.FlattenRgba32(dst, dstStride, size, layers, byteSrcs);
+
+        // FlattenRgba32 output layout: [B, G, R, A] per pixel (BGRA32)
+        using var image = Image.LoadPixelData<Bgra32>(dst, width, height);
+        using var ms = new MemoryStream();
+        image.SaveAsPng(ms);
+        return ms.ToArray();
+    }
 }

--- a/src/apps/Highbyte.DotNet6502.App.Headless/Highbyte.DotNet6502.App.Headless.csproj
+++ b/src/apps/Highbyte.DotNet6502.App.Headless/Highbyte.DotNet6502.App.Headless.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="SixLabors.ImageSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/Rasterizer/Vic2RasterizerPixelGenerator.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/Rasterizer/Vic2RasterizerPixelGenerator.cs
@@ -92,6 +92,20 @@ public sealed class Vic2RasterizerUintPixelGenerator
     private int _scrollX;
     private int _scrollY;
 
+    // Tracks the start of a new foreground band. When a program changes the active
+    // character/bitmap source or vertical fine scroll mid-frame, later foreground
+    // writes can be shifted upward into the previous band. The clip line prevents
+    // those scrolled writes from leaking above the line where the new band starts.
+    private bool _hasPreviousForegroundSourceState;
+    private ushort _previousForegroundVideoMatrixBaseAddress;
+    private ushort _previousForegroundBitmapBaseAddress;
+    private ushort _previousForegroundCharacterSetAddressInVIC2Bank;
+    private bool _previousForegroundIsTextMode;
+    private CharMode _previousForegroundCharacterMode;
+    private BitmMode _previousForegroundBitmapMode;
+    private int _previousForegroundScrollY;
+    private int _foregroundScrollClipTopScreenLine = int.MinValue;
+
     private byte _borderColor;
     private byte _backgroundColor0;
     private byte _backgroundColor1;
@@ -339,6 +353,8 @@ public sealed class Vic2RasterizerUintPixelGenerator
                     // New frame: character grid locked to the screen top.
                     _charGridYOffset = 0;
                     _prevInvalidMode = false;
+                    _hasPreviousForegroundSourceState = false;
+                    _foregroundScrollClipTopScreenLine = int.MinValue;
 
                     // New frame: reset the sprite display latch so no sprite carries over.
                     if (_perLineSprites)
@@ -389,6 +405,8 @@ public sealed class Vic2RasterizerUintPixelGenerator
 
                 _is38ColModeEnabled = _c64.Vic2.Is38ColumnDisplayEnabled;
                 _is24RowModeEnabled = _c64.Vic2.Is24RowDisplayEnabled;
+
+                UpdateForegroundScrollClipTop(screenLine);
 
                 _leftBorderEndXAdjusted = _leftBorderEndX + (_is38ColModeEnabled ? Vic2Screen.COL_38_LEFT_BORDER_END_X_DELTA : 0);
                 _leftBorderLengthAdjusted = _leftBorderEndXAdjusted - _leftBorderStartX + 1;
@@ -1140,6 +1158,16 @@ public sealed class Vic2RasterizerUintPixelGenerator
             // Adjust for invalid mode lines offset
             ypos -= _charGridYOffset;
 
+            var sourceScreenLine = _screenLayoutInclNonVisibleScreenStartY + drawLine;
+            var targetScreenLine = _screenLayoutInclNonVisibleTopBorderStartY + ypos;
+
+            // Fine-scroll foreground pixels before the normal border clip. A new
+            // raster band must not write shifted pixels into the band above it.
+            if (ShouldClipForegroundAboveRasterSplit(foreground, fnAdjustForScrollY, sourceScreenLine, targetScreenLine))
+            {
+                return;
+            }
+
             if (ypos <= _topBorderEndYAdjusted || ypos >= _bottomBorderStartYAdjusted)
                 return;
 
@@ -1193,6 +1221,73 @@ public sealed class Vic2RasterizerUintPixelGenerator
             else
                 _setBackgroundPixels(fnEightPixels, sourcePixelStart, lBitmapIndex, fnLength);
         }
+    }
+
+    /// <summary>
+    /// Detects when the foreground rendering source or vertical fine scroll changes mid-frame and
+    /// records that screen line as the top of a new foreground band.
+    /// </summary>
+    private void UpdateForegroundScrollClipTop(int screenLine)
+    {
+        if (!_hasPreviousForegroundSourceState)
+        {
+            StoreForegroundSourceState();
+            _hasPreviousForegroundSourceState = true;
+            return;
+        }
+
+        // Source/mode/vertical-scroll changes mean the foreground below this line is
+        // logically a new raster band, even if the scrolled destination overlaps rows above.
+        var foregroundSourceChanged =
+            _vic2VideoMatrixBaseAddress != _previousForegroundVideoMatrixBaseAddress
+            || _vic2BitmapBaseAddress != _previousForegroundBitmapBaseAddress
+            || _vic2CharacterSetAddressInVIC2Bank != _previousForegroundCharacterSetAddressInVIC2Bank
+            || _isTextMode != _previousForegroundIsTextMode
+            || _characterMode != _previousForegroundCharacterMode
+            || _bitmapMode != _previousForegroundBitmapMode
+            || _scrollY != _previousForegroundScrollY;
+
+        if (foregroundSourceChanged)
+        {
+            _foregroundScrollClipTopScreenLine = screenLine;
+        }
+
+        StoreForegroundSourceState();
+    }
+
+    /// <summary>
+    /// Saves the foreground source state for comparison with the next raster line.
+    /// </summary>
+    private void StoreForegroundSourceState()
+    {
+        _previousForegroundVideoMatrixBaseAddress = _vic2VideoMatrixBaseAddress;
+        _previousForegroundBitmapBaseAddress = _vic2BitmapBaseAddress;
+        _previousForegroundCharacterSetAddressInVIC2Bank = _vic2CharacterSetAddressInVIC2Bank;
+        _previousForegroundIsTextMode = _isTextMode;
+        _previousForegroundCharacterMode = _characterMode;
+        _previousForegroundBitmapMode = _bitmapMode;
+        _previousForegroundScrollY = _scrollY;
+    }
+
+    /// <summary>
+    /// Returns true when a negatively fine-scrolled foreground write from the current band would
+    /// land above the band start and should be skipped.
+    /// </summary>
+    private bool ShouldClipForegroundAboveRasterSplit(
+        bool foreground,
+        bool adjustForScrollY,
+        int sourceScreenLine,
+        int targetScreenLine)
+    {
+        // Only foreground pixels are shifted by vertical fine scroll. With negative scroll,
+        // rows from the new band can target earlier screen lines; clip only the part that
+        // would land above the band start, leaving normal in-band scrolling untouched.
+        return foreground
+            && adjustForScrollY
+            && _scrollY < 0
+            && _foregroundScrollClipTopScreenLine != int.MinValue
+            && sourceScreenLine >= _foregroundScrollClipTopScreenLine
+            && targetScreenLine < _foregroundScrollClipTopScreenLine;
     }
 
     private void PrefillStandardTextBackgroundLine(int screenLine)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/Rasterizer/Vic2RasterizerPixelGenerator.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/Rasterizer/Vic2RasterizerPixelGenerator.cs
@@ -125,8 +125,6 @@ public sealed class Vic2RasterizerUintPixelGenerator
     private readonly bool _perLineSprites;
 
     // Sprite clipping/positioning (main screen area, without 38-col / 24-row consideration).
-    private int _spriteScreenEndX;
-    private int _spriteScreenEndY;
     private int _spriteScreenOffsetX;
     private int _spriteScreenOffsetY;
 
@@ -169,6 +167,13 @@ public sealed class Vic2RasterizerUintPixelGenerator
     private readonly uint[] _bandRowColorFg = new uint[MAX_BANDS * SPRITE_ROWS];
     private readonly uint[] _bandRowColorMc0 = new uint[MAX_BANDS * SPRITE_ROWS];
     private readonly uint[] _bandRowColorMc1 = new uint[MAX_BANDS * SPRITE_ROWS];
+    // Border clipping can change on raster splits ($D016 38/40 columns, $D011 24/25 rows).
+    // Sprite bands are drawn at end-of-frame, so each sprite row keeps the clipping window that was
+    // active while that row was displayed.
+    private readonly int[] _bandRowClipStartX = new int[MAX_BANDS * SPRITE_ROWS];
+    private readonly int[] _bandRowClipEndX = new int[MAX_BANDS * SPRITE_ROWS];
+    private readonly int[] _bandRowClipStartY = new int[MAX_BANDS * SPRITE_ROWS];
+    private readonly int[] _bandRowClipEndY = new int[MAX_BANDS * SPRITE_ROWS];
     private int _bandCount;
 
     // Band index of each sprite's currently-displaying band (-1 = none / dropped), so the gate can
@@ -249,9 +254,7 @@ public sealed class Vic2RasterizerUintPixelGenerator
         _screenStartX = visibleMainScreenAreaNormalized.Screen.Start.X;
         _screenStartY = visibleMainScreenAreaNormalized.Screen.Start.Y;
 
-        // Sprite clip bounds (closed borders) and the VIC-II sprite coordinate offsets.
-        _spriteScreenEndX = visibleMainScreenAreaNormalized.Screen.End.X;
-        _spriteScreenEndY = visibleMainScreenAreaNormalized.Screen.End.Y;
+        // VIC-II sprite coordinate offsets.
         _spriteScreenOffsetX = _c64.Vic2.SpriteManager.ScreenOffsetX;
         _spriteScreenOffsetY = _c64.Vic2.SpriteManager.ScreenOffsetY;
 
@@ -509,6 +512,10 @@ public sealed class Vic2RasterizerUintPixelGenerator
                 _bandRowColorFg[ci] = _c64ToRenderColorMap[sprites[spriteIndex].Color];
                 _bandRowColorMc0[ci] = _c64ToRenderColorMap[_c64.ReadIOStorage(Vic2Addr.SPRITE_MULTI_COLOR_0)];
                 _bandRowColorMc1[ci] = _c64ToRenderColorMap[_c64.ReadIOStorage(Vic2Addr.SPRITE_MULTI_COLOR_1)];
+                _bandRowClipStartX[ci] = _screenStartXAdjusted;
+                _bandRowClipEndX[ci] = _rightBorderStartXAdjusted;
+                _bandRowClipStartY[ci] = _topBorderEndYAdjusted + 1;
+                _bandRowClipEndY[ci] = _bottomBorderStartYAdjusted;
             }
 
             // Advance the active-run gate (double-height keeps each row for 2 lines). This only
@@ -555,6 +562,10 @@ public sealed class Vic2RasterizerUintPixelGenerator
             _bandRowColorFg[colorBase + row] = fg;
             _bandRowColorMc0[colorBase + row] = mc0;
             _bandRowColorMc1[colorBase + row] = mc1;
+            _bandRowClipStartX[colorBase + row] = _screenStartXAdjusted;
+            _bandRowClipEndX[colorBase + row] = _rightBorderStartXAdjusted;
+            _bandRowClipStartY[colorBase + row] = _topBorderEndYAdjusted + 1;
+            _bandRowClipEndY[colorBase + row] = _bottomBorderStartYAdjusted;
         }
 
         // Snapshot shape so a later pointer change (next band) can't corrupt this one.
@@ -594,9 +605,13 @@ public sealed class Vic2RasterizerUintPixelGenerator
                 var fg = _bandRowColorFg[colorBase + row];
                 var mc0 = _bandRowColorMc0[colorBase + row];
                 var mc1 = _bandRowColorMc1[colorBase + row];
-                DecodeAndWriteSpriteRow(rowBytes, destX, pixelArrayY, isDoubleWidth, isMultiColor, priority, fg, mc0, mc1);
+                var clipStartX = _bandRowClipStartX[colorBase + row];
+                var clipEndX = _bandRowClipEndX[colorBase + row];
+                var clipStartY = _bandRowClipStartY[colorBase + row];
+                var clipEndY = _bandRowClipEndY[colorBase + row];
+                DecodeAndWriteSpriteRow(rowBytes, destX, pixelArrayY, isDoubleWidth, isMultiColor, priority, fg, mc0, mc1, clipStartX, clipEndX, clipStartY, clipEndY);
                 if (lineAdvance == 2)
-                    DecodeAndWriteSpriteRow(rowBytes, destX, pixelArrayY + 1, isDoubleWidth, isMultiColor, priority, fg, mc0, mc1);
+                    DecodeAndWriteSpriteRow(rowBytes, destX, pixelArrayY + 1, isDoubleWidth, isMultiColor, priority, fg, mc0, mc1, clipStartX, clipEndX, clipStartY, clipEndY);
             }
             pixelArrayY += lineAdvance;
         }
@@ -608,7 +623,7 @@ public sealed class Vic2RasterizerUintPixelGenerator
     /// difference between them is which producer supplies the position, shape and per-row colours.
     /// Handles single/multi colour and X expansion; the caller handles Y expansion (calls twice).
     /// </summary>
-    private void DecodeAndWriteSpriteRow(ReadOnlySpan<byte> rowBytes, int destX, int destY, bool isDoubleWidth, bool isMultiColor, bool priorityOverForeground, uint spriteForegroundPixelColor, uint spriteMultiColor0PixelColor, uint spriteMultiColor1PixelColor)
+    private void DecodeAndWriteSpriteRow(ReadOnlySpan<byte> rowBytes, int destX, int destY, bool isDoubleWidth, bool isMultiColor, bool priorityOverForeground, uint spriteForegroundPixelColor, uint spriteMultiColor0PixelColor, uint spriteMultiColor1PixelColor, int clipStartX, int clipEndX, int clipStartY, int clipEndY)
     {
         var singleColorPixelAdvance = isDoubleWidth ? 2 : 1;
         var multiColorPixelAdvance = isDoubleWidth ? 4 : 2;
@@ -640,12 +655,12 @@ public sealed class Vic2RasterizerUintPixelGenerator
 
                     if (spriteColor > 0)
                     {
-                        WriteSpritePixel(destX + x, destY, spriteColor, priorityOverForeground);
-                        WriteSpritePixel(destX + x + 1, destY, spriteColor, priorityOverForeground);
+                        WriteSpritePixel(destX + x, destY, spriteColor, priorityOverForeground, clipStartX, clipEndX, clipStartY, clipEndY);
+                        WriteSpritePixel(destX + x + 1, destY, spriteColor, priorityOverForeground, clipStartX, clipEndX, clipStartY, clipEndY);
                         if (isDoubleWidth)
                         {
-                            WriteSpritePixel(destX + x + 2, destY, spriteColor, priorityOverForeground);
-                            WriteSpritePixel(destX + x + 3, destY, spriteColor, priorityOverForeground);
+                            WriteSpritePixel(destX + x + 2, destY, spriteColor, priorityOverForeground, clipStartX, clipEndX, clipStartY, clipEndY);
+                            WriteSpritePixel(destX + x + 3, destY, spriteColor, priorityOverForeground, clipStartX, clipEndX, clipStartY, clipEndY);
                         }
                     }
 
@@ -662,9 +677,9 @@ public sealed class Vic2RasterizerUintPixelGenerator
                 {
                     if ((spriteLinePart & mask) == mask)
                     {
-                        WriteSpritePixel(destX + x, destY, spriteForegroundPixelColor, priorityOverForeground);
+                        WriteSpritePixel(destX + x, destY, spriteForegroundPixelColor, priorityOverForeground, clipStartX, clipEndX, clipStartY, clipEndY);
                         if (isDoubleWidth)
-                            WriteSpritePixel(destX + x + 1, destY, spriteForegroundPixelColor, priorityOverForeground);
+                            WriteSpritePixel(destX + x + 1, destY, spriteForegroundPixelColor, priorityOverForeground, clipStartX, clipEndX, clipStartY, clipEndY);
                     }
                     mask >>= 1;
                     x += singleColorPixelAdvance;
@@ -674,13 +689,13 @@ public sealed class Vic2RasterizerUintPixelGenerator
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void WriteSpritePixel(int screenPosX, int screenPosY, uint color, bool priorityOverForeground)
+    private void WriteSpritePixel(int screenPosX, int screenPosY, uint color, bool priorityOverForeground, int clipStartX, int clipEndX, int clipStartY, int clipEndY)
     {
         if (screenPosX < 0 || screenPosX >= _width || screenPosY < 0 || screenPosY > _height)
             return;
-        if (screenPosX < _screenStartX || screenPosX > _spriteScreenEndX)   // side borders closed (TODO: open)
+        if (screenPosX < clipStartX || screenPosX >= clipEndX)   // side borders closed (TODO: open)
             return;
-        if (screenPosY < _screenStartY || screenPosY > _spriteScreenEndY)   // top/bottom borders closed (TODO: open)
+        if (screenPosY < clipStartY || screenPosY >= clipEndY)   // top/bottom borders closed (TODO: open)
             return;
 
         if (FlipY)
@@ -948,17 +963,39 @@ public sealed class Vic2RasterizerUintPixelGenerator
                 spriteForegroundPixelColor = _c64ToRenderColorMap[spriteColorValue];
                 spriteMultiColor0PixelColor = _c64ToRenderColorMap[screenLineIORegisters.SpriteMultiColor0];
                 spriteMultiColor1PixelColor = _c64ToRenderColorMap[screenLineIORegisters.SpriteMultiColor1];
+                var is38ColumnLine = !screenLineIORegisters.ColMode40;
+                var is24RowLine = !screenLineIORegisters.RowMode25;
+                var clipStartX = GetSpriteClipStartX(is38ColumnLine);
+                var clipEndX = GetSpriteClipEndX(is38ColumnLine);
+                var clipStartY = GetSpriteClipStartY(is24RowLine);
+                var clipEndY = GetSpriteClipEndY(is24RowLine);
 
                 // Decode the row using the shared core (same code path as the per-line band draw).
                 // For a Y-expanded sprite the second physical line is the same decode at y+1.
-                DecodeAndWriteSpriteRow(spriteRow.Bytes, spriteScreenPosX, spriteScreenPosY + y, isDoubleWidth, isMultiColor, priorityOverForground, spriteForegroundPixelColor, spriteMultiColor0PixelColor, spriteMultiColor1PixelColor);
+                DecodeAndWriteSpriteRow(spriteRow.Bytes, spriteScreenPosX, spriteScreenPosY + y, isDoubleWidth, isMultiColor, priorityOverForground, spriteForegroundPixelColor, spriteMultiColor0PixelColor, spriteMultiColor1PixelColor, clipStartX, clipEndX, clipStartY, clipEndY);
                 if (isDoubleHeight)
-                    DecodeAndWriteSpriteRow(spriteRow.Bytes, spriteScreenPosX, spriteScreenPosY + y + 1, isDoubleWidth, isMultiColor, priorityOverForground, spriteForegroundPixelColor, spriteMultiColor0PixelColor, spriteMultiColor1PixelColor);
+                    DecodeAndWriteSpriteRow(spriteRow.Bytes, spriteScreenPosX, spriteScreenPosY + y + 1, isDoubleWidth, isMultiColor, priorityOverForground, spriteForegroundPixelColor, spriteMultiColor0PixelColor, spriteMultiColor1PixelColor, clipStartX, clipEndX, clipStartY, clipEndY);
 
                 y += spriteLineAdvance;
             }
         }
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int GetSpriteClipStartX(bool is38ColumnLine)
+        => _screenStartX + (is38ColumnLine ? Vic2Screen.COL_38_SCREEN_START_X_DELTA : 0);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int GetSpriteClipEndX(bool is38ColumnLine)
+        => _rightBorderStartX + (is38ColumnLine ? Vic2Screen.COL_38_RIGHT_BORDER_START_X_DELTA : 0);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int GetSpriteClipStartY(bool is24RowLine)
+        => _screenStartY + (is24RowLine ? Vic2Screen.ROW_24_SCREEN_START_Y_DELTA : 0);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int GetSpriteClipEndY(bool is24RowLine)
+        => _bottomBorderStartY + (is24RowLine ? Vic2Screen.ROW_24_BOTTOM_BORDER_START_Y_DELTA : 0);
 
     private void DrawBorderPixels(int normalizedScreenLine)
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/Rasterizer/Vic2RasterizerPixelGenerator.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/Rasterizer/Vic2RasterizerPixelGenerator.cs
@@ -92,20 +92,6 @@ public sealed class Vic2RasterizerUintPixelGenerator
     private int _scrollX;
     private int _scrollY;
 
-    // Tracks the start of a new foreground band. When a program changes the active
-    // character/bitmap source or vertical fine scroll mid-frame, later foreground
-    // writes can be shifted upward into the previous band. The clip line prevents
-    // those scrolled writes from leaking above the line where the new band starts.
-    private bool _hasPreviousForegroundSourceState;
-    private ushort _previousForegroundVideoMatrixBaseAddress;
-    private ushort _previousForegroundBitmapBaseAddress;
-    private ushort _previousForegroundCharacterSetAddressInVIC2Bank;
-    private bool _previousForegroundIsTextMode;
-    private CharMode _previousForegroundCharacterMode;
-    private BitmMode _previousForegroundBitmapMode;
-    private int _previousForegroundScrollY;
-    private int _foregroundScrollClipTopScreenLine = int.MinValue;
-
     private byte _borderColor;
     private byte _backgroundColor0;
     private byte _backgroundColor1;
@@ -353,9 +339,6 @@ public sealed class Vic2RasterizerUintPixelGenerator
                     // New frame: character grid locked to the screen top.
                     _charGridYOffset = 0;
                     _prevInvalidMode = false;
-                    _hasPreviousForegroundSourceState = false;
-                    _foregroundScrollClipTopScreenLine = int.MinValue;
-
                     // New frame: reset the sprite display latch so no sprite carries over.
                     if (_perLineSprites)
                     {
@@ -405,8 +388,6 @@ public sealed class Vic2RasterizerUintPixelGenerator
 
                 _is38ColModeEnabled = _c64.Vic2.Is38ColumnDisplayEnabled;
                 _is24RowModeEnabled = _c64.Vic2.Is24RowDisplayEnabled;
-
-                UpdateForegroundScrollClipTop(screenLine);
 
                 _leftBorderEndXAdjusted = _leftBorderEndX + (_is38ColModeEnabled ? Vic2Screen.COL_38_LEFT_BORDER_END_X_DELTA : 0);
                 _leftBorderLengthAdjusted = _leftBorderEndXAdjusted - _leftBorderStartX + 1;
@@ -1020,10 +1001,13 @@ public sealed class Vic2RasterizerUintPixelGenerator
             return;
         }
 
-        // Snap the character grid to the row boundary after an invalid-mode band (see _charGridYOffset).
-        // Normally 0, so this is identical to drawLine/8 and drawLine%8 for ordinary screens.
-        // This is adjusted again when the actual pixels are drawn to pixel buffer in WriteToPixelArray. 
-        var gridLine = drawLine - _charGridYOffset;
+        // Vertical fine scroll changes which character row/line is sampled at the current raster
+        // line. Do not delay the destination Y write itself, because raster splits must affect the
+        // pixels being drawn on this line instead of appearing a few lines later.
+        var gridLine = drawLine - _charGridYOffset - _scrollY;
+        if (gridLine < 0)
+            return;
+
         var characterRow = gridLine / 8;
         var characterLine = (ushort)(gridLine % 8);
         var backgroundIsPrefilled = _isTextMode && _characterMode == CharMode.Standard;
@@ -1139,8 +1123,9 @@ public sealed class Vic2RasterizerUintPixelGenerator
         if (!backgroundIsPrefilled)
             WriteToPixelArray(_oneLineSameColorPixels[_backgroundColor0], foreground: false, drawLine, col * 8, fnLength: 8, fnAdjustForScrollX: false, fnAdjustForScrollY: false);
 
-        // Write the character to the pixel array for foreground (adjusted for fine scrolling)
-        WriteToPixelArray(eightPixels, foreground: true, drawLine, col * 8, fnLength: 8, fnAdjustForScrollX: true, fnAdjustForScrollY: true);
+        // Write the character to the current raster line. Horizontal fine scroll still shifts the
+        // destination X, but vertical fine scroll was already applied to gridLine above.
+        WriteToPixelArray(eightPixels, foreground: true, drawLine, col * 8, fnLength: 8, fnAdjustForScrollX: true, fnAdjustForScrollY: false);
 
 
         //void WriteToPixelArray(uint[] fnEightPixels, uint[] fnPixelArray, int fnMainScreenY, int fnMainScreenX, int fnLength, bool fnAdjustForScrollX, bool fnAdjustForScrollY)
@@ -1157,16 +1142,6 @@ public sealed class Vic2RasterizerUintPixelGenerator
 
             // Adjust for invalid mode lines offset
             ypos -= _charGridYOffset;
-
-            var sourceScreenLine = _screenLayoutInclNonVisibleScreenStartY + drawLine;
-            var targetScreenLine = _screenLayoutInclNonVisibleTopBorderStartY + ypos;
-
-            // Fine-scroll foreground pixels before the normal border clip. A new
-            // raster band must not write shifted pixels into the band above it.
-            if (ShouldClipForegroundAboveRasterSplit(foreground, fnAdjustForScrollY, sourceScreenLine, targetScreenLine))
-            {
-                return;
-            }
 
             if (ypos <= _topBorderEndYAdjusted || ypos >= _bottomBorderStartYAdjusted)
                 return;
@@ -1221,73 +1196,6 @@ public sealed class Vic2RasterizerUintPixelGenerator
             else
                 _setBackgroundPixels(fnEightPixels, sourcePixelStart, lBitmapIndex, fnLength);
         }
-    }
-
-    /// <summary>
-    /// Detects when the foreground rendering source or vertical fine scroll changes mid-frame and
-    /// records that screen line as the top of a new foreground band.
-    /// </summary>
-    private void UpdateForegroundScrollClipTop(int screenLine)
-    {
-        if (!_hasPreviousForegroundSourceState)
-        {
-            StoreForegroundSourceState();
-            _hasPreviousForegroundSourceState = true;
-            return;
-        }
-
-        // Source/mode/vertical-scroll changes mean the foreground below this line is
-        // logically a new raster band, even if the scrolled destination overlaps rows above.
-        var foregroundSourceChanged =
-            _vic2VideoMatrixBaseAddress != _previousForegroundVideoMatrixBaseAddress
-            || _vic2BitmapBaseAddress != _previousForegroundBitmapBaseAddress
-            || _vic2CharacterSetAddressInVIC2Bank != _previousForegroundCharacterSetAddressInVIC2Bank
-            || _isTextMode != _previousForegroundIsTextMode
-            || _characterMode != _previousForegroundCharacterMode
-            || _bitmapMode != _previousForegroundBitmapMode
-            || _scrollY != _previousForegroundScrollY;
-
-        if (foregroundSourceChanged)
-        {
-            _foregroundScrollClipTopScreenLine = screenLine;
-        }
-
-        StoreForegroundSourceState();
-    }
-
-    /// <summary>
-    /// Saves the foreground source state for comparison with the next raster line.
-    /// </summary>
-    private void StoreForegroundSourceState()
-    {
-        _previousForegroundVideoMatrixBaseAddress = _vic2VideoMatrixBaseAddress;
-        _previousForegroundBitmapBaseAddress = _vic2BitmapBaseAddress;
-        _previousForegroundCharacterSetAddressInVIC2Bank = _vic2CharacterSetAddressInVIC2Bank;
-        _previousForegroundIsTextMode = _isTextMode;
-        _previousForegroundCharacterMode = _characterMode;
-        _previousForegroundBitmapMode = _bitmapMode;
-        _previousForegroundScrollY = _scrollY;
-    }
-
-    /// <summary>
-    /// Returns true when a negatively fine-scrolled foreground write from the current band would
-    /// land above the band start and should be skipped.
-    /// </summary>
-    private bool ShouldClipForegroundAboveRasterSplit(
-        bool foreground,
-        bool adjustForScrollY,
-        int sourceScreenLine,
-        int targetScreenLine)
-    {
-        // Only foreground pixels are shifted by vertical fine scroll. With negative scroll,
-        // rows from the new band can target earlier screen lines; clip only the part that
-        // would land above the band start, leaving normal in-band scrolling untouched.
-        return foreground
-            && adjustForScrollY
-            && _scrollY < 0
-            && _foregroundScrollClipTopScreenLine != int.MinValue
-            && sourceScreenLine >= _foregroundScrollClipTopScreenLine
-            && targetScreenLine < _foregroundScrollClipTopScreenLine;
     }
 
     private void PrefillStandardTextBackgroundLine(int screenLine)

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Render/Vic2RasterizerPixelGeneratorTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Render/Vic2RasterizerPixelGeneratorTests.cs
@@ -45,6 +45,24 @@ public class Vic2RasterizerPixelGeneratorTests
         Assert.Equal(visibleMainScreenArea.Screen.Start.Y + 2, row);
     }
 
+    [Fact]
+    public void DrawSprites_clips_right_edge_to_38_column_border()
+    {
+        var c64 = BuildC64();
+        var normalLayout = c64.Vic2.ScreenLayouts.GetLayout(Vic2ScreenLayouts.LayoutType.VisibleNormalized, for24RowMode: false, for38ColMode: false);
+        var col38Layout = c64.Vic2.ScreenLayouts.GetLayout(Vic2ScreenLayouts.LayoutType.VisibleNormalized, for24RowMode: false, for38ColMode: true);
+        var spriteScreenX = col38Layout.RightBorder.Start.X - 4;
+        var spriteX = c64.Vic2.SpriteManager.ScreenOffsetX + spriteScreenX - normalLayout.Screen.Start.X;
+        SetAllScreenLinesToColumnMode(c64, colMode40: false);
+        CreateVisibleSprite(c64, spriteNumber: 0, doubleWidth: false, doubleHeight: false, CreateSingleRowSprite(0xff), spritePointer: 192, x: spriteX);
+
+        var foreground = RenderSprites(c64);
+
+        var (_, startX, endX) = GetFirstRenderedSpan(foreground, c64.Screen.VisibleWidth);
+        Assert.Equal(spriteScreenX, startX);
+        Assert.Equal(col38Layout.RightBorder.Start.X - 1, endX);
+    }
+
     [Theory]
     [InlineData("C64PAL", "PAL")]
     [InlineData("C64NTSC", "NTSC")]
@@ -86,11 +104,15 @@ public class Vic2RasterizerPixelGeneratorTests
         }, NullLoggerFactory.Instance);
     }
 
-    private static void CreateVisibleSprite(C64 c64, int spriteNumber, bool doubleWidth, bool doubleHeight, byte[] spriteShape, byte spritePointer)
+    private static void CreateVisibleSprite(C64 c64, int spriteNumber, bool doubleWidth, bool doubleHeight, byte[] spriteShape, byte spritePointer, int? x = null)
     {
         var spriteManager = c64.Vic2.SpriteManager;
-        c64.WriteIOStorage((ushort)(Vic2Addr.SPRITE_0_X + spriteNumber * 2), (byte)spriteManager.ScreenOffsetX);
+        var spriteX = x ?? spriteManager.ScreenOffsetX;
+        c64.WriteIOStorage((ushort)(Vic2Addr.SPRITE_0_X + spriteNumber * 2), (byte)(spriteX & 0xff));
         c64.WriteIOStorage((ushort)(Vic2Addr.SPRITE_0_Y + spriteNumber * 2), (byte)spriteManager.ScreenOffsetY);
+        var spriteMsbX = c64.ReadIOStorage(Vic2Addr.SPRITE_MSB_X);
+        spriteMsbX = spriteX > 255 ? (byte)(spriteMsbX | (1 << spriteNumber)) : (byte)(spriteMsbX & ~(1 << spriteNumber));
+        c64.WriteIOStorage(Vic2Addr.SPRITE_MSB_X, spriteMsbX);
 
         var spriteEnable = c64.ReadIOStorage(Vic2Addr.SPRITE_ENABLE);
         spriteEnable |= (byte)(1 << spriteNumber);
@@ -134,6 +156,14 @@ public class Vic2RasterizerPixelGeneratorTests
 
         generator.DrawSpritesToBitmapBackedByPixelArray();
         return foreground;
+    }
+
+    private static void SetAllScreenLinesToColumnMode(C64 c64, bool colMode40)
+    {
+        foreach (var screenLineData in c64.Vic2.ScreenLineIORegisterValues.Values)
+        {
+            screenLineData.ColMode40 = colMode40;
+        }
     }
 
     private static (int Row, int StartX, int EndX) GetFirstRenderedSpan(uint[] pixels, int width)


### PR DESCRIPTION
## Summary
- Fix VIC-II vertical fine-scroll row sampling across raster splits, preventing Paradroid playfield pop-in/blank rows.
- Clip sprites against the active VIC-II border window, including 38-column raster split lines.
- Add focused rasterizer regression coverage for 38-column sprite clipping.

