### PR TITLE
Feature/download cache

### DIFF
--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/BrowserDownloadCache.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/BrowserDownloadCache.cs
@@ -1,0 +1,140 @@
+using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Highbyte.DotNet6502.Systems.Caching;
+using Microsoft.Extensions.Logging;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Browser;
+
+[SupportedOSPlatform("browser")]
+internal static partial class BrowserDownloadCache
+{
+    public static async Task<IDownloadCache?> TryCreateAsync(ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger(nameof(BrowserDownloadCache));
+        try
+        {
+            if (!await JSInterop.IsDownloadCacheAvailableAsync())
+            {
+                logger.LogWarning("IndexedDB download cache is not available; browser downloads will not be cached.");
+                return null;
+            }
+
+            return new DelegateDownloadCache(
+                tryGet: (url, cancellationToken) => TryGetAsync(url, logger, cancellationToken),
+                put: PutAsync,
+                list: ListAsync,
+                remove: RemoveAsync,
+                clear: ClearAsync);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to initialize IndexedDB download cache; browser downloads will not be cached.");
+            return null;
+        }
+    }
+
+    private static async Task<byte[]?> TryGetAsync(string url, ILogger logger, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return null;
+
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var json = await JSInterop.TryGetDownloadCacheEntryAsync(url);
+            if (string.IsNullOrWhiteSpace(json))
+                return null;
+
+            var record = JsonSerializer.Deserialize(json, HostConfigJsonContext.Default.BrowserDownloadCacheRecord);
+            if (record == null || string.IsNullOrEmpty(record.Base64))
+                return null;
+
+            var content = Convert.FromBase64String(record.Base64);
+            if (record.Entry.Size != content.Length || !string.Equals(record.Entry.Sha256, ComputeSha256Hex(content), StringComparison.Ordinal))
+            {
+                logger.LogWarning("IndexedDB download cache entry for {Url} failed integrity check; pruning entry.", url);
+                await JSInterop.RemoveDownloadCacheEntryAsync(url);
+                return null;
+            }
+
+            return content;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogWarning(ex, "IndexedDB download cache read failed for {Url}; treating as a cache miss.", url);
+            return null;
+        }
+    }
+
+    private static async Task PutAsync(DownloadCacheEntry entry, byte[] content, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        entry.Size = content.Length;
+        entry.Sha256 = ComputeSha256Hex(content);
+
+        var entryJson = JsonSerializer.Serialize(entry, HostConfigJsonContext.Default.DownloadCacheEntry);
+        var base64 = Convert.ToBase64String(content);
+        await JSInterop.PutDownloadCacheEntryAsync(entryJson, base64);
+    }
+
+    private static async Task<IReadOnlyList<DownloadCacheEntry>> ListAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var json = await JSInterop.ListDownloadCacheEntriesAsync();
+        if (string.IsNullOrWhiteSpace(json))
+            return [];
+
+        return JsonSerializer.Deserialize(json, HostConfigJsonContext.Default.ListDownloadCacheEntry) ?? [];
+    }
+
+    private static async Task RemoveAsync(string url, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return;
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await JSInterop.RemoveDownloadCacheEntryAsync(url);
+    }
+
+    private static async Task ClearAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await JSInterop.ClearDownloadCacheAsync();
+    }
+
+    private static string ComputeSha256Hex(byte[] bytes)
+        => Convert.ToHexStringLower(SHA256.HashData(bytes));
+
+    [SupportedOSPlatform("browser")]
+    private static partial class JSInterop
+    {
+        [JSImport("isDownloadCacheAvailable", "BrowserDownloadCache")]
+        public static partial Task<bool> IsDownloadCacheAvailableAsync();
+
+        [JSImport("tryGetDownloadCacheEntry", "BrowserDownloadCache")]
+        public static partial Task<string?> TryGetDownloadCacheEntryAsync(string url);
+
+        [JSImport("putDownloadCacheEntry", "BrowserDownloadCache")]
+        public static partial Task PutDownloadCacheEntryAsync(string entryJson, string base64);
+
+        [JSImport("listDownloadCacheEntries", "BrowserDownloadCache")]
+        public static partial Task<string?> ListDownloadCacheEntriesAsync();
+
+        [JSImport("removeDownloadCacheEntry", "BrowserDownloadCache")]
+        public static partial Task RemoveDownloadCacheEntryAsync(string url);
+
+        [JSImport("clearDownloadCache", "BrowserDownloadCache")]
+        public static partial Task ClearDownloadCacheAsync();
+    }
+}
+
+internal sealed class BrowserDownloadCacheRecord
+{
+    public DownloadCacheEntry Entry { get; set; } = new();
+    public string Base64 { get; set; } = string.Empty;
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/BrowserDownloadCache.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/BrowserDownloadCache.cs
@@ -10,6 +10,8 @@ namespace Highbyte.DotNet6502.App.Avalonia.Browser;
 [SupportedOSPlatform("browser")]
 internal static partial class BrowserDownloadCache
 {
+    private const long MaxTotalBytes = DownloadCacheDefaults.MaxTotalBytes;
+
     public static async Task<IDownloadCache?> TryCreateAsync(ILoggerFactory loggerFactory)
     {
         var logger = loggerFactory.CreateLogger(nameof(BrowserDownloadCache));
@@ -23,7 +25,7 @@ internal static partial class BrowserDownloadCache
 
             return new DelegateDownloadCache(
                 tryGet: (url, cancellationToken) => TryGetAsync(url, logger, cancellationToken),
-                put: PutAsync,
+                put: (entry, content, cancellationToken) => PutAsync(entry, content, logger, cancellationToken),
                 list: ListAsync,
                 remove: RemoveAsync,
                 clear: ClearAsync);
@@ -69,7 +71,7 @@ internal static partial class BrowserDownloadCache
         }
     }
 
-    private static async Task PutAsync(DownloadCacheEntry entry, byte[] content, CancellationToken cancellationToken)
+    private static async Task PutAsync(DownloadCacheEntry entry, byte[] content, ILogger logger, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -79,6 +81,7 @@ internal static partial class BrowserDownloadCache
         var entryJson = JsonSerializer.Serialize(entry, HostConfigJsonContext.Default.DownloadCacheEntry);
         var base64 = Convert.ToBase64String(content);
         await JSInterop.PutDownloadCacheEntryAsync(entryJson, base64);
+        await EvictIfOverCapAsync(logger, cancellationToken);
     }
 
     private static async Task<IReadOnlyList<DownloadCacheEntry>> ListAsync(CancellationToken cancellationToken)
@@ -105,6 +108,17 @@ internal static partial class BrowserDownloadCache
     {
         cancellationToken.ThrowIfCancellationRequested();
         await JSInterop.ClearDownloadCacheAsync();
+    }
+
+    private static async Task EvictIfOverCapAsync(ILogger logger, CancellationToken cancellationToken)
+    {
+        var entries = await ListAsync(cancellationToken);
+        foreach (var entry in DownloadCacheEviction.SelectLruEvictions(entries, MaxTotalBytes))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await JSInterop.RemoveDownloadCacheEntryAsync(entry.Url);
+            logger.LogInformation("Evicted cached {Url} ({Size} bytes) to stay under cache size cap.", entry.Url, entry.Size);
+        }
     }
 
     private static string ComputeSha256Hex(byte[] bytes)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/BrowserDownloadCache.js
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/BrowserDownloadCache.js
@@ -38,13 +38,13 @@ export async function tryGetDownloadCacheEntry(url) {
 
     return JSON.stringify({
         entry: record.entry,
-        base64: bytesToBase64(new Uint8Array(record.content))
+        base64: globalThis.dn6502Base64.bytesToBase64(new Uint8Array(record.content))
     });
 }
 
 export async function putDownloadCacheEntry(entryJson, base64) {
     const entry = JSON.parse(entryJson);
-    const content = base64ToBytes(base64);
+    const content = globalThis.dn6502Base64.base64ToBytes(base64);
     const contentCopy = content.buffer.slice(content.byteOffset, content.byteOffset + content.byteLength);
 
     const record = {
@@ -117,23 +117,4 @@ function requestToPromise(request) {
         request.onsuccess = () => resolve(request.result);
         request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed."));
     });
-}
-
-function base64ToBytes(base64) {
-    const binary = atob(base64);
-    const len = binary.length;
-    const bytes = new Uint8Array(len);
-    for (let i = 0; i < len; i++)
-        bytes[i] = binary.charCodeAt(i);
-    return bytes;
-}
-
-function bytesToBase64(bytes) {
-    const chunkSize = 0x8000;
-    let binary = "";
-
-    for (let i = 0; i < bytes.length; i += chunkSize)
-        binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
-
-    return btoa(binary);
 }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/BrowserDownloadCache.js
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/BrowserDownloadCache.js
@@ -1,0 +1,139 @@
+const databaseName = "dotnet6502-download-cache";
+const databaseVersion = 1;
+const storeName = "entries";
+
+let openPromise = null;
+
+export async function isDownloadCacheAvailable() {
+    if (!globalThis.indexedDB)
+        return false;
+
+    try {
+        const db = await openDatabase();
+        db.close();
+        openPromise = null;
+        return true;
+    } catch (error) {
+        console.warn("IndexedDB download cache is unavailable.", error);
+        openPromise = null;
+        return false;
+    }
+}
+
+export async function tryGetDownloadCacheEntry(url) {
+    const db = await openDatabase();
+    const record = await requestToPromise(
+        db.transaction(storeName, "readwrite")
+            .objectStore(storeName)
+            .get(url));
+
+    if (!record?.content || !record.entry)
+        return "";
+
+    record.entry.LastAccessUtc = new Date().toISOString();
+    await requestToPromise(
+        db.transaction(storeName, "readwrite")
+            .objectStore(storeName)
+            .put(record));
+
+    return JSON.stringify({
+        entry: record.entry,
+        base64: bytesToBase64(new Uint8Array(record.content))
+    });
+}
+
+export async function putDownloadCacheEntry(entryJson, base64) {
+    const entry = JSON.parse(entryJson);
+    const content = base64ToBytes(base64);
+    const contentCopy = content.buffer.slice(content.byteOffset, content.byteOffset + content.byteLength);
+
+    const record = {
+        url: entry.Url,
+        entry,
+        content: contentCopy
+    };
+
+    const db = await openDatabase();
+    await requestToPromise(
+        db.transaction(storeName, "readwrite")
+            .objectStore(storeName)
+            .put(record));
+}
+
+export async function listDownloadCacheEntries() {
+    const db = await openDatabase();
+    const records = await requestToPromise(
+        db.transaction(storeName, "readonly")
+            .objectStore(storeName)
+            .getAll());
+
+    const entries = (records ?? [])
+        .map(record => record.entry)
+        .filter(entry => !!entry)
+        .sort((a, b) => Date.parse(b.LastAccessUtc ?? "") - Date.parse(a.LastAccessUtc ?? ""));
+
+    return JSON.stringify(entries);
+}
+
+export async function removeDownloadCacheEntry(url) {
+    const db = await openDatabase();
+    await requestToPromise(
+        db.transaction(storeName, "readwrite")
+            .objectStore(storeName)
+            .delete(url));
+}
+
+export async function clearDownloadCache() {
+    const db = await openDatabase();
+    await requestToPromise(
+        db.transaction(storeName, "readwrite")
+            .objectStore(storeName)
+            .clear());
+}
+
+function openDatabase() {
+    if (openPromise)
+        return openPromise;
+
+    openPromise = new Promise((resolve, reject) => {
+        const request = indexedDB.open(databaseName, databaseVersion);
+
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains(storeName))
+                db.createObjectStore(storeName, { keyPath: "url" });
+        };
+
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error ?? new Error("Failed to open IndexedDB."));
+        request.onblocked = () => reject(new Error("IndexedDB download cache upgrade was blocked."));
+    });
+
+    return openPromise;
+}
+
+function requestToPromise(request) {
+    return new Promise((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed."));
+    });
+}
+
+function base64ToBytes(base64) {
+    const binary = atob(base64);
+    const len = binary.length;
+    const bytes = new Uint8Array(len);
+    for (let i = 0; i < len; i++)
+        bytes[i] = binary.charCodeAt(i);
+    return bytes;
+}
+
+function bytesToBase64(bytes) {
+    const chunkSize = 0x8000;
+    let binary = "";
+
+    for (let i = 0; i < bytes.length; i += chunkSize)
+        binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+
+    return btoa(binary);
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/BrowserDownloadCacheResources.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/BrowserDownloadCacheResources.cs
@@ -1,0 +1,19 @@
+using System.Runtime.Versioning;
+using System.Text;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Browser;
+
+[SupportedOSPlatform("browser")]
+internal static class BrowserDownloadCacheResources
+{
+    public static string GetJavaScriptModuleDataUri()
+    {
+        var assembly = typeof(BrowserDownloadCacheResources).Assembly;
+        var resourceName = "Highbyte.DotNet6502.App.Avalonia.Browser.BrowserDownloadCache.js";
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException($"Embedded resource '{resourceName}' not found.");
+        using var reader = new StreamReader(stream);
+        var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(reader.ReadToEnd()));
+        return $"data:text/javascript;base64,{base64}";
+    }
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/BrowserScripting.js
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/BrowserScripting.js
@@ -122,6 +122,11 @@ function bytesToBase64(bytes) {
     return btoa(binary);
 }
 
+// Expose the base64 helpers so other browser JS modules can reuse them. These modules are
+// loaded as data-URI ES modules (see *Resources.cs), which cannot resolve relative imports,
+// so a shared global is used instead of an import to keep a single implementation.
+globalThis.dn6502Base64 ??= { base64ToBytes, bytesToBase64 };
+
 export function getScriptsFromLocalStorage(prefix) {
     const results = [];
     for (let i = 0; i < localStorage.length; i++) {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/Highbyte.DotNet6502.App.Avalonia.Browser.csproj
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/Highbyte.DotNet6502.App.Avalonia.Browser.csproj
@@ -120,6 +120,7 @@
   <!-- Embedded JavaScript resources for browser interop -->
   <ItemGroup>
     <EmbeddedResource Include="BrowserScripting.js" />
+    <EmbeddedResource Include="BrowserDownloadCache.js" />
   </ItemGroup>
 
   <!-- Serve Lua example scripts as browser static assets. -->

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/HostConfigJsonContext.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/HostConfigJsonContext.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Highbyte.DotNet6502.Systems.Caching;
 
 namespace Highbyte.DotNet6502.App.Avalonia.Browser;
 
@@ -18,6 +19,9 @@ namespace Highbyte.DotNet6502.App.Avalonia.Browser;
     JsonSerializable(typeof(LocalStorageScript)),
     JsonSerializable(typeof(List<LocalStorageScript>)),
     JsonSerializable(typeof(List<string>)),
+    JsonSerializable(typeof(DownloadCacheEntry)),
+    JsonSerializable(typeof(List<DownloadCacheEntry>)),
+    JsonSerializable(typeof(BrowserDownloadCacheRecord)),
 ]
 internal partial class HostConfigJsonContext : JsonSerializerContext
 {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/Program.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/Program.cs
@@ -16,6 +16,7 @@ using Highbyte.DotNet6502.Impl.Browser.Input;
 using Highbyte.DotNet6502.Impl.NAudio.WavePlayers.WebAudioAPI;
 using Highbyte.DotNet6502.Scripting.MoonSharp;
 using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Caching;
 using Highbyte.DotNet6502.Systems.Logging.Console;
 using Highbyte.DotNet6502.Systems.Logging.InMem;
 using Microsoft.Extensions.DependencyInjection;
@@ -386,6 +387,12 @@ internal sealed partial class Program
         // Load custom JS module for localStorage-based Lua script loading
         WriteBootstrapLog("Importing BrowserScripting JS module.");
         await JSHost.ImportAsync("BrowserScripting", BrowserScriptingResources.GetJavaScriptModuleDataUri());
+
+        WriteBootstrapLog("Importing BrowserDownloadCache JS module.");
+        await JSHost.ImportAsync("BrowserDownloadCache", BrowserDownloadCacheResources.GetJavaScriptModuleDataUri());
+        var browserDownloadCache = await BrowserDownloadCache.TryCreateAsync(loggerFactory);
+        if (!emulatorConfig.DownloadCacheEnabled)
+            startupLogger.LogInformation("Browser download cache use is disabled by settings.");
 
         // Detect the browser keyboard layout / OS so the C64 input handler can auto-select the
         // keyboard layout and apply the macOS ISO-key fix. The Avalonia input context is created
@@ -784,7 +791,21 @@ internal sealed partial class Program
         try
         {
             WriteBootstrapLog("Starting Avalonia Browser app...");
-            await BuildAvaloniaApp(configuration, emulatorConfig, logStore, logConfig, loggerFactory, avaloniaLoggerBridge, browserGamepad, scriptingEngine, LoadScript, SaveScript, DeleteScript, LoadExamplesAsync, automatedStartupRunner: automatedStartupRunner)
+            await BuildAvaloniaApp(
+                    configuration,
+                    emulatorConfig,
+                    logStore,
+                    logConfig,
+                    loggerFactory,
+                    avaloniaLoggerBridge,
+                    browserGamepad,
+                    scriptingEngine,
+                    LoadScript,
+                    SaveScript,
+                    DeleteScript,
+                    LoadExamplesAsync,
+                    automatedStartupRunner: automatedStartupRunner,
+                    downloadCacheFactory: browserDownloadCache == null ? null : () => browserDownloadCache)
                 .StartBrowserAppAsync("out");
 
             WriteBootstrapLog("Avalonia Browser app exiting.");
@@ -1535,7 +1556,8 @@ internal sealed partial class Program
         Action<string, string>? saveScript = null,
         Action<string>? deleteScript = null,
         Func<Task>? loadExamples = null,
-        Func<IHostApp, Task>? automatedStartupRunner = null)
+        Func<IHostApp, Task>? automatedStartupRunner = null,
+        Func<IDownloadCache?>? downloadCacheFactory = null)
     {
         return AppBuilder.Configure(() =>
         {
@@ -1555,7 +1577,8 @@ internal sealed partial class Program
                                 loadExamples: loadExamples,
                                 automatedStartupRunner: automatedStartupRunner,
                                 appFilePicker: new BrowserAppFilePicker(),
-                                appFileSaver: new BrowserAppFileSaver()
+                                appFileSaver: new BrowserAppFileSaver(),
+                                downloadCacheFactory: downloadCacheFactory
                             );
         })
         .AfterSetup(_ =>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/App.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/App.axaml.cs
@@ -15,6 +15,7 @@ using Highbyte.DotNet6502.App.Avalonia.Core.Views;
 using Highbyte.DotNet6502.Impl.Avalonia.Input;
 using Highbyte.DotNet6502.Impl.NAudio;
 using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Caching;
 using Highbyte.DotNet6502.Systems.Input;
 using Highbyte.DotNet6502.Systems.Logging.InMem;
 using Highbyte.DotNet6502.Systems.Plugins;
@@ -49,6 +50,7 @@ public partial class App : Application
     private readonly Func<IHostApp, Task>? _automatedStartupRunner;
     private readonly IAppFilePicker? _appFilePicker;
     private readonly IAppFileSaver? _appFileSaver;
+    private readonly Func<IDownloadCache?>? _downloadCacheFactory;
     private AvaloniaHostApp _hostApp = default!;
     private IServiceProvider _serviceProvider = default!;
 
@@ -137,7 +139,8 @@ public partial class App : Application
         Func<Task>? loadExamples = null,
         Func<IHostApp, Task>? automatedStartupRunner = null,
         IAppFilePicker? appFilePicker = null,
-        IAppFileSaver? appFileSaver = null)
+        IAppFileSaver? appFileSaver = null,
+        Func<IDownloadCache?>? downloadCacheFactory = null)
     {
         WriteBootstrapLog("App constructor called");
 
@@ -157,6 +160,7 @@ public partial class App : Application
         _automatedStartupRunner = automatedStartupRunner;
         _appFilePicker = appFilePicker;
         _appFileSaver = appFileSaver;
+        _downloadCacheFactory = downloadCacheFactory;
 
         // Set static reference for external access (e.g., debug adapter)
         Current = this;
@@ -432,7 +436,8 @@ public partial class App : Application
                 _loadScript,
                 _saveScript,
                 _deleteScript,
-                _loadExamples);
+                _loadExamples,
+                _downloadCacheFactory);
 
             // Wire Lua scripting engine (NoScriptingEngine used when null, e.g. in WASM)
             _hostApp.SetScriptingEngine(_scriptingEngine ?? new NoScriptingEngine());

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/AvaloniaHostApp.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/AvaloniaHostApp.cs
@@ -57,6 +57,7 @@ public class AvaloniaHostApp : HostApp, INotifyPropertyChanged, IDebuggableHostA
     private readonly Action<string, string>? _saveScript;
     private readonly Action<string>? _deleteScript;
     private readonly Func<Task>? _loadExamples;
+    private readonly Func<IDownloadCache?>? _downloadCacheFactory;
     private float _defaultAudioVolumePercent;
 
     private readonly SystemList _systemList;
@@ -177,18 +178,40 @@ public class AvaloniaHostApp : HostApp, INotifyPropertyChanged, IDebuggableHostA
     /// <summary>
     /// The read-through cache for auto-downloaded C64 content (<c>.d64</c>/<c>.prg</c>), or null when
     /// caching is unavailable. Desktop hosts get a <see cref="FileDownloadCache"/> under
-    /// <see cref="AppStoragePaths.GetDownloadCacheDirectory"/>; the browser (WASM) host returns null
-    /// for now (a filesystem cache would be non-persistent there — an IndexedDB backend is the
-    /// intended future implementation). Exposed so per-system shell view models can pass it into the
+    /// <see cref="AppStoragePaths.GetDownloadCacheDirectory"/>; browser hosts can supply an
+    /// IndexedDB-backed cache factory. Exposed so per-system shell view models can pass it into the
     /// download-and-run flow without access to the internal config.
     /// </summary>
     public IDownloadCache? GetDownloadCache()
+    {
+        if (!_emulatorConfig.DownloadCacheEnabled)
+            return null;
+
+        return GetOrCreateDownloadCache();
+    }
+
+    internal IDownloadCache? GetDownloadCacheForManagement()
+        => GetOrCreateDownloadCache();
+
+    private IDownloadCache? GetOrCreateDownloadCache()
     {
         if (_downloadCacheResolved)
             return _downloadCache;
 
         _downloadCacheResolved = true;
-        if (!OperatingSystem.IsBrowser())
+        if (OperatingSystem.IsBrowser())
+        {
+            try
+            {
+                _downloadCache = _downloadCacheFactory?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                _loggerFactory.CreateLogger(nameof(AvaloniaHostApp))
+                    .LogWarning(ex, "Failed to initialize the browser download cache; downloads will not be cached.");
+            }
+        }
+        else
         {
             try
             {
@@ -223,6 +246,7 @@ public class AvaloniaHostApp : HostApp, INotifyPropertyChanged, IDebuggableHostA
     /// <param name="saveScript">Optional callback to persist a script by file name and content (browser: to localStorage).</param>
     /// <param name="deleteScript">Optional callback to remove a script by file name (browser: from localStorage).</param>
     /// <param name="loadExamples">Optional callback to seed bundled example scripts into the host's script storage.</param>
+    /// <param name="downloadCacheFactory">Optional host-provided cache backend (browser: IndexedDB).</param>
     internal AvaloniaHostApp(
         SystemList systemList,
         ILoggerFactory loggerFactory,
@@ -235,7 +259,8 @@ public class AvaloniaHostApp : HostApp, INotifyPropertyChanged, IDebuggableHostA
         Func<string, string?>? loadScript = null,
         Action<string, string>? saveScript = null,
         Action<string>? deleteScript = null,
-        Func<Task>? loadExamples = null
+        Func<Task>? loadExamples = null,
+        Func<IDownloadCache?>? downloadCacheFactory = null
 
         ) : base("Avalonia", systemList, loggerFactory, useStatsNamePrefix: false)
     {
@@ -248,6 +273,7 @@ public class AvaloniaHostApp : HostApp, INotifyPropertyChanged, IDebuggableHostA
         _saveScript = saveScript;
         _deleteScript = deleteScript;
         _loadExamples = loadExamples;
+        _downloadCacheFactory = downloadCacheFactory;
 
         _logger = loggerFactory.CreateLogger(typeof(AvaloniaHostApp).Name);
         _emulatorConfig = emulatorConfig;

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/AvaloniaHostApp.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/AvaloniaHostApp.cs
@@ -21,6 +21,8 @@ using Highbyte.DotNet6502.Impl.NAudio.WavePlayers.WebAudioAPI;
 using Highbyte.DotNet6502.Remoting;
 using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Audio;
+using Highbyte.DotNet6502.Systems.Caching;
+using Highbyte.DotNet6502.Systems.Configuration;
 using Highbyte.DotNet6502.Systems.Input;
 using Highbyte.DotNet6502.Systems.Logging.InMem;
 using Highbyte.DotNet6502.Systems.Rendering;
@@ -168,6 +170,40 @@ public class AvaloniaHostApp : HostApp, INotifyPropertyChanged, IDebuggableHostA
     /// per-system shell view models can build share links without access to the internal config.
     /// </summary>
     public string? GetShareBaseUrl() => _emulatorConfig.ShareBaseUrl;
+
+    private IDownloadCache? _downloadCache;
+    private bool _downloadCacheResolved;
+
+    /// <summary>
+    /// The read-through cache for auto-downloaded C64 content (<c>.d64</c>/<c>.prg</c>), or null when
+    /// caching is unavailable. Desktop hosts get a <see cref="FileDownloadCache"/> under
+    /// <see cref="AppStoragePaths.GetDownloadCacheDirectory"/>; the browser (WASM) host returns null
+    /// for now (a filesystem cache would be non-persistent there — an IndexedDB backend is the
+    /// intended future implementation). Exposed so per-system shell view models can pass it into the
+    /// download-and-run flow without access to the internal config.
+    /// </summary>
+    public IDownloadCache? GetDownloadCache()
+    {
+        if (_downloadCacheResolved)
+            return _downloadCache;
+
+        _downloadCacheResolved = true;
+        if (!OperatingSystem.IsBrowser())
+        {
+            try
+            {
+                _downloadCache = new FileDownloadCache(AppStoragePaths.GetDownloadCacheDirectory(), _loggerFactory);
+            }
+            catch (Exception ex)
+            {
+                // Never let a cache-setup failure break the download flow; fall back to no caching.
+                _loggerFactory.CreateLogger(nameof(AvaloniaHostApp))
+                    .LogWarning(ex, "Failed to initialize the download cache; downloads will not be cached.");
+            }
+        }
+
+        return _downloadCache;
+    }
 
     // Expose InputHandlerContext for debug views
     internal AvaloniaInputHandlerContext InputHandlerContext => _inputHandlerContext;

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/EmulatorConfig.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/EmulatorConfig.cs
@@ -71,6 +71,12 @@ public class EmulatorConfig
     public string CorsProxyUrl { get; set; } = BrowserServiceDefaults.DefaultCorsProxyUrl;
 
     /// <summary>
+    /// Enables the read-through cache used by C64 auto-downloaded <c>.d64</c>/<c>.prg</c>
+    /// content. Desktop uses a file-backed cache; Browser uses IndexedDB when available.
+    /// </summary>
+    public bool DownloadCacheEnabled { get; set; } = true;
+
+    /// <summary>
     /// The effective CORS proxy URL to use: the configured <see cref="CorsProxyUrl"/> (falling back
     /// to <see cref="BrowserServiceDefaults.DefaultCorsProxyUrl"/> when blank) in the browser, or
     /// <see langword="null"/> on desktop where cross-origin fetches are unrestricted.
@@ -186,6 +192,7 @@ public class EmulatorConfig
             RestoreConfigOnLoad = RestoreConfigOnLoad,
             SnapshotDirectory = OperatingSystem.IsBrowser() ? null : SnapshotDirectory,
             CorsProxyUrl = CorsProxyUrl,
+            DownloadCacheEnabled = DownloadCacheEnabled,
             AudioSettingsProfile = AudioSettingsProfile,
             BrowserSampleAudioMode = BrowserSampleAudioMode,
             Monitor = new EmulatorMonitorUserSettings
@@ -210,6 +217,7 @@ internal sealed class EmulatorConfigUserSettings
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? SnapshotDirectory { get; set; }
     public string CorsProxyUrl { get; set; } = BrowserServiceDefaults.DefaultCorsProxyUrl;
+    public bool DownloadCacheEnabled { get; set; } = true;
     [JsonConverter(typeof(JsonStringEnumConverter<WavePlayerSettingsProfile>))]
     public WavePlayerSettingsProfile AudioSettingsProfile { get; set; } = WavePlayerSettingsProfile.Balanced;
     [JsonConverter(typeof(JsonStringEnumConverter<BrowserSampleAudioMode>))]

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/EmulatorConfigViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/EmulatorConfigViewModel.cs
@@ -8,6 +8,7 @@ using Highbyte.DotNet6502.Monitor;
 using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Utils;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using ReactiveUI;
 
 namespace Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
@@ -17,6 +18,7 @@ public class EmulatorConfigViewModel : ViewModelBase
     private readonly AvaloniaHostApp _hostApp;
     private readonly IConfiguration _configuration;
     private readonly EmulatorConfig _emulatorConfig;
+    private readonly ILogger _logger;
 
     private bool _isBusy;
     private string? _statusMessage;
@@ -38,12 +40,14 @@ public class EmulatorConfigViewModel : ViewModelBase
     public ReactiveCommand<Unit, Unit> SaveCommand { get; }
     public ReactiveCommand<Unit, Unit> CancelCommand { get; }
     public ReactiveCommand<Unit, Unit> ResetToDefaultsCommand { get; }
+    public ReactiveCommand<Unit, Unit> ClearDownloadCacheCommand { get; }
 
     public EmulatorConfigViewModel(AvaloniaHostApp hostApp, IConfiguration configuration)
     {
         _hostApp = hostApp ?? throw new ArgumentNullException(nameof(hostApp));
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         _emulatorConfig = hostApp.EmulatorConfig;
+        _logger = hostApp.LoggerFactory.CreateLogger(nameof(EmulatorConfigViewModel));
 
         // Initialize available options. The list of selectable systems comes dynamically from the
         // systems registered with the emulator (e.g. C64, Vic20, Generic), sorted for stable display.
@@ -93,6 +97,10 @@ public class EmulatorConfigViewModel : ViewModelBase
             },
             outputScheduler: RxSchedulers.MainThreadScheduler);
 
+        ClearDownloadCacheCommand = ReactiveCommandHelper.CreateSafeCommand(
+            ClearDownloadCacheAsync,
+            outputScheduler: RxSchedulers.MainThreadScheduler);
+
         // Show info message on desktop about permanent settings
         if (!IsRunningInWebAssembly)
         {
@@ -115,12 +123,17 @@ public class EmulatorConfigViewModel : ViewModelBase
             this.RaiseAndSetIfChanged(ref _isBusy, value);
             this.RaisePropertyChanged(nameof(IsNotBusy));
             this.RaisePropertyChanged(nameof(CanSave));
+            this.RaisePropertyChanged(nameof(CanClearDownloadCache));
         }
     }
 
     public bool IsNotBusy => !IsBusy;
 
     public bool CanSave => IsNotBusy && !HasValidationErrors;
+
+    public bool IsDownloadCacheAvailable => _hostApp.GetDownloadCache() != null;
+
+    public bool CanClearDownloadCache => IsNotBusy && IsDownloadCacheAvailable;
 
     public string? StatusMessage
     {
@@ -343,6 +356,38 @@ public class EmulatorConfigViewModel : ViewModelBase
 
         UpdateValidation();
         StatusMessage = "Settings reset to defaults. Click Save to apply.";
+    }
+
+    private async Task ClearDownloadCacheAsync()
+    {
+        var downloadCache = _hostApp.GetDownloadCache();
+        if (downloadCache == null)
+        {
+            StatusMessage = "Download cache is not available.";
+            return;
+        }
+
+        try
+        {
+            IsBusy = true;
+            StatusMessage = "Clearing download cache...";
+
+            var entryCount = (await downloadCache.ListAsync()).Count;
+            await downloadCache.ClearAsync();
+
+            StatusMessage = entryCount == 1
+                ? "Download cache cleared (1 entry)."
+                : $"Download cache cleared ({entryCount} entries).";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to clear download cache.");
+            StatusMessage = $"Error clearing download cache: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
     }
 
     private async Task<bool> TryApplyChangesAsync()

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/EmulatorConfigViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/EmulatorConfigViewModel.cs
@@ -36,6 +36,7 @@ public class EmulatorConfigViewModel : ViewModelBase
     private string _snapshotDirectory;
     private bool _allowUrlScripts;
     private string _corsProxyUrl;
+    private bool _downloadCacheEnabled;
 
     public ReactiveCommand<Unit, Unit> SaveCommand { get; }
     public ReactiveCommand<Unit, Unit> CancelCommand { get; }
@@ -68,6 +69,7 @@ public class EmulatorConfigViewModel : ViewModelBase
         _snapshotDirectory = _emulatorConfig.SnapshotDirectory;
         _allowUrlScripts = _hostApp.ScriptingEngine.AllowUrlScripts;
         _corsProxyUrl = _emulatorConfig.CorsProxyUrl;
+        _downloadCacheEnabled = _emulatorConfig.DownloadCacheEnabled;
 
         // Initialize ReactiveUI Commands with MainThreadScheduler for Browser compatibility
         SaveCommand = ReactiveCommandHelper.CreateSafeCommand(
@@ -131,7 +133,7 @@ public class EmulatorConfigViewModel : ViewModelBase
 
     public bool CanSave => IsNotBusy && !HasValidationErrors;
 
-    public bool IsDownloadCacheAvailable => _hostApp.GetDownloadCache() != null;
+    public bool IsDownloadCacheAvailable => _hostApp.GetDownloadCacheForManagement() != null;
 
     public bool CanClearDownloadCache => IsNotBusy && IsDownloadCacheAvailable;
 
@@ -320,6 +322,22 @@ public class EmulatorConfigViewModel : ViewModelBase
 
     public static string CorsProxyUrlWatermark => BrowserServiceDefaults.DefaultCorsProxyUrl;
 
+    /// <summary>
+    /// Enables the download cache for emulator content. Clearing remains available when the cache
+    /// backend can be opened, even if cache use is disabled.
+    /// </summary>
+    public bool DownloadCacheEnabled
+    {
+        get => _downloadCacheEnabled;
+        set
+        {
+            if (_downloadCacheEnabled == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _downloadCacheEnabled, value);
+        }
+    }
+
     private void UpdateValidation()
     {
         _validationErrors.Clear();
@@ -353,6 +371,7 @@ public class EmulatorConfigViewModel : ViewModelBase
         // Browser-only knob; defaults to disabled.
         AllowUrlScripts = false;
         CorsProxyUrl = defaults.CorsProxyUrl;
+        DownloadCacheEnabled = defaults.DownloadCacheEnabled;
 
         UpdateValidation();
         StatusMessage = "Settings reset to defaults. Click Save to apply.";
@@ -360,7 +379,7 @@ public class EmulatorConfigViewModel : ViewModelBase
 
     private async Task ClearDownloadCacheAsync()
     {
-        var downloadCache = _hostApp.GetDownloadCache();
+        var downloadCache = _hostApp.GetDownloadCacheForManagement();
         if (downloadCache == null)
         {
             StatusMessage = "Download cache is not available.";
@@ -411,6 +430,7 @@ public class EmulatorConfigViewModel : ViewModelBase
             if (!IsRunningInWebAssembly)
                 _emulatorConfig.SnapshotDirectory = _snapshotDirectory;
             _emulatorConfig.CorsProxyUrl = _corsProxyUrl;
+            _emulatorConfig.DownloadCacheEnabled = _downloadCacheEnabled;
 
             // Persist emulator config (note: the _emulatorConfig object is owned by AvaloniaHostApp)
             await _hostApp.PersistEmulatorConfigAsync();

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorConfigUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorConfigUserControl.axaml
@@ -237,7 +237,7 @@
         </StackPanel>
 
         <!-- Download Cache Section -->
-        <StackPanel Width="400" Classes="wrap-item" IsVisible="{Binding !IsRunningInWebAssembly}">
+        <StackPanel Width="400" Classes="wrap-item">
           <Border Classes="content-section">
             <StackPanel Classes="spacing-tight">
               <TextBlock Text="Download Cache" Classes=""/>
@@ -245,6 +245,14 @@
               <TextBlock Text="Automatically downloaded C64 programs and disk images are cached locally."
                          Classes="small secondary-text"
                          TextWrapping="Wrap"/>
+              <CheckBox Content="Use download cache"
+                        AutomationProperties.AutomationId="DownloadCacheEnabledCheckBox"
+                        AutomationProperties.Name="Use download cache"
+                        IsChecked="{Binding DownloadCacheEnabled}"/>
+              <TextBlock Text="Desktop stores cached files on disk; Browser stores them in IndexedDB when available. Disable this if caching causes problems."
+                         Classes="small secondary-text"
+                         TextWrapping="Wrap"
+                         Margin="20,0,0,0"/>
               <Button Content="Clear cache"
                       AutomationProperties.AutomationId="ClearDownloadCacheButton"
                       AutomationProperties.Name="Clear download cache"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorConfigUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorConfigUserControl.axaml
@@ -236,6 +236,27 @@
           </Border>
         </StackPanel>
 
+        <!-- Download Cache Section -->
+        <StackPanel Width="400" Classes="wrap-item" IsVisible="{Binding !IsRunningInWebAssembly}">
+          <Border Classes="content-section">
+            <StackPanel Classes="spacing-tight">
+              <TextBlock Text="Download Cache" Classes=""/>
+
+              <TextBlock Text="Automatically downloaded C64 programs and disk images are cached locally."
+                         Classes="small secondary-text"
+                         TextWrapping="Wrap"/>
+              <Button Content="Clear cache"
+                      AutomationProperties.AutomationId="ClearDownloadCacheButton"
+                      AutomationProperties.Name="Clear download cache"
+                      Command="{Binding ClearDownloadCacheCommand}"
+                      IsEnabled="{Binding CanClearDownloadCache}"
+                      MinWidth="110"
+                      HorizontalAlignment="Left"
+                      Classes="danger"/>
+            </StackPanel>
+          </Border>
+        </StackPanel>
+
         <!-- Lua Scripting Section -->
         <StackPanel Width="400" Classes="wrap-item">
           <Border Classes="content-section">

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/ViewModels/C64MenuViewModel.cs
@@ -1434,7 +1434,8 @@ public class C64MenuViewModel : ViewModelBase, ISystemMenuContributor
                    _loggerFactory,
                    _httpClient,
                    hostApp,
-                   corsProxyUrl: _avaloniaHostApp.GetCorsProxyUrl());
+                   corsProxyUrl: _avaloniaHostApp.GetCorsProxyUrl(),
+                   downloadCache: _avaloniaHostApp.GetDownloadCache());
             }
 
             await _c64AutoLoadAndRun.DownloadAndRunProgram(

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Commodore64/C64TerminalMenuView.cs
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Commodore64/C64TerminalMenuView.cs
@@ -2,8 +2,10 @@ using System.Collections.ObjectModel;
 using Highbyte.DotNet6502.App.Terminal;
 using Highbyte.DotNet6502.Impl.Terminal.Commodore64;
 using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Caching;
 using Highbyte.DotNet6502.Systems.Commodore64;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Systems.Configuration;
 using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.DiskDrive;
 using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.DiskDrive.D64;
 using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.DiskDrive.Download;
@@ -353,7 +355,10 @@ public sealed class C64TerminalMenuView : View, ITerminalMenuContribution
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
             "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
 
-        return new C64AutoLoadAndRun(_loggerFactory, _httpClient, _host);
+        // Desktop host: back the download-and-run flow with a persistent file cache so previously
+        // downloaded .d64/.prg content re-runs offline and skips redundant network fetches.
+        var downloadCache = new FileDownloadCache(AppStoragePaths.GetDownloadCacheDirectory(), _loggerFactory);
+        return new C64AutoLoadAndRun(_loggerFactory, _httpClient, _host, downloadCache: downloadCache);
     }
 
     private async Task ApplyPreloadedProgramConfig(C64DownloadProgramInfo programInfo)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/DiskDrive/D64/Download/D64Downloader.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/DiskDrive/D64/Download/D64Downloader.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Highbyte.DotNet6502.Systems.Caching;
 using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.DiskDrive.Download;
 using Highbyte.DotNet6502.Utils;
 
@@ -10,25 +11,44 @@ public class D64Downloader
     private readonly ILogger _logger;
     private readonly HttpClient _httpClient;
     private readonly string? _corsProxyUrl;
+    private readonly IDownloadCache? _downloadCache;
 
     public D64Downloader(
         ILoggerFactory loggerFactory,
         HttpClient httpClient,
-        string? corsProxyUrl = null)
+        string? corsProxyUrl = null,
+        IDownloadCache? downloadCache = null)
     {
         _logger = loggerFactory.CreateLogger(typeof(D64Downloader).Name);
         _httpClient = httpClient;
         _corsProxyUrl = corsProxyUrl;
+        _downloadCache = downloadCache;
     }
 
 
     /// <summary>
-    /// Downloads and processes a disk image file (supports both .d64 and .zip files)
+    /// Downloads and processes a disk image file (supports both .d64 and .zip files).
+    /// Cache-first: a valid cached copy (keyed on the original source URL) is returned without
+    /// hitting the network; otherwise the freshly downloaded / extracted .d64 is cached for reuse.
     /// </summary>
     /// <param name="diskInfo">Information about the program to download</param>
     /// <returns>The .d64 file content as byte array</returns>
     public async Task<byte[]> DownloadAndProcessDiskImage(C64DownloadProgramInfo diskInfo)
     {
+        if (_downloadCache != null)
+        {
+            var cached = await _downloadCache.TryGetAsync(diskInfo.DownloadUrl);
+            if (cached != null)
+            {
+                _logger.LogInformation(
+                    "Using cached disk image {DisplayName} for source URL {SourceUrl} ({ByteCount} bytes)",
+                    diskInfo.DisplayName,
+                    diskInfo.DownloadUrl,
+                    cached.Length);
+                return cached;
+            }
+        }
+
         _logger.LogInformation(
             "Downloading disk image {DisplayName} from source URL {SourceUrl}",
             diskInfo.DisplayName,
@@ -46,18 +66,27 @@ public class D64Downloader
 
         try
         {
+            byte[] d64Bytes;
+            string? etag;
+            string? lastModified;
+
             // Check the download type to determine download strategy
             if (diskInfo.DownloadType == C64DownloadProgramType.D64Zip)
             {
                 _logger.LogInformation("Processing ZIP file to extract .d64");
-                return await DownloadAndExtractZipD64(downloadUrl);
+                (d64Bytes, etag, lastModified) = await DownloadAndExtractZipD64(downloadUrl);
+            }
+            else
+            {
+                // Download direct .d64 file
+                using var response = await _httpClient.GetAsync(downloadUrl);
+                response.EnsureSuccessStatusCode();
+                d64Bytes = await response.Content.ReadAsByteArrayAsync();
+                (etag, lastModified) = GetValidators(response);
+                _logger.LogInformation("Downloaded .d64 file: {ByteCount} bytes", d64Bytes.Length);
             }
 
-            // Download direct .d64 file
-            using var response = await _httpClient.GetAsync(downloadUrl);
-            response.EnsureSuccessStatusCode();
-            var d64Bytes = await response.Content.ReadAsByteArrayAsync();
-            _logger.LogInformation("Downloaded .d64 file: {ByteCount} bytes", d64Bytes.Length);
+            await CacheD64Async(diskInfo, d64Bytes, etag, lastModified);
             return d64Bytes;
         }
         catch (Exception ex)
@@ -84,12 +113,42 @@ public class D64Downloader
     /// Downloads a ZIP file and extracts the first .d64 file in it.
     /// </summary>
     /// <param name="url">The URL to download the ZIP from</param>
-    /// <returns>The .d64 file content as byte array</returns>
-    private async Task<byte[]> DownloadAndExtractZipD64(string url)
+    /// <returns>The extracted .d64 bytes plus the ZIP response's HTTP validators.</returns>
+    private async Task<(byte[] d64Bytes, string? etag, string? lastModified)> DownloadAndExtractZipD64(string url)
     {
         using var response = await _httpClient.GetAsync(url);
         response.EnsureSuccessStatusCode();
+        var (etag, lastModified) = GetValidators(response);
         using var responseStream = await response.Content.ReadAsStreamAsync();
-        return D64ZipExtractor.ExtractFirstD64FromZip(responseStream, _logger);
+        var d64Bytes = D64ZipExtractor.ExtractFirstD64FromZip(responseStream, _logger);
+        return (d64Bytes, etag, lastModified);
+    }
+
+    private async Task CacheD64Async(C64DownloadProgramInfo diskInfo, byte[] d64Bytes, string? etag, string? lastModified)
+    {
+        if (_downloadCache == null)
+            return;
+
+        try
+        {
+            await _downloadCache.PutAsync(diskInfo.DownloadUrl, d64Bytes, "d64", diskInfo.DisplayName, etag, lastModified);
+            _logger.LogInformation(
+                "Added disk image {DisplayName} to download cache from source URL {SourceUrl} ({ByteCount} bytes)",
+                diskInfo.DisplayName,
+                diskInfo.DownloadUrl,
+                d64Bytes.Length);
+        }
+        catch (Exception ex)
+        {
+            // Caching is best-effort; a cache write failure must not fail the load.
+            _logger.LogWarning(ex, "Failed to cache disk image {DisplayName} for source URL {SourceUrl}.", diskInfo.DisplayName, diskInfo.DownloadUrl);
+        }
+    }
+
+    private static (string? etag, string? lastModified) GetValidators(HttpResponseMessage response)
+    {
+        var etag = response.Headers.ETag?.ToString();
+        var lastModified = response.Content.Headers.LastModified?.ToString("o");
+        return (etag, lastModified);
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/DiskDrive/Download/C64AutoLoadAndRun.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/DiskDrive/Download/C64AutoLoadAndRun.cs
@@ -1,3 +1,4 @@
+using Highbyte.DotNet6502.Systems.Caching;
 using Highbyte.DotNet6502.Utils;
 using Microsoft.Extensions.Logging;
 
@@ -10,18 +11,21 @@ public class C64AutoLoadAndRun
     private readonly HttpClient _httpClient;
     private readonly IHostApp _hostApp;
     private readonly string? _corsProxyUrl;
+    private readonly IDownloadCache? _downloadCache;
 
     public C64AutoLoadAndRun(
         ILoggerFactory loggerFactory,
         HttpClient httpClient,
         IHostApp hostApp,
-        string? corsProxyUrl = null)
+        string? corsProxyUrl = null,
+        IDownloadCache? downloadCache = null)
     {
         _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger(typeof(C64AutoLoadAndRun).Name);
         _httpClient = httpClient;
         _hostApp = hostApp;
         _corsProxyUrl = corsProxyUrl;
+        _downloadCache = downloadCache;
     }
 
     public async Task DownloadAndRunProgram(
@@ -116,11 +120,13 @@ public class C64AutoLoadAndRun
             C64DownloadProgramType.D64 or C64DownloadProgramType.D64Zip => new C64D64ContentLoader(
                 _loggerFactory,
                 _httpClient,
-                _corsProxyUrl),
+                _corsProxyUrl,
+                _downloadCache),
             C64DownloadProgramType.Prg => new C64PrgContentLoader(
                 _loggerFactory,
                 _httpClient,
-                _corsProxyUrl),
+                _corsProxyUrl,
+                _downloadCache),
             _ => throw new InvalidOperationException($"Unsupported C64 download program type: {programInfo.DownloadType}."),
         };
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/DiskDrive/Download/C64D64ContentLoader.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/DiskDrive/Download/C64D64ContentLoader.cs
@@ -1,3 +1,4 @@
+using Highbyte.DotNet6502.Systems.Caching;
 using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.DiskDrive.D64;
 using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.DiskDrive.D64.Download;
 using Highbyte.DotNet6502.Utils;
@@ -13,10 +14,11 @@ public class C64D64ContentLoader : IC64AutoLoadContentLoader
     public C64D64ContentLoader(
         ILoggerFactory loggerFactory,
         HttpClient httpClient,
-        string? corsProxyUrl = null)
+        string? corsProxyUrl = null,
+        IDownloadCache? downloadCache = null)
     {
         _logger = loggerFactory.CreateLogger(typeof(C64D64ContentLoader).Name);
-        _d64Downloader = new D64Downloader(loggerFactory, httpClient, corsProxyUrl);
+        _d64Downloader = new D64Downloader(loggerFactory, httpClient, corsProxyUrl, downloadCache);
     }
 
     public async Task LoadAsync(C64DownloadProgramInfo programInfo, C64 c64)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/DiskDrive/Download/C64PrgContentLoader.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/DiskDrive/Download/C64PrgContentLoader.cs
@@ -1,3 +1,4 @@
+using Highbyte.DotNet6502.Systems.Caching;
 using Highbyte.DotNet6502.Utils;
 using Microsoft.Extensions.Logging;
 
@@ -8,15 +9,18 @@ public class C64PrgContentLoader : IC64AutoLoadContentLoader
     private readonly ILogger _logger;
     private readonly HttpClient _httpClient;
     private readonly string? _corsProxyUrl;
+    private readonly IDownloadCache? _downloadCache;
 
     public C64PrgContentLoader(
         ILoggerFactory loggerFactory,
         HttpClient httpClient,
-        string? corsProxyUrl = null)
+        string? corsProxyUrl = null,
+        IDownloadCache? downloadCache = null)
     {
         _logger = loggerFactory.CreateLogger(typeof(C64PrgContentLoader).Name);
         _httpClient = httpClient;
         _corsProxyUrl = corsProxyUrl;
+        _downloadCache = downloadCache;
     }
 
     public async Task LoadAsync(C64DownloadProgramInfo programInfo, C64 c64)
@@ -25,17 +29,9 @@ public class C64PrgContentLoader : IC64AutoLoadContentLoader
             ? _corsProxyUrl + Uri.EscapeDataString(programInfo.DownloadUrl)
             : programInfo.DownloadUrl;
 
-        _logger.LogInformation(
-            "Downloading PRG program {DisplayName} from source URL {SourceUrl} using request URL {RequestUrl}",
-            programInfo.DisplayName,
-            programInfo.DownloadUrl,
-            downloadUrl);
-
         try
         {
-            using var response = await _httpClient.GetAsync(downloadUrl);
-            response.EnsureSuccessStatusCode();
-            var prgBytes = await response.Content.ReadAsByteArrayAsync();
+            var prgBytes = await GetPrgBytesAsync(programInfo, downloadUrl);
 
             BinaryLoader.Load(
                 c64.Mem,
@@ -67,5 +63,58 @@ public class C64PrgContentLoader : IC64AutoLoadContentLoader
 
             throw new InvalidOperationException(userMessage, ex);
         }
+    }
+
+    /// <summary>
+    /// Cache-first fetch of the PRG bytes. Returns a valid cached copy (keyed on the original source
+    /// URL) without hitting the network; otherwise downloads and caches the bytes for reuse.
+    /// </summary>
+    private async Task<byte[]> GetPrgBytesAsync(C64DownloadProgramInfo programInfo, string downloadUrl)
+    {
+        if (_downloadCache != null)
+        {
+            var cached = await _downloadCache.TryGetAsync(programInfo.DownloadUrl);
+            if (cached != null)
+            {
+                _logger.LogInformation(
+                    "Using cached PRG program {DisplayName} for source URL {SourceUrl} ({ByteCount} bytes)",
+                    programInfo.DisplayName,
+                    programInfo.DownloadUrl,
+                    cached.Length);
+                return cached;
+            }
+        }
+
+        _logger.LogInformation(
+            "Downloading PRG program {DisplayName} from source URL {SourceUrl} using request URL {RequestUrl}",
+            programInfo.DisplayName,
+            programInfo.DownloadUrl,
+            downloadUrl);
+
+        using var response = await _httpClient.GetAsync(downloadUrl);
+        response.EnsureSuccessStatusCode();
+        var prgBytes = await response.Content.ReadAsByteArrayAsync();
+
+        if (_downloadCache != null)
+        {
+            try
+            {
+                var etag = response.Headers.ETag?.ToString();
+                var lastModified = response.Content.Headers.LastModified?.ToString("o");
+                await _downloadCache.PutAsync(programInfo.DownloadUrl, prgBytes, "prg", programInfo.DisplayName, etag, lastModified);
+                _logger.LogInformation(
+                    "Added PRG program {DisplayName} to download cache from source URL {SourceUrl} ({ByteCount} bytes)",
+                    programInfo.DisplayName,
+                    programInfo.DownloadUrl,
+                    prgBytes.Length);
+            }
+            catch (Exception ex)
+            {
+                // Caching is best-effort; a cache write failure must not fail the load.
+                _logger.LogWarning(ex, "Failed to cache PRG program {DisplayName} for source URL {SourceUrl}.", programInfo.DisplayName, programInfo.DownloadUrl);
+            }
+        }
+
+        return prgBytes;
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems/Caching/DelegateDownloadCache.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Caching/DelegateDownloadCache.cs
@@ -1,0 +1,71 @@
+namespace Highbyte.DotNet6502.Systems.Caching;
+
+/// <summary>
+/// Delegate-backed <see cref="IDownloadCache"/>. Lets a host supply its own storage backend without
+/// the caching subsystem depending on host-specific APIs — mirroring the
+/// <c>DelegateScriptStore</c> pattern used for the Lua key/value store.
+/// </summary>
+/// <remarks>
+/// Intended for the Avalonia Browser (WASM) host, where the natural backend is IndexedDB accessed via
+/// JS interop (an inherently asynchronous, filesystem-free store). That backend is not wired yet;
+/// this type exists so it can be slotted in without touching the C64 download call sites.
+/// </remarks>
+public sealed class DelegateDownloadCache : IDownloadCache
+{
+    private readonly Func<string, CancellationToken, Task<byte[]?>> _tryGet;
+    private readonly Func<DownloadCacheEntry, byte[], CancellationToken, Task> _put;
+    private readonly Func<CancellationToken, Task<IReadOnlyList<DownloadCacheEntry>>> _list;
+    private readonly Func<string, CancellationToken, Task> _remove;
+    private readonly Func<CancellationToken, Task> _clear;
+
+    public DelegateDownloadCache(
+        Func<string, CancellationToken, Task<byte[]?>> tryGet,
+        Func<DownloadCacheEntry, byte[], CancellationToken, Task> put,
+        Func<CancellationToken, Task<IReadOnlyList<DownloadCacheEntry>>> list,
+        Func<string, CancellationToken, Task> remove,
+        Func<CancellationToken, Task> clear)
+    {
+        _tryGet = tryGet ?? throw new ArgumentNullException(nameof(tryGet));
+        _put = put ?? throw new ArgumentNullException(nameof(put));
+        _list = list ?? throw new ArgumentNullException(nameof(list));
+        _remove = remove ?? throw new ArgumentNullException(nameof(remove));
+        _clear = clear ?? throw new ArgumentNullException(nameof(clear));
+    }
+
+    public Task<byte[]?> TryGetAsync(string url, CancellationToken cancellationToken = default)
+        => _tryGet(url, cancellationToken);
+
+    public Task PutAsync(
+        string url,
+        byte[] content,
+        string extension,
+        string? displayName = null,
+        string? etag = null,
+        string? lastModified = null,
+        CancellationToken cancellationToken = default)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var entry = new DownloadCacheEntry
+        {
+            Url = url,
+            File = url,
+            Extension = extension,
+            Size = content.Length,
+            ETag = etag,
+            LastModified = lastModified,
+            DisplayName = displayName,
+            SavedUtc = now,
+            LastAccessUtc = now,
+        };
+        return _put(entry, content, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<DownloadCacheEntry>> ListAsync(CancellationToken cancellationToken = default)
+        => _list(cancellationToken);
+
+    public Task RemoveAsync(string url, CancellationToken cancellationToken = default)
+        => _remove(url, cancellationToken);
+
+    public Task ClearAsync(CancellationToken cancellationToken = default)
+        => _clear(cancellationToken);
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems/Caching/DownloadCacheDefaults.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Caching/DownloadCacheDefaults.cs
@@ -1,0 +1,10 @@
+namespace Highbyte.DotNet6502.Systems.Caching;
+
+/// <summary>
+/// Shared defaults for download cache backends.
+/// </summary>
+public static class DownloadCacheDefaults
+{
+    /// <summary>Default cap on total cached content size (256 MiB).</summary>
+    public const long MaxTotalBytes = 256L * 1024 * 1024;
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems/Caching/DownloadCacheEviction.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Caching/DownloadCacheEviction.cs
@@ -1,0 +1,35 @@
+namespace Highbyte.DotNet6502.Systems.Caching;
+
+/// <summary>
+/// Shared least-recently-used eviction policy for download-cache backends. Storage-specific
+/// backends decide how to delete the selected entries.
+/// </summary>
+public static class DownloadCacheEviction
+{
+    public static IReadOnlyList<DownloadCacheEntry> SelectLruEvictions(
+        IReadOnlyCollection<DownloadCacheEntry> entries,
+        long maxTotalBytes)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        if (maxTotalBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxTotalBytes), "Cache size cap must be positive.");
+
+        var total = entries.Sum(e => e.Size);
+        if (total <= maxTotalBytes || entries.Count <= 1)
+            return [];
+
+        var remainingCount = entries.Count;
+        var evictions = new List<DownloadCacheEntry>();
+        foreach (var entry in entries.OrderBy(e => e.LastAccessUtc))
+        {
+            if (total <= maxTotalBytes || remainingCount <= 1)
+                break;
+
+            evictions.Add(entry);
+            total -= entry.Size;
+            remainingCount--;
+        }
+
+        return evictions;
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems/Caching/DownloadCacheManifest.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Caching/DownloadCacheManifest.cs
@@ -1,0 +1,66 @@
+using System.Text.Json.Serialization;
+
+namespace Highbyte.DotNet6502.Systems.Caching;
+
+/// <summary>
+/// One entry in the download-cache manifest: a URL mapped to its cached artifact file plus the
+/// metadata needed for integrity checks, LRU eviction, conditional revalidation, and UI inspection.
+/// </summary>
+public sealed class DownloadCacheEntry
+{
+    /// <summary>The original source URL this entry was downloaded from (the cache key).</summary>
+    public string Url { get; set; } = "";
+
+    /// <summary>Content file name (relative to the cache directory), e.g. <c>&lt;sha256(url)&gt;.d64</c>.</summary>
+    public string File { get; set; } = "";
+
+    /// <summary>Bare file extension of the cached artifact, e.g. <c>d64</c> / <c>prg</c>.</summary>
+    public string Extension { get; set; } = "";
+
+    /// <summary>Size of the cached content in bytes (integrity check).</summary>
+    public long Size { get; set; }
+
+    /// <summary>Lower-case hex SHA-256 of the cached content (integrity check).</summary>
+    public string Sha256 { get; set; } = "";
+
+    /// <summary>HTTP <c>ETag</c> validator from the download response, if any.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ETag { get; set; }
+
+    /// <summary>HTTP <c>Last-Modified</c> validator from the download response, if any.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? LastModified { get; set; }
+
+    /// <summary>Friendly display name for inspection UIs, if provided at store time.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    /// <summary>When the entry was first written.</summary>
+    public DateTimeOffset SavedUtc { get; set; }
+
+    /// <summary>When the entry was last read or written (drives LRU eviction).</summary>
+    public DateTimeOffset LastAccessUtc { get; set; }
+}
+
+/// <summary>
+/// The <c>index.json</c> manifest stored alongside the cached content files.
+/// </summary>
+public sealed class DownloadCacheManifest
+{
+    /// <summary>On-disk manifest format version this code reads/writes.</summary>
+    public const int CurrentFormatVersion = 1;
+
+    public int FormatVersion { get; set; } = CurrentFormatVersion;
+    public List<DownloadCacheEntry> Entries { get; set; } = new();
+}
+
+/// <summary>
+/// Source-generated JSON metadata for the download-cache manifest. Using the source generator
+/// (rather than reflection-based serialization) keeps the manifest round-trippable in trimmed / AOT
+/// hosts, matching the pattern used by the snapshot manifest.
+/// </summary>
+[JsonSourceGenerationOptions(WriteIndented = true, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(DownloadCacheManifest))]
+internal partial class DownloadCacheManifestJsonContext : System.Text.Json.Serialization.JsonSerializerContext
+{
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems/Caching/FileDownloadCache.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Caching/FileDownloadCache.cs
@@ -1,0 +1,301 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Highbyte.DotNet6502.Systems.Caching;
+
+/// <summary>
+/// File-system-backed <see cref="IDownloadCache"/>. Stores each cached artifact as a
+/// <c>&lt;sha256(url)&gt;.&lt;ext&gt;</c> blob in a directory, alongside an <c>index.json</c> manifest
+/// holding the URL→file mapping plus integrity, LRU, and HTTP-validator metadata.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reads are integrity-checked (size + SHA-256): a missing, truncated, or corrupt blob is treated
+/// as a miss and pruned so the caller re-downloads rather than loading garbage into the emulator.
+/// </para>
+/// <para>
+/// A total-size cap with least-recently-used eviction keeps the cache from growing unbounded.
+/// All manifest access is serialized through a <see cref="SemaphoreSlim"/>, so concurrent
+/// downloads that hit the same cache stay consistent.
+/// </para>
+/// </remarks>
+public sealed class FileDownloadCache : IDownloadCache
+{
+    /// <summary>Default cap on total cached content size (256 MiB).</summary>
+    public const long DefaultMaxTotalBytes = 256L * 1024 * 1024;
+
+    private const string ManifestFileName = "index.json";
+
+    private readonly string _directory;
+    private readonly long _maxTotalBytes;
+    private readonly ILogger _logger;
+    private readonly SemaphoreSlim _mutex = new(1, 1);
+
+    public FileDownloadCache(string directory, ILoggerFactory loggerFactory, long maxTotalBytes = DefaultMaxTotalBytes)
+    {
+        if (string.IsNullOrWhiteSpace(directory))
+            throw new ArgumentException("Cache directory must be specified.", nameof(directory));
+        if (maxTotalBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxTotalBytes), "Cache size cap must be positive.");
+
+        _directory = Path.GetFullPath(directory);
+        _maxTotalBytes = maxTotalBytes;
+        _logger = loggerFactory.CreateLogger(typeof(FileDownloadCache).Name);
+    }
+
+    public async Task<byte[]?> TryGetAsync(string url, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return null;
+
+        await _mutex.WaitAsync(cancellationToken);
+        try
+        {
+            var manifest = await LoadManifestAsync(cancellationToken);
+            var entry = manifest.Entries.FirstOrDefault(e => e.Url == url);
+            if (entry == null)
+                return null;
+
+            var contentPath = Path.Combine(_directory, entry.File);
+            if (!File.Exists(contentPath))
+            {
+                _logger.LogWarning("Cached file missing for {Url}; pruning entry.", url);
+                manifest.Entries.Remove(entry);
+                await SaveManifestAsync(manifest, cancellationToken);
+                return null;
+            }
+
+            var bytes = await File.ReadAllBytesAsync(contentPath, cancellationToken);
+            if (bytes.Length != entry.Size || ComputeSha256Hex(bytes) != entry.Sha256)
+            {
+                _logger.LogWarning("Cached file for {Url} failed integrity check; pruning and re-downloading.", url);
+                manifest.Entries.Remove(entry);
+                TryDeleteFile(contentPath);
+                await SaveManifestAsync(manifest, cancellationToken);
+                return null;
+            }
+
+            entry.LastAccessUtc = DateTimeOffset.UtcNow;
+            await SaveManifestAsync(manifest, cancellationToken);
+
+            _logger.LogDebug("Download cache hit for {Url} ({Size} bytes).", url, entry.Size);
+            return bytes;
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    public async Task PutAsync(
+        string url,
+        byte[] content,
+        string extension,
+        string? displayName = null,
+        string? etag = null,
+        string? lastModified = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            throw new ArgumentException("URL must be specified.", nameof(url));
+        ArgumentNullException.ThrowIfNull(content);
+
+        await _mutex.WaitAsync(cancellationToken);
+        try
+        {
+            Directory.CreateDirectory(_directory);
+
+            var manifest = await LoadManifestAsync(cancellationToken);
+            var now = DateTimeOffset.UtcNow;
+            var safeExtension = NormalizeExtension(extension);
+            var fileName = $"{ComputeSha256Hex(Encoding.UTF8.GetBytes(url))}.{safeExtension}";
+            var contentPath = Path.Combine(_directory, fileName);
+
+            await File.WriteAllBytesAsync(contentPath, content, cancellationToken);
+
+            var existing = manifest.Entries.FirstOrDefault(e => e.Url == url);
+            var isNewEntry = existing == null;
+            if (existing != null)
+            {
+                // Overwriting: drop any stale blob if the extension (hence file name) changed.
+                if (!string.Equals(existing.File, fileName, StringComparison.Ordinal))
+                    TryDeleteFile(Path.Combine(_directory, existing.File));
+                manifest.Entries.Remove(existing);
+            }
+
+            manifest.Entries.Add(new DownloadCacheEntry
+            {
+                Url = url,
+                File = fileName,
+                Extension = safeExtension,
+                Size = content.Length,
+                Sha256 = ComputeSha256Hex(content),
+                ETag = etag,
+                LastModified = lastModified,
+                DisplayName = displayName,
+                SavedUtc = existing?.SavedUtc ?? now,
+                LastAccessUtc = now,
+            });
+
+            EvictIfOverCap(manifest);
+            await SaveManifestAsync(manifest, cancellationToken);
+
+            _logger.LogDebug(
+                "{Action} download cache entry for {Url} as {File} ({Size} bytes).",
+                isNewEntry ? "Added" : "Updated",
+                url,
+                fileName,
+                content.Length);
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<DownloadCacheEntry>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        await _mutex.WaitAsync(cancellationToken);
+        try
+        {
+            var manifest = await LoadManifestAsync(cancellationToken);
+            return manifest.Entries
+                .OrderByDescending(e => e.LastAccessUtc)
+                .ToList();
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    public async Task RemoveAsync(string url, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return;
+
+        await _mutex.WaitAsync(cancellationToken);
+        try
+        {
+            var manifest = await LoadManifestAsync(cancellationToken);
+            var entry = manifest.Entries.FirstOrDefault(e => e.Url == url);
+            if (entry == null)
+                return;
+
+            manifest.Entries.Remove(entry);
+            TryDeleteFile(Path.Combine(_directory, entry.File));
+            await SaveManifestAsync(manifest, cancellationToken);
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    public async Task ClearAsync(CancellationToken cancellationToken = default)
+    {
+        await _mutex.WaitAsync(cancellationToken);
+        try
+        {
+            var manifest = await LoadManifestAsync(cancellationToken);
+            foreach (var entry in manifest.Entries)
+                TryDeleteFile(Path.Combine(_directory, entry.File));
+
+            manifest.Entries.Clear();
+            await SaveManifestAsync(manifest, cancellationToken);
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    private void EvictIfOverCap(DownloadCacheManifest manifest)
+    {
+        var total = manifest.Entries.Sum(e => e.Size);
+        if (total <= _maxTotalBytes)
+            return;
+
+        // Oldest access first; keep evicting until under the cap (never evict the last entry, so a
+        // single artifact larger than the cap is still usable rather than immediately discarded).
+        foreach (var entry in manifest.Entries.OrderBy(e => e.LastAccessUtc).ToList())
+        {
+            if (total <= _maxTotalBytes || manifest.Entries.Count <= 1)
+                break;
+
+            manifest.Entries.Remove(entry);
+            TryDeleteFile(Path.Combine(_directory, entry.File));
+            total -= entry.Size;
+            _logger.LogInformation("Evicted cached {Url} ({Size} bytes) to stay under cache size cap.", entry.Url, entry.Size);
+        }
+    }
+
+    private async Task<DownloadCacheManifest> LoadManifestAsync(CancellationToken cancellationToken)
+    {
+        var manifestPath = Path.Combine(_directory, ManifestFileName);
+        if (!File.Exists(manifestPath))
+            return new DownloadCacheManifest();
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(manifestPath, cancellationToken);
+            if (string.IsNullOrWhiteSpace(json))
+                return new DownloadCacheManifest();
+
+            return JsonSerializer.Deserialize(json, DownloadCacheManifestJsonContext.Default.DownloadCacheManifest)
+                ?? new DownloadCacheManifest();
+        }
+        catch (Exception ex) when (ex is JsonException or IOException)
+        {
+            _logger.LogWarning(ex, "Download cache manifest unreadable; starting from an empty manifest.");
+            return new DownloadCacheManifest();
+        }
+    }
+
+    private async Task SaveManifestAsync(DownloadCacheManifest manifest, CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(_directory);
+        var manifestPath = Path.Combine(_directory, ManifestFileName);
+        var json = JsonSerializer.Serialize(manifest, DownloadCacheManifestJsonContext.Default.DownloadCacheManifest);
+
+        var tempFile = Path.Combine(_directory, $".{ManifestFileName}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            await File.WriteAllTextAsync(tempFile, json, cancellationToken);
+            File.Move(tempFile, manifestPath, overwrite: true);
+        }
+        finally
+        {
+            TryDeleteFile(tempFile);
+        }
+    }
+
+    private static string NormalizeExtension(string extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+            return "bin";
+
+        var trimmed = extension.Trim().TrimStart('.').ToLowerInvariant();
+        // Keep only characters that are safe in a file name; fall back to "bin" if nothing remains.
+        var cleaned = new string(trimmed.Where(c => char.IsLetterOrDigit(c)).ToArray());
+        return cleaned.Length == 0 ? "bin" : cleaned;
+    }
+
+    private static string ComputeSha256Hex(byte[] bytes)
+        => Convert.ToHexStringLower(SHA256.HashData(bytes));
+
+    private void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (IOException ex)
+        {
+            _logger.LogWarning(ex, "Failed to delete cache file {Path}.", path);
+        }
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems/Caching/FileDownloadCache.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Caching/FileDownloadCache.cs
@@ -23,9 +23,6 @@ namespace Highbyte.DotNet6502.Systems.Caching;
 /// </remarks>
 public sealed class FileDownloadCache : IDownloadCache
 {
-    /// <summary>Default cap on total cached content size (256 MiB).</summary>
-    public const long DefaultMaxTotalBytes = 256L * 1024 * 1024;
-
     private const string ManifestFileName = "index.json";
 
     private readonly string _directory;
@@ -33,7 +30,7 @@ public sealed class FileDownloadCache : IDownloadCache
     private readonly ILogger _logger;
     private readonly SemaphoreSlim _mutex = new(1, 1);
 
-    public FileDownloadCache(string directory, ILoggerFactory loggerFactory, long maxTotalBytes = DefaultMaxTotalBytes)
+    public FileDownloadCache(string directory, ILoggerFactory loggerFactory, long maxTotalBytes = DownloadCacheDefaults.MaxTotalBytes)
     {
         if (string.IsNullOrWhiteSpace(directory))
             throw new ArgumentException("Cache directory must be specified.", nameof(directory));
@@ -214,20 +211,10 @@ public sealed class FileDownloadCache : IDownloadCache
 
     private void EvictIfOverCap(DownloadCacheManifest manifest)
     {
-        var total = manifest.Entries.Sum(e => e.Size);
-        if (total <= _maxTotalBytes)
-            return;
-
-        // Oldest access first; keep evicting until under the cap (never evict the last entry, so a
-        // single artifact larger than the cap is still usable rather than immediately discarded).
-        foreach (var entry in manifest.Entries.OrderBy(e => e.LastAccessUtc).ToList())
+        foreach (var entry in DownloadCacheEviction.SelectLruEvictions(manifest.Entries, _maxTotalBytes))
         {
-            if (total <= _maxTotalBytes || manifest.Entries.Count <= 1)
-                break;
-
             manifest.Entries.Remove(entry);
             TryDeleteFile(Path.Combine(_directory, entry.File));
-            total -= entry.Size;
             _logger.LogInformation("Evicted cached {Url} ({Size} bytes) to stay under cache size cap.", entry.Url, entry.Size);
         }
     }

--- a/src/libraries/Highbyte.DotNet6502.Systems/Caching/IDownloadCache.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Caching/IDownloadCache.cs
@@ -1,0 +1,54 @@
+namespace Highbyte.DotNet6502.Systems.Caching;
+
+/// <summary>
+/// Host-agnostic read-through cache for auto-downloaded, effectively-immutable binary content
+/// keyed by its source URL (e.g. a C64 <c>.d64</c> disk image or a <c>.prg</c> program).
+/// </summary>
+/// <remarks>
+/// The cache is keyed on the <b>original source URL</b>, never a transport-specific variant such as
+/// a CORS-proxied URL. Callers store the <b>final processed artifact</b> (the extracted <c>.d64</c>
+/// / the <c>.prg</c> bytes that actually get loaded), not the raw download.
+///
+/// Two implementations exist today:
+/// <list type="bullet">
+///   <item><see cref="FileDownloadCache"/> — desktop, file-blob + JSON manifest.</item>
+///   <item><see cref="DelegateDownloadCache"/> — host-pluggable (e.g. a future browser IndexedDB backend).</item>
+/// </list>
+/// A <c>null</c> cache reference means "no caching" — callers fall back to always-download.
+/// </remarks>
+public interface IDownloadCache
+{
+    /// <summary>
+    /// Returns the cached content for <paramref name="url"/> if a valid, integrity-checked entry
+    /// exists; otherwise <c>null</c>. A corrupt or truncated entry is treated as a miss (and pruned)
+    /// so the caller re-downloads rather than loading garbage.
+    /// </summary>
+    Task<byte[]?> TryGetAsync(string url, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stores (or overwrites) <paramref name="content"/> for <paramref name="url"/>.
+    /// </summary>
+    /// <param name="url">The original source URL (the cache key).</param>
+    /// <param name="content">The final processed artifact bytes to cache.</param>
+    /// <param name="extension">Bare file extension for the cached artifact, e.g. <c>d64</c> or <c>prg</c>.</param>
+    /// <param name="displayName">Optional friendly name, surfaced when listing cache entries.</param>
+    /// <param name="etag">Optional HTTP <c>ETag</c> validator, stored for future conditional revalidation.</param>
+    /// <param name="lastModified">Optional HTTP <c>Last-Modified</c> validator.</param>
+    Task PutAsync(
+        string url,
+        byte[] content,
+        string extension,
+        string? displayName = null,
+        string? etag = null,
+        string? lastModified = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Returns metadata for all cached entries (for an inspect / clear UI).</summary>
+    Task<IReadOnlyList<DownloadCacheEntry>> ListAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Removes the entry for <paramref name="url"/>. No-op if absent.</summary>
+    Task RemoveAsync(string url, CancellationToken cancellationToken = default);
+
+    /// <summary>Removes every cached entry.</summary>
+    Task ClearAsync(CancellationToken cancellationToken = default);
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems/Configuration/AppStoragePaths.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Configuration/AppStoragePaths.cs
@@ -45,6 +45,22 @@ public static class AppStoragePaths
     public static string GetSnapshotsDirectory()
         => Path.Combine(GetUserContentRoot(), "snapshots");
 
+    /// <summary>
+    /// Root directory for regenerable, machine-local cache data. Anchored at
+    /// <see cref="Environment.SpecialFolder.LocalApplicationData"/> (not <c>MyDocuments</c>) because
+    /// cache is not user-edited content and should stay out of the user's documents / backup / sync.
+    /// Host-agnostic (no per-host segment): cached content is equally valid for any desktop host.
+    /// </summary>
+    public static string GetCacheRoot()
+        => Path.Combine(GetSpecialFolderPath(Environment.SpecialFolder.LocalApplicationData), CompanyFolderName, AppFolderName, "cache");
+
+    /// <summary>
+    /// Directory holding the read-through cache of auto-downloaded content (C64 <c>.d64</c>/<c>.prg</c>).
+    /// See <c>Highbyte.DotNet6502.Systems.Caching.FileDownloadCache</c>.
+    /// </summary>
+    public static string GetDownloadCacheDirectory()
+        => Path.Combine(GetCacheRoot(), "downloads");
+
     private static string GetSpecialFolderPath(Environment.SpecialFolder specialFolder)
     {
         var path = Environment.GetFolderPath(specialFolder);

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Caching/DownloadCacheEvictionTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Caching/DownloadCacheEvictionTests.cs
@@ -1,0 +1,52 @@
+using Highbyte.DotNet6502.Systems.Caching;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Caching;
+
+public class DownloadCacheEvictionTests
+{
+    [Fact]
+    public void SelectLruEvictions_ReturnsEmpty_WhenUnderCap()
+    {
+        var entries = new[]
+        {
+            Entry("a", size: 10, lastAccessOffset: 0),
+            Entry("b", size: 10, lastAccessOffset: 1)
+        };
+
+        Assert.Empty(DownloadCacheEviction.SelectLruEvictions(entries, maxTotalBytes: 20));
+    }
+
+    [Fact]
+    public void SelectLruEvictions_SelectsOldestEntriesUntilUnderCap()
+    {
+        var entries = new[]
+        {
+            Entry("oldest", size: 10, lastAccessOffset: 0),
+            Entry("middle", size: 10, lastAccessOffset: 1),
+            Entry("newest", size: 10, lastAccessOffset: 2)
+        };
+
+        var evictions = DownloadCacheEviction.SelectLruEvictions(entries, maxTotalBytes: 10);
+
+        Assert.Equal(["oldest", "middle"], evictions.Select(e => e.Url));
+    }
+
+    [Fact]
+    public void SelectLruEvictions_KeepsLastEntry_EvenWhenOverCap()
+    {
+        var entries = new[]
+        {
+            Entry("oversized", size: 100, lastAccessOffset: 0)
+        };
+
+        Assert.Empty(DownloadCacheEviction.SelectLruEvictions(entries, maxTotalBytes: 10));
+    }
+
+    private static DownloadCacheEntry Entry(string url, long size, int lastAccessOffset)
+        => new()
+        {
+            Url = url,
+            Size = size,
+            LastAccessUtc = DateTimeOffset.UnixEpoch.AddSeconds(lastAccessOffset)
+        };
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Caching/FileDownloadCacheTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Caching/FileDownloadCacheTests.cs
@@ -19,7 +19,7 @@ public class FileDownloadCacheTests : IDisposable
             Directory.Delete(_directory, recursive: true);
     }
 
-    private FileDownloadCache CreateCache(long maxTotalBytes = FileDownloadCache.DefaultMaxTotalBytes)
+    private FileDownloadCache CreateCache(long maxTotalBytes = DownloadCacheDefaults.MaxTotalBytes)
         => new(_directory, NullLoggerFactory.Instance, maxTotalBytes);
 
     [Fact]

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Caching/FileDownloadCacheTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Caching/FileDownloadCacheTests.cs
@@ -1,0 +1,196 @@
+using System.Text;
+using Highbyte.DotNet6502.Systems.Caching;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Caching;
+
+public class FileDownloadCacheTests : IDisposable
+{
+    private readonly string _directory;
+
+    public FileDownloadCacheTests()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), $"dotnet6502-cache-{Guid.NewGuid():N}");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directory))
+            Directory.Delete(_directory, recursive: true);
+    }
+
+    private FileDownloadCache CreateCache(long maxTotalBytes = FileDownloadCache.DefaultMaxTotalBytes)
+        => new(_directory, NullLoggerFactory.Instance, maxTotalBytes);
+
+    [Fact]
+    public async Task TryGet_ReturnsNull_OnMiss()
+    {
+        var cache = CreateCache();
+        Assert.Null(await cache.TryGetAsync("https://example.com/game.d64"));
+    }
+
+    [Fact]
+    public async Task Put_ThenTryGet_RoundTripsContent()
+    {
+        var cache = CreateCache();
+        var url = "https://example.com/game.d64";
+        var content = Encoding.UTF8.GetBytes("disk-image-bytes");
+
+        await cache.PutAsync(url, content, "d64", displayName: "My Game");
+        var roundTripped = await cache.TryGetAsync(url);
+
+        Assert.NotNull(roundTripped);
+        Assert.Equal(content, roundTripped);
+    }
+
+    [Fact]
+    public async Task Put_WritesContentFileWithExtension_AndManifest()
+    {
+        var cache = CreateCache();
+        await cache.PutAsync("https://example.com/game.prg", new byte[] { 1, 2, 3 }, ".PRG");
+
+        Assert.True(File.Exists(Path.Combine(_directory, "index.json")));
+        Assert.Single(Directory.EnumerateFiles(_directory, "*.prg"));
+    }
+
+    [Fact]
+    public async Task Put_IsKeyedOnUrl_NotProxiedVariant()
+    {
+        var cache = CreateCache();
+        var url = "https://example.com/game.d64";
+        await cache.PutAsync(url, new byte[] { 9 }, "d64");
+
+        // The proxied URL is a different key → miss; the original URL → hit.
+        Assert.Null(await cache.TryGetAsync("https://proxy/?url=" + url));
+        Assert.NotNull(await cache.TryGetAsync(url));
+    }
+
+    [Fact]
+    public async Task Put_OverwritesExistingEntry()
+    {
+        var cache = CreateCache();
+        var url = "https://example.com/game.d64";
+
+        await cache.PutAsync(url, new byte[] { 1 }, "d64");
+        await cache.PutAsync(url, new byte[] { 2, 2 }, "d64");
+
+        var content = await cache.TryGetAsync(url);
+        Assert.Equal(new byte[] { 2, 2 }, content);
+        var entries = await cache.ListAsync();
+        Assert.Single(entries);
+    }
+
+    [Fact]
+    public async Task TryGet_TreatsCorruptContentAsMiss_AndPrunes()
+    {
+        var cache = CreateCache();
+        var url = "https://example.com/game.d64";
+        await cache.PutAsync(url, new byte[] { 1, 2, 3, 4 }, "d64");
+
+        // Corrupt the stored blob so it no longer matches the manifest size/checksum.
+        var contentFile = Directory.EnumerateFiles(_directory, "*.d64").Single();
+        await File.WriteAllBytesAsync(contentFile, new byte[] { 0xFF });
+
+        Assert.Null(await cache.TryGetAsync(url));
+        // Entry is pruned so a re-download is forced next time.
+        Assert.Empty(await cache.ListAsync());
+    }
+
+    [Fact]
+    public async Task TryGet_MissingContentFile_IsPruned()
+    {
+        var cache = CreateCache();
+        var url = "https://example.com/game.d64";
+        await cache.PutAsync(url, new byte[] { 1, 2, 3 }, "d64");
+
+        File.Delete(Directory.EnumerateFiles(_directory, "*.d64").Single());
+
+        Assert.Null(await cache.TryGetAsync(url));
+        Assert.Empty(await cache.ListAsync());
+    }
+
+    [Fact]
+    public async Task Put_StoresValidators_ExposedViaList()
+    {
+        var cache = CreateCache();
+        await cache.PutAsync("https://example.com/game.d64", new byte[] { 1 }, "d64",
+            displayName: "Game", etag: "\"abc\"", lastModified: "Mon, 01 Jan 2024 00:00:00 GMT");
+
+        var entry = Assert.Single(await cache.ListAsync());
+        Assert.Equal("Game", entry.DisplayName);
+        Assert.Equal("\"abc\"", entry.ETag);
+        Assert.Equal("Mon, 01 Jan 2024 00:00:00 GMT", entry.LastModified);
+        Assert.Equal(1, entry.Size);
+    }
+
+    [Fact]
+    public async Task Remove_DeletesEntryAndContentFile()
+    {
+        var cache = CreateCache();
+        var url = "https://example.com/game.d64";
+        await cache.PutAsync(url, new byte[] { 1, 2 }, "d64");
+
+        await cache.RemoveAsync(url);
+
+        Assert.Null(await cache.TryGetAsync(url));
+        Assert.Empty(Directory.EnumerateFiles(_directory, "*.d64"));
+    }
+
+    [Fact]
+    public async Task Clear_RemovesAllEntriesAndFiles()
+    {
+        var cache = CreateCache();
+        await cache.PutAsync("https://example.com/a.d64", new byte[] { 1 }, "d64");
+        await cache.PutAsync("https://example.com/b.prg", new byte[] { 2 }, "prg");
+
+        await cache.ClearAsync();
+
+        Assert.Empty(await cache.ListAsync());
+        Assert.Empty(Directory.EnumerateFiles(_directory, "*.d64"));
+        Assert.Empty(Directory.EnumerateFiles(_directory, "*.prg"));
+    }
+
+    [Fact]
+    public async Task Put_EvictsLeastRecentlyUsed_WhenOverSizeCap()
+    {
+        // Cap of 20 bytes; each entry is 10 bytes, so the 3rd Put must evict one.
+        var cache = CreateCache(maxTotalBytes: 20);
+        var ten = new byte[10];
+
+        await cache.PutAsync("https://example.com/a.d64", ten, "d64");
+        await cache.PutAsync("https://example.com/b.d64", ten, "d64");
+
+        // Touch "a" so "b" becomes the least-recently-used.
+        Assert.NotNull(await cache.TryGetAsync("https://example.com/a.d64"));
+
+        await cache.PutAsync("https://example.com/c.d64", ten, "d64");
+
+        Assert.NotNull(await cache.TryGetAsync("https://example.com/a.d64"));
+        Assert.NotNull(await cache.TryGetAsync("https://example.com/c.d64"));
+        Assert.Null(await cache.TryGetAsync("https://example.com/b.d64"));
+    }
+
+    [Fact]
+    public async Task Put_SingleArtifactLargerThanCap_IsStillUsable()
+    {
+        var cache = CreateCache(maxTotalBytes: 4);
+        var url = "https://example.com/big.d64";
+        var big = new byte[16];
+
+        await cache.PutAsync(url, big, "d64");
+
+        Assert.NotNull(await cache.TryGetAsync(url));
+    }
+
+    [Fact]
+    public async Task NewCacheInstance_ReadsPersistedManifest()
+    {
+        var url = "https://example.com/game.d64";
+        var content = new byte[] { 4, 5, 6 };
+        await CreateCache().PutAsync(url, content, "d64");
+
+        // A fresh instance over the same directory should see the persisted entry.
+        var reopened = await CreateCache().TryGetAsync(url);
+        Assert.Equal(content, reopened);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/TimerAndPeripheral/DiskDrive/D64/Download/D64DownloaderCacheTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/TimerAndPeripheral/DiskDrive/D64/Download/D64DownloaderCacheTests.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using Highbyte.DotNet6502.Systems.Caching;
+using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.DiskDrive.Download;
+using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral.DiskDrive.D64.Download;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64.TimerAndPeripheral.DiskDrive.D64.Download;
+
+/// <summary>
+/// Verifies the read-through cache wiring in <see cref="D64Downloader"/>: a first download populates
+/// the cache; a second call for the same URL is served from the cache without another network fetch.
+/// </summary>
+public class D64DownloaderCacheTests : IDisposable
+{
+    private readonly string _cacheDir;
+
+    public D64DownloaderCacheTests()
+    {
+        _cacheDir = Path.Combine(Path.GetTempPath(), $"dotnet6502-d64cache-{Guid.NewGuid():N}");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_cacheDir))
+            Directory.Delete(_cacheDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task DownloadAndProcessDiskImage_CachesFirstDownload_AndServesSecondFromCache()
+    {
+        var d64Bytes = new byte[] { 0x10, 0x20, 0x30, 0x40 };
+        var handler = new CountingHandler(d64Bytes);
+        var httpClient = new HttpClient(handler);
+        var cache = new FileDownloadCache(_cacheDir, NullLoggerFactory.Instance);
+
+        var downloader = new D64Downloader(NullLoggerFactory.Instance, httpClient, corsProxyUrl: null, downloadCache: cache);
+        var diskInfo = new C64DownloadProgramInfo(
+            displayName: "Game",
+            downloadUrl: "https://example.com/game.d64",
+            downloadType: C64DownloadProgramType.D64);
+
+        var first = await downloader.DownloadAndProcessDiskImage(diskInfo);
+        var second = await downloader.DownloadAndProcessDiskImage(diskInfo);
+
+        Assert.Equal(d64Bytes, first);
+        Assert.Equal(d64Bytes, second);
+        // The second call must be a cache hit — only one network request total.
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task DownloadAndProcessDiskImage_WithoutCache_AlwaysDownloads()
+    {
+        var d64Bytes = new byte[] { 1, 2 };
+        var handler = new CountingHandler(d64Bytes);
+        var httpClient = new HttpClient(handler);
+
+        var downloader = new D64Downloader(NullLoggerFactory.Instance, httpClient, corsProxyUrl: null, downloadCache: null);
+        var diskInfo = new C64DownloadProgramInfo(
+            displayName: "Game",
+            downloadUrl: "https://example.com/game.d64",
+            downloadType: C64DownloadProgramType.D64);
+
+        await downloader.DownloadAndProcessDiskImage(diskInfo);
+        await downloader.DownloadAndProcessDiskImage(diskInfo);
+
+        Assert.Equal(2, handler.RequestCount);
+    }
+
+    private sealed class CountingHandler : HttpMessageHandler
+    {
+        private readonly byte[] _content;
+        public int RequestCount { get; private set; }
+
+        public CountingHandler(byte[] content) => _content = content;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(_content),
+            });
+        }
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Configuration/AppStoragePathsTest.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Configuration/AppStoragePathsTest.cs
@@ -35,6 +35,20 @@ public class AppStoragePathsTest
     }
 
     [Fact]
+    public void DownloadCacheDirectory_UsesLocalAppDataCacheFolder()
+    {
+        var cacheRoot = AppStoragePaths.GetCacheRoot();
+        var downloads = AppStoragePaths.GetDownloadCacheDirectory();
+
+        Assert.EndsWith(Path.Combine(AppStoragePaths.CompanyFolderName, AppStoragePaths.AppFolderName, "cache"), cacheRoot);
+        Assert.EndsWith(Path.Combine(AppStoragePaths.CompanyFolderName, AppStoragePaths.AppFolderName, "cache", "downloads"), downloads);
+        Assert.StartsWith(cacheRoot, downloads);
+
+        // Cache is machine-local (LocalApplicationData), not under the user-facing content root (MyDocuments).
+        Assert.DoesNotContain(AppStoragePaths.GetUserContentRoot(), cacheRoot);
+    }
+
+    [Fact]
     public async Task MergeSectionAsync_CreatesFileAndMergesNestedSection()
     {
         var directory = Path.Combine(Path.GetTempPath(), $"dotnet6502-settings-{Guid.NewGuid():N}");


### PR DESCRIPTION
## Summary
Adds a read-through cache for the C64 "download & run" feature so effectively-immutable content (`.d64` disk images, `.prg` programs) fetched from the internet is only downloaded once. On subsequent runs the emulator loads straight from a local cache instead of re-hitting the network.

## What changed
- **New host-agnostic caching abstraction** (`Highbyte.DotNet6502.Systems/Caching`):
  - `IDownloadCache` — keyed on the **original source URL** (never a CORS-proxied variant), storing the **final processed artifact** bytes.
  - `FileDownloadCache` — desktop file-backed implementation: `<sha256(url)>.<ext>` blobs plus a JSON manifest, with SHA-256 integrity checks (corrupt/truncated entries treated as a miss and pruned), and a total-size cap with LRU eviction (default 256 MiB).
  - `DelegateDownloadCache` — pluggable backend seam for a future browser IndexedDB implementation.
- **Wired cache into the download flow**: `D64Downloader`, `C64AutoLoadAndRun`, and the `.d64`/`.prg` content loaders are now cache-first — a cache hit skips the network entirely; misses download, then populate the cache.
- **Storage path**: `AppStoragePaths.GetDownloadCacheDirectory()` for the desktop cache location.
- **Logging**: Information-level logs distinguish cache hits (`Using cached…`), downloads, and new entries (`Added…to download cache`).

## Behavior notes
- A `null` cache reference means "no caching" — callers fall back to always-download.
- **Desktop** (Terminal + Avalonia): caching active. **Browser/WASM**: still passes a `null` cache; IndexedDB backend deferred to a follow-up.

## Tests
- `FileDownloadCacheTests` — hit/miss, integrity validation, LRU eviction.
- `D64DownloaderCacheTests` — cache-first / no-network-on-hit behavior.
- `AppStoragePathsTest` — cache directory resolution.
