### PR TITLE
Feature/implement user data storage

### DIFF
--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/Highbyte.DotNet6502.App.Avalonia.Browser.csproj
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/Highbyte.DotNet6502.App.Avalonia.Browser.csproj
@@ -122,12 +122,25 @@
     <EmbeddedResource Include="BrowserScripting.js" />
   </ItemGroup>
 
-  <!-- Copy Lua example scripts from central resources location to wwwroot so they are served at runtime -->
-  <Target Name="CopyExampleScripts" AfterTargets="AfterBuild">
+  <!-- Serve Lua example scripts as browser static assets. -->
+  <ItemGroup>
+    <Content Remove="wwwroot\scripts\*.lua" />
+    <None Remove="wwwroot\scripts\*.lua" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\..\..\..\resources\scripts\shared\*.lua"
+                      LogicalName="Highbyte.DotNet6502.App.Avalonia.Browser.ExampleScripts.%(Filename)%(Extension)" />
+    <Content Include="$(MSBuildThisFileDirectory)..\..\..\..\resources\scripts\shared\*.lua"
+             Link="wwwroot\scripts\%(Filename)%(Extension)"
+             TargetPath="wwwroot\scripts\%(Filename)%(Extension)"
+             CopyToOutputDirectory="PreserveNewest"
+             CopyToPublishDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <Target Name="CopyExampleScriptsToWwwroot" AfterTargets="Build">
     <ItemGroup>
-      <_SharedScripts Include="$(MSBuildThisFileDirectory)..\..\..\..\resources\scripts\shared\*" />
+      <_SharedScripts Include="$(MSBuildThisFileDirectory)..\..\..\..\resources\scripts\shared\*.lua" />
     </ItemGroup>
-    <Copy SourceFiles="@(_SharedScripts)" DestinationFolder="wwwroot\scripts" SkipUnchangedFiles="true" />
+    <MakeDir Directories="$(MSBuildThisFileDirectory)wwwroot\scripts" />
+    <Copy SourceFiles="@(_SharedScripts)" DestinationFolder="$(MSBuildThisFileDirectory)wwwroot\scripts" />
   </Target>
 
   <Target Name="CopySharedAssets" AfterTargets="AfterBuild">

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/Program.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/Program.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices.JavaScript;
 using System.Runtime.Versioning;
+using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using AvaloniaBrowserApp = Highbyte.DotNet6502.App.Avalonia.Core.App;
@@ -1353,18 +1354,23 @@ internal sealed partial class Program
         }
     }
 
-    private static async Task SeedExampleScriptsAsync(Action<string, string> saveScript)
+    private static Task SeedExampleScriptsAsync(Action<string, string> saveScript)
     {
-        using var http = GetAppUrlHttpClient();
         foreach (var scriptName in _exampleScriptNames)
         {
             var key = $"{LOCAL_STORAGE_SCRIPT_PREFIX}{scriptName}";
-            if (JSInterop.GetLocalStorage(key) != null)
-                continue;   // already exists (user content) — skip
+            if (!string.IsNullOrWhiteSpace(JSInterop.GetLocalStorage(key)))
+                continue;   // already exists with content (user content) — skip
 
             try
             {
-                var content = await GetUtf8TextAsync(http, $"scripts/{scriptName}");
+                var content = ReadBundledExampleScript(scriptName);
+                if (string.IsNullOrEmpty(content))
+                {
+                    WriteBootstrapLog($"Could not seed example script '{scriptName}': embedded resource was empty or missing.", LogLevel.Warning);
+                    continue;
+                }
+
                 saveScript(scriptName, content);   // writes localStorage + hot-adds to engine
                 WriteBootstrapLog($"Seeded example script: {scriptName}");
             }
@@ -1373,6 +1379,19 @@ internal sealed partial class Program
                 WriteBootstrapLog($"Could not seed example script '{scriptName}': {ex.Message}", LogLevel.Warning);
             }
         }
+
+        return Task.CompletedTask;
+    }
+
+    private static string? ReadBundledExampleScript(string scriptName)
+    {
+        var resourceName = $"Highbyte.DotNet6502.App.Avalonia.Browser.ExampleScripts.{scriptName}";
+        using var stream = typeof(Program).Assembly.GetManifestResourceStream(resourceName);
+        if (stream == null)
+            return null;
+
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        return reader.ReadToEnd();
     }
 
     private static IEnumerable<(string fileName, string content)> LoadScriptsFromLocalStorage()

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/App.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/App.axaml.cs
@@ -111,7 +111,7 @@ public partial class App : Application
     /// <param name="loadScript">Optional callback to load a script's source by file name (browser: from localStorage).</param>
     /// <param name="saveScript">Optional callback to persist a script by file name and content (browser: to localStorage).</param>
     /// <param name="deleteScript">Optional callback to remove a script by file name (browser: from localStorage).</param>
-    /// <param name="loadExamples">Optional callback to fetch and seed bundled example scripts (browser-only).</param>
+    /// <param name="loadExamples">Optional callback to seed bundled example scripts into the host's script storage.</param>
     /// <param name="automatedStartupRunner">
     /// Optional automated-startup delegate invoked from <see cref="ViewModels.MainViewModel.SetDefaultSystemSelectionAsync"/>
     /// after the view tree has been loaded. When non-null, the UI's default system selection is
@@ -404,6 +404,8 @@ public partial class App : Application
 #pragma warning disable VSTHRD002
             systemList.RemoveSystemsWithNoConfigurationVariants(_logger).GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002
+
+            systemList.EnsureUserContentDirectories(_logger);
 
             // No usable system: a fatal startup error. The caller (OnFrameworkInitializationCompleted)
             // catches this and shows the fatal error screen instead of the main UI.

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/AvaloniaHostApp.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/AvaloniaHostApp.cs
@@ -186,7 +186,7 @@ public class AvaloniaHostApp : HostApp, INotifyPropertyChanged, IDebuggableHostA
     /// <param name="loadScript">Optional callback to load a script's source content by file name (browser: from localStorage).</param>
     /// <param name="saveScript">Optional callback to persist a script by file name and content (browser: to localStorage).</param>
     /// <param name="deleteScript">Optional callback to remove a script by file name (browser: from localStorage).</param>
-    /// <param name="loadExamples">Optional callback to fetch and seed bundled example scripts (browser-only).</param>
+    /// <param name="loadExamples">Optional callback to seed bundled example scripts into the host's script storage.</param>
     internal AvaloniaHostApp(
         SystemList systemList,
         ILoggerFactory loggerFactory,
@@ -886,7 +886,7 @@ public class AvaloniaHostApp : HostApp, INotifyPropertyChanged, IDebuggableHostA
         if (_saveCustomConfigString == null)
             return;
         var configSectionName = EmulatorConfig.ConfigSectionName;
-        var json = _emulatorConfig.GetConfigAsJson();
+        var json = _emulatorConfig.GetUserSettingsJson();
         await _saveCustomConfigString(configSectionName, json, null);
     }
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/EmulatorConfig.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/EmulatorConfig.cs
@@ -141,4 +141,49 @@ public class EmulatorConfig
         var json = JsonSerializer.Serialize(this, EmulatorConfigJsonContext.Default.EmulatorConfig);
         return json;
     }
+
+    public string GetUserSettingsJson()
+    {
+        var settings = new EmulatorConfigUserSettings
+        {
+            DefaultEmulator = DefaultEmulator,
+            DefaultDrawScale = DefaultDrawScale,
+            ShowErrorDialog = ShowErrorDialog,
+            ShowDebugTools = ShowDebugTools,
+            IncludeConfigInSnapshot = IncludeConfigInSnapshot,
+            RestoreConfigOnLoad = RestoreConfigOnLoad,
+            CorsProxyUrl = CorsProxyUrl,
+            AudioSettingsProfile = AudioSettingsProfile,
+            BrowserSampleAudioMode = BrowserSampleAudioMode,
+            Monitor = new EmulatorMonitorUserSettings
+            {
+                StopAfterBRKInstruction = Monitor.StopAfterBRKInstruction,
+                StopAfterUnknownInstruction = Monitor.StopAfterUnknownInstruction
+            }
+        };
+
+        return JsonSerializer.Serialize(settings, EmulatorConfigJsonContext.Default.EmulatorConfigUserSettings);
+    }
+}
+
+internal sealed class EmulatorConfigUserSettings
+{
+    public string DefaultEmulator { get; set; } = "C64";
+    public float DefaultDrawScale { get; set; } = 2.0f;
+    public bool ShowErrorDialog { get; set; } = true;
+    public bool ShowDebugTools { get; set; }
+    public bool IncludeConfigInSnapshot { get; set; } = true;
+    public bool RestoreConfigOnLoad { get; set; } = true;
+    public string CorsProxyUrl { get; set; } = BrowserServiceDefaults.DefaultCorsProxyUrl;
+    [JsonConverter(typeof(JsonStringEnumConverter<WavePlayerSettingsProfile>))]
+    public WavePlayerSettingsProfile AudioSettingsProfile { get; set; } = WavePlayerSettingsProfile.Balanced;
+    [JsonConverter(typeof(JsonStringEnumConverter<BrowserSampleAudioMode>))]
+    public BrowserSampleAudioMode BrowserSampleAudioMode { get; set; } = BrowserSampleAudioMode.Stable;
+    public EmulatorMonitorUserSettings Monitor { get; set; } = new();
+}
+
+internal sealed class EmulatorMonitorUserSettings
+{
+    public bool StopAfterBRKInstruction { get; set; } = true;
+    public bool StopAfterUnknownInstruction { get; set; } = true;
 }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/EmulatorConfig.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/EmulatorConfig.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -7,6 +8,8 @@ using Highbyte.DotNet6502.Impl.NAudio;
 using Highbyte.DotNet6502.Impl.NAudio.WavePlayers;
 using Highbyte.DotNet6502.Monitor;
 using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Configuration;
+using Highbyte.DotNet6502.Utils;
 using Microsoft.Extensions.Configuration;
 
 namespace Highbyte.DotNet6502.App.Avalonia.Core;
@@ -28,6 +31,35 @@ public class EmulatorConfig
 
     /// <summary>Apply any settings ("config") embedded in a snapshot when loading it (opt-in).</summary>
     public bool RestoreConfigOnLoad { get; set; } = true;
+
+    /// <summary>
+    /// Optional desktop snapshot folder override. When empty, <see cref="DefaultSnapshotDirectory"/> is used.
+    /// Ignored in browser, where snapshots are uploaded/downloaded through browser file APIs.
+    /// </summary>
+    public string SnapshotDirectory { get; set; } = string.Empty;
+
+    [JsonIgnore]
+    public static string DefaultSnapshotDirectory => AppStoragePaths.GetSnapshotsDirectory();
+
+    [JsonIgnore]
+    public string EffectiveSnapshotDirectory =>
+        string.IsNullOrWhiteSpace(SnapshotDirectory) && !OperatingSystem.IsBrowser()
+            ? DefaultSnapshotDirectory
+            : SnapshotDirectory;
+
+    public string ResolvedSnapshotDirectory()
+        => ResolveDirectory(EffectiveSnapshotDirectory);
+
+    private static string ResolveDirectory(string directory)
+    {
+        var expandedDirectory = PathHelper.ExpandOSEnvironmentVariables(directory);
+
+        if (string.IsNullOrEmpty(expandedDirectory) || Path.IsPathRooted(expandedDirectory))
+            return expandedDirectory;
+
+        var cwdPath = Path.GetFullPath(expandedDirectory);
+        return Directory.Exists(cwdPath) ? cwdPath : Path.GetFullPath(expandedDirectory, AppContext.BaseDirectory);
+    }
 
     /// <summary>
     /// CORS proxy prefix used to route cross-origin HTTP fetches when running in the browser
@@ -152,6 +184,7 @@ public class EmulatorConfig
             ShowDebugTools = ShowDebugTools,
             IncludeConfigInSnapshot = IncludeConfigInSnapshot,
             RestoreConfigOnLoad = RestoreConfigOnLoad,
+            SnapshotDirectory = OperatingSystem.IsBrowser() ? null : SnapshotDirectory,
             CorsProxyUrl = CorsProxyUrl,
             AudioSettingsProfile = AudioSettingsProfile,
             BrowserSampleAudioMode = BrowserSampleAudioMode,
@@ -174,6 +207,8 @@ internal sealed class EmulatorConfigUserSettings
     public bool ShowDebugTools { get; set; }
     public bool IncludeConfigInSnapshot { get; set; } = true;
     public bool RestoreConfigOnLoad { get; set; } = true;
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SnapshotDirectory { get; set; }
     public string CorsProxyUrl { get; set; } = BrowserServiceDefaults.DefaultCorsProxyUrl;
     [JsonConverter(typeof(JsonStringEnumConverter<WavePlayerSettingsProfile>))]
     public WavePlayerSettingsProfile AudioSettingsProfile { get; set; } = WavePlayerSettingsProfile.Balanced;

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/EmulatorConfigJsonContext.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/EmulatorConfigJsonContext.cs
@@ -10,6 +10,7 @@ namespace Highbyte.DotNet6502.App.Avalonia.Core;
     PropertyNameCaseInsensitive = true // your option from the code
 )]
 [JsonSerializable(typeof(EmulatorConfig))]
+[JsonSerializable(typeof(EmulatorConfigUserSettings))]
 internal partial class EmulatorConfigJsonContext : JsonSerializerContext
 {
 }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Services/IAppFilePicker.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Services/IAppFilePicker.cs
@@ -18,7 +18,8 @@ public sealed record AppFilePickerFileType(string Name, IReadOnlyList<string> Pa
 public sealed record AppFilePickerOpenOptions(
     string Title,
     bool AllowMultiple,
-    IReadOnlyList<AppFilePickerFileType> FileTypes)
+    IReadOnlyList<AppFilePickerFileType> FileTypes,
+    string? SuggestedStartDirectory = null)
 {
     public string ToBrowserAccept()
     {
@@ -84,6 +85,7 @@ public sealed class AvaloniaStorageAppFilePicker : IAppFilePicker
             {
                 Title = options.Title,
                 AllowMultiple = options.AllowMultiple,
+                SuggestedStartLocation = await AppFilePickerStartLocation.ResolveAsync(topLevel.StorageProvider, options.SuggestedStartDirectory),
                 FileTypeFilter = options.FileTypes
                     .Select(ToAvaloniaFileType)
                     .ToArray()
@@ -114,7 +116,8 @@ public sealed record AppFileSaveOptions(
     string Title,
     string SuggestedFileName,
     string DefaultExtension,
-    IReadOnlyList<AppFilePickerFileType> FileTypes);
+    IReadOnlyList<AppFilePickerFileType> FileTypes,
+    string? SuggestedStartDirectory = null);
 
 /// <summary>
 /// App-level save-file abstraction used by Avalonia views that need to write bytes to a user-chosen
@@ -153,6 +156,7 @@ public sealed class AvaloniaStorageAppFileSaver : IAppFileSaver
                 Title = options.Title,
                 SuggestedFileName = options.SuggestedFileName,
                 DefaultExtension = options.DefaultExtension,
+                SuggestedStartLocation = await AppFilePickerStartLocation.ResolveAsync(topLevel.StorageProvider, options.SuggestedStartDirectory),
                 FileTypeChoices = options.FileTypes.Select(AppFileTypeConverter.ToAvaloniaFileType).ToArray()
             });
             if (file == null)
@@ -180,5 +184,23 @@ internal static class AppFileTypeConverter
         {
             Patterns = fileType.Patterns
         };
+    }
+}
+
+internal static class AppFilePickerStartLocation
+{
+    public static async Task<IStorageFolder?> ResolveAsync(IStorageProvider storageProvider, string? directory)
+    {
+        if (string.IsNullOrWhiteSpace(directory) || !Directory.Exists(directory))
+            return null;
+
+        try
+        {
+            return await storageProvider.TryGetFolderFromPathAsync(directory);
+        }
+        catch
+        {
+            return null;
+        }
     }
 }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/EmulatorConfigViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/EmulatorConfigViewModel.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Highbyte.DotNet6502.Impl.NAudio.WavePlayers;
 using Highbyte.DotNet6502.Monitor;
 using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Utils;
 using Microsoft.Extensions.Configuration;
 using ReactiveUI;
 
@@ -30,6 +31,7 @@ public class EmulatorConfigViewModel : ViewModelBase
     private BrowserSampleAudioMode _selectedBrowserSampleAudioMode;
     private bool _stopAfterBRKInstruction;
     private bool _stopAfterUnknownInstruction;
+    private string _snapshotDirectory;
     private bool _allowUrlScripts;
     private string _corsProxyUrl;
 
@@ -59,6 +61,7 @@ public class EmulatorConfigViewModel : ViewModelBase
         _selectedBrowserSampleAudioMode = _emulatorConfig.BrowserSampleAudioMode;
         _stopAfterBRKInstruction = _emulatorConfig.Monitor.StopAfterBRKInstruction;
         _stopAfterUnknownInstruction = _emulatorConfig.Monitor.StopAfterUnknownInstruction;
+        _snapshotDirectory = _emulatorConfig.SnapshotDirectory;
         _allowUrlScripts = _hostApp.ScriptingEngine.AllowUrlScripts;
         _corsProxyUrl = _emulatorConfig.CorsProxyUrl;
 
@@ -246,8 +249,24 @@ public class EmulatorConfigViewModel : ViewModelBase
         }
     }
 
+    public string SnapshotDirectory
+    {
+        get => _snapshotDirectory;
+        set => this.RaiseAndSetIfChanged(ref _snapshotDirectory, value ?? string.Empty);
+    }
+
+    public string SnapshotDirectoryDescription =>
+        $"Optional snapshot folder override. Leave blank to use the default: {PathHelper.ExpandOSEnvironmentVariables(EmulatorConfig.DefaultSnapshotDirectory)}.";
+
     // Lua Scripting (read-only, informational)
-    public string LuaScriptDirectory => _hostApp.ScriptingEngine.ScriptDirectory;
+    public string LuaScriptDirectory =>
+        _configuration
+            .GetSection(ScriptingConfig.ConfigSectionName)
+            .GetValue(nameof(ScriptingConfig.ScriptDirectory), string.Empty) ?? string.Empty;
+
+    public string LuaScriptDirectoryDescription =>
+        $"Optional script directory override. Leave blank to use the default: {PathHelper.ExpandOSEnvironmentVariables(ScriptingConfig.DefaultScriptDirectory)}. Restart the app for changes to take effect.";
+
     public string LuaStorePrefix => _emulatorConfig.LuaStorePrefix;
 
     /// <summary>
@@ -317,6 +336,7 @@ public class EmulatorConfigViewModel : ViewModelBase
         SelectedBrowserSampleAudioMode = defaults.BrowserSampleAudioMode;
         StopAfterBRKInstruction = defaults.Monitor.StopAfterBRKInstruction;
         StopAfterUnknownInstruction = defaults.Monitor.StopAfterUnknownInstruction;
+        SnapshotDirectory = defaults.SnapshotDirectory;
         // Browser-only knob; defaults to disabled.
         AllowUrlScripts = false;
         CorsProxyUrl = defaults.CorsProxyUrl;
@@ -343,6 +363,8 @@ public class EmulatorConfigViewModel : ViewModelBase
             _emulatorConfig.BrowserSampleAudioMode = _selectedBrowserSampleAudioMode;
             _emulatorConfig.Monitor.StopAfterBRKInstruction = _stopAfterBRKInstruction;
             _emulatorConfig.Monitor.StopAfterUnknownInstruction = _stopAfterUnknownInstruction;
+            if (!IsRunningInWebAssembly)
+                _emulatorConfig.SnapshotDirectory = _snapshotDirectory;
             _emulatorConfig.CorsProxyUrl = _corsProxyUrl;
 
             // Persist emulator config (note: the _emulatorConfig object is owned by AvaloniaHostApp)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/EmulatorConfigViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/EmulatorConfigViewModel.cs
@@ -93,7 +93,7 @@ public class EmulatorConfigViewModel : ViewModelBase
         // Show info message on desktop about permanent settings
         if (!IsRunningInWebAssembly)
         {
-            StatusMessage = "To change the settings permanently, update the appsettings.json file.";
+            StatusMessage = "Changes are saved to your user settings.";
         }
     }
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorConfigUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorConfigUserControl.axaml
@@ -231,7 +231,7 @@
                          Width="250"
                          HorizontalAlignment="Left"/>
                 <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
-                           Text="The directory from which Lua scripts are loaded. Configure it in appsettings.json or appsettings.user.json and restart the application."
+                           Text="The directory from which Lua scripts are loaded. Restart the app for changes to take effect."
                            Classes="small secondary-text"
                            TextWrapping="Wrap"
                            Margin="0,4,0,0"/>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorConfigUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorConfigUserControl.axaml
@@ -209,6 +209,33 @@
           </Border>
         </StackPanel>
 
+        <!-- Snapshot Settings Section -->
+        <StackPanel Width="400" Classes="wrap-item" IsVisible="{Binding !IsRunningInWebAssembly}">
+          <Border Classes="content-section">
+            <StackPanel Classes="spacing-tight">
+              <TextBlock Text="Snapshots" Classes=""/>
+
+              <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto" Classes="spacing-tight">
+                <TextBlock Grid.Row="0" Grid.Column="0"
+                           Text="Snapshot folder:"
+                           Classes="secondary-text"
+                           VerticalAlignment="Center"/>
+                <TextBox Grid.Row="0" Grid.Column="1"
+                         AutomationProperties.AutomationId="SnapshotDirectoryTextBox"
+                         AutomationProperties.Name="Snapshot folder"
+                         Text="{Binding SnapshotDirectory}"
+                         Width="250"
+                         HorizontalAlignment="Left"/>
+                <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                           Text="{Binding SnapshotDirectoryDescription}"
+                           Classes="small secondary-text"
+                           TextWrapping="Wrap"
+                           Margin="0,4,0,0"/>
+              </Grid>
+            </StackPanel>
+          </Border>
+        </StackPanel>
+
         <!-- Lua Scripting Section -->
         <StackPanel Width="400" Classes="wrap-item">
           <Border Classes="content-section">
@@ -231,7 +258,7 @@
                          Width="250"
                          HorizontalAlignment="Left"/>
                 <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
-                           Text="The directory from which Lua scripts are loaded. Restart the app for changes to take effect."
+                           Text="{Binding LuaScriptDirectoryDescription}"
                            Classes="small secondary-text"
                            TextWrapping="Wrap"
                            Margin="0,4,0,0"/>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorConfigUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorConfigUserControl.axaml
@@ -231,7 +231,7 @@
                          Width="250"
                          HorizontalAlignment="Left"/>
                 <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
-                           Text="The directory from which Lua scripts are loaded. To change it, modify appsettings.json file and restart the application."
+                           Text="The directory from which Lua scripts are loaded. Configure it in appsettings.json or appsettings.user.json and restart the application."
                            Classes="small secondary-text"
                            TextWrapping="Wrap"
                            Margin="0,4,0,0"/>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
@@ -605,8 +605,19 @@
                                                                 BorderThickness="0"
                                                                 VerticalAlignment="Center"
                                                                 ToolTip.Tip="Open script folder in file browser"/>
+                                                        <Button Content="Copy Examples"
+                                                                AutomationProperties.AutomationId="CopyExampleScriptsButton"
+                                                                AutomationProperties.Name="Copy bundled example scripts to script folder"
+                                                                Command="{Binding LoadExamplesCommand}"
+                                                                IsVisible="{Binding CanLoadExamples}"
+                                                                FontSize="10"
+                                                                Padding="6,2"
+                                                                MinWidth="0"
+                                                                MinHeight="0"
+                                                                VerticalAlignment="Center"
+                                                                ToolTip.Tip="Copy bundled example scripts to the script folder without overwriting existing files"/>
                                                     </StackPanel>
-                                                    <TextBlock Text="Use your OS file browser and editor to add, edit, or delete scripts. The script directory is set in appsettings.json in the same folder as the emulator executable. Restart app after making changes to the script directory path."
+                                                    <TextBlock Text="Use your OS file browser and editor to add, edit, or delete scripts. The script directory is configured in appsettings.json or appsettings.user.json. Restart app after making changes to the script directory path."
                                                                Classes="small"
                                                                Foreground="{DynamicResource SecondaryText}"
                                                                TextWrapping="Wrap"/>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
@@ -611,13 +611,15 @@
                                                                 Command="{Binding LoadExamplesCommand}"
                                                                 IsVisible="{Binding CanLoadExamples}"
                                                                 FontSize="10"
-                                                                Padding="6,2"
+                                                                Height="22"
+                                                                Padding="6,0"
                                                                 MinWidth="0"
                                                                 MinHeight="0"
                                                                 VerticalAlignment="Center"
+                                                                VerticalContentAlignment="Center"
                                                                 ToolTip.Tip="Copy bundled example scripts to the script folder without overwriting existing files"/>
                                                     </StackPanel>
-                                                    <TextBlock Text="Use your OS file browser and editor to add, edit, or delete scripts. The script directory is configured in appsettings.json or appsettings.user.json. Restart app after making changes to the script directory path."
+                                                    <TextBlock Text="Use your OS file browser and editor to add, edit, or delete scripts. Set script directory can be set in Options."
                                                                Classes="small"
                                                                Foreground="{DynamicResource SecondaryText}"
                                                                TextWrapping="Wrap"/>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml.cs
@@ -1157,6 +1157,7 @@ public partial class MainView : UserControl
                 // SuggestedFileName is extension-less; each saver adds the extension (Desktop via the
                 // StorageProvider DefaultExtension, Browser by appending it to the download name).
                 var suggestedName = hostApp.SelectedSystemName.Replace(" ", "_");
+                var snapshotDirectory = EnsureSnapshotDirectory(hostApp.EmulatorConfig);
                 var saved = await fileSaver.SaveFileAsync(
                     this,
                     new AppFileSaveOptions(
@@ -1166,7 +1167,8 @@ public partial class MainView : UserControl
                         [
                             new AppFilePickerFileType("Emulator snapshot", ["*.d6502snap"]),
                             AppFilePickerFileType.AllFiles
-                        ]),
+                        ],
+                        snapshotDirectory),
                     buffer.ToArray());
 
                 if (saved)
@@ -1205,6 +1207,7 @@ public partial class MainView : UserControl
             if (wasRunning)
                 hostApp.Pause();
 
+            var snapshotDirectory = EnsureSnapshotDirectory(hostApp.EmulatorConfig);
             var picked = await filePicker.OpenFileAsync(
                 this,
                 new AppFilePickerOpenOptions(
@@ -1213,7 +1216,8 @@ public partial class MainView : UserControl
                     [
                         new AppFilePickerFileType("Emulator snapshot", ["*.d6502snap"]),
                         AppFilePickerFileType.AllFiles
-                    ]));
+                    ],
+                    snapshotDirectory));
             if (picked == null)
             {
                 // Cancelled — resume the machine we paused for the dialog.
@@ -1252,4 +1256,17 @@ public partial class MainView : UserControl
                 throw;
             }
         });
+
+    private static string? EnsureSnapshotDirectory(EmulatorConfig emulatorConfig)
+    {
+        if (OperatingSystem.IsBrowser())
+            return null;
+
+        var snapshotDirectory = emulatorConfig.ResolvedSnapshotDirectory();
+        if (string.IsNullOrWhiteSpace(snapshotDirectory))
+            return null;
+
+        Directory.CreateDirectory(snapshotDirectory);
+        return snapshotDirectory;
+    }
 }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Highbyte.DotNet6502.App.Avalonia.Desktop.csproj
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Highbyte.DotNet6502.App.Avalonia.Desktop.csproj
@@ -81,8 +81,10 @@
     <ItemGroup>
       <_SharedScripts Include="$(MSBuildThisFileDirectory)..\..\..\..\resources\scripts\shared\*" />
       <_DesktopScripts Include="$(MSBuildThisFileDirectory)..\..\..\..\resources\scripts\desktop\*" />
+      <_OldOutputExampleScripts Include="$(OutDir)scripts\example_*.lua" />
     </ItemGroup>
-    <Copy SourceFiles="@(_SharedScripts)" DestinationFolder="$(OutDir)scripts" SkipUnchangedFiles="true" />
-    <Copy SourceFiles="@(_DesktopScripts)" DestinationFolder="$(OutDir)scripts" SkipUnchangedFiles="true" />
+    <Delete Files="@(_OldOutputExampleScripts)" />
+    <Copy SourceFiles="@(_SharedScripts)" DestinationFolder="$(OutDir)example-scripts" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(_DesktopScripts)" DestinationFolder="$(OutDir)example-scripts" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Program.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Program.cs
@@ -24,12 +24,15 @@ using Highbyte.DotNet6502.Remoting;
 using Highbyte.DotNet6502.Scripting;
 using Highbyte.DotNet6502.Scripting.MoonSharp;
 using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Configuration;
 using Highbyte.DotNet6502.Systems.Instrumentation.Stats;
 
 namespace Highbyte.DotNet6502.App.Avalonia.Desktop;
 
 internal sealed partial class Program
 {
+    private const string BundledExampleScriptsDirectoryName = "example-scripts";
+
     private static AutomatedRunController? s_automatedRunController;
 
     /// <summary>
@@ -575,6 +578,9 @@ internal sealed partial class Program
             builder.AddUserSecrets<Program>();
         }
 
+        var userSettingsFilePath = AppStoragePaths.GetUserSettingsFilePath("Avalonia.Desktop");
+        builder.AddJsonFile(userSettingsFilePath, optional: true, reloadOnChange: true);
+
         IConfiguration configuration = builder.Build();
 
         // ----------
@@ -874,7 +880,10 @@ internal sealed partial class Program
         // Start Avalonia app
         // ----------
         WriteBootstrapLog($"Starting Avalonia app.");
-        var app = BuildAvaloniaApp(configuration, emulatorConfig, logStore, logConfig, loggerFactory, avaloniaLoggerBridge, gamepad, debugController, remoteController, scriptingEngine, automatedStartupRunner);
+        Func<Task>? loadExampleScripts = scriptingEngine is { IsEnabled: true, CanManageScripts: false } && !string.IsNullOrWhiteSpace(scriptingEngine.ScriptDirectory)
+            ? () => CopyBundledExampleScriptsAsync(scriptingEngine.ScriptDirectory, loggerFactory)
+            : null;
+        var app = BuildAvaloniaApp(configuration, emulatorConfig, logStore, logConfig, loggerFactory, avaloniaLoggerBridge, gamepad, debugController, remoteController, scriptingEngine, automatedStartupRunner, loadExampleScripts);
 
         app.StartWithClassicDesktopLifetime(args);
 
@@ -926,19 +935,21 @@ internal sealed partial class Program
         IExternalDebugController? externalDebugController = null,
         IRemoteControlController? remoteControlController = null,
         IScriptingEngine? scriptingEngine = null,
-        Func<IHostApp, Task>? automatedStartupRunner = null)
+        Func<IHostApp, Task>? automatedStartupRunner = null,
+        Func<Task>? loadExamples = null)
         => AppBuilder.Configure(() => new Core.App(
                 configuration,
                 emulatorConfig,
                 logStore,
                 logConfig,
                 loggerFactory,
-                saveCustomConfigString: null,
-                saveCustomConfigSection: null,
+                saveCustomConfigString: PersistStringToUserSettingsAsync,
+                saveCustomConfigSection: PersistConfigSectionToUserSettingsAsync,
                 gamepad: gamepad,
                 externalDebugController: externalDebugController,
                 remoteControlController: remoteControlController,
                 scriptingEngine: scriptingEngine,
+                loadExamples: loadExamples,
                 automatedStartupRunner: automatedStartupRunner))
             .UsePlatformDetect()
             .LogToTrace()
@@ -947,6 +958,70 @@ internal sealed partial class Program
                 // Set up the Avalonia logger bridge to route logs via Avalonia Logger through ILogger
                 global::Avalonia.Logging.Logger.Sink = avaloniaLoggerBridge;
             });
+
+    private static Task PersistStringToUserSettingsAsync(string configSectionName, string configSectionJson, string? optionalFileName = null)
+    {
+        var userSettingsFilePath = string.IsNullOrWhiteSpace(optionalFileName)
+            ? AppStoragePaths.GetUserSettingsFilePath("Avalonia.Desktop")
+            : Path.Combine(AppStoragePaths.GetUserSettingsDirectory("Avalonia.Desktop"), optionalFileName);
+        return AppSettingsUserFile.MergeSectionAsync(userSettingsFilePath, configSectionName, configSectionJson);
+    }
+
+    private static Task PersistConfigSectionToUserSettingsAsync(string configSectionName, IConfigurationSection configSection, string? optionalFileName = null)
+    {
+        var json = System.Text.Json.JsonSerializer.Serialize(ToDictionary(configSection));
+        return PersistStringToUserSettingsAsync(configSectionName, json, optionalFileName);
+    }
+
+    private static Task CopyBundledExampleScriptsAsync(string scriptDirectory, ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger(nameof(Program));
+        var sourceDirectory = Path.Combine(AppContext.BaseDirectory, BundledExampleScriptsDirectoryName);
+
+        if (!Directory.Exists(sourceDirectory))
+        {
+            logger.LogWarning("Bundled example scripts directory does not exist: {Directory}", sourceDirectory);
+            return Task.CompletedTask;
+        }
+
+        Directory.CreateDirectory(scriptDirectory);
+
+        var copiedCount = 0;
+        var skippedCount = 0;
+        foreach (var sourceFile in Directory.GetFiles(sourceDirectory, "*.lua", SearchOption.TopDirectoryOnly))
+        {
+            var destinationFile = Path.Combine(scriptDirectory, Path.GetFileName(sourceFile));
+            if (File.Exists(destinationFile))
+            {
+                skippedCount++;
+                continue;
+            }
+
+            File.Copy(sourceFile, destinationFile);
+            copiedCount++;
+        }
+
+        logger.LogInformation(
+            "Copied {CopiedCount} bundled example script(s) to {Directory}; skipped {SkippedCount} existing file(s).",
+            copiedCount,
+            scriptDirectory,
+            skippedCount);
+        return Task.CompletedTask;
+    }
+
+    private static Dictionary<string, object?> ToDictionary(IConfigurationSection section)
+    {
+        var result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var child in section.GetChildren())
+        {
+            var children = child.GetChildren().ToList();
+            result[child.Key] = children.Count == 0
+                ? child.Value
+                : ToDictionary(child);
+        }
+
+        return result;
+    }
 }
 
 internal sealed partial class Program

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.json
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.json
@@ -5,11 +5,10 @@
   //"EnabledSystems": [ "C64", "Generic" ],
   "Highbyte.DotNet6502.Scripting": {
     // Set Enabled to true and configure ScriptDirectory to load Lua scripts each emulator frame.
-    // ScriptDirectory: absolute path, or relative to the application working directory.
-    // In the desktop UI, use "Copy Examples" to copy bundled example scripts into this folder.
+    // ScriptDirectory: optional override. Omit or leave blank to use the default user script directory.
+    // In the desktop UI, use "Copy Examples" to copy bundled example scripts into the effective script folder.
     // MaxExecutionWarningMs: log a warning if a hook takes longer than this many ms. Set to 0 to disable. Default: 5.
     "Enabled": true,
-    "ScriptDirectory": "%HOME%/Documents/Highbyte/DotNet6502/scripts",
     "MaxExecutionWarningMs": 5,
     "EnableScriptsAtStart": false,
     // AllowFileIO: true = register the 'file' global in Lua. Set to false in environments without filesystem access (e.g. WASM/browser).
@@ -18,7 +17,7 @@
     // Read operations (file.read, file.read_bytes, file.exists, file.list) are always allowed when AllowFileIO is true.
     "AllowFileWrite": true,
     // FileBaseDirectory: restrict file I/O to a specific directory (absolute or relative to app working dir).
-    // When not set, defaults to ScriptDirectory.
+    // When not set, defaults to the effective ScriptDirectory.
     //"FileBaseDirectory": "%HOME%/Documents/Highbyte/DotNet6502/scripts",
     // AllowHttpRequests: true = register the 'http' global in Lua, allowing scripts to make outbound HTTP requests.
     "AllowHttpRequests": true,

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.json
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.json
@@ -6,9 +6,10 @@
   "Highbyte.DotNet6502.Scripting": {
     // Set Enabled to true and configure ScriptDirectory to load Lua scripts each emulator frame.
     // ScriptDirectory: absolute path, or relative to the application working directory.
+    // In the desktop UI, use "Copy Examples" to copy bundled example scripts into this folder.
     // MaxExecutionWarningMs: log a warning if a hook takes longer than this many ms. Set to 0 to disable. Default: 5.
     "Enabled": true,
-    "ScriptDirectory": "scripts",
+    "ScriptDirectory": "%HOME%/Documents/Highbyte/DotNet6502/scripts",
     "MaxExecutionWarningMs": 5,
     "EnableScriptsAtStart": false,
     // AllowFileIO: true = register the 'file' global in Lua. Set to false in environments without filesystem access (e.g. WASM/browser).
@@ -18,7 +19,7 @@
     "AllowFileWrite": true,
     // FileBaseDirectory: restrict file I/O to a specific directory (absolute or relative to app working dir).
     // When not set, defaults to ScriptDirectory.
-    //"FileBaseDirectory": "scripts",
+    //"FileBaseDirectory": "%HOME%/Documents/Highbyte/DotNet6502/scripts",
     // AllowHttpRequests: true = register the 'http' global in Lua, allowing scripts to make outbound HTTP requests.
     "AllowHttpRequests": true,
     // AllowTcpClient: true = register the 'tcp' global in Lua, allowing scripts to open outbound TCP connections.
@@ -57,9 +58,6 @@
       // "AudioTargetType": "Highbyte.DotNet6502.Impl.NAudio.NAudioSampleTarget, Highbyte.DotNet6502.Impl.NAudio",
 
       //"Vic2RasterizerPerLineSprites": false,
-
-      //"ROMDirectory": "%USERPROFILE%/Documents/C64/VICE/C64",
-      "ROMDirectory": "%HOME%/Downloads/C64",
       "ROMs": [
         {
           "Name": "basic",
@@ -106,7 +104,6 @@
 
   "Highbyte.DotNet6502.Vic20.Avalonia": {
     "SystemConfig": {
-      "ROMDirectory": "%HOME%/Downloads/VIC20",
       "ROMs": [
         { "Name": "basic",   "File": "basic.901486-01.bin" },
         { "Name": "kernal",  "File": "kernal.901486-07.bin" },

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/C64AcknowledgmentService.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/C64AcknowledgmentService.cs
@@ -232,7 +232,7 @@ public sealed class C64AcknowledgmentService
             HorizontalAlignment = HorizontalAlignment.Right,
             Spacing = 10,
             Margin = new Thickness(0, 8, 0, 0),
-            Children = { confirmButton, cancelButton }
+            Children = { cancelButton, confirmButton }
         });
 
         var dialogContent = BuildDialogShell(title, bodyChildren);
@@ -447,8 +447,8 @@ public sealed class C64AcknowledgmentService
                                 Margin = new Thickness(0, 8, 0, 0),
                                 Children =
                                 {
-                                    openConfigButton,
-                                    cancelButton
+                                    cancelButton,
+                                    openConfigButton
                                 }
                             }
                         }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64ConfigDialogViewModel.cs
@@ -603,6 +603,9 @@ public class C64ConfigDialogViewModel : ViewModelBase
         }
     }
 
+    public string RomDirectoryToolTip =>
+        $"Optional ROM folder override. Leave blank to use the default: {PathHelper.ExpandOSEnvironmentVariables(C64SystemConfig.DefaultROMDirectory)}";
+
     public RenderProviderOption? SelectedRenderProvider
     {
         get => _selectedRenderProvider;
@@ -833,7 +836,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
             SetStatusMessage("Downloading ROMs...");
             ValidationMessage = string.Empty;
 
-            var romFolder = PathHelper.ExpandOSEnvironmentVariables(_workingConfig.SystemConfig.ROMDirectory);
+            var romFolder = PathHelper.ExpandOSEnvironmentVariables(_workingConfig.SystemConfig.EffectiveROMDirectory);
             if (!Directory.Exists(romFolder))
             {
                 Directory.CreateDirectory(romFolder);
@@ -1511,7 +1514,7 @@ public class C64ConfigDialogViewModel : ViewModelBase
         {
             try
             {
-                var romFilePath = rom.GetROMFilePath(_workingConfig.SystemConfig.ROMDirectory);
+                var romFilePath = rom.GetROMFilePath(_workingConfig.SystemConfig.EffectiveROMDirectory);
                 fileExists = File.Exists(romFilePath);
             }
             catch

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64ConfigUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64ConfigUserControl.axaml
@@ -74,6 +74,7 @@
                             AutomationProperties.Name="ROM directory"
                             Text="{Binding RomDirectory}"
                             PlaceholderText="Directory path"
+                            ToolTip.Tip="{Binding RomDirectoryToolTip}"
                             Classes="field-aligned"/>
                 </Grid>
             </StackPanel>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Vic20RomPromptService.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Vic20RomPromptService.cs
@@ -156,8 +156,8 @@ public sealed class Vic20RomPromptService
                                 Margin = new Thickness(0, 8, 0, 0),
                                 Children =
                                 {
-                                    confirmButton,
-                                    cancelButton
+                                    cancelButton,
+                                    confirmButton
                                 }
                             }
                         }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/ViewModels/Vic20ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/ViewModels/Vic20ConfigDialogViewModel.cs
@@ -175,6 +175,8 @@ public class Vic20ConfigDialogViewModel : ViewModelBase
         }
     }
 
+    public string RomDirectoryToolTip =>
+        $"Optional ROM folder override. Leave blank to use the default: {PathHelper.ExpandOSEnvironmentVariables(Vic20SystemConfig.DefaultROMDirectory)}";
 
     public RenderProviderOption? SelectedRenderProvider
     {
@@ -296,7 +298,7 @@ public class Vic20ConfigDialogViewModel : ViewModelBase
             StatusMessage = "Downloading ROMs...";
             ValidationMessage = string.Empty;
 
-            var romFolder = PathHelper.ExpandOSEnvironmentVariables(_workingConfig.SystemConfig.ROMDirectory);
+            var romFolder = PathHelper.ExpandOSEnvironmentVariables(_workingConfig.SystemConfig.EffectiveROMDirectory);
             if (!Directory.Exists(romFolder))
                 Directory.CreateDirectory(romFolder);
 
@@ -592,7 +594,7 @@ public class Vic20ConfigDialogViewModel : ViewModelBase
         {
             try
             {
-                var romFilePath = rom.GetROMFilePath(_workingConfig.SystemConfig.ROMDirectory);
+                var romFilePath = rom.GetROMFilePath(_workingConfig.SystemConfig.EffectiveROMDirectory);
                 fileExists = File.Exists(romFilePath);
             }
             catch

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20ConfigDialogView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Vic20/Views/Vic20ConfigDialogView.axaml
@@ -68,6 +68,7 @@
                                              AutomationProperties.Name="VIC-20 ROM directory"
                                              Text="{Binding RomDirectory}"
                                              PlaceholderText="Directory path"
+                                             ToolTip.Tip="{Binding RomDirectoryToolTip}"
                                              Classes="field-aligned"/>
                                 </Grid>
                             </StackPanel>

--- a/src/apps/Highbyte.DotNet6502.App.Headless/Highbyte.DotNet6502.App.Headless.csproj
+++ b/src/apps/Highbyte.DotNet6502.App.Headless/Highbyte.DotNet6502.App.Headless.csproj
@@ -76,8 +76,10 @@
     <ItemGroup>
       <_SharedScripts Include="$(MSBuildThisFileDirectory)..\..\..\resources\scripts\shared\*" />
       <_DesktopScripts Include="$(MSBuildThisFileDirectory)..\..\..\resources\scripts\desktop\*" />
+      <_OldOutputExampleScripts Include="$(OutDir)scripts\example_*.lua" />
     </ItemGroup>
-    <Copy SourceFiles="@(_SharedScripts)" DestinationFolder="$(OutDir)scripts" SkipUnchangedFiles="true" />
-    <Copy SourceFiles="@(_DesktopScripts)" DestinationFolder="$(OutDir)scripts" SkipUnchangedFiles="true" />
+    <Delete Files="@(_OldOutputExampleScripts)" />
+    <Copy SourceFiles="@(_SharedScripts)" DestinationFolder="$(OutDir)example-scripts" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(_DesktopScripts)" DestinationFolder="$(OutDir)example-scripts" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/src/apps/Highbyte.DotNet6502.App.Headless/Program.cs
+++ b/src/apps/Highbyte.DotNet6502.App.Headless/Program.cs
@@ -5,6 +5,7 @@ using Highbyte.DotNet6502.Scripting;
 using Highbyte.DotNet6502.Scripting.MoonSharp;
 using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Audio;
+using Highbyte.DotNet6502.Systems.Configuration;
 using Highbyte.DotNet6502.Systems.Input;
 using Highbyte.DotNet6502.Systems.Plugins;
 using Microsoft.Extensions.Configuration;
@@ -65,6 +66,8 @@ if (isDevelopment)
 {
     builder.AddUserSecrets<Program>();
 }
+
+builder.AddJsonFile(AppStoragePaths.GetUserSettingsFilePath("Headless"), optional: true, reloadOnChange: true);
 
 IConfiguration configuration = builder.Build();
 
@@ -201,6 +204,7 @@ foreach (var configurer in serviceProvider
 
 // Drop any system that declares no configuration variants — it cannot be built or run.
 await systemList.RemoveSystemsWithNoConfigurationVariants(pluginLogger);
+systemList.EnsureUserContentDirectories(pluginLogger);
 
 // No usable system: a headless run cannot do anything without one. There is no UI to show an
 // error dialog in, so log a clear message and exit with a non-zero code.

--- a/src/apps/Highbyte.DotNet6502.App.Headless/appsettings.json
+++ b/src/apps/Highbyte.DotNet6502.App.Headless/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Highbyte.DotNet6502.Scripting": {
     "Enabled": true,
-    "ScriptDirectory": "scripts",
+    "ScriptDirectory": "%HOME%/Documents/Highbyte/DotNet6502/scripts",
     "MaxExecutionWarningMs": 5,
     "EnableScriptsAtStart": false,
     "AllowFileIO": true,
@@ -23,7 +23,6 @@
       "ConnectOnBoot": false
     },
     "SystemConfig": {
-      "ROMDirectory": "%HOME%/Downloads/C64",
       "SwiftLink": {
         "Enabled": false,
         "CartridgeIOAddress": "DE00",

--- a/src/apps/Highbyte.DotNet6502.App.Headless/appsettings.json
+++ b/src/apps/Highbyte.DotNet6502.App.Headless/appsettings.json
@@ -1,7 +1,6 @@
 {
   "Highbyte.DotNet6502.Scripting": {
     "Enabled": true,
-    "ScriptDirectory": "%HOME%/Documents/Highbyte/DotNet6502/scripts",
     "MaxExecutionWarningMs": 5,
     "EnableScriptsAtStart": false,
     "AllowFileIO": true,

--- a/src/apps/SadConsole/Highbyte.DotNet6502.App.SadConsole.Shell.Commodore64/ConfigUI/C64ConfigUIConsole.cs
+++ b/src/apps/SadConsole/Highbyte.DotNet6502.App.SadConsole.Shell.Commodore64/ConfigUI/C64ConfigUIConsole.cs
@@ -18,7 +18,12 @@ public class C64ConfigUIConsole : Window
     public const int CONSOLE_WIDTH = USABLE_WIDTH;
     public const int CONSOLE_HEIGHT = USABLE_HEIGHT;
     private const int USABLE_WIDTH = 60;
-    private const int USABLE_HEIGHT = 30;
+    private const int USABLE_HEIGHT = 33;
+    private const int ActionButtonRow = USABLE_HEIGHT - 7;
+    private const int ValidationErrorLabelRow = USABLE_HEIGHT - 5;
+    private const int ValidationErrorListRow = USABLE_HEIGHT - 4;
+    private const int ValidationErrorHorizontalScrollBarRow = USABLE_HEIGHT - 1;
+    private const int ValidationErrorListVisibleTextWidth = USABLE_WIDTH - 6;
 
     public C64SystemConfig C64SystemConfig => C64HostConfig.SystemConfig;
     public readonly C64HostConfig C64HostConfig;
@@ -26,6 +31,7 @@ public class C64ConfigUIConsole : Window
     private readonly ILoggerFactory _loggerFactory;
     private readonly List<(Type audioProviderType, Type audioTargetType)> _audioCombinations;
     private ComboBox? _audioTargetComboBox;
+    private List<string> _validationErrors = new();
     // Mutable so the audio-target ComboBox's SelectedItemChanged closure resolves the
     // currently-visible types after RebuildAudioTargetComboBox swaps the item set.
     private List<Type> _audioTargetDisplayTypes = new();
@@ -315,22 +321,11 @@ public class C64ConfigUIConsole : Window
         RebuildAudioTargetComboBox();
 
 
-        // Validaton errors
-        var validationErrorsLabel = CreateLabel("Validation errors", 1, audioTargetLabel.Bounds.MaxExtentY + 2, "validationErrorsLabel");
-        var validationErrorsListBox = new ListBox(Width - 3, 3)
-        {
-            Name = "validationErrorsListBox",
-            Position = (1, validationErrorsLabel.Bounds.MaxExtentY + 1),
-            IsScrollBarVisible = true,
-            IsEnabled = true,
-        };
-        Controls.Add(validationErrorsListBox);
-
         var okButton = new Button(6, 1)
         {
             Name = "okButton",
             Text = "OK",
-            Position = (1, Height - 2)
+            Position = (1, ActionButtonRow)
         };
         okButton.Click += (s, e) => { DialogResult = true; Hide(); };
         Controls.Add(okButton);
@@ -338,10 +333,30 @@ public class C64ConfigUIConsole : Window
         var cancelButton = new Button(10, 1)
         {
             Text = "Cancel",
-            Position = (okButton.Bounds.MaxExtentX + 2, Height - 2)
+            Position = (okButton.Bounds.MaxExtentX + 2, okButton.Position.Y)
         };
         cancelButton.Click += (s, e) => { DialogResult = false; Hide(); };
         Controls.Add(cancelButton);
+
+        // Validation errors
+        var validationErrorsLabel = CreateLabel("Validation errors", 1, ValidationErrorLabelRow, "validationErrorsLabel");
+        var validationErrorsListBox = new ListBox(Width - 3, 3)
+        {
+            Name = "validationErrorsListBox",
+            Position = (1, ValidationErrorListRow),
+            IsScrollBarVisible = true,
+            IsEnabled = true,
+        };
+        Controls.Add(validationErrorsListBox);
+
+        var validationErrorsHorizontalScrollBar = new ScrollBar(Orientation.Horizontal, Width - 4)
+        {
+            Name = "validationErrorsHorizontalScrollBar",
+            Position = (1, ValidationErrorHorizontalScrollBarRow),
+            MaximumValue = 0
+        };
+        validationErrorsHorizontalScrollBar.ValueChanged += (s, e) => RefreshValidationErrorsListBox();
+        Controls.Add(validationErrorsHorizontalScrollBar);
 
 
         // Helper function to create a label and add it to the console
@@ -474,10 +489,34 @@ public class C64ConfigUIConsole : Window
         validationErrorsLabel.IsVisible = !isOk;
         var validationErrorsListBox = GetControlOrThrow<ListBox>("validationErrorsListBox");
         validationErrorsListBox.IsVisible = !isOk;
+        var validationErrorsHorizontalScrollBar = GetControlOrThrow<ScrollBar>("validationErrorsHorizontalScrollBar");
+        validationErrorsHorizontalScrollBar.IsVisible = !isOk;
+
+        _validationErrors = validationErrors;
+        var maxHorizontalOffset = _validationErrors.Count == 0
+            ? 0
+            : Math.Max(0, _validationErrors.Max(error => error.Length) - ValidationErrorListVisibleTextWidth);
+        validationErrorsHorizontalScrollBar.MaximumValue = maxHorizontalOffset;
+        validationErrorsHorizontalScrollBar.IsEnabled = maxHorizontalOffset > 0;
+        if (validationErrorsHorizontalScrollBar.Value > maxHorizontalOffset)
+            validationErrorsHorizontalScrollBar.Value = maxHorizontalOffset;
+
+        RefreshValidationErrorsListBox();
+    }
+
+    private void RefreshValidationErrorsListBox()
+    {
+        var validationErrorsListBox = GetControlOrThrow<ListBox>("validationErrorsListBox");
+        var validationErrorsHorizontalScrollBar = GetControlOrThrow<ScrollBar>("validationErrorsHorizontalScrollBar");
+        var horizontalOffset = validationErrorsHorizontalScrollBar.Value;
+
         validationErrorsListBox.Items.Clear();
-        foreach (var error in validationErrors)
+        foreach (var error in _validationErrors)
         {
-            var coloredString = new ColoredString(error, foreground: Color.Red, background: Color.Black);
+            var visibleError = error.Length <= horizontalOffset
+                ? string.Empty
+                : error.Substring(horizontalOffset, Math.Min(ValidationErrorListVisibleTextWidth, error.Length - horizontalOffset));
+            var coloredString = new ColoredString(visibleError, foreground: Color.Red, background: Color.Black);
             validationErrorsListBox.Items.Add(coloredString);
         }
     }

--- a/src/apps/SadConsole/Highbyte.DotNet6502.App.SadConsole.Shell.Commodore64/ConfigUI/C64ConfigUIConsole.cs
+++ b/src/apps/SadConsole/Highbyte.DotNet6502.App.SadConsole.Shell.Commodore64/ConfigUI/C64ConfigUIConsole.cs
@@ -366,7 +366,7 @@ public class C64ConfigUIConsole : Window
 
     private void ShowROMFilePickerDialog(string romName)
     {
-        var currentFolder = PathHelper.ExpandOSEnvironmentVariables(C64SystemConfig.ROMDirectory);
+        var currentFolder = PathHelper.ExpandOSEnvironmentVariables(C64SystemConfig.EffectiveROMDirectory);
         var window = new FilePickerConsole(FilePickerMode.OpenFile, currentFolder, C64SystemConfig.GetROM(romName).GetROMFilePath(currentFolder));
         window.Center();
         window.Closed += (s2, e2) =>
@@ -385,7 +385,7 @@ public class C64ConfigUIConsole : Window
 
     private void ShowROMFolderPickerDialog()
     {
-        var currentFolder = PathHelper.ExpandOSEnvironmentVariables(C64SystemConfig.ROMDirectory);
+        var currentFolder = PathHelper.ExpandOSEnvironmentVariables(C64SystemConfig.EffectiveROMDirectory);
         var window = new FilePickerConsole(FilePickerMode.OpenFolder, currentFolder);
         window.Center();
         window.Closed += (s2, e2) =>
@@ -401,7 +401,7 @@ public class C64ConfigUIConsole : Window
 
     private async Task AutoDownloadROMs()
     {
-        var romFolder = PathHelper.ExpandOSEnvironmentVariables(C64SystemConfig.ROMDirectory);
+        var romFolder = PathHelper.ExpandOSEnvironmentVariables(C64SystemConfig.EffectiveROMDirectory);
         if (!Directory.Exists(romFolder))
         {
             Directory.CreateDirectory(romFolder);

--- a/src/apps/SadConsole/Highbyte.DotNet6502.App.SadConsole/Program.cs
+++ b/src/apps/SadConsole/Highbyte.DotNet6502.App.SadConsole/Program.cs
@@ -1,6 +1,7 @@
 using Highbyte.DotNet6502.App.SadConsole.Core;
 using Highbyte.DotNet6502.Impl.SadConsole;
 using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Configuration;
 using Highbyte.DotNet6502.Systems.Logging.InMem;
 using Highbyte.DotNet6502.Systems.Plugins;
 using Microsoft.Extensions.Configuration;
@@ -49,12 +50,15 @@ try
         .AddJsonFile("appsettings.json")
         .AddJsonFile("appsettings.Development.json", optional: true);
 
-    var devEnvironmentVariable = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT ");
-    var isDevelopment = string.IsNullOrEmpty(devEnvironmentVariable) || devEnvironmentVariable.ToLower() == "development";
+    var devEnvironmentVariable = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+    var isDevelopment = string.IsNullOrEmpty(devEnvironmentVariable)
+        || devEnvironmentVariable.Equals("development", StringComparison.OrdinalIgnoreCase);
     if (isDevelopment) //only add secrets in development
     {
-        configBuilder.AddUserSecrets<Program>();
+        configBuilder.AddUserSecrets<Program>(optional: true);
     }
+
+    configBuilder.AddJsonFile(AppStoragePaths.GetUserSettingsFilePath("SadConsole"), optional: true, reloadOnChange: true);
 
     IConfiguration Configuration = configBuilder.Build();
 
@@ -143,6 +147,7 @@ try
     // Drop any system that declares no configuration variants — it cannot be built or run, and
     // would crash the variant picker in the menu. Treated as unavailable, like a missing plug-in.
     await systemList.RemoveSystemsWithNoConfigurationVariants(pluginLogger);
+    systemList.EnsureUserContentDirectories(pluginLogger);
 
     // ----------
     // Start SadConsoleHostApp

--- a/src/apps/SadConsole/Highbyte.DotNet6502.App.SadConsole/appsettings.json
+++ b/src/apps/SadConsole/Highbyte.DotNet6502.App.SadConsole/appsettings.json
@@ -12,8 +12,6 @@
   "Highbyte.DotNet6502.C64.SadConsole": {
 
     "SystemConfig": {
-      //"ROMDirectory": "%USERPROFILE%/Documents/C64/VICE/C64",
-      "ROMDirectory": "%HOME%/Downloads/C64",
       "ROMs": [
         {
           "Name": "basic",

--- a/src/apps/SilkNetNative/Highbyte.DotNet6502.App.SilkNetNative.Shell.Commodore64/ConfigUI/SilkNetImGuiC64Config.cs
+++ b/src/apps/SilkNetNative/Highbyte.DotNet6502.App.SilkNetNative.Shell.Commodore64/ConfigUI/SilkNetImGuiC64Config.cs
@@ -487,7 +487,7 @@ public class SilkNetImGuiC64Config
         try
         {
             var systemConfig = GetSystemConfigOrThrow();
-            var romFolder = PathHelper.ExpandOSEnvironmentVariables(systemConfig.ROMDirectory);
+            var romFolder = PathHelper.ExpandOSEnvironmentVariables(systemConfig.EffectiveROMDirectory);
             await DownloadC64RomsAsync(systemConfig.ROMDownloadUrls, romFolder);
 
             // Update the system config with the downloaded ROM files

--- a/src/apps/SilkNetNative/Highbyte.DotNet6502.App.SilkNetNative/Program.cs
+++ b/src/apps/SilkNetNative/Highbyte.DotNet6502.App.SilkNetNative/Program.cs
@@ -1,6 +1,7 @@
 using Highbyte.DotNet6502.App.SilkNetNative.Core;
 using Highbyte.DotNet6502.Impl.SilkNet;
 using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Configuration;
 using Highbyte.DotNet6502.Systems.Logging.InMem;
 using Highbyte.DotNet6502.Systems.Plugins;
 using Microsoft.Extensions.Configuration;
@@ -64,7 +65,8 @@ try
     var configBuilder = new ConfigurationBuilder()
         .SetBasePath(appDir)
         .AddJsonFile("appsettings.json")
-        .AddJsonFile("appsettings.Development.json", optional: true);
+        .AddJsonFile("appsettings.Development.json", optional: true)
+        .AddJsonFile(AppStoragePaths.GetUserSettingsFilePath("SilkNetNative"), optional: true, reloadOnChange: true);
 
     IConfiguration Configuration = configBuilder.Build();
 
@@ -161,6 +163,7 @@ try
     // Drop any system that declares no configuration variants — it cannot be built or run, and
     // would crash the variant picker in the menu. Treated as unavailable, like a missing plug-in.
     await systemList.RemoveSystemsWithNoConfigurationVariants(pluginLogger);
+    systemList.EnsureUserContentDirectories(pluginLogger);
 
     // Any fatal startup error (no systems, invalid DefaultEmulator, ...) is caught inside the host
     // app's OnLoad and shown as a quit-only error dialog — see SilkNetHostApp.OnLoad.

--- a/src/apps/SilkNetNative/Highbyte.DotNet6502.App.SilkNetNative/appsettings.json
+++ b/src/apps/SilkNetNative/Highbyte.DotNet6502.App.SilkNetNative/appsettings.json
@@ -15,8 +15,6 @@
   "Highbyte.DotNet6502.C64.SilkNetNative": {
 
     "SystemConfig": {
-      //"ROMDirectory": "%USERPROFILE%/Documents/C64/VICE/C64",
-      "ROMDirectory": "%HOME%/Downloads/C64",
       "ROMs": [
         {
           "Name": "basic",

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Commodore64/C64ConfigDialog.cs
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Commodore64/C64ConfigDialog.cs
@@ -335,7 +335,7 @@ internal static class C64ConfigDialog
     /// </summary>
     private static async Task DownloadRoms(C64SystemConfig cfg)
     {
-        var romFolder = PathHelper.ExpandOSEnvironmentVariables(cfg.ROMDirectory);
+        var romFolder = PathHelper.ExpandOSEnvironmentVariables(cfg.EffectiveROMDirectory);
         if (!Directory.Exists(romFolder))
             Directory.CreateDirectory(romFolder);
 
@@ -396,7 +396,7 @@ internal static class C64ConfigDialog
 
     private static string? PickPath(TuiHostApp host, C64SystemConfig cfg, bool isDirectory)
     {
-        var startDir = PathHelper.ExpandOSEnvironmentVariables(cfg.ROMDirectory);
+        var startDir = PathHelper.ExpandOSEnvironmentVariables(cfg.EffectiveROMDirectory);
         using var picker = new OpenDialog
         {
             Title = isDirectory ? "Select ROM directory" : "Select ROM file",

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Vic20/Vic20ConfigDialog.cs
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Vic20/Vic20ConfigDialog.cs
@@ -183,7 +183,7 @@ internal static class Vic20ConfigDialog
     /// </summary>
     private static async Task DownloadRoms(Vic20SystemConfig cfg)
     {
-        var romFolder = PathHelper.ExpandOSEnvironmentVariables(cfg.ROMDirectory);
+        var romFolder = PathHelper.ExpandOSEnvironmentVariables(cfg.EffectiveROMDirectory);
         if (!Directory.Exists(romFolder))
             Directory.CreateDirectory(romFolder);
 
@@ -242,7 +242,7 @@ internal static class Vic20ConfigDialog
 
     private static string? PickPath(TuiHostApp host, Vic20SystemConfig cfg, bool isDirectory)
     {
-        var startDir = PathHelper.ExpandOSEnvironmentVariables(cfg.ROMDirectory);
+        var startDir = PathHelper.ExpandOSEnvironmentVariables(cfg.EffectiveROMDirectory);
         using var picker = new OpenDialog
         {
             Title = isDirectory ? "Select ROM directory" : "Select ROM file",

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/Program.cs
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/Program.cs
@@ -1,5 +1,6 @@
 using Highbyte.DotNet6502.App.Terminal;
 using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Configuration;
 using Highbyte.DotNet6502.Systems.Logging.InMem;
 using Highbyte.DotNet6502.Systems.Plugins;
 using Microsoft.Extensions.Configuration;
@@ -33,6 +34,8 @@ var isDevelopment = string.IsNullOrEmpty(devEnvironmentVariable)
     || devEnvironmentVariable.Equals("development", StringComparison.OrdinalIgnoreCase);
 if (isDevelopment)
     configBuilder.AddUserSecrets<Program>(optional: true);
+
+configBuilder.AddJsonFile(AppStoragePaths.GetUserSettingsFilePath("Terminal"), optional: true, reloadOnChange: true);
 
 IConfiguration configuration = configBuilder.Build();
 
@@ -105,6 +108,7 @@ try
     foreach (var configurer in serviceProvider.GetServices<ISystemConfigurer>())
         systemList.AddSystem(configurer);
     await systemList.RemoveSystemsWithNoConfigurationVariants(bootstrapLogger);
+    systemList.EnsureUserContentDirectories(bootstrapLogger);
 
     // Resolve a system's optional terminal contributions (cast from the UI-agnostic plug-in result).
     ITerminalMenuContribution? ResolveMenuContribution(string systemName) =>

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/appsettings.json
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/appsettings.json
@@ -13,7 +13,6 @@
 
   "Highbyte.DotNet6502.C64.Terminal": {
     "SystemConfig": {
-      "ROMDirectory": "%HOME%/Downloads/C64",
       "ROMs": [
         {
           "Name": "basic",
@@ -53,7 +52,6 @@
 
   "Highbyte.DotNet6502.Vic20.Terminal": {
     "SystemConfig": {
-      "ROMDirectory": "%HOME%/Downloads/VIC20",
       "ROMs": [
         { "Name": "basic", "File": "basic.901486-01.bin" },
         { "Name": "kernal", "File": "kernal.901486-07.bin" },

--- a/src/libraries/Highbyte.DotNet6502.Scripting.MoonSharp/MoonSharpScriptingConfigurator.cs
+++ b/src/libraries/Highbyte.DotNet6502.Scripting.MoonSharp/MoonSharpScriptingConfigurator.cs
@@ -32,11 +32,15 @@ public static class MoonSharpScriptingConfigurator
             return new NoScriptingEngine();
         }
 
-        // Automated startup mode (--start etc) owns the lifecycle — suppress scripts from config
-        if (suppressConfigScripts)
+        var hasScriptFilePaths = scriptFilePaths is { Count: > 0 };
+
+        // Automated startup mode (--start etc) owns the lifecycle, so suppress scripts from config.
+        // Blank ScriptDirectory normally means "use the default", so return a disabled engine
+        // unless an explicit CLI script source is present.
+        if (suppressConfigScripts && scriptDirectoryOverride == null && !hasScriptFilePaths)
         {
-            logger.LogInformation("[Scripting] Suppressing scripts from configuration (automated startup mode).");
-            config.ScriptDirectory = string.Empty;
+            logger.LogInformation("[Scripting] Suppressing scripts from configuration (automated startup mode). Using NoScriptingEngine.");
+            return new NoScriptingEngine();
         }
 
         // Apply CLI overrides
@@ -46,10 +50,10 @@ public static class MoonSharpScriptingConfigurator
             config.ScriptDirectory = scriptDirectoryOverride;
         }
 
-        if (scriptFilePaths != null && scriptFilePaths.Count > 0)
+        if (hasScriptFilePaths)
         {
             logger.LogInformation("[Scripting] Loading {Count} specific script(s) via CLI: {Files}",
-                scriptFilePaths.Count, string.Join(", ", scriptFilePaths));
+                scriptFilePaths!.Count, string.Join(", ", scriptFilePaths));
             config.ScriptLoader = () => scriptFilePaths.Select(path =>
             {
                 var fullPath = Path.GetFullPath(path);
@@ -58,19 +62,21 @@ public static class MoonSharpScriptingConfigurator
         }
 
         // Force auto-enable when CLI overrides are in effect (automation intent)
-        if (scriptFilePaths?.Count > 0 || scriptDirectoryOverride != null)
+        if (hasScriptFilePaths || scriptDirectoryOverride != null)
         {
             config.EnableScriptsAtStart = true;
         }
 
-        // ScriptDirectory is only required when no ScriptLoader is set
-        if (config.ScriptLoader == null && string.IsNullOrWhiteSpace(config.ScriptDirectory))
+        var resolvedScriptDirectory = config.ResolvedScriptDirectory();
+
+        // ScriptDirectory is only required when no ScriptLoader is set and no default is available.
+        if (config.ScriptLoader == null && string.IsNullOrWhiteSpace(resolvedScriptDirectory))
         {
             logger.LogWarning("[Scripting] Enabled but ScriptDirectory is not set. Using NoScriptingEngine.");
             return new NoScriptingEngine();
         }
 
-        logger.LogInformation("[Scripting] MoonSharp engine enabled. ScriptDirectory: {Dir}", config.ScriptDirectory);
+        logger.LogInformation("[Scripting] MoonSharp engine enabled. ScriptDirectory: {Dir}", resolvedScriptDirectory);
         var adapter = new MoonSharpScriptingEngineAdapter(loggerFactory, hostType);
         return new ScriptingEngine(adapter, config, loggerFactory);
     }

--- a/src/libraries/Highbyte.DotNet6502.Scripting.MoonSharp/MoonSharpScriptingEngineAdapter.cs
+++ b/src/libraries/Highbyte.DotNet6502.Scripting.MoonSharp/MoonSharpScriptingEngineAdapter.cs
@@ -140,9 +140,7 @@ public class MoonSharpScriptingEngineAdapter : IScriptingEngineAdapter
         // Set AllowFileIO: false in environments without filesystem access (e.g. WASM/browser).
         if (config.AllowFileIO)
         {
-            var fileBaseDir = string.IsNullOrWhiteSpace(config.FileBaseDirectory)
-                ? config.ResolvedScriptDirectory()
-                : config.FileBaseDirectory;
+            var fileBaseDir = config.ResolvedFileBaseDirectory();
             _fileProxy = new LuaFileProxy(fileBaseDir, config.AllowFileWrite);
 
             var fileTable = new Table(_script);

--- a/src/libraries/Highbyte.DotNet6502.Scripting.MoonSharp/MoonSharpScriptingEngineAdapter.cs
+++ b/src/libraries/Highbyte.DotNet6502.Scripting.MoonSharp/MoonSharpScriptingEngineAdapter.cs
@@ -321,10 +321,11 @@ public class MoonSharpScriptingEngineAdapter : IScriptingEngineAdapter
         if (config.AllowStore)
         {
             IScriptStore? storeBackend = config.StoreBackend;
-            if (storeBackend == null && !string.IsNullOrEmpty(config.ScriptDirectory))
+            var resolvedScriptDirectory = config.ResolvedScriptDirectory();
+            if (storeBackend == null && !string.IsNullOrEmpty(resolvedScriptDirectory))
             {
                 var subDir = string.IsNullOrEmpty(config.StoreSubDirectory) ? ".store" : config.StoreSubDirectory;
-                var storeDir = Path.Combine(config.ResolvedScriptDirectory(), subDir);
+                var storeDir = Path.Combine(resolvedScriptDirectory, subDir);
                 storeBackend = new FileSystemScriptStore(storeDir);
             }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64SystemConfigurerCore.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64SystemConfigurerCore.cs
@@ -59,6 +59,9 @@ public class C64SystemConfigurerCore : ISystemConfigurer
 
     public string SystemName => C64.SystemName;
 
+    public virtual IEnumerable<string> GetUserContentDirectories()
+        => [C64SystemConfig.DefaultROMDirectory];
+
     public Task<List<string>> GetConfigurationVariants(ISystemConfig systemConfig)
         => Task.FromResult(C64ModelInventory.C64Models.Keys.ToList());
 
@@ -119,7 +122,7 @@ public class C64SystemConfigurerCore : ISystemConfigurer
             KeyboardJoystick = c64SystemConfig.KeyboardJoystick,
             SwiftLink = c64SystemConfig.SwiftLink.Clone(),
             ROMs = c64SystemConfig.ROMs,
-            ROMDirectory = c64SystemConfig.ROMDirectory,
+            ROMDirectory = c64SystemConfig.EffectiveROMDirectory,
             RenderProviderType = c64SystemConfig.RenderProviderType ?? DefaultRenderProviderType,
             AudioProviderType = c64SystemConfig.AudioProviderType,
             SidEmulationMode = c64SystemConfig.SidEmulationMode,

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SystemConfig.cs
@@ -1,6 +1,6 @@
-using System.Runtime.InteropServices;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
+using Highbyte.DotNet6502.Systems.Configuration;
 using Highbyte.DotNet6502.Systems.Commodore64.Audio;
 using Highbyte.DotNet6502.Systems.Commodore64.Audio.Sample;
 using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
@@ -225,10 +225,19 @@ public partial class C64SystemConfig : ISystemConfig, ISnapshotableConfig
         }
         set
         {
-            _romDirectory = value;
+            _romDirectory = value ?? string.Empty;
             _isDirty = true;
         }
     }
+
+    [JsonIgnore]
+    public static string DefaultROMDirectory => AppStoragePaths.GetRomDirectory("C64");
+
+    [JsonIgnore]
+    public string EffectiveROMDirectory => string.IsNullOrWhiteSpace(ROMDirectory)
+        && !OperatingSystem.IsBrowser()
+        ? DefaultROMDirectory
+        : ROMDirectory;
 
     public Dictionary<string, string> ROMDownloadUrls { get; } = new()
     {
@@ -354,16 +363,7 @@ public partial class C64SystemConfig : ISystemConfig, ISnapshotableConfig
         // Defaults
         _roms = new List<ROM>();
 
-        // Only set default ROM directory if running on Desktop OS.
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")) ||
-            RuntimeInformation.OSArchitecture == Architecture.Wasm)
-        {
-            _romDirectory = string.Empty;
-        }
-        else
-        {
-            _romDirectory = "%USERPROFILE%/Documents/C64/VICE/C64";
-        }
+        _romDirectory = string.Empty;
 
         _colorMapName = ColorMaps.DEFAULT_COLOR_MAP_NAME;
 
@@ -467,8 +467,9 @@ public partial class C64SystemConfig : ISystemConfig, ISnapshotableConfig
             validationErrors.Add($"Missing ROMs: {string.Join(", ", missingRoms)}.");
         }
 
-        var romDir = PathHelper.ExpandOSEnvironmentVariables(ROMDirectory);
-        if (!string.IsNullOrEmpty(romDir))
+        var effectiveRomDirectory = EffectiveROMDirectory;
+        var romDir = PathHelper.ExpandOSEnvironmentVariables(effectiveRomDirectory);
+        if (ROMs.Any(rom => !string.IsNullOrEmpty(rom.File)) && !string.IsNullOrEmpty(romDir))
         {
             if (!Directory.Exists(romDir))
                 validationErrors.Add($"{nameof(ROMDirectory)} is not an existing directory: {romDir}");
@@ -479,7 +480,7 @@ public partial class C64SystemConfig : ISystemConfig, ISnapshotableConfig
             foreach (var rom in ROMs)
             {
                 var romValidationErrors = new List<string>();
-                if (!rom.Validate(out romValidationErrors, ROMDirectory))
+                if (!rom.Validate(out romValidationErrors, effectiveRomDirectory))
                     validationErrors.AddRange(romValidationErrors);
             }
         }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20SystemConfig.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
-using System.Runtime.InteropServices;
 using System.Diagnostics.CodeAnalysis;
+using Highbyte.DotNet6502.Systems.Configuration;
 using Highbyte.DotNet6502.Utils;
 using Highbyte.DotNet6502.Systems.Vic20.Render;
 
@@ -77,8 +77,17 @@ public class Vic20SystemConfig : ISystemConfig
     public string ROMDirectory
     {
         get => _romDirectory;
-        set { _romDirectory = value; _isDirty = true; }
+        set { _romDirectory = value ?? string.Empty; _isDirty = true; }
     }
+
+    [JsonIgnore]
+    public static string DefaultROMDirectory => AppStoragePaths.GetRomDirectory("VIC20");
+
+    [JsonIgnore]
+    public string EffectiveROMDirectory => string.IsNullOrWhiteSpace(ROMDirectory)
+        && !OperatingSystem.IsBrowser()
+        ? DefaultROMDirectory
+        : ROMDirectory;
 
     public Dictionary<string, string> ROMDownloadUrls { get; } = new()
     {
@@ -182,16 +191,7 @@ public class Vic20SystemConfig : ISystemConfig
 
     public Vic20SystemConfig()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")) ||
-            RuntimeInformation.OSArchitecture == Architecture.Wasm)
-        {
-            _romDirectory = string.Empty;
-        }
-        else
-        {
-            _romDirectory = "%USERPROFILE%/Documents/VIC20/VICE/VIC20";
-        }
-
+        _romDirectory = string.Empty;
         SetRenderProviderType(GetSupportedRenderProviderTypes().First());
     }
 
@@ -219,15 +219,16 @@ public class Vic20SystemConfig : ISystemConfig
         if (missing.Count > 0)
             validationErrors.Add($"Missing ROMs: {string.Join(", ", missing)}.");
 
-        var romDir = PathHelper.ExpandOSEnvironmentVariables(_romDirectory);
-        if (!string.IsNullOrEmpty(romDir) && !Directory.Exists(romDir))
+        var effectiveRomDirectory = EffectiveROMDirectory;
+        var romDir = PathHelper.ExpandOSEnvironmentVariables(effectiveRomDirectory);
+        if (_roms.Any(rom => !string.IsNullOrEmpty(rom.File)) && !string.IsNullOrEmpty(romDir) && !Directory.Exists(romDir))
             validationErrors.Add($"{nameof(ROMDirectory)} does not exist: {romDir}");
 
         if (validationErrors.Count == 0)
         {
             foreach (var rom in _roms)
             {
-                if (!rom.Validate(out var romErrors, _romDirectory))
+                if (!rom.Validate(out var romErrors, effectiveRomDirectory))
                     validationErrors.AddRange(romErrors);
             }
         }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Vic20SystemConfigurerCore.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Vic20SystemConfigurerCore.cs
@@ -49,8 +49,31 @@ public class Vic20SystemConfigurerCore : ISystemConfigurer
     public virtual Task<IHostSystemConfig> GetNewHostSystemConfig()
     {
         var hostConfig = _hostConfigFactory();
-        Configuration.GetSection(_configSectionName).Bind(hostConfig);
+        var section = Configuration.GetSection(_configSectionName);
+        section.Bind(hostConfig);
+
+        // IConfiguration.Bind() does not apply the JsonPropertyName aliases used for the
+        // persisted Type-valued render settings, so read those keys explicitly.
+        ApplyTypeOverridesFromConfig(section.GetSection(nameof(IHostSystemConfig.SystemConfig)), hostConfig.SystemConfig);
+
         return Task.FromResult(hostConfig);
+    }
+
+    private static void ApplyTypeOverridesFromConfig(IConfiguration systemConfigSection, ISystemConfig systemConfig)
+    {
+        ApplyTypeKey(systemConfigSection, "RenderProviderType", systemConfig.SetRenderProviderType);
+        ApplyTypeKey(systemConfigSection, "RenderTargetType", systemConfig.SetRenderTargetType);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2057", Justification = "Configured type names are validated immediately and constrained to application-defined types.")]
+    private static void ApplyTypeKey(IConfiguration section, string key, Action<Type?> setter)
+    {
+        var value = section[key];
+        if (string.IsNullOrWhiteSpace(value))
+            return;
+        var t = Type.GetType(value)
+            ?? throw new DotNet6502Exception($"{key} '{value}' could not be resolved.");
+        setter(t);
     }
 
     public virtual Task PersistHostSystemConfig(IHostSystemConfig hostSystemConfig)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Vic20SystemConfigurerCore.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Vic20SystemConfigurerCore.cs
@@ -36,6 +36,9 @@ public class Vic20SystemConfigurerCore : ISystemConfigurer
 
     public string SystemName => Vic20.SystemName;
 
+    public virtual IEnumerable<string> GetUserContentDirectories()
+        => [Vic20SystemConfig.DefaultROMDirectory];
+
     public const string VariantNtsc = "NTSC";
     public const string VariantPal = "PAL";
 
@@ -61,7 +64,7 @@ public class Vic20SystemConfigurerCore : ISystemConfigurer
 
         Dictionary<string, byte[]>? romData = null;
         if (vic20SystemConfig.ROMs.Count > 0)
-            romData = ROM.LoadROMS(vic20SystemConfig.ROMDirectory, vic20SystemConfig.ROMs.ToArray());
+            romData = ROM.LoadROMS(vic20SystemConfig.EffectiveROMDirectory, vic20SystemConfig.ROMs.ToArray());
 
         var vic20 = new Vic20(vic20Config, LoggerFactory, romData);
         vic20.SetCurrentRenderProviderType(vic20SystemConfig.RenderProviderType);

--- a/src/libraries/Highbyte.DotNet6502.Systems/Configuration/AppStoragePaths.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Configuration/AppStoragePaths.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Highbyte.DotNet6502.Systems.Configuration;
+
+public static class AppStoragePaths
+{
+    public const string CompanyFolderName = "Highbyte";
+    public const string AppFolderName = "DotNet6502";
+    public const string UserSettingsFileName = "appsettings.user.json";
+
+    public static string GetUserSettingsDirectory(string hostName)
+    {
+        if (string.IsNullOrWhiteSpace(hostName))
+            throw new ArgumentException("Host name must be specified.", nameof(hostName));
+
+        return Path.Combine(GetSpecialFolderPath(Environment.SpecialFolder.LocalApplicationData), CompanyFolderName, AppFolderName, hostName);
+    }
+
+    public static string GetUserSettingsFilePath(string hostName)
+        => Path.Combine(GetUserSettingsDirectory(hostName), UserSettingsFileName);
+
+    public static string GetUserContentRoot()
+        => Path.Combine(GetSpecialFolderPath(Environment.SpecialFolder.MyDocuments), CompanyFolderName, AppFolderName);
+
+    public static IEnumerable<string> GetSharedUserContentDirectories()
+    {
+        yield return GetUserContentRoot();
+        yield return Path.Combine(GetUserContentRoot(), "roms");
+        yield return GetScriptsDirectory();
+        yield return GetSnapshotsDirectory();
+    }
+
+    public static string GetRomDirectory(string systemName)
+    {
+        if (string.IsNullOrWhiteSpace(systemName))
+            throw new ArgumentException("System name must be specified.", nameof(systemName));
+
+        return Path.Combine(GetUserContentRoot(), "roms", systemName);
+    }
+
+    public static string GetScriptsDirectory()
+        => Path.Combine(GetUserContentRoot(), "scripts");
+
+    public static string GetSnapshotsDirectory()
+        => Path.Combine(GetUserContentRoot(), "snapshots");
+
+    private static string GetSpecialFolderPath(Environment.SpecialFolder specialFolder)
+    {
+        var path = Environment.GetFolderPath(specialFolder);
+        if (!string.IsNullOrWhiteSpace(path))
+            return path;
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(home))
+            home = Environment.GetEnvironmentVariable("HOME") ?? AppContext.BaseDirectory;
+
+        return specialFolder switch
+        {
+            Environment.SpecialFolder.LocalApplicationData => Path.Combine(home, ".local", "share"),
+            Environment.SpecialFolder.MyDocuments => Path.Combine(home, "Documents"),
+            _ => home
+        };
+    }
+}
+
+public static class AppSettingsUserFile
+{
+    private static readonly JsonSerializerOptions s_writeOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    public static async Task MergeSectionAsync(string userSettingsFilePath, string sectionName, string sectionJson)
+    {
+        if (string.IsNullOrWhiteSpace(userSettingsFilePath))
+            throw new ArgumentException("User settings file path must be specified.", nameof(userSettingsFilePath));
+        if (string.IsNullOrWhiteSpace(sectionName))
+            throw new ArgumentException("Section name must be specified.", nameof(sectionName));
+        if (string.IsNullOrWhiteSpace(sectionJson))
+            throw new ArgumentException("Section JSON must be specified.", nameof(sectionJson));
+
+        var root = await LoadRootAsync(userSettingsFilePath);
+        var section = JsonNode.Parse(sectionJson)
+            ?? throw new JsonException($"Configuration section '{sectionName}' is empty.");
+
+        if (root[sectionName] is JsonObject existingSection && section is JsonObject incomingSection)
+            MergeObject(existingSection, incomingSection);
+        else
+            root[sectionName] = section;
+
+        await WriteAtomicAsync(userSettingsFilePath, root.ToJsonString(s_writeOptions));
+    }
+
+    private static async Task<JsonObject> LoadRootAsync(string filePath)
+    {
+        if (!File.Exists(filePath))
+            return new JsonObject();
+
+        var json = await File.ReadAllTextAsync(filePath);
+        if (string.IsNullOrWhiteSpace(json))
+            return new JsonObject();
+
+        return JsonNode.Parse(json) as JsonObject
+            ?? throw new JsonException($"User settings file must contain a JSON object: {filePath}");
+    }
+
+    private static void MergeObject(JsonObject target, JsonObject source)
+    {
+        foreach (var property in source)
+        {
+            if (target[property.Key] is JsonObject targetObject && property.Value is JsonObject sourceObject)
+            {
+                MergeObject(targetObject, sourceObject);
+                continue;
+            }
+
+            target[property.Key] = property.Value?.DeepClone();
+        }
+    }
+
+    private static async Task WriteAtomicAsync(string filePath, string json)
+    {
+        var directory = Path.GetDirectoryName(filePath)
+            ?? throw new InvalidOperationException($"Cannot determine directory for {filePath}.");
+        Directory.CreateDirectory(directory);
+
+        var tempFile = Path.Combine(directory, $".{Path.GetFileName(filePath)}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            await File.WriteAllTextAsync(tempFile, json);
+            File.Move(tempFile, filePath, overwrite: true);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems/ISystemConfigurer.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/ISystemConfigurer.cs
@@ -8,6 +8,8 @@ public interface ISystemConfigurer
     public Task<IHostSystemConfig> GetNewHostSystemConfig();
     public Task PersistHostSystemConfig(IHostSystemConfig hostSystemConfig);
 
+    public IEnumerable<string> GetUserContentDirectories() => [];
+
     /// <summary>
     /// Builds the <see cref="SystemRunner"/> for a run of the system.
     ///

--- a/src/libraries/Highbyte.DotNet6502.Systems/Scripting/ScriptingConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Scripting/ScriptingConfig.cs
@@ -1,3 +1,5 @@
+using Highbyte.DotNet6502.Utils;
+
 namespace Highbyte.DotNet6502.Systems;
 
 public class ScriptingConfig
@@ -12,6 +14,7 @@ public class ScriptingConfig
     /// <summary>
     /// Directory path where .lua script files are loaded from.
     /// Can be absolute or relative to the application working directory.
+    /// OS-specific environment variables and "~" are expanded before resolving the path.
     /// </summary>
     public string ScriptDirectory { get; set; } = string.Empty;
 
@@ -56,6 +59,7 @@ public class ScriptingConfig
     /// All paths passed to file operations are resolved relative to this directory;
     /// traversal outside it (e.g. "../") is blocked.
     /// When null or empty, defaults to <see cref="ScriptDirectory"/>.
+    /// OS-specific environment variables and "~" are expanded before resolving the path.
     /// </summary>
     public string? FileBaseDirectory { get; set; } = null;
 
@@ -124,9 +128,28 @@ public class ScriptingConfig
     /// </summary>
     public string ResolvedScriptDirectory()
     {
-        if (string.IsNullOrEmpty(ScriptDirectory) || Path.IsPathRooted(ScriptDirectory))
-            return ScriptDirectory;
-        var cwdPath = Path.GetFullPath(ScriptDirectory);
-        return Directory.Exists(cwdPath) ? cwdPath : Path.GetFullPath(ScriptDirectory, AppContext.BaseDirectory);
+        return ResolveDirectory(ScriptDirectory);
+    }
+
+    /// <summary>
+    /// Returns <see cref="FileBaseDirectory"/> resolved to an absolute path, or the resolved
+    /// <see cref="ScriptDirectory"/> when no file base directory override is configured.
+    /// </summary>
+    public string ResolvedFileBaseDirectory()
+    {
+        return string.IsNullOrWhiteSpace(FileBaseDirectory)
+            ? ResolvedScriptDirectory()
+            : ResolveDirectory(FileBaseDirectory);
+    }
+
+    private static string ResolveDirectory(string directory)
+    {
+        var expandedDirectory = PathHelper.ExpandOSEnvironmentVariables(directory);
+
+        if (string.IsNullOrEmpty(expandedDirectory) || Path.IsPathRooted(expandedDirectory))
+            return expandedDirectory;
+
+        var cwdPath = Path.GetFullPath(expandedDirectory);
+        return Directory.Exists(cwdPath) ? cwdPath : Path.GetFullPath(expandedDirectory, AppContext.BaseDirectory);
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems/Scripting/ScriptingConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Scripting/ScriptingConfig.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+using Highbyte.DotNet6502.Systems.Configuration;
 using Highbyte.DotNet6502.Utils;
 
 namespace Highbyte.DotNet6502.Systems;
@@ -12,11 +14,35 @@ public class ScriptingConfig
     public bool Enabled { get; set; } = true;
 
     /// <summary>
-    /// Directory path where .lua script files are loaded from.
+    private string _scriptDirectory = string.Empty;
+
+    /// <summary>
+    /// Default directory path where .lua script files are loaded from when <see cref="ScriptDirectory"/> is not set.
+    /// </summary>
+    [JsonIgnore]
+    public static string DefaultScriptDirectory => AppStoragePaths.GetScriptsDirectory();
+
+    /// <summary>
+    /// Optional override directory path where .lua script files are loaded from.
+    /// When empty, desktop hosts use <see cref="DefaultScriptDirectory"/>.
     /// Can be absolute or relative to the application working directory.
     /// OS-specific environment variables and "~" are expanded before resolving the path.
     /// </summary>
-    public string ScriptDirectory { get; set; } = string.Empty;
+    public string ScriptDirectory
+    {
+        get => _scriptDirectory;
+        set => _scriptDirectory = value ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Effective script directory path after applying the default for hosts with filesystem access.
+    /// Browser hosts keep an empty directory because they normally load scripts from storage callbacks.
+    /// </summary>
+    [JsonIgnore]
+    public string EffectiveScriptDirectory =>
+        string.IsNullOrWhiteSpace(ScriptDirectory) && !OperatingSystem.IsBrowser()
+            ? DefaultScriptDirectory
+            : ScriptDirectory;
 
     /// <summary>
     /// Log a warning if a script hook (on_before_frame / on_after_frame) takes longer than this many milliseconds.
@@ -119,7 +145,7 @@ public class ScriptingConfig
     public IScriptStore? StoreBackend { get; set; }
 
     /// <summary>
-    /// Returns <see cref="ScriptDirectory"/> resolved to an absolute path.
+    /// Returns <see cref="EffectiveScriptDirectory"/> resolved to an absolute path.
     /// For relative paths, tries the current working directory first; if that directory
     /// does not exist, falls back to <see cref="AppContext.BaseDirectory"/> (the binary's
     /// output folder). This ensures that example scripts copied to the build output are
@@ -128,7 +154,7 @@ public class ScriptingConfig
     /// </summary>
     public string ResolvedScriptDirectory()
     {
-        return ResolveDirectory(ScriptDirectory);
+        return ResolveDirectory(EffectiveScriptDirectory);
     }
 
     /// <summary>

--- a/src/libraries/Highbyte.DotNet6502.Systems/SystemList.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/SystemList.cs
@@ -1,5 +1,7 @@
+using Highbyte.DotNet6502.Systems.Configuration;
 using Highbyte.DotNet6502.Systems.Input;
 using Highbyte.DotNet6502.Systems.Rendering;
+using Highbyte.DotNet6502.Utils;
 using Microsoft.Extensions.Logging;
 
 namespace Highbyte.DotNet6502.Systems;
@@ -160,6 +162,31 @@ public class SystemList
             }
         }
         return removed;
+    }
+
+    public void EnsureUserContentDirectories(ILogger? logger = null)
+    {
+        if (OperatingSystem.IsBrowser())
+            return;
+
+        var directories = AppStoragePaths.GetSharedUserContentDirectories()
+            .Concat(_systemConfigurers.Values.SelectMany(configurer => configurer.GetUserContentDirectories()))
+            .Where(directory => !string.IsNullOrWhiteSpace(directory))
+            .Select(PathHelper.ExpandOSEnvironmentVariables)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        foreach (var directory in directories)
+        {
+            try
+            {
+                Directory.CreateDirectory(directory);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+            {
+                logger?.LogWarning(ex, "Could not create user content directory '{Directory}'.", directory);
+            }
+        }
     }
 
     public async Task<bool> IsValidConfig(string systemName)

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64SystemConfigTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64SystemConfigTests.cs
@@ -6,6 +6,26 @@ namespace Highbyte.DotNet6502.Systems.Tests.Commodore64;
 public class C64SystemConfigTests
 {
     [Fact]
+    public void ROMDirectory_WhenBlank_Uses_DefaultROMDirectory()
+    {
+        var config = new C64SystemConfig();
+
+        Assert.Equal(string.Empty, config.ROMDirectory);
+        Assert.Equal(C64SystemConfig.DefaultROMDirectory, config.EffectiveROMDirectory);
+    }
+
+    [Fact]
+    public void ROMDirectory_WhenSet_Uses_Override()
+    {
+        var config = new C64SystemConfig
+        {
+            ROMDirectory = "/custom/c64"
+        };
+
+        Assert.Equal("/custom/c64", config.EffectiveROMDirectory);
+    }
+
+    [Fact]
     public void IsValid_Includes_SwiftLink_Validation_Errors()
     {
         var config = new C64SystemConfig();

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Configuration/AppStoragePathsTest.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Configuration/AppStoragePathsTest.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using Highbyte.DotNet6502.Systems.Configuration;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Configuration;
+
+public class AppStoragePathsTest
+{
+    [Fact]
+    public void UserSettingsFilePath_UsesHostSpecificAppFolder()
+    {
+        var path = AppStoragePaths.GetUserSettingsFilePath("Avalonia.Desktop");
+
+        Assert.EndsWith(
+            Path.Combine(AppStoragePaths.CompanyFolderName, AppStoragePaths.AppFolderName, "Avalonia.Desktop", AppStoragePaths.UserSettingsFileName),
+            path);
+    }
+
+    [Fact]
+    public void UserContentDirectories_UseDocumentsAppFolder()
+    {
+        Assert.EndsWith(Path.Combine(AppStoragePaths.CompanyFolderName, AppStoragePaths.AppFolderName, "scripts"), AppStoragePaths.GetScriptsDirectory());
+        Assert.EndsWith(Path.Combine(AppStoragePaths.CompanyFolderName, AppStoragePaths.AppFolderName, "snapshots"), AppStoragePaths.GetSnapshotsDirectory());
+        Assert.EndsWith(Path.Combine(AppStoragePaths.CompanyFolderName, AppStoragePaths.AppFolderName, "roms", "C64"), AppStoragePaths.GetRomDirectory("C64"));
+    }
+
+    [Fact]
+    public void SharedUserContentDirectories_Include_CategoryRoots()
+    {
+        var directories = AppStoragePaths.GetSharedUserContentDirectories().ToList();
+
+        Assert.Contains(AppStoragePaths.GetUserContentRoot(), directories);
+        Assert.Contains(Path.Combine(AppStoragePaths.GetUserContentRoot(), "roms"), directories);
+        Assert.Contains(AppStoragePaths.GetScriptsDirectory(), directories);
+        Assert.Contains(AppStoragePaths.GetSnapshotsDirectory(), directories);
+    }
+
+    [Fact]
+    public async Task MergeSectionAsync_CreatesFileAndMergesNestedSection()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"dotnet6502-settings-{Guid.NewGuid():N}");
+        var settingsPath = Path.Combine(directory, AppStoragePaths.UserSettingsFileName);
+
+        try
+        {
+            await AppSettingsUserFile.MergeSectionAsync(
+                settingsPath,
+                "Highbyte.DotNet6502.AvaloniaConfig",
+                """
+                {
+                  "DefaultEmulator": "C64",
+                  "Monitor": {
+                    "StopAfterBRKInstruction": false
+                  }
+                }
+                """);
+
+            await AppSettingsUserFile.MergeSectionAsync(
+                settingsPath,
+                "Highbyte.DotNet6502.AvaloniaConfig",
+                """
+                {
+                  "ShowDebugTools": true,
+                  "Monitor": {
+                    "StopAfterUnknownInstruction": false
+                  }
+                }
+                """);
+
+            using var document = JsonDocument.Parse(await File.ReadAllTextAsync(settingsPath));
+            var section = document.RootElement.GetProperty("Highbyte.DotNet6502.AvaloniaConfig");
+            Assert.Equal("C64", section.GetProperty("DefaultEmulator").GetString());
+            Assert.True(section.GetProperty("ShowDebugTools").GetBoolean());
+
+            var monitor = section.GetProperty("Monitor");
+            Assert.False(monitor.GetProperty("StopAfterBRKInstruction").GetBoolean());
+            Assert.False(monitor.GetProperty("StopAfterUnknownInstruction").GetBoolean());
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Highbyte.DotNet6502.Systems.Tests.csproj
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Highbyte.DotNet6502.Systems.Tests.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\libraries\Highbyte.DotNet6502.Systems\Highbyte.DotNet6502.Systems.csproj" />
     <ProjectReference Include="..\..\src\libraries\Highbyte.DotNet6502.Impl.Avalonia\Highbyte.DotNet6502.Impl.Avalonia.csproj" />
     <ProjectReference Include="..\..\src\libraries\Highbyte.DotNet6502.Impl.Avalonia.Commodore64\Highbyte.DotNet6502.Impl.Avalonia.Commodore64.csproj" />
     <ProjectReference Include="..\..\src\libraries\Highbyte.DotNet6502.Systems.Commodore64\Highbyte.DotNet6502.Systems.Commodore64.csproj" />

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Scripting/ScriptingConfigTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Scripting/ScriptingConfigTests.cs
@@ -1,0 +1,64 @@
+using Highbyte.DotNet6502.Utils;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Scripting;
+
+public class ScriptingConfigTests
+{
+    [Fact]
+    public void ResolvedScriptDirectory_ExpandsHomeVariableBeforeResolvingPath()
+    {
+        const string configuredPath = "%HOME%/Documents/Highbyte/DotNet6502/scripts";
+        var config = new ScriptingConfig
+        {
+            ScriptDirectory = configuredPath
+        };
+
+        var resolvedPath = config.ResolvedScriptDirectory();
+
+        Assert.Equal(PathHelper.ExpandOSEnvironmentVariables(configuredPath), resolvedPath);
+        Assert.DoesNotContain("%HOME%", resolvedPath);
+        Assert.False(resolvedPath.StartsWith(AppContext.BaseDirectory, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ResolvedScriptDirectory_ExpandsTildeBeforeResolvingPath()
+    {
+        const string configuredPath = "~/Documents/Highbyte/DotNet6502/scripts";
+        var config = new ScriptingConfig
+        {
+            ScriptDirectory = configuredPath
+        };
+
+        var resolvedPath = config.ResolvedScriptDirectory();
+
+        Assert.Equal(PathHelper.ExpandOSEnvironmentVariables(configuredPath), resolvedPath);
+        Assert.DoesNotContain("~", resolvedPath);
+        Assert.False(resolvedPath.StartsWith(AppContext.BaseDirectory, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ResolvedFileBaseDirectory_ExpandsOverridePath()
+    {
+        const string configuredPath = "%HOME%/Documents/Highbyte/DotNet6502/scripts/files";
+        var config = new ScriptingConfig
+        {
+            ScriptDirectory = "scripts",
+            FileBaseDirectory = configuredPath
+        };
+
+        Assert.Equal(PathHelper.ExpandOSEnvironmentVariables(configuredPath), config.ResolvedFileBaseDirectory());
+    }
+
+    [Fact]
+    public void ResolvedFileBaseDirectory_UsesResolvedScriptDirectory_WhenOverrideIsEmpty()
+    {
+        const string configuredPath = "%HOME%/Documents/Highbyte/DotNet6502/scripts";
+        var config = new ScriptingConfig
+        {
+            ScriptDirectory = configuredPath,
+            FileBaseDirectory = string.Empty
+        };
+
+        Assert.Equal(config.ResolvedScriptDirectory(), config.ResolvedFileBaseDirectory());
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Scripting/ScriptingConfigTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Scripting/ScriptingConfigTests.cs
@@ -5,6 +5,31 @@ namespace Highbyte.DotNet6502.Systems.Tests.Scripting;
 public class ScriptingConfigTests
 {
     [Fact]
+    public void ResolvedScriptDirectory_WhenBlank_UsesDefaultScriptDirectory()
+    {
+        var config = new ScriptingConfig
+        {
+            ScriptDirectory = string.Empty
+        };
+
+        Assert.Equal(ScriptingConfig.DefaultScriptDirectory, config.EffectiveScriptDirectory);
+        Assert.Equal(ScriptingConfig.DefaultScriptDirectory, config.ResolvedScriptDirectory());
+    }
+
+    [Fact]
+    public void ResolvedScriptDirectory_WhenSet_UsesOverride()
+    {
+        const string configuredPath = "%HOME%/CustomScripts";
+        var config = new ScriptingConfig
+        {
+            ScriptDirectory = configuredPath
+        };
+
+        Assert.Equal(configuredPath, config.EffectiveScriptDirectory);
+        Assert.Equal(PathHelper.ExpandOSEnvironmentVariables(configuredPath), config.ResolvedScriptDirectory());
+    }
+
+    [Fact]
     public void ResolvedScriptDirectory_ExpandsHomeVariableBeforeResolvingPath()
     {
         const string configuredPath = "%HOME%/Documents/Highbyte/DotNet6502/scripts";

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Vic20/Vic20SystemConfigTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Vic20/Vic20SystemConfigTests.cs
@@ -1,0 +1,26 @@
+using Highbyte.DotNet6502.Systems.Vic20.Config;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Vic20;
+
+public class Vic20SystemConfigTests
+{
+    [Fact]
+    public void ROMDirectory_WhenBlank_Uses_DefaultROMDirectory()
+    {
+        var config = new Vic20SystemConfig();
+
+        Assert.Equal(string.Empty, config.ROMDirectory);
+        Assert.Equal(Vic20SystemConfig.DefaultROMDirectory, config.EffectiveROMDirectory);
+    }
+
+    [Fact]
+    public void ROMDirectory_WhenSet_Uses_Override()
+    {
+        var config = new Vic20SystemConfig
+        {
+            ROMDirectory = "/custom/vic20"
+        };
+
+        Assert.Equal("/custom/vic20", config.EffectiveROMDirectory);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Vic20/Vic20SystemConfigTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Vic20/Vic20SystemConfigTests.cs
@@ -1,4 +1,8 @@
 using Highbyte.DotNet6502.Systems.Vic20.Config;
+using Highbyte.DotNet6502.Systems.Vic20;
+using Highbyte.DotNet6502.Systems.Vic20.Render;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Highbyte.DotNet6502.Systems.Tests.Vic20;
 
@@ -22,5 +26,39 @@ public class Vic20SystemConfigTests
         };
 
         Assert.Equal("/custom/vic20", config.EffectiveROMDirectory);
+    }
+
+    [Fact]
+    public async Task GetNewHostSystemConfig_Applies_Render_Type_Overrides_From_Configuration()
+    {
+        var renderProviderType = typeof(Vic20VideoCommandStream);
+        var renderTargetType = typeof(TestRenderTarget);
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Vic20:SystemConfig:RenderProviderType"] = renderProviderType.AssemblyQualifiedName,
+                ["Vic20:SystemConfig:RenderTargetType"] = renderTargetType.AssemblyQualifiedName
+            })
+            .Build();
+
+        var configurer = new Vic20SystemConfigurerCore(
+            NullLoggerFactory.Instance,
+            configuration,
+            () => new TestVic20HostConfig(),
+            "Vic20");
+
+        var hostConfig = (TestVic20HostConfig)await configurer.GetNewHostSystemConfig();
+
+        Assert.Equal(renderProviderType, hostConfig.SystemConfig.RenderProviderType);
+        Assert.Equal(renderTargetType, hostConfig.SystemConfig.RenderTargetType);
+    }
+
+    private sealed class TestVic20HostConfig : HostSystemConfigBase<Vic20SystemConfig>
+    {
+        public override bool AudioSupported => false;
+    }
+
+    private sealed class TestRenderTarget
+    {
     }
 }


### PR DESCRIPTION
## Summary

- Add standardized app storage paths under `Highbyte/DotNet6502`:
  - user settings in the OS app-data location (`AppStoragePaths.GetUserSettingsFilePath(...)`)
  - user content in Documents (`roms`, `scripts`, `snapshots`)
- Move `AppStoragePaths` into `Highbyte.DotNet6502.Systems` so host apps and systems share the same path logic without depending on the core CPU emulator project.
- Create expected user-content directories on startup through system-provided directory declarations.
- Make ROM and script directories optional overrides: blank appsettings values now resolve to centralized defaults.
- Add an Avalonia Desktop-only snapshot directory override and use the effective snapshot directory for save/load dialogs.
- Seed bundled example Lua scripts into the standardized script storage location for Avalonia Desktop and Browser.
- Update C64/VIC20 config UI text to clarify directory override behavior.
- Fix VIC20 persisted render provider/target settings so they reload from user config like C64.
- Improve the SadConsole C64 config dialog validation area so multiple long validation errors do not overwrite OK/Cancel buttons and can be scrolled.

