### PR TITLE
Surface snapshot load/save errors to the user

### DIFF
--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml.cs
@@ -1175,6 +1175,10 @@ public partial class MainView : UserControl
             catch (Exception ex)
             {
                 Logger.LogError(ex, "Error saving snapshot");
+
+                // Rethrow so the app's global error handling surfaces the failure to the user instead
+                // of silently leaving them looking at an unchanged screen with only a log entry.
+                throw;
             }
             finally
             {
@@ -1241,6 +1245,11 @@ public partial class MainView : UserControl
                 // this guard leaves it stopped rather than rebuilding a fresh machine.
                 if (wasRunning && hostApp.EmulatorState == EmulatorState.Paused)
                     await hostApp.Start();
+
+                // Rethrow so the app's global error handling surfaces the failure to the user (e.g.
+                // "Snapshot could not be restored: ROM file does not exist: ...") instead of silently
+                // leaving them looking at an unchanged screen with only a log entry to explain why.
+                throw;
             }
         });
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems/ROM.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/ROM.cs
@@ -97,7 +97,15 @@ public class ROM
         var romsData = new Dictionary<string, byte[]>();
         foreach (var rom in roms)
         {
-            var romData = rom.GetRomData(romFileAssumedToExist: true, directory);
+            byte[]? romData;
+            try
+            {
+                romData = rom.GetRomData(romFileAssumedToExist: true, directory);
+            }
+            catch (IOException ex)
+            {
+                throw new DotNet6502Exception($"Failed to load ROM '{rom.Name}' from '{rom.GetROMFilePath(directory)}': {ex.Message}", ex);
+            }
             romsData.Add(rom.Name, romData!);
         }
         return romsData;

--- a/src/libraries/Highbyte.DotNet6502.Systems/SystemList.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/SystemList.cs
@@ -71,9 +71,14 @@ public class SystemList
         if (!Systems.Contains(systemName))
             throw new DotNet6502Exception($"System does not exist: {systemName}");
 
-        bool isValid = await IsValidConfig(systemName);
+        var (isValid, validationErrors) = await IsValidConfigWithDetails(systemName);
         if (!isValid)
-            throw new DotNet6502Exception($"Internal error. Configuration for system {systemName} variant {configurationVariant} is invalid.");
+        {
+            var details = validationErrors.Count > 0
+                ? string.Join("; ", validationErrors)
+                : "no details available";
+            throw new DotNet6502Exception($"Configuration for system {systemName} variant {configurationVariant} is invalid: {details}");
+        }
 
         var hostSystemConfig = await GetHostSystemConfig(systemName);
         var system = await _systemConfigurers[systemName].BuildSystem(configurationVariant, hostSystemConfig.SystemConfig);

--- a/src/libraries/Highbyte.DotNet6502/DotNet6502Exception.cs
+++ b/src/libraries/Highbyte.DotNet6502/DotNet6502Exception.cs
@@ -5,4 +5,8 @@ public class DotNet6502Exception : Exception
     public DotNet6502Exception(string message) : base(message)
     {
     }
+
+    public DotNet6502Exception(string message, Exception innerException) : base(message, innerException)
+    {
+    }
 }


### PR DESCRIPTION
BuildSystem now includes real validation details (e.g. missing ROM paths) instead of a generic "Internal error" message, ROM.LoadROMS wraps file-read failures in a clear exception, and the Avalonia load/save snapshot handlers rethrow so the app's error dialog actually displays the failure.