### PR TITLE
Feature/app self update

### DIFF
--- a/.github/workflows/release-desktop-apps.yml
+++ b/.github/workflows/release-desktop-apps.yml
@@ -33,6 +33,16 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      # Stamp the release version (tag without leading "v", e.g. "0.40.2-alpha") into the
+      # published app assemblies so the in-app update checker can compare against GitHub
+      # releases. Only set on the `release` trigger; for `workflow_dispatch` it stays empty,
+      # so publish.sh leaves the default 1.0.0 (treated as "unknown -> skip update check").
+      - name: Determine release version
+        if: github.event_name == 'release'
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: echo "RELEASE_VERSION=${TAG_NAME#v}" >> "$GITHUB_ENV"
+
       - name: Publish SilkNetNative App
         run: |
           chmod u+x src/apps/SilkNetNative/Highbyte.DotNet6502.App.SilkNetNative/publish.sh

--- a/dotnet-6502.slnx
+++ b/dotnet-6502.slnx
@@ -61,6 +61,7 @@
     <Project Path="src/libraries/Highbyte.DotNet6502.Systems.Generic/Highbyte.DotNet6502.Systems.Generic.csproj" />
     <Project Path="src/libraries/Highbyte.DotNet6502.Systems.Vic20/Highbyte.DotNet6502.Systems.Vic20.csproj" />
     <Project Path="src/libraries/Highbyte.DotNet6502.Systems/Highbyte.DotNet6502.Systems.csproj" />
+    <Project Path="src/libraries/Highbyte.DotNet6502.Updates/Highbyte.DotNet6502.Updates.csproj" />
     <Project Path="src/libraries/Highbyte.DotNet6502/Highbyte.DotNet6502.csproj" />
   </Folder>
   <Folder Name="/Solution Items/">
@@ -95,5 +96,6 @@
     <Project Path="tests/Highbyte.DotNet6502.Monitor.Tests/Highbyte.DotNet6502.Monitor.Tests.csproj" />
     <Project Path="tests/Highbyte.DotNet6502.Systems.Tests/Highbyte.DotNet6502.Systems.Tests.csproj" />
     <Project Path="tests/Highbyte.DotNet6502.Tests/Highbyte.DotNet6502.Tests.csproj" />
+    <Project Path="tests/Highbyte.DotNet6502.Updates.Tests/Highbyte.DotNet6502.Updates.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/wwwroot/index.html
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/wwwroot/index.html
@@ -37,10 +37,12 @@ function checkForUpdates() {
 function showUpdateNotification() {
     const notification = document.createElement('div');
     notification.id = 'update-notification';
+    // Update-notice green (Material Green 800). Kept in sync with the Avalonia desktop app's update
+    // banner (Core/Views/MainWindow.axaml) so both surfaces match; deep enough for readable white text.
     notification.innerHTML = `
-        <div style="position: fixed; top: 0; left: 0; right: 0; background: #4CAF50; color: white; padding: 12px; text-align: center; z-index: 10000; font-family: Arial, sans-serif;">
+        <div style="position: fixed; top: 0; left: 0; right: 0; background: #2E7D32; color: white; padding: 12px; text-align: center; z-index: 10000; font-family: Arial, sans-serif;">
             <span>🔄 A new version is available! </span>
-            <button onclick="forceRefresh()" style="margin-left: 10px; padding: 4px 12px; background: white; color: #4CAF50; border: none; border-radius: 4px; cursor: pointer;">
+            <button onclick="forceRefresh()" style="margin-left: 10px; padding: 4px 12px; background: white; color: #2E7D32; border: none; border-radius: 4px; cursor: pointer;">
                 Update Now
             </button>
             <button onclick="dismissUpdate()" style="margin-left: 8px; padding: 4px 8px; background: transparent; color: white; border: 1px solid white; border-radius: 4px; cursor: pointer;">

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/App.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/App.axaml.cs
@@ -50,6 +50,7 @@ public partial class App : Application
     private readonly Func<IHostApp, Task>? _automatedStartupRunner;
     private readonly IAppFilePicker? _appFilePicker;
     private readonly IAppFileSaver? _appFileSaver;
+    private readonly Services.IAppUpdateService? _appUpdateService;
     private readonly Func<IDownloadCache?>? _downloadCacheFactory;
     private AvaloniaHostApp _hostApp = default!;
     private IServiceProvider _serviceProvider = default!;
@@ -140,7 +141,8 @@ public partial class App : Application
         Func<IHostApp, Task>? automatedStartupRunner = null,
         IAppFilePicker? appFilePicker = null,
         IAppFileSaver? appFileSaver = null,
-        Func<IDownloadCache?>? downloadCacheFactory = null)
+        Func<IDownloadCache?>? downloadCacheFactory = null,
+        Services.IAppUpdateService? appUpdateService = null)
     {
         WriteBootstrapLog("App constructor called");
 
@@ -161,6 +163,7 @@ public partial class App : Application
         _appFilePicker = appFilePicker;
         _appFileSaver = appFileSaver;
         _downloadCacheFactory = downloadCacheFactory;
+        _appUpdateService = appUpdateService;
 
         // Set static reference for external access (e.g., debug adapter)
         Current = this;
@@ -322,6 +325,9 @@ public partial class App : Application
         services.AddSingleton(new CustomConfigPersistence(_saveCustomConfigString));
         services.AddSingleton<IAppFilePicker>(_appFilePicker ?? new AvaloniaStorageAppFilePicker());
         services.AddSingleton<IAppFileSaver>(_appFileSaver ?? new AvaloniaStorageAppFileSaver());
+        // The desktop host supplies a real update service; the browser host leaves it null (no
+        // package-manager update path there), so the update UI stays inert via NullAppUpdateService.
+        services.AddSingleton<Services.IAppUpdateService>(_appUpdateService ?? new Services.NullAppUpdateService());
         if (_logStore != null)
             services.AddSingleton(_logStore);
         if (_logConfig != null)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/EmulatorConfig.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/EmulatorConfig.cs
@@ -77,6 +77,13 @@ public class EmulatorConfig
     public bool DownloadCacheEnabled { get; set; } = true;
 
     /// <summary>
+    /// Enables the automatic startup check for a newer released version (brew/scoop installs only).
+    /// Also suppressed by the <c>CI</c> env var or <c>DOTNET6502_NO_UPDATE_CHECK</c>. The explicit
+    /// "Check now" button in the About dialog ignores this and always checks.
+    /// </summary>
+    public bool UpdateCheckEnabled { get; set; } = true;
+
+    /// <summary>
     /// The effective CORS proxy URL to use: the configured <see cref="CorsProxyUrl"/> (falling back
     /// to <see cref="BrowserServiceDefaults.DefaultCorsProxyUrl"/> when blank) in the browser, or
     /// <see langword="null"/> on desktop where cross-origin fetches are unrestricted.
@@ -193,6 +200,7 @@ public class EmulatorConfig
             SnapshotDirectory = OperatingSystem.IsBrowser() ? null : SnapshotDirectory,
             CorsProxyUrl = CorsProxyUrl,
             DownloadCacheEnabled = DownloadCacheEnabled,
+            UpdateCheckEnabled = UpdateCheckEnabled,
             AudioSettingsProfile = AudioSettingsProfile,
             BrowserSampleAudioMode = BrowserSampleAudioMode,
             Monitor = new EmulatorMonitorUserSettings
@@ -218,6 +226,7 @@ internal sealed class EmulatorConfigUserSettings
     public string? SnapshotDirectory { get; set; }
     public string CorsProxyUrl { get; set; } = BrowserServiceDefaults.DefaultCorsProxyUrl;
     public bool DownloadCacheEnabled { get; set; } = true;
+    public bool UpdateCheckEnabled { get; set; } = true;
     [JsonConverter(typeof(JsonStringEnumConverter<WavePlayerSettingsProfile>))]
     public WavePlayerSettingsProfile AudioSettingsProfile { get; set; } = WavePlayerSettingsProfile.Balanced;
     [JsonConverter(typeof(JsonStringEnumConverter<BrowserSampleAudioMode>))]

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Services/IAppUpdateService.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Services/IAppUpdateService.cs
@@ -1,0 +1,75 @@
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Core.Services;
+
+/// <summary>
+/// Result of an update check, in terms the UI needs — deliberately free of any
+/// <c>Highbyte.DotNet6502.Updates</c> type so this abstraction (and the whole Core project, which the
+/// WASM/browser build AOT-compiles) never references the process/HTTP-using update library. The
+/// desktop host maps its <c>UpdateCheckResult</c> onto this.
+/// </summary>
+public sealed record AppUpdateStatus(
+    bool IsManaged,
+    bool IsUpdateAvailable,
+    string CurrentVersionDisplay,
+    string? LatestVersionDisplay,
+    string? SuggestedCommand,
+    string? ReleaseNotesUrl,
+    bool IsDismissed);
+
+/// <summary>
+/// Host-provided update capability. Implemented by the desktop host (backed by the Updates library);
+/// the browser host gets <see cref="NullAppUpdateService"/> (<see cref="IsSupported"/> = false), which
+/// keeps the update UI inert there per the feature scope.
+/// </summary>
+public interface IAppUpdateService
+{
+    /// <summary>False on platforms with no package-manager update path (browser). Gates all update UI.</summary>
+    bool IsSupported { get; }
+
+    /// <summary>Current app version for display, e.g. <c>v0.40.2-alpha</c> or <c>development build</c>.</summary>
+    string CurrentVersionDisplay { get; }
+
+    /// <summary>
+    /// Runs a check (respecting the daily cadence cache unless <paramref name="force"/>), or returns
+    /// null when unsupported / suppressed. Never throws for the expected failure modes.
+    /// </summary>
+    Task<AppUpdateStatus?> CheckAsync(bool force, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Records that the user dismissed the banner for <paramref name="versionDisplay"/> (the
+    /// <see cref="AppUpdateStatus.LatestVersionDisplay"/> value), so it won't reappear for that version
+    /// on future launches — but a newer version still will. Persisted; a no-op when unsupported.
+    /// </summary>
+    void DismissVersion(string versionDisplay);
+}
+
+/// <summary>No-op update service for hosts without a package-manager channel (browser). Shows the version only.</summary>
+public sealed class NullAppUpdateService : IAppUpdateService
+{
+    public bool IsSupported => false;
+
+    public string CurrentVersionDisplay { get; } = ReadEntryAssemblyVersionDisplay();
+
+    public Task<AppUpdateStatus?> CheckAsync(bool force, CancellationToken cancellationToken = default)
+        => Task.FromResult<AppUpdateStatus?>(null);
+
+    public void DismissVersion(string versionDisplay)
+    {
+        // No update path here, so nothing to remember.
+    }
+
+    private static string ReadEntryAssemblyVersionDisplay()
+    {
+        var raw = Assembly.GetEntryAssembly()?
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (string.IsNullOrWhiteSpace(raw))
+            return "unknown";
+        // Strip any SourceLink "+build" metadata.
+        var plus = raw.IndexOf('+');
+        var version = plus >= 0 ? raw[..plus] : raw;
+        return version is "1.0.0" ? "development build" : $"v{version}";
+    }
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Services/IAppUpdateService.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Services/IAppUpdateService.cs
@@ -44,6 +44,20 @@ public interface IAppUpdateService
     /// on future launches — but a newer version still will. Persisted; a no-op when unsupported.
     /// </summary>
     void DismissVersion(string versionDisplay);
+
+    /// <summary>
+    /// One-click self-update: spawns the detached "wait for this app to exit → run the package-manager
+    /// upgrade → relaunch" helper. Returns true if the helper was spawned, in which case the caller
+    /// must quit the app so the upgrade can proceed. False when unsupported, not managed, or no update.
+    /// </summary>
+    Task<bool> TryStartSelfUpdateAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// One-shot check on startup: if a previous one-click update was started but the version didn't
+    /// change (the upgrade failed / didn't take effect), returns a short notice to show the user (once);
+    /// otherwise null. Consumes the pending-update marker so it never fires twice.
+    /// </summary>
+    string? ConsumeFailedUpdateNotice();
 }
 
 /// <summary>No-op update service for hosts without a package-manager channel (browser). Shows the version only.</summary>
@@ -60,6 +74,11 @@ public sealed class NullAppUpdateService : IAppUpdateService
     {
         // No update path here, so nothing to remember.
     }
+
+    public Task<bool> TryStartSelfUpdateAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+
+    public string? ConsumeFailedUpdateNotice() => null;
 
     private static string ReadEntryAssemblyVersionDisplay()
     {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/AboutViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/AboutViewModel.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Reactive;
+using System.Threading.Tasks;
+using Highbyte.DotNet6502.App.Avalonia.Core.Services;
+using ReactiveUI;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
+
+/// <summary>
+/// Backs the About dialog: always shows the current version, and for a package-manager install adds
+/// the update status, the exact <c>brew</c>/<c>scoop</c> command to copy, and a "What's new" link.
+/// </summary>
+public class AboutViewModel : ViewModelBase
+{
+    private readonly IAppUpdateService _updateService;
+
+    private string _statusText = string.Empty;
+    private bool _isChecking;
+    private bool _isUpdateAvailable;
+    private string? _latestVersionDisplay;
+    private string? _suggestedCommand;
+    private string? _releaseNotesUrl;
+
+    /// <summary>Raised when the dialog should close (host removes the overlay).</summary>
+    public event EventHandler? RequestClose;
+
+    public AboutViewModel(IAppUpdateService updateService)
+    {
+        _updateService = updateService;
+        CurrentVersionDisplay = updateService.CurrentVersionDisplay;
+        IsUpdateCheckSupported = updateService.IsSupported;
+
+        CheckNowCommand = ReactiveCommandHelper.CreateSafeCommand(() => CheckAsync(force: true));
+        CloseCommand = ReactiveCommandHelper.CreateSafeCommand(() => RequestClose?.Invoke(this, EventArgs.Empty));
+
+        StatusText = IsUpdateCheckSupported
+            ? "Checking for updates…"
+            : "Update checks aren't available for this build.";
+
+        if (IsUpdateCheckSupported)
+            _ = CheckAsync(force: false); // populate from the cadence cache on open
+    }
+
+    public string CurrentVersionDisplay { get; }
+    public bool IsUpdateCheckSupported { get; }
+
+    public ReactiveCommand<Unit, Unit> CheckNowCommand { get; }
+    public ReactiveCommand<Unit, Unit> CloseCommand { get; }
+
+    public string StatusText
+    {
+        get => _statusText;
+        private set => this.RaiseAndSetIfChanged(ref _statusText, value);
+    }
+
+    public bool IsChecking
+    {
+        get => _isChecking;
+        private set => this.RaiseAndSetIfChanged(ref _isChecking, value);
+    }
+
+    public bool IsUpdateAvailable
+    {
+        get => _isUpdateAvailable;
+        private set => this.RaiseAndSetIfChanged(ref _isUpdateAvailable, value);
+    }
+
+    public string? LatestVersionDisplay
+    {
+        get => _latestVersionDisplay;
+        private set => this.RaiseAndSetIfChanged(ref _latestVersionDisplay, value);
+    }
+
+    /// <summary>The <c>brew</c>/<c>scoop</c> command to run; non-null only when an update is available.</summary>
+    public string? SuggestedCommand
+    {
+        get => _suggestedCommand;
+        private set
+        {
+            this.RaiseAndSetIfChanged(ref _suggestedCommand, value);
+            this.RaisePropertyChanged(nameof(HasSuggestedCommand));
+        }
+    }
+
+    public bool HasSuggestedCommand => !string.IsNullOrEmpty(_suggestedCommand);
+
+    public string? ReleaseNotesUrl
+    {
+        get => _releaseNotesUrl;
+        private set
+        {
+            this.RaiseAndSetIfChanged(ref _releaseNotesUrl, value);
+            this.RaisePropertyChanged(nameof(HasReleaseNotes));
+        }
+    }
+
+    public bool HasReleaseNotes => !string.IsNullOrEmpty(_releaseNotesUrl);
+
+    private async Task CheckAsync(bool force)
+    {
+        if (!IsUpdateCheckSupported || IsChecking)
+            return;
+
+        IsChecking = true;
+        StatusText = "Checking for updates…";
+        try
+        {
+            var status = await _updateService.CheckAsync(force);
+            ApplyStatus(status);
+        }
+        catch (Exception ex)
+        {
+            IsUpdateAvailable = false;
+            SuggestedCommand = null;
+            ReleaseNotesUrl = null;
+            StatusText = $"Update check failed: {ex.Message}";
+        }
+        finally
+        {
+            IsChecking = false;
+        }
+    }
+
+    private void ApplyStatus(AppUpdateStatus? status)
+    {
+        if (status is null)
+        {
+            StatusText = "Update checks aren't available for this build.";
+            IsUpdateAvailable = false;
+            SuggestedCommand = null;
+            ReleaseNotesUrl = null;
+            return;
+        }
+
+        IsUpdateAvailable = status.IsUpdateAvailable;
+        SuggestedCommand = status.SuggestedCommand;
+        ReleaseNotesUrl = status.ReleaseNotesUrl;
+        LatestVersionDisplay = status.LatestVersionDisplay;
+
+        if (!status.IsManaged)
+            StatusText = "This build isn't installed via Homebrew or Scoop, so there's no update to check for.";
+        else if (status.IsUpdateAvailable)
+            StatusText = $"Update available: {status.CurrentVersionDisplay} → {status.LatestVersionDisplay}";
+        else
+            StatusText = $"You're on the latest version ({status.CurrentVersionDisplay}).";
+    }
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/AboutViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/AboutViewModel.cs
@@ -24,28 +24,36 @@ public class AboutViewModel : ViewModelBase
     /// <summary>Raised when the dialog should close (host removes the overlay).</summary>
     public event EventHandler? RequestClose;
 
+    /// <summary>Raised after the one-click self-update helper was spawned — the host must now quit the app.</summary>
+    public event EventHandler? UpdateStarted;
+
     public AboutViewModel(IAppUpdateService updateService)
     {
         _updateService = updateService;
         CurrentVersionDisplay = updateService.CurrentVersionDisplay;
         IsUpdateCheckSupported = updateService.IsSupported;
 
-        CheckNowCommand = ReactiveCommandHelper.CreateSafeCommand(() => CheckAsync(force: true));
+        UpdateNowCommand = ReactiveCommandHelper.CreateSafeCommand(UpdateNowAsync);
         CloseCommand = ReactiveCommandHelper.CreateSafeCommand(() => RequestClose?.Invoke(this, EventArgs.Empty));
 
         StatusText = IsUpdateCheckSupported
             ? "Checking for updates…"
             : "Update checks aren't available for this build.";
 
+        // Opening the About dialog is an explicit user action, so always run a fresh check (force:true
+        // bypasses the daily cadence and the disabled-setting/CI gating). No separate "Check now" needed.
         if (IsUpdateCheckSupported)
-            _ = CheckAsync(force: false); // populate from the cadence cache on open
+            _ = CheckAsync(force: true);
     }
 
     public string CurrentVersionDisplay { get; }
     public bool IsUpdateCheckSupported { get; }
 
-    public ReactiveCommand<Unit, Unit> CheckNowCommand { get; }
+    public ReactiveCommand<Unit, Unit> UpdateNowCommand { get; }
     public ReactiveCommand<Unit, Unit> CloseCommand { get; }
+
+    /// <summary>True when a one-click update can be started (managed install with an available update).</summary>
+    public bool CanUpdateNow => IsUpdateCheckSupported && _isUpdateAvailable;
 
     public string StatusText
     {
@@ -62,7 +70,11 @@ public class AboutViewModel : ViewModelBase
     public bool IsUpdateAvailable
     {
         get => _isUpdateAvailable;
-        private set => this.RaiseAndSetIfChanged(ref _isUpdateAvailable, value);
+        private set
+        {
+            this.RaiseAndSetIfChanged(ref _isUpdateAvailable, value);
+            this.RaisePropertyChanged(nameof(CanUpdateNow));
+        }
     }
 
     public string? LatestVersionDisplay
@@ -95,6 +107,16 @@ public class AboutViewModel : ViewModelBase
     }
 
     public bool HasReleaseNotes => !string.IsNullOrEmpty(_releaseNotesUrl);
+
+    private async Task UpdateNowAsync()
+    {
+        StatusText = "Starting update...";
+        var started = await _updateService.TryStartSelfUpdateAsync();
+        if (started)
+            UpdateStarted?.Invoke(this, EventArgs.Empty); // host quits the app so the upgrade can proceed
+        else
+            StatusText = "Could not start the automatic update. Copy the command above and run it manually.";
+    }
 
     private async Task CheckAsync(bool force)
     {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/EmulatorConfigViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/EmulatorConfigViewModel.cs
@@ -37,6 +37,7 @@ public class EmulatorConfigViewModel : ViewModelBase
     private bool _allowUrlScripts;
     private string _corsProxyUrl;
     private bool _downloadCacheEnabled;
+    private bool _updateCheckEnabled;
 
     public ReactiveCommand<Unit, Unit> SaveCommand { get; }
     public ReactiveCommand<Unit, Unit> CancelCommand { get; }
@@ -70,6 +71,7 @@ public class EmulatorConfigViewModel : ViewModelBase
         _allowUrlScripts = _hostApp.ScriptingEngine.AllowUrlScripts;
         _corsProxyUrl = _emulatorConfig.CorsProxyUrl;
         _downloadCacheEnabled = _emulatorConfig.DownloadCacheEnabled;
+        _updateCheckEnabled = _emulatorConfig.UpdateCheckEnabled;
 
         // Initialize ReactiveUI Commands with MainThreadScheduler for Browser compatibility
         SaveCommand = ReactiveCommandHelper.CreateSafeCommand(
@@ -338,6 +340,23 @@ public class EmulatorConfigViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// Enables the automatic startup check for a newer released version (brew/scoop installs only).
+    /// Also suppressed by the <c>CI</c> env var or <c>DOTNET6502_NO_UPDATE_CHECK</c>; the About
+    /// dialog's "Check now" button always checks regardless.
+    /// </summary>
+    public bool UpdateCheckEnabled
+    {
+        get => _updateCheckEnabled;
+        set
+        {
+            if (_updateCheckEnabled == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _updateCheckEnabled, value);
+        }
+    }
+
     private void UpdateValidation()
     {
         _validationErrors.Clear();
@@ -372,6 +391,7 @@ public class EmulatorConfigViewModel : ViewModelBase
         AllowUrlScripts = false;
         CorsProxyUrl = defaults.CorsProxyUrl;
         DownloadCacheEnabled = defaults.DownloadCacheEnabled;
+        UpdateCheckEnabled = defaults.UpdateCheckEnabled;
 
         UpdateValidation();
         StatusMessage = "Settings reset to defaults. Click Save to apply.";
@@ -431,6 +451,7 @@ public class EmulatorConfigViewModel : ViewModelBase
                 _emulatorConfig.SnapshotDirectory = _snapshotDirectory;
             _emulatorConfig.CorsProxyUrl = _corsProxyUrl;
             _emulatorConfig.DownloadCacheEnabled = _downloadCacheEnabled;
+            _emulatorConfig.UpdateCheckEnabled = _updateCheckEnabled;
 
             // Persist emulator config (note: the _emulatorConfig object is owned by AvaloniaHostApp)
             await _hostApp.PersistEmulatorConfigAsync();

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/MainViewModel.cs
@@ -28,6 +28,7 @@ public class MainViewModel : ViewModelBase, IDisposable
 {
     private readonly AvaloniaHostApp _hostApp;
     private readonly EmulatorConfig _emulatorConfig;
+    private readonly Services.IAppUpdateService _appUpdateService;
     private readonly ILogger _logger;
 
     // Expose HostApp for EmulatorView that currently needs it (TODO: Consider removing this dependency via MainViewModel. Better that EmulatorViewModel provides it.)
@@ -638,6 +639,14 @@ public class MainViewModel : ViewModelBase, IDisposable
 
     public ReactiveCommand<Unit, Unit> EmulatorOptionsCommand { get; }
 
+    // Event for requesting the About / updates overlay (UI operation handled in View)
+    public event EventHandler? AboutRequested;
+
+    public ReactiveCommand<Unit, Unit> AboutCommand { get; }
+
+    /// <summary>Drives the dismissible "update available" banner (desktop host only). Never null.</summary>
+    public UpdateBannerViewModel UpdateBanner { get; }
+
     // --- End ReactiveUI Commands ---
 
     //public string Version => System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "Unknown";
@@ -675,15 +684,21 @@ public class MainViewModel : ViewModelBase, IDisposable
         StatisticsViewModel statisticsViewModel,
         EmulatorViewModel emulatorViewModel,
         EmulatorPlaceholderViewModel emulatorPlaceholderViewModel,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        Services.IAppUpdateService appUpdateService)
     {
         _hostApp = hostApp ?? throw new ArgumentNullException(nameof(hostApp));
         _emulatorConfig = emulatorConfig;
+        _appUpdateService = appUpdateService ?? throw new ArgumentNullException(nameof(appUpdateService));
         _logger = loggerFactory?.CreateLogger(nameof(MainViewModel)) ?? throw new ArgumentNullException(nameof(loggerFactory));
 
         _shellPlugins = (shellPlugins ?? throw new ArgumentNullException(nameof(shellPlugins)))
             .ToDictionary(p => p.SystemName, p => p, StringComparer.OrdinalIgnoreCase);
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+
+        // Update-available banner (desktop host only; a no-op NullAppUpdateService keeps it hidden in browser).
+        UpdateBanner = new UpdateBannerViewModel(_appUpdateService);
+        UpdateBanner.DetailsRequested += (_, _) => AboutRequested?.Invoke(this, EventArgs.Empty);
 
         // Store injected child ViewModels
         StatisticsViewModel = statisticsViewModel ?? throw new ArgumentNullException(nameof(statisticsViewModel));
@@ -1115,6 +1130,11 @@ public class MainViewModel : ViewModelBase, IDisposable
                 state => state == EmulatorState.Uninitialized),
             RxSchedulers.MainThreadScheduler);
 
+        AboutCommand = ReactiveCommandHelper.CreateSafeCommand(
+            () => AboutRequested?.Invoke(this, EventArgs.Empty),
+            null,
+            RxSchedulers.MainThreadScheduler);
+
         // Initialize timer for batched log UI updates
         InitializeLogUpdateTimer();
 
@@ -1158,6 +1178,12 @@ public class MainViewModel : ViewModelBase, IDisposable
         RefreshScriptStatuses();
         _hostApp.ScriptingEngine.ScriptStatusChanged += OnScriptStatusChanged;
     }
+
+    /// <summary>
+    /// Runs the (cadence-cached, non-blocking) startup update check and shows the banner if a managed
+    /// update is available. Called from the view once loaded; a no-op in the browser host.
+    /// </summary>
+    public Task CheckForUpdatesOnStartupAsync() => UpdateBanner.RefreshAsync();
 
     private string GetAudioToolTip(IHostSystemConfig config)
     {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/UpdateBannerViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/UpdateBannerViewModel.cs
@@ -1,21 +1,29 @@
 using System;
 using System.Reactive;
 using System.Threading.Tasks;
+using Avalonia.Media;
 using Highbyte.DotNet6502.App.Avalonia.Core.Services;
 using ReactiveUI;
 
 namespace Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
 
 /// <summary>
-/// Drives the dismissible "update available" banner shown at the top of the desktop window. Stays
-/// hidden unless a managed install has a newer release; only rendered by the desktop host (the browser
-/// host has no <see cref="IAppUpdateService.IsSupported"/>).
+/// Drives the dismissible top-of-window banner: normally the green "update available" notice, but on
+/// the launch after a one-click update that didn't take effect, an amber "update didn't complete"
+/// notice. Only rendered by the desktop host (the browser host has no
+/// <see cref="IAppUpdateService.IsSupported"/>).
 /// </summary>
 public class UpdateBannerViewModel : ViewModelBase
 {
+    // Update-notice green (Material Green 800), kept in sync with the browser banner; amber for the
+    // "update didn't complete" warning state.
+    private static readonly IBrush UpdateAvailableBrush = new SolidColorBrush(Color.Parse("#2E7D32"));
+    private static readonly IBrush WarningBrush = new SolidColorBrush(Color.Parse("#B45309"));
+
     private readonly IAppUpdateService _updateService;
     private bool _dismissed;
     private bool _isVisible;
+    private bool _isWarning;
     private string _message = string.Empty;
     private string? _latestVersionDisplay;
 
@@ -49,6 +57,20 @@ public class UpdateBannerViewModel : ViewModelBase
         private set => this.RaiseAndSetIfChanged(ref _message, value);
     }
 
+    /// <summary>True when the banner is the amber "update didn't complete" warning rather than the green notice.</summary>
+    public bool IsWarning
+    {
+        get => _isWarning;
+        private set
+        {
+            this.RaiseAndSetIfChanged(ref _isWarning, value);
+            this.RaisePropertyChanged(nameof(Background));
+        }
+    }
+
+    /// <summary>Banner background brush: green for "update available", amber for the failure warning.</summary>
+    public IBrush Background => _isWarning ? WarningBrush : UpdateAvailableBrush;
+
     public ReactiveCommand<Unit, Unit> ShowDetailsCommand { get; }
     public ReactiveCommand<Unit, Unit> DismissCommand { get; }
 
@@ -64,12 +86,23 @@ public class UpdateBannerViewModel : ViewModelBase
 
         try
         {
+            // First: did a previous one-click update fail to take effect? (amber, one-shot)
+            var failedNotice = _updateService.ConsumeFailedUpdateNotice();
+            if (failedNotice != null)
+            {
+                Message = failedNotice;
+                IsWarning = true;
+                IsVisible = true;
+                return;
+            }
+
             var status = await _updateService.CheckAsync(force: false);
             // Skip if the user already dismissed this exact version on a previous launch.
             if (status is { IsUpdateAvailable: true, IsDismissed: false } && !_dismissed)
             {
                 _latestVersionDisplay = status.LatestVersionDisplay;
                 Message = $"Update available: {status.CurrentVersionDisplay} → {status.LatestVersionDisplay}";
+                IsWarning = false;
                 IsVisible = true;
             }
         }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/UpdateBannerViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/UpdateBannerViewModel.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Reactive;
+using System.Threading.Tasks;
+using Highbyte.DotNet6502.App.Avalonia.Core.Services;
+using ReactiveUI;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
+
+/// <summary>
+/// Drives the dismissible "update available" banner shown at the top of the desktop window. Stays
+/// hidden unless a managed install has a newer release; only rendered by the desktop host (the browser
+/// host has no <see cref="IAppUpdateService.IsSupported"/>).
+/// </summary>
+public class UpdateBannerViewModel : ViewModelBase
+{
+    private readonly IAppUpdateService _updateService;
+    private bool _dismissed;
+    private bool _isVisible;
+    private string _message = string.Empty;
+    private string? _latestVersionDisplay;
+
+    /// <summary>Raised when the user clicks "Details" — the host opens the About dialog in response.</summary>
+    public event EventHandler? DetailsRequested;
+
+    public UpdateBannerViewModel(IAppUpdateService updateService)
+    {
+        _updateService = updateService;
+        ShowDetailsCommand = ReactiveCommandHelper.CreateSafeCommand(() => DetailsRequested?.Invoke(this, EventArgs.Empty));
+        DismissCommand = ReactiveCommandHelper.CreateSafeCommand(() =>
+        {
+            _dismissed = true;
+            IsVisible = false;
+            // Remember this version so the banner won't reappear for it on future launches
+            // (a newer version still will).
+            if (_latestVersionDisplay != null)
+                _updateService.DismissVersion(_latestVersionDisplay);
+        });
+    }
+
+    public bool IsVisible
+    {
+        get => _isVisible;
+        private set => this.RaiseAndSetIfChanged(ref _isVisible, value);
+    }
+
+    public string Message
+    {
+        get => _message;
+        private set => this.RaiseAndSetIfChanged(ref _message, value);
+    }
+
+    public ReactiveCommand<Unit, Unit> ShowDetailsCommand { get; }
+    public ReactiveCommand<Unit, Unit> DismissCommand { get; }
+
+    /// <summary>
+    /// Runs the (cadence-cached) startup check and shows the banner if a managed update is available.
+    /// Called from the UI thread; awaits without <c>ConfigureAwait(false)</c> so property updates stay
+    /// on the UI thread. Never throws.
+    /// </summary>
+    public async Task RefreshAsync()
+    {
+        if (!_updateService.IsSupported || _dismissed)
+            return;
+
+        try
+        {
+            var status = await _updateService.CheckAsync(force: false);
+            // Skip if the user already dismissed this exact version on a previous launch.
+            if (status is { IsUpdateAvailable: true, IsDismissed: false } && !_dismissed)
+            {
+                _latestVersionDisplay = status.LatestVersionDisplay;
+                Message = $"Update available: {status.CurrentVersionDisplay} → {status.LatestVersionDisplay}";
+                IsVisible = true;
+            }
+        }
+        catch
+        {
+            // A failed startup check must never disrupt the app; the banner just stays hidden.
+        }
+    }
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/AboutUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/AboutUserControl.axaml
@@ -1,0 +1,68 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:Highbyte.DotNet6502.App.Avalonia.Core.ViewModels"
+        x:Class="Highbyte.DotNet6502.App.Avalonia.Core.Views.AboutUserControl"
+        x:DataType="vm:AboutViewModel"
+        AutomationProperties.AutomationId="AboutDialog"
+        AutomationProperties.Name="About and updates"
+        Width="480"
+        MinWidth="360">
+
+    <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" Margin="16">
+
+        <!-- Title header -->
+        <Border Grid.Row="0" CornerRadius="4" Classes="panel-container" Margin="0,0,0,12">
+            <TextBlock Text="DotNet 6502 Emulator" Classes="h-center h2"/>
+        </Border>
+
+        <!-- Current version -->
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8" Margin="0,0,0,8">
+            <TextBlock Text="Version:" VerticalAlignment="Center"/>
+            <TextBlock Text="{Binding CurrentVersionDisplay}" Classes="monospace" VerticalAlignment="Center"/>
+        </StackPanel>
+
+        <!-- Update status line -->
+        <TextBlock Grid.Row="2"
+                   Text="{Binding StatusText}"
+                   TextWrapping="Wrap"
+                   Margin="0,0,0,8"/>
+
+        <!-- Indeterminate progress while checking -->
+        <ProgressBar Grid.Row="3"
+                     IsIndeterminate="True"
+                     IsVisible="{Binding IsChecking}"
+                     Height="4"
+                     Margin="0,0,0,8"/>
+
+        <!-- Suggested upgrade command (managed + update available) -->
+        <Grid Grid.Row="4"
+              ColumnDefinitions="*,Auto"
+              IsVisible="{Binding HasSuggestedCommand}"
+              Margin="0,0,0,12">
+            <TextBox Grid.Column="0"
+                     Text="{Binding SuggestedCommand}"
+                     Classes="monospace"
+                     IsReadOnly="True"
+                     VerticalAlignment="Center"/>
+            <Button Grid.Column="1"
+                    x:Name="CopyCommandButton"
+                    Content="Copy"
+                    Margin="8,0,0,0"
+                    Click="OnCopyCommandClick"/>
+        </Grid>
+
+        <!-- Action buttons -->
+        <StackPanel Grid.Row="5" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+            <Button x:Name="ReleaseNotesButton"
+                    Content="What's new"
+                    IsVisible="{Binding HasReleaseNotes}"
+                    Click="OnReleaseNotesClick"/>
+            <Button Content="Check now"
+                    IsVisible="{Binding IsUpdateCheckSupported}"
+                    Command="{Binding CheckNowCommand}"/>
+            <Button Content="Close"
+                    IsDefault="True"
+                    Command="{Binding CloseCommand}"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/AboutUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/AboutUserControl.axaml
@@ -51,18 +51,29 @@
                     Click="OnCopyCommandClick"/>
         </Grid>
 
-        <!-- Action buttons -->
-        <StackPanel Grid.Row="5" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
-            <Button x:Name="ReleaseNotesButton"
+        <!-- Action buttons: secondary "What's new" link on the left; dismiss + the positive primary
+             action ("Update now", rightmost, green) on the right. Close stays the Enter-default so an
+             accidental Enter can't trigger the quit-and-relaunch update. -->
+        <Grid Grid.Row="5" ColumnDefinitions="*,Auto">
+            <Button Grid.Column="0"
+                    x:Name="ReleaseNotesButton"
                     Content="What's new"
+                    HorizontalAlignment="Left"
+                    Classes="text"
                     IsVisible="{Binding HasReleaseNotes}"
                     Click="OnReleaseNotesClick"/>
-            <Button Content="Check now"
-                    IsVisible="{Binding IsUpdateCheckSupported}"
-                    Command="{Binding CheckNowCommand}"/>
-            <Button Content="Close"
-                    IsDefault="True"
-                    Command="{Binding CloseCommand}"/>
-        </StackPanel>
+
+            <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
+                <Button Content="Close"
+                        IsDefault="True"
+                        Command="{Binding CloseCommand}"/>
+                <Button Content="Update now"
+                        AutomationProperties.AutomationId="UpdateNowButton"
+                        Classes="primary"
+                        IsVisible="{Binding CanUpdateNow}"
+                        Command="{Binding UpdateNowCommand}"
+                        ToolTip.Tip="Quits the app, runs the package-manager upgrade, and reopens it."/>
+            </StackPanel>
+        </Grid>
     </Grid>
 </UserControl>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/AboutUserControl.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/AboutUserControl.axaml.cs
@@ -1,5 +1,7 @@
 using System;
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
@@ -30,6 +32,7 @@ public partial class AboutUserControl : UserControl
         {
             _subscribedViewModel = vm;
             vm.RequestClose += OnRequestClose;
+            vm.UpdateStarted += OnUpdateStarted;
         }
     }
 
@@ -38,11 +41,20 @@ public partial class AboutUserControl : UserControl
         if (_subscribedViewModel != null)
         {
             _subscribedViewModel.RequestClose -= OnRequestClose;
+            _subscribedViewModel.UpdateStarted -= OnUpdateStarted;
             _subscribedViewModel = null;
         }
     }
 
     private void OnRequestClose(object? sender, EventArgs e) => DialogClosed?.Invoke(this, EventArgs.Empty);
+
+    // The self-update helper is now waiting for this app to exit before it upgrades and relaunches,
+    // so quit the app.
+    private void OnUpdateStarted(object? sender, EventArgs e)
+    {
+        if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            desktop.Shutdown();
+    }
 
     private void OnCopyCommandClick(object? sender, RoutedEventArgs e)
     {

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/AboutUserControl.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/AboutUserControl.axaml.cs
@@ -1,0 +1,70 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Core.Views;
+
+public partial class AboutUserControl : UserControl
+{
+    private AboutViewModel? _subscribedViewModel;
+
+    /// <summary>Raised when the dialog should be closed so the host can remove the overlay.</summary>
+    public event EventHandler? DialogClosed;
+
+    public AboutUserControl()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+        DetachedFromVisualTree += (_, _) => Unsubscribe();
+    }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        Unsubscribe();
+        if (DataContext is AboutViewModel vm)
+        {
+            _subscribedViewModel = vm;
+            vm.RequestClose += OnRequestClose;
+        }
+    }
+
+    private void Unsubscribe()
+    {
+        if (_subscribedViewModel != null)
+        {
+            _subscribedViewModel.RequestClose -= OnRequestClose;
+            _subscribedViewModel = null;
+        }
+    }
+
+    private void OnRequestClose(object? sender, EventArgs e) => DialogClosed?.Invoke(this, EventArgs.Empty);
+
+    private void OnCopyCommandClick(object? sender, RoutedEventArgs e)
+    {
+        var command = (DataContext as AboutViewModel)?.SuggestedCommand;
+        if (string.IsNullOrEmpty(command))
+            return;
+        var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+        if (clipboard == null)
+            return;
+
+        var dataTransfer = new DataTransfer();
+        dataTransfer.Add(DataTransferItem.CreateText(command));
+        SafeAsyncHelper.Execute(() => clipboard.SetDataAsync(dataTransfer));
+    }
+
+    private void OnReleaseNotesClick(object? sender, RoutedEventArgs e)
+    {
+        var url = (DataContext as AboutViewModel)?.ReleaseNotesUrl;
+        if (string.IsNullOrEmpty(url) || !Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return;
+        var launcher = TopLevel.GetTopLevel(this)?.Launcher;
+        if (launcher != null)
+            SafeAsyncHelper.Execute(() => launcher.LaunchUriAsync(uri));
+    }
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorConfigUserControl.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/EmulatorConfigUserControl.axaml
@@ -265,6 +265,27 @@
           </Border>
         </StackPanel>
 
+        <!-- Updates Section (desktop only; the browser app has no package-manager update path) -->
+        <StackPanel Width="400" Classes="wrap-item" IsVisible="{Binding !IsRunningInWebAssembly}">
+          <Border Classes="content-section">
+            <StackPanel Classes="spacing-tight">
+              <TextBlock Text="Updates" Classes=""/>
+
+              <TextBlock Text="Only applies when installed via Homebrew or Scoop."
+                         Classes="small secondary-text"
+                         TextWrapping="Wrap"/>
+              <CheckBox Content="Check for updates on startup"
+                        AutomationProperties.AutomationId="UpdateCheckEnabledCheckBox"
+                        AutomationProperties.Name="Check for updates on startup"
+                        IsChecked="{Binding UpdateCheckEnabled}"/>
+              <TextBlock Text="When enabled, the app checks about once a day for a newer released version and shows a banner if one is available. The About dialog's 'Check now' button always checks regardless."
+                         Classes="small secondary-text"
+                         TextWrapping="Wrap"
+                         Margin="20,0,0,0"/>
+            </StackPanel>
+          </Border>
+        </StackPanel>
+
         <!-- Lua Scripting Section -->
         <StackPanel Width="400" Classes="wrap-item">
           <Border Classes="content-section">

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml
@@ -239,6 +239,14 @@
                                     Classes="grid small"
                                     ToolTip.Tip="Configure general emulator settings"/>
 
+                            <!-- About / check for updates -->
+                            <Button Grid.Column="2"
+                                    Content="About"
+                                    AutomationProperties.AutomationId="AboutButton"
+                                    Command="{Binding AboutCommand}"
+                                    Classes="grid small"
+                                    ToolTip.Tip="Version and check for updates"/>
+
                        </Grid>
                     </StackPanel>
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml.cs
@@ -129,6 +129,7 @@ public partial class MainView : UserControl
         {
             _subscribedViewModel.PropertyChanged -= OnViewModelPropertyChanged;
             _subscribedViewModel.EmulatorOptionsRequested -= OnEmulatorOptionsRequested;
+            _subscribedViewModel.AboutRequested -= OnAboutRequested;
         }
 
         // Subscribe to new ViewModel's property changes
@@ -137,6 +138,7 @@ public partial class MainView : UserControl
         {
             _subscribedViewModel.PropertyChanged += OnViewModelPropertyChanged;
             _subscribedViewModel.EmulatorOptionsRequested += OnEmulatorOptionsRequested;
+            _subscribedViewModel.AboutRequested += OnAboutRequested;
             _subscribedViewModel.RequestAddScript += OnRequestAddScript;
             _subscribedViewModel.RequestEditScript += OnRequestEditScript;
             _subscribedViewModel.RequestDeleteScript += OnRequestDeleteScript;
@@ -281,7 +283,9 @@ public partial class MainView : UserControl
 
     private void MainView_Loaded(object? sender, RoutedEventArgs e)
     {
-        // Initialization complete
+        // Kick off the non-blocking startup update check (a no-op in the browser host).
+        if (_subscribedViewModel != null)
+            SafeAsyncHelper.Execute(_subscribedViewModel.CheckForUpdatesOnStartupAsync);
     }
 
     // ComboBox SelectionChanged handlers - invoke commands
@@ -468,6 +472,7 @@ public partial class MainView : UserControl
         {
             _subscribedViewModel.PropertyChanged -= OnViewModelPropertyChanged;
             _subscribedViewModel.EmulatorOptionsRequested -= OnEmulatorOptionsRequested;
+            _subscribedViewModel.AboutRequested -= OnAboutRequested;
             _subscribedViewModel.RequestAddScript -= OnRequestAddScript;
             _subscribedViewModel.RequestEditScript -= OnRequestEditScript;
             _subscribedViewModel.RequestDeleteScript -= OnRequestDeleteScript;
@@ -895,6 +900,38 @@ public partial class MainView : UserControl
 
     private void OnEmulatorOptionsRequested(object? sender, EventArgs e)
         => SafeAsyncHelper.Execute(EmulatorOptionsUserControlOverlayAsync);
+
+    private void OnAboutRequested(object? sender, EventArgs e)
+        => SafeAsyncHelper.Execute(ShowAboutOverlayAsync);
+
+    private async Task ShowAboutOverlayAsync()
+    {
+        var serviceProvider = (Application.Current as App)?.GetServiceProvider();
+        if (serviceProvider == null)
+            return;
+
+        var updateService = serviceProvider.GetRequiredService<Services.IAppUpdateService>();
+        var aboutControl = new AboutUserControl
+        {
+            DataContext = new AboutViewModel(updateService),
+        };
+
+        var tcs = new TaskCompletionSource<bool>();
+        aboutControl.DialogClosed += (_, _) => tcs.TrySetResult(true);
+
+        var overlayDialogHelper = serviceProvider.GetRequiredService<OverlayDialogHelper>();
+        var overlayPanel = overlayDialogHelper.BuildOverlayDialogPanel(aboutControl);
+        var mainGrid = overlayDialogHelper.ShowOverlayDialog(overlayPanel, this);
+
+        try
+        {
+            await tcs.Task;
+        }
+        finally
+        {
+            mainGrid.Children.Remove(overlayPanel);
+        }
+    }
 
     private void OnRequestAddScript(object? sender, EventArgs e)
         => SafeAsyncHelper.Execute(ShowAddScriptDialogAsync);

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainWindow.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainWindow.axaml
@@ -19,6 +19,36 @@
         <vm:MainViewModel/>
     </Design.DataContext>
 
-    <!-- MainView will inherit DataContext from Window -->
-    <views:MainView />
+    <DockPanel LastChildFill="True">
+        <!-- Dismissible "update available" banner. Hidden unless a package-manager install has a
+             newer release (desktop only; UpdateBanner is inert in the browser host). -->
+        <!-- Update-notice green (Material Green 800). Kept in sync with the Avalonia Browser app's
+             "new version available" banner in wwwroot/index.html so both surfaces match. Deep enough
+             that white text meets contrast and it still stands off the dark app chrome. -->
+        <Border DockPanel.Dock="Top"
+                IsVisible="{Binding UpdateBanner.IsVisible}"
+                Background="#2E7D32"
+                Padding="10,6">
+            <Grid ColumnDefinitions="*,Auto,Auto">
+                <TextBlock Grid.Column="0"
+                           Text="{Binding UpdateBanner.Message}"
+                           Foreground="White"
+                           VerticalAlignment="Center"
+                           TextWrapping="Wrap"/>
+                <Button Grid.Column="1"
+                        Content="Details"
+                        AutomationProperties.AutomationId="UpdateBannerDetailsButton"
+                        Margin="8,0,0,0"
+                        Command="{Binding UpdateBanner.ShowDetailsCommand}"/>
+                <Button Grid.Column="2"
+                        Content="Dismiss"
+                        AutomationProperties.AutomationId="UpdateBannerDismissButton"
+                        Margin="8,0,0,0"
+                        Command="{Binding UpdateBanner.DismissCommand}"/>
+            </Grid>
+        </Border>
+
+        <!-- MainView will inherit DataContext from Window -->
+        <views:MainView />
+    </DockPanel>
 </Window>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainWindow.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainWindow.axaml
@@ -20,14 +20,13 @@
     </Design.DataContext>
 
     <DockPanel LastChildFill="True">
-        <!-- Dismissible "update available" banner. Hidden unless a package-manager install has a
-             newer release (desktop only; UpdateBanner is inert in the browser host). -->
-        <!-- Update-notice green (Material Green 800). Kept in sync with the Avalonia Browser app's
-             "new version available" banner in wwwroot/index.html so both surfaces match. Deep enough
-             that white text meets contrast and it still stands off the dark app chrome. -->
+        <!-- Dismissible top banner: green "update available" (Material Green 800, kept in sync with the
+             Avalonia Browser banner in wwwroot/index.html), or amber "update didn't complete" after a
+             failed one-click update. The background brush is chosen in UpdateBannerViewModel. Hidden
+             otherwise (desktop only; UpdateBanner is inert in the browser host). -->
         <Border DockPanel.Dock="Top"
                 IsVisible="{Binding UpdateBanner.IsVisible}"
-                Background="#2E7D32"
+                Background="{Binding UpdateBanner.Background}"
                 Padding="10,6">
             <Grid ColumnDefinitions="*,Auto,Auto">
                 <TextBlock Grid.Column="0"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/DesktopAppUpdateService.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/DesktopAppUpdateService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Threading;
@@ -147,16 +148,40 @@ public sealed class DesktopAppUpdateService : IAppUpdateService
         }
     }
 
-    // How to relaunch the Avalonia GUI after the upgrade. macOS: `open -a "<AppName>"` (robust across
-    // the cask replacing the bundle). Windows/Linux: relaunch the current executable — the Scoop
-    // `current` junction / brew shim path stays valid after the update.
+    // How to relaunch the Avalonia GUI after the upgrade. If the app was started as
+    // `dotnet <app>.dll` (the local dev/update-trigger flow), reconstruct that exact launch on every
+    // OS. Otherwise macOS uses `open -a "<AppName>"` (robust across the cask replacing the bundle),
+    // while Windows/Linux relaunch the current executable — the Scoop `current` junction / brew shim
+    // path stays valid after the update.
     private static RelaunchSpec BuildRelaunchSpec()
     {
+        var processPath = Environment.ProcessPath ?? string.Empty;
+        var commandLineArgs = Environment.GetCommandLineArgs();
+
+        if (IsDotNetHost(processPath) && commandLineArgs.Length > 0)
+        {
+            var relaunchArgs = new List<string>(commandLineArgs.Length);
+            relaunchArgs.AddRange(commandLineArgs);
+            return new RelaunchSpec(processPath, relaunchArgs);
+        }
+
         if (OperatingSystem.IsMacOS())
             return new RelaunchSpec("/usr/bin/open", new[] { "-a", "DotNet 6502 Emulator" });
 
-        var exePath = Environment.ProcessPath ?? "";
-        return new RelaunchSpec(exePath, Array.Empty<string>());
+        var appArgs = commandLineArgs.Length > 1
+            ? commandLineArgs[1..]
+            : Array.Empty<string>();
+        return new RelaunchSpec(processPath, appArgs);
+    }
+
+    private static bool IsDotNetHost(string processPath)
+    {
+        if (string.IsNullOrWhiteSpace(processPath))
+            return false;
+
+        var fileName = Path.GetFileName(processPath);
+        return string.Equals(fileName, "dotnet", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(fileName, "dotnet.exe", StringComparison.OrdinalIgnoreCase);
     }
 
     public void DismissVersion(string versionDisplay)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/DesktopAppUpdateService.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/DesktopAppUpdateService.cs
@@ -22,11 +22,13 @@ public sealed class DesktopAppUpdateService : IAppUpdateService
     private readonly HttpClient _httpClient = new() { Timeout = TimeSpan.FromSeconds(5) };
     private readonly UpdateChecker _checker;
     private readonly EmulatorConfig _emulatorConfig;
+    private readonly ILogger _logger;
 
     public DesktopAppUpdateService(ILoggerFactory loggerFactory, EmulatorConfig emulatorConfig)
     {
         _emulatorConfig = emulatorConfig;
-        _checker = UpdateChecker.CreateDefault(CreateDescriptor(), _httpClient, loggerFactory.CreateLogger("UpdateCheck"));
+        _logger = loggerFactory.CreateLogger("UpdateCheck");
+        _checker = UpdateChecker.CreateDefault(CreateDescriptor(), _httpClient, _logger);
         var current = AppVersion.GetCurrent();
         CurrentVersionDisplay = current is null ? "development build" : $"v{current}";
     }
@@ -64,6 +66,97 @@ public sealed class DesktopAppUpdateService : IAppUpdateService
             SuggestedCommand: result.SuggestedCommand,
             ReleaseNotesUrl: result.ReleaseNotesUrl,
             IsDismissed: latestDisplay is not null && string.Equals(dismissed, latestDisplay, StringComparison.Ordinal));
+    }
+
+    public async Task<bool> TryStartSelfUpdateAsync(CancellationToken cancellationToken = default)
+    {
+        // Confirm managed + update-available right now, and get the resolved manager path.
+        var result = await _checker.CheckAsync(new UpdateCheckContext { ForceCheck = true }, cancellationToken).ConfigureAwait(false);
+        if (!result.IsUpdateAvailable || result.ManagerExecutablePath is null)
+        {
+            _logger.LogWarning("Self-update requested, but no update is available or the package manager could not be resolved.");
+            return false;
+        }
+
+        var spawned = UpdateApplier.TrySpawnDetachedRelaunch(
+            result.ManagerExecutablePath,
+            CreateDescriptor().UpgradeArgs(result.Channel),
+            Environment.ProcessId,
+            BuildRelaunchSpec());
+
+        if (spawned)
+        {
+            // Remember what we were on, so the next launch can tell whether the upgrade took effect.
+            WritePendingUpdate(CurrentVersionDisplay);
+            _logger.LogInformation(
+                "Starting self-update ({Command}). The app will quit, upgrade, and relaunch; upgrade output goes to {LogPath}.",
+                result.SuggestedCommand, UpdateApplier.GetUpdateLogPath());
+        }
+        else
+        {
+            _logger.LogWarning("Could not start the update helper process; the app will stay open.");
+        }
+
+        return spawned;
+    }
+
+    public string? ConsumeFailedUpdateNotice()
+    {
+        string fromVersion;
+        var path = PendingUpdateFilePath();
+        try
+        {
+            if (!File.Exists(path))
+                return null;
+            fromVersion = File.ReadAllText(path).Trim();
+            File.Delete(path); // consume: only ever notify once per attempt
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+
+        // Version changed since the attempt → the upgrade took effect → nothing to report.
+        if (string.IsNullOrEmpty(fromVersion) || !string.Equals(fromVersion, CurrentVersionDisplay, StringComparison.Ordinal))
+        {
+            if (!string.IsNullOrEmpty(fromVersion))
+                _logger.LogInformation("Self-update completed: now on {Version}.", CurrentVersionDisplay);
+            return null;
+        }
+
+        // Still on the same version → the upgrade failed or didn't take effect.
+        _logger.LogWarning("A previous one-click update did not complete; still on {Version}. See {LogPath}.",
+            fromVersion, UpdateApplier.GetUpdateLogPath());
+        return $"The last update didn't complete — you're still on {fromVersion}. See the log at {UpdateApplier.GetUpdateLogPath()}";
+    }
+
+    private static string PendingUpdateFilePath()
+        => Path.Combine(AppStoragePaths.GetCacheRoot(), "updates", "pending-update.txt");
+
+    private static void WritePendingUpdate(string fromVersionDisplay)
+    {
+        try
+        {
+            var path = PendingUpdateFilePath();
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, fromVersionDisplay);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Best effort: not remembering just means no post-update notice.
+        }
+    }
+
+    // How to relaunch the Avalonia GUI after the upgrade. macOS: `open -a "<AppName>"` (robust across
+    // the cask replacing the bundle). Windows/Linux: relaunch the current executable — the Scoop
+    // `current` junction / brew shim path stays valid after the update.
+    private static RelaunchSpec BuildRelaunchSpec()
+    {
+        if (OperatingSystem.IsMacOS())
+            return new RelaunchSpec("/usr/bin/open", new[] { "-a", "DotNet 6502 Emulator" });
+
+        var exePath = Environment.ProcessPath ?? "";
+        return new RelaunchSpec(exePath, Array.Empty<string>());
     }
 
     public void DismissVersion(string versionDisplay)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/DesktopAppUpdateService.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/DesktopAppUpdateService.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Highbyte.DotNet6502.App.Avalonia.Core;
+using Highbyte.DotNet6502.App.Avalonia.Core.Services;
+using Highbyte.DotNet6502.Systems.Configuration;
+using Highbyte.DotNet6502.Updates;
+using Microsoft.Extensions.Logging;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Desktop;
+
+/// <summary>
+/// Desktop <see cref="IAppUpdateService"/> backed by <see cref="UpdateChecker"/>. Lives in the desktop
+/// host (not Core) so the process/HTTP-using Updates library never enters the browser/WASM AOT graph.
+/// The shared <see cref="UpdateChecker"/> logs an "update available" line via the host's
+/// <see cref="ILoggerFactory"/> (routed to the in-app Logs tab, and console when --console-log).
+/// </summary>
+public sealed class DesktopAppUpdateService : IAppUpdateService
+{
+    private readonly HttpClient _httpClient = new() { Timeout = TimeSpan.FromSeconds(5) };
+    private readonly UpdateChecker _checker;
+    private readonly EmulatorConfig _emulatorConfig;
+
+    public DesktopAppUpdateService(ILoggerFactory loggerFactory, EmulatorConfig emulatorConfig)
+    {
+        _emulatorConfig = emulatorConfig;
+        _checker = UpdateChecker.CreateDefault(CreateDescriptor(), _httpClient, loggerFactory.CreateLogger("UpdateCheck"));
+        var current = AppVersion.GetCurrent();
+        CurrentVersionDisplay = current is null ? "development build" : $"v{current}";
+    }
+
+    /// <summary>The Avalonia desktop app: package <c>dotnet-6502</c>, a Homebrew cask on macOS but a formula on Linux.</summary>
+    public static AppUpdateDescriptor CreateDescriptor() => new()
+    {
+        HomebrewPackage = "dotnet-6502",
+        HomebrewIsCask = OperatingSystem.IsMacOS(),
+        ScoopPackage = "dotnet-6502",
+    };
+
+    public bool IsSupported => true;
+
+    public string CurrentVersionDisplay { get; }
+
+    public async Task<AppUpdateStatus?> CheckAsync(bool force, CancellationToken cancellationToken = default)
+    {
+        // The automatic (non-forced) startup check honors the settings toggle and the standard
+        // CI / DOTNET6502_NO_UPDATE_CHECK suppressors. The explicit "Check now" button forces and ignores them.
+        if (!force && (!_emulatorConfig.UpdateCheckEnabled || ConsoleUpdateCli.IsSuppressedByEnvironment()))
+            return null;
+
+        var result = await _checker.CheckAsync(new UpdateCheckContext { ForceCheck = force }, cancellationToken)
+            .ConfigureAwait(false);
+
+        var latestDisplay = result.LatestVersion is null ? null : $"v{result.LatestVersion}";
+        var dismissed = ReadDismissedVersion();
+
+        return new AppUpdateStatus(
+            IsManaged: result.Channel is InstallChannel.Homebrew or InstallChannel.Scoop,
+            IsUpdateAvailable: result.IsUpdateAvailable,
+            CurrentVersionDisplay: result.CurrentVersion is null ? CurrentVersionDisplay : $"v{result.CurrentVersion}",
+            LatestVersionDisplay: latestDisplay,
+            SuggestedCommand: result.SuggestedCommand,
+            ReleaseNotesUrl: result.ReleaseNotesUrl,
+            IsDismissed: latestDisplay is not null && string.Equals(dismissed, latestDisplay, StringComparison.Ordinal));
+    }
+
+    public void DismissVersion(string versionDisplay)
+    {
+        if (string.IsNullOrWhiteSpace(versionDisplay))
+            return;
+        try
+        {
+            var path = DismissedVersionFilePath();
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, versionDisplay);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Best effort: failing to remember a dismissal just means the banner may reappear.
+        }
+    }
+
+    private static string? ReadDismissedVersion()
+    {
+        try
+        {
+            var path = DismissedVersionFilePath();
+            return File.Exists(path) ? File.ReadAllText(path).Trim() : null;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    // Kept in its own file (not the update-check cache) so UpdateChecker's cache writes can't clobber it.
+    private static string DismissedVersionFilePath()
+        => Path.Combine(AppStoragePaths.GetCacheRoot(), "updates", "dismissed-version.txt");
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Highbyte.DotNet6502.App.Avalonia.Desktop.csproj
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Highbyte.DotNet6502.App.Avalonia.Desktop.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Highbyte.DotNet6502.App.Avalonia.Core\Highbyte.DotNet6502.App.Avalonia.Core.csproj" />
+    <ProjectReference Include="..\..\..\libraries\Highbyte.DotNet6502.Updates\Highbyte.DotNet6502.Updates.csproj" />
     <!-- Convention glob: every per-system shell is deployed for SystemPluginDiscovery without
          editing this entry exe when a new system is added. -->
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\Highbyte.DotNet6502.App.Avalonia.Shell.*\*.csproj" />

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Program.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Program.cs
@@ -26,6 +26,7 @@ using Highbyte.DotNet6502.Scripting.MoonSharp;
 using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Configuration;
 using Highbyte.DotNet6502.Systems.Instrumentation.Stats;
+using Highbyte.DotNet6502.Updates;
 
 namespace Highbyte.DotNet6502.App.Avalonia.Desktop;
 
@@ -364,6 +365,11 @@ internal sealed partial class Program
     [STAThread]
     public static int Main(string[] args)
     {
+        // Update-check CLI flags run before any GUI/startup work and exit immediately.
+        var updateExitCode = TryHandleUpdateCli(args);
+        if (updateExitCode is not null)
+            return updateExitCode.Value;
+
         try
         {
             return RunApp(args);
@@ -1035,6 +1041,41 @@ internal sealed partial class Program
     [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool FreeConsole();
+
+    // Windows API to attach the (WinExe, console-less) process to the parent terminal's console,
+    // so stdout from the --version / --check-update / --update flags reaches the invoking shell.
+    private const uint AttachParentProcess = 0xFFFFFFFF; // ATTACH_PARENT_PROCESS
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool AttachConsole(uint dwProcessId);
+
+    /// <summary>
+    /// Handles the update-check CLI flags (<c>--version</c> / <c>--check-update</c> / <c>--update</c>)
+    /// before any GUI startup, returning the process exit code — or null if none was passed. The same
+    /// shared <see cref="ConsoleUpdateCli"/> the console hosts use. No automatic startup notice: the GUI
+    /// is normally launched without an attached terminal. This app ships as a Homebrew cask on macOS but
+    /// a formula on Linux (same package name), hence <c>HomebrewIsCask = OperatingSystem.IsMacOS()</c>.
+    /// </summary>
+    private static int? TryHandleUpdateCli(string[] args)
+    {
+        if (!ConsoleUpdateCli.WantsHandling(args))
+            return null;
+
+        // WinExe has no console attached; attach to the parent (best effort) before writing output.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            AttachConsole(AttachParentProcess);
+
+        var descriptor = new AppUpdateDescriptor
+        {
+            HomebrewPackage = "dotnet-6502",
+            HomebrewIsCask = OperatingSystem.IsMacOS(),
+            ScoopPackage = "dotnet-6502",
+        };
+        // Blocking is safe: this is the process entry point, before any UI/synchronization context exists.
+#pragma warning disable VSTHRD002
+        return ConsoleUpdateCli.RunAsync(args, descriptor, Console.Out).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
+    }
 
     /// <summary>
     /// Parses the log level from command line arguments.

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Program.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Program.cs
@@ -956,7 +956,8 @@ internal sealed partial class Program
                 remoteControlController: remoteControlController,
                 scriptingEngine: scriptingEngine,
                 loadExamples: loadExamples,
-                automatedStartupRunner: automatedStartupRunner))
+                automatedStartupRunner: automatedStartupRunner,
+                appUpdateService: new DesktopAppUpdateService(loggerFactory, emulatorConfig)))
             .UsePlatformDetect()
             .LogToTrace()
             .AfterSetup(_ =>
@@ -1065,15 +1066,9 @@ internal sealed partial class Program
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             AttachConsole(AttachParentProcess);
 
-        var descriptor = new AppUpdateDescriptor
-        {
-            HomebrewPackage = "dotnet-6502",
-            HomebrewIsCask = OperatingSystem.IsMacOS(),
-            ScoopPackage = "dotnet-6502",
-        };
         // Blocking is safe: this is the process entry point, before any UI/synchronization context exists.
 #pragma warning disable VSTHRD002
-        return ConsoleUpdateCli.RunAsync(args, descriptor, Console.Out).GetAwaiter().GetResult();
+        return ConsoleUpdateCli.RunAsync(args, DesktopAppUpdateService.CreateDescriptor(), Console.Out).GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002
     }
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.json
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.json
@@ -36,6 +36,10 @@
   "Highbyte.DotNet6502.AvaloniaConfig": {
     "DefaultEmulator": "C64",
     "DefaultDrawScale": 2.0,
+    // Set to false to disable the automatic startup check for a newer released version.
+    // (Also disabled by the CI env var or DOTNET6502_NO_UPDATE_CHECK; only applies to brew/scoop installs.
+    //  The About dialog's "Check now" button always checks regardless.)
+    "UpdateCheckEnabled": true,
     // ShowErrorDialog: true = Log to console/logger and show error dialog for unhandled exceptions (default)
     //                  false = Log to console/logger and trigger debugger (or exit if no debugger attached)
     "ShowErrorDialog": true,

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/publish.sh
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/publish.sh
@@ -68,6 +68,14 @@ if [[ "$INCLUDE_PDB" == false ]]; then
     PUBLISH_ARGS+=(-p:DebugType=None -p:DebugSymbols=false)
 fi
 
+# Stamp the release version if provided (set by CI from the git tag, e.g. "0.40.2-alpha").
+# Locally this is unset, so the app keeps its default 1.0.0 which the update checker
+# treats as "unknown -> skip update check" (dev builds never nag).
+if [[ -n "$RELEASE_VERSION" ]]; then
+    echo "  Version: $RELEASE_VERSION"
+    PUBLISH_ARGS+=(-p:Version="$RELEASE_VERSION")
+fi
+
 # Run dotnet publish
 dotnet publish "${PUBLISH_ARGS[@]}"
 

--- a/src/apps/Highbyte.DotNet6502.App.Headless/Highbyte.DotNet6502.App.Headless.csproj
+++ b/src/apps/Highbyte.DotNet6502.App.Headless/Highbyte.DotNet6502.App.Headless.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\..\libraries\Highbyte.DotNet6502.DebugAdapter\Highbyte.DotNet6502.DebugAdapter.csproj" />
     <ProjectReference Include="..\..\libraries\Highbyte.DotNet6502.Remoting\Highbyte.DotNet6502.Remoting.csproj" />
     <ProjectReference Include="..\..\libraries\Highbyte.DotNet6502.Scripting.MoonSharp\Highbyte.DotNet6502.Scripting.MoonSharp.csproj" />
+    <ProjectReference Include="..\..\libraries\Highbyte.DotNet6502.Updates\Highbyte.DotNet6502.Updates.csproj" />
   </ItemGroup>
 
   <!-- Headless host integration (C64 + Generic engine plug-ins). Keeps the system-specific

--- a/src/apps/Highbyte.DotNet6502.App.Headless/Program.cs
+++ b/src/apps/Highbyte.DotNet6502.App.Headless/Program.cs
@@ -11,6 +11,17 @@ using Highbyte.DotNet6502.Systems.Plugins;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Highbyte.DotNet6502.Updates;
+
+// ----------
+// Update check CLI flags (--version / --check-update / --update). Handled before any startup work.
+// Headless is opt-in only: no automatic startup notice, just these explicit flags.
+// ----------
+if (ConsoleUpdateCli.WantsHandling(args))
+    return await ConsoleUpdateCli.RunAsync(
+        args,
+        new AppUpdateDescriptor { HomebrewPackage = "dotnet-6502-headless", ScoopPackage = "dotnet-6502-headless" },
+        Console.Out);
 
 // ----------
 // Parse command line arguments

--- a/src/apps/Highbyte.DotNet6502.App.Headless/Program.cs
+++ b/src/apps/Highbyte.DotNet6502.App.Headless/Program.cs
@@ -15,7 +15,7 @@ using Highbyte.DotNet6502.Updates;
 
 // ----------
 // Update check CLI flags (--version / --check-update / --update). Handled before any startup work.
-// Headless is opt-in only: no automatic startup notice, just these explicit flags.
+// Headless also performs a gated non-blocking startup check after logging is configured.
 // ----------
 if (ConsoleUpdateCli.WantsHandling(args))
     return await ConsoleUpdateCli.RunAsync(

--- a/src/apps/Highbyte.DotNet6502.App.Headless/Program.cs
+++ b/src/apps/Highbyte.DotNet6502.App.Headless/Program.cs
@@ -99,6 +99,14 @@ var loggerFactory = LoggerFactory.Create(logBuilder =>
 
 var logger = loggerFactory.CreateLogger(nameof(Program));
 
+// Non-blocking startup update check (Headless logs to console). Gated by the UpdateCheckEnabled
+// setting and the standard CI / DOTNET6502_NO_UPDATE_CHECK suppressors, so scripted/CI runs make no
+// network call. Uses the config built above.
+_ = ConsoleUpdateCli.CheckAndLogOnStartupAsync(
+    new AppUpdateDescriptor { HomebrewPackage = "dotnet-6502-headless", ScoopPackage = "dotnet-6502-headless" },
+    loggerFactory.CreateLogger("UpdateCheck"),
+    configuration.GetValue("UpdateCheckEnabled", true));
+
 // ----------
 // Get emulator host config
 // ----------

--- a/src/apps/Highbyte.DotNet6502.App.Headless/appsettings.json
+++ b/src/apps/Highbyte.DotNet6502.App.Headless/appsettings.json
@@ -1,4 +1,8 @@
 {
+  // Set to false to disable the automatic startup check for a newer released version.
+  // (Also disabled by the CI env var or DOTNET6502_NO_UPDATE_CHECK; only applies to brew/scoop installs.)
+  "UpdateCheckEnabled": true,
+
   "Highbyte.DotNet6502.Scripting": {
     "Enabled": true,
     "MaxExecutionWarningMs": 5,

--- a/src/apps/Highbyte.DotNet6502.App.Headless/publish.sh
+++ b/src/apps/Highbyte.DotNet6502.App.Headless/publish.sh
@@ -62,6 +62,14 @@ if [[ "$INCLUDE_PDB" == false ]]; then
     PUBLISH_ARGS+=(-p:DebugType=None -p:DebugSymbols=false)
 fi
 
+# Stamp the release version if provided (set by CI from the git tag, e.g. "0.40.2-alpha").
+# Locally this is unset, so the app keeps its default 1.0.0 which the update checker
+# treats as "unknown -> skip update check" (dev builds never nag).
+if [[ -n "$RELEASE_VERSION" ]]; then
+    echo "  Version: $RELEASE_VERSION"
+    PUBLISH_ARGS+=(-p:Version="$RELEASE_VERSION")
+fi
+
 dotnet publish "${PUBLISH_ARGS[@]}"
 
 if [[ $? -eq 0 ]]; then

--- a/src/apps/Highbyte.DotNet6502.App.RemoteClient/Highbyte.DotNet6502.App.RemoteClient.csproj
+++ b/src/apps/Highbyte.DotNet6502.App.RemoteClient/Highbyte.DotNet6502.App.RemoteClient.csproj
@@ -5,4 +5,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\libraries\Highbyte.DotNet6502.Updates\Highbyte.DotNet6502.Updates.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/apps/Highbyte.DotNet6502.App.RemoteClient/Program.cs
+++ b/src/apps/Highbyte.DotNet6502.App.RemoteClient/Program.cs
@@ -49,13 +49,14 @@ var commands = new[]
     ("ui.message",    "--text <string> [--level info|warning|error]", "Display message in emulator UI"),
 };
 
-// Update check: explicit flags (--version / --check-update / --update) short-circuit to stdout;
-// otherwise a quiet, gated one-line "update available" notice goes to stderr so it never pollutes
-// the machine-readable command output on stdout.
-var updateDescriptor = new AppUpdateDescriptor { HomebrewPackage = "dotnet-6502-remote", ScoopPackage = "dotnet-6502-remote" };
+// Update check: explicit flags (--version / --check-update / --update) only, to stdout. RemoteClient
+// is a request/response automation tool whose stdout is the server response, so it does NO automatic
+// startup check/notice and adds no logging that could interfere with scripted consumers.
 if (ConsoleUpdateCli.WantsHandling(args))
-    return await ConsoleUpdateCli.RunAsync(args, updateDescriptor, Console.Out);
-await ConsoleUpdateCli.NotifyOnStartupAsync(updateDescriptor, Console.Error);
+    return await ConsoleUpdateCli.RunAsync(
+        args,
+        new AppUpdateDescriptor { HomebrewPackage = "dotnet-6502-remote", ScoopPackage = "dotnet-6502-remote" },
+        Console.Out);
 
 if (args.Contains("--help") || args.Contains("-h") || args.Length == 0)
 {

--- a/src/apps/Highbyte.DotNet6502.App.RemoteClient/Program.cs
+++ b/src/apps/Highbyte.DotNet6502.App.RemoteClient/Program.cs
@@ -2,6 +2,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
 using Highbyte.DotNet6502.App.RemoteClient;
+using Highbyte.DotNet6502.Updates;
 
 // Remote client for the DotNet 6502 emulator TCP remote control server.
 // Usage: dotnet-6502-remote [--port <port>] [--host <host>] <command> [params...]
@@ -47,6 +48,14 @@ var commands = new[]
     ("screenshot",    "[--output <file.png>]",      "Capture screenshot (Base64 PNG or saved to file)"),
     ("ui.message",    "--text <string> [--level info|warning|error]", "Display message in emulator UI"),
 };
+
+// Update check: explicit flags (--version / --check-update / --update) short-circuit to stdout;
+// otherwise a quiet, gated one-line "update available" notice goes to stderr so it never pollutes
+// the machine-readable command output on stdout.
+var updateDescriptor = new AppUpdateDescriptor { HomebrewPackage = "dotnet-6502-remote", ScoopPackage = "dotnet-6502-remote" };
+if (ConsoleUpdateCli.WantsHandling(args))
+    return await ConsoleUpdateCli.RunAsync(args, updateDescriptor, Console.Out);
+await ConsoleUpdateCli.NotifyOnStartupAsync(updateDescriptor, Console.Error);
 
 if (args.Contains("--help") || args.Contains("-h") || args.Length == 0)
 {

--- a/src/apps/Highbyte.DotNet6502.App.RemoteClient/publish.sh
+++ b/src/apps/Highbyte.DotNet6502.App.RemoteClient/publish.sh
@@ -62,6 +62,14 @@ if [[ "$INCLUDE_PDB" == false ]]; then
     PUBLISH_ARGS+=(-p:DebugType=None -p:DebugSymbols=false)
 fi
 
+# Stamp the release version if provided (set by CI from the git tag, e.g. "0.40.2-alpha").
+# Locally this is unset, so the app keeps its default 1.0.0 which the update checker
+# treats as "unknown -> skip update check" (dev builds never nag).
+if [[ -n "$RELEASE_VERSION" ]]; then
+    echo "  Version: $RELEASE_VERSION"
+    PUBLISH_ARGS+=(-p:Version="$RELEASE_VERSION")
+fi
+
 dotnet publish "${PUBLISH_ARGS[@]}"
 
 if [[ $? -eq 0 ]]; then

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/Highbyte.DotNet6502.App.Terminal.csproj
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/Highbyte.DotNet6502.App.Terminal.csproj
@@ -29,6 +29,7 @@
   -->
   <ItemGroup>
     <ProjectReference Include="..\Highbyte.DotNet6502.App.Terminal.Core\Highbyte.DotNet6502.App.Terminal.Core.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\..\libraries\Highbyte.DotNet6502.Updates\Highbyte.DotNet6502.Updates.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\..\libraries\Highbyte.DotNet6502.Impl.Terminal.*\*.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\Highbyte.DotNet6502.App.Terminal.Shell.*\*.csproj" />
   </ItemGroup>

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/Program.cs
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/Program.cs
@@ -6,6 +6,7 @@ using Highbyte.DotNet6502.Systems.Plugins;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Highbyte.DotNet6502.Updates;
 
 // ----------
 // DotNet 6502 emulator — interactive terminal (TUI) host.
@@ -16,6 +17,15 @@ using Microsoft.Extensions.Logging;
 // ISystemConfigurer, and shell plug-ins (App.Terminal.Shell.<System>) optionally contribute a
 // system-specific menu control shown in the controls column.
 // ----------
+
+// Update check CLI flags (--version / --check-update / --update), handled before the TUI takes over
+// the screen. No automatic startup notice here: an ephemeral stdout line would just be wiped by the
+// full-screen TUI. Environment.Exit keeps the app's existing exit-code handling intact.
+if (ConsoleUpdateCli.WantsHandling(args))
+    Environment.Exit(await ConsoleUpdateCli.RunAsync(
+        args,
+        new AppUpdateDescriptor { HomebrewPackage = "dotnet-6502-terminal", ScoopPackage = "dotnet-6502-terminal" },
+        Console.Out));
 
 // Anchor file/relative resource access to the built app location.
 Environment.CurrentDirectory = AppContext.BaseDirectory;

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/Program.cs
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/Program.cs
@@ -63,6 +63,14 @@ using var loggerFactory = LoggerFactory.Create(logBuilder =>
 
 var bootstrapLogger = loggerFactory.CreateLogger("Program");
 
+// Non-blocking startup update check. On a managed (brew/scoop) install with a newer release it logs
+// one Information line to the in-mem store shown in the "Logs" pane. Gated by the UpdateCheckEnabled
+// setting and the standard CI / DOTNET6502_NO_UPDATE_CHECK suppressors.
+_ = ConsoleUpdateCli.CheckAndLogOnStartupAsync(
+    new AppUpdateDescriptor { HomebrewPackage = "dotnet-6502-terminal", ScoopPackage = "dotnet-6502-terminal" },
+    loggerFactory.CreateLogger("UpdateCheck"),
+    configuration.GetValue("UpdateCheckEnabled", true));
+
 try
 {
     // ----------

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/appsettings.json
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/appsettings.json
@@ -1,4 +1,8 @@
 {
+  // Set to false to disable the automatic startup check for a newer released version.
+  // (Also disabled by the CI env var or DOTNET6502_NO_UPDATE_CHECK; only applies to brew/scoop installs.)
+  "UpdateCheckEnabled": true,
+
   "EnabledSystems": [ "C64", "VIC-20" ],
 
   "Highbyte.DotNet6502.TerminalConfig": {

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/publish.sh
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/publish.sh
@@ -62,6 +62,14 @@ if [[ "$INCLUDE_PDB" == false ]]; then
     PUBLISH_ARGS+=(-p:DebugType=None -p:DebugSymbols=false)
 fi
 
+# Stamp the release version if provided (set by CI from the git tag, e.g. "0.40.2-alpha").
+# Locally this is unset, so the app keeps its default 1.0.0 which the update checker
+# treats as "unknown -> skip update check" (dev builds never nag).
+if [[ -n "$RELEASE_VERSION" ]]; then
+    echo "  Version: $RELEASE_VERSION"
+    PUBLISH_ARGS+=(-p:Version="$RELEASE_VERSION")
+fi
+
 dotnet publish "${PUBLISH_ARGS[@]}"
 
 if [[ $? -eq 0 ]]; then

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64SystemConfig.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using Highbyte.DotNet6502.Systems.Configuration;
 using Highbyte.DotNet6502.Systems.Commodore64.Audio;
@@ -26,26 +25,26 @@ public partial class C64SystemConfig : ISystemConfig, ISnapshotableConfig
     public Type? RenderProviderType { get; private set; }
 
     /// <summary>
-    /// Serializable version of RenderProviderType as assembly qualified name
+    /// Serializable version of RenderProviderType as simple assembly-qualified name.
     /// </summary>
     [JsonPropertyName("RenderProviderType")]
     public string? RenderProviderTypeName
     {
-        get => RenderProviderType?.AssemblyQualifiedName;
-        set => SetRenderProviderType(ResolveConfiguredType(value));
+        get => ConfiguredTypeName.Format(RenderProviderType);
+        set => SetRenderProviderType(ConfiguredTypeName.Resolve(value));
     }
 
     [JsonIgnore]
     public Type? RenderTargetType { get; private set; }
 
     /// <summary>
-    /// Serializable version of RenderTargetType as assembly qualified name
+    /// Serializable version of RenderTargetType as simple assembly-qualified name.
     /// </summary>
     [JsonPropertyName("RenderTargetType")]
     public string? RenderTargetTypeTypeName
     {
-        get => RenderTargetType?.AssemblyQualifiedName;
-        set => SetRenderTargetType(ResolveConfiguredType(value));
+        get => ConfiguredTypeName.Format(RenderTargetType);
+        set => SetRenderTargetType(ConfiguredTypeName.Resolve(value));
     }
 
 
@@ -94,31 +93,27 @@ public partial class C64SystemConfig : ISystemConfig, ISnapshotableConfig
     public Type? AudioProviderType { get; private set; }
 
     /// <summary>
-    /// Serializable version of AudioProviderType as assembly qualified name.
+    /// Serializable version of AudioProviderType as simple assembly-qualified name.
     /// </summary>
     [JsonPropertyName("AudioProviderType")]
     public string? AudioProviderTypeName
     {
-        get => AudioProviderType?.AssemblyQualifiedName;
-        set => SetAudioProviderType(ResolveConfiguredType(value));
+        get => ConfiguredTypeName.Format(AudioProviderType);
+        set => SetAudioProviderType(ConfiguredTypeName.Resolve(value));
     }
 
     [JsonIgnore]
     public Type? AudioTargetType { get; private set; }
 
     /// <summary>
-    /// Serializable version of AudioTargetType as assembly qualified name.
+    /// Serializable version of AudioTargetType as simple assembly-qualified name.
     /// </summary>
     [JsonPropertyName("AudioTargetType")]
     public string? AudioTargetTypeName
     {
-        get => AudioTargetType?.AssemblyQualifiedName;
-        set => SetAudioTargetType(ResolveConfiguredType(value));
+        get => ConfiguredTypeName.Format(AudioTargetType);
+        set => SetAudioTargetType(ConfiguredTypeName.Resolve(value));
     }
-
-    [UnconditionalSuppressMessage("Trimming", "IL2057", Justification = "Configured type names are persisted application types and are immediately validated by the receiving setters.")]
-    private static Type? ResolveConfiguredType(string? typeName)
-        => string.IsNullOrWhiteSpace(typeName) ? null : Type.GetType(typeName);
 
     public List<Type> GetSupportedAudioProviderTypes()
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Generic/Config/GenericComputerSystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Generic/Config/GenericComputerSystemConfig.cs
@@ -1,5 +1,5 @@
 using System.Text.Json.Serialization;
-using System.Diagnostics.CodeAnalysis;
+using Highbyte.DotNet6502.Systems.Configuration;
 using Highbyte.DotNet6502.Systems.Generic.Render;
 
 namespace Highbyte.DotNet6502.Systems.Generic.Config;
@@ -14,31 +14,27 @@ public class GenericComputerSystemConfig : ISystemConfig
     public Type? RenderProviderType { get; private set; }
 
     /// <summary>
-    /// Serializable version of RenderProviderType as assembly qualified name
+    /// Serializable version of RenderProviderType as simple assembly-qualified name.
     /// </summary>
     [JsonPropertyName("RenderProviderType")]
     public string? RenderProviderTypeName
     {
-        get => RenderProviderType?.AssemblyQualifiedName;
-        set => SetRenderProviderType(ResolveConfiguredType(value));
+        get => ConfiguredTypeName.Format(RenderProviderType);
+        set => SetRenderProviderType(ConfiguredTypeName.Resolve(value));
     }
 
     [JsonIgnore]
     public Type? RenderTargetType { get; private set; }
 
     /// <summary>
-    /// Serializable version of RenderTargetType as assembly qualified name
+    /// Serializable version of RenderTargetType as simple assembly-qualified name.
     /// </summary>
     [JsonPropertyName("RenderTargetType")]
     public string? RenderTargetTypeTypeName
     {
-        get => RenderTargetType?.AssemblyQualifiedName;
-        set => SetRenderTargetType(ResolveConfiguredType(value));
+        get => ConfiguredTypeName.Format(RenderTargetType);
+        set => SetRenderTargetType(ConfiguredTypeName.Resolve(value));
     }
-
-    [UnconditionalSuppressMessage("Trimming", "IL2057", Justification = "Configured type names are persisted application types and are immediately validated by the receiving setters.")]
-    private static Type? ResolveConfiguredType(string? typeName)
-        => string.IsNullOrWhiteSpace(typeName) ? null : Type.GetType(typeName);
 
     public bool AudioEnabled { get; set; }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Config/Vic20SystemConfig.cs
@@ -1,5 +1,4 @@
 using System.Text.Json.Serialization;
-using System.Diagnostics.CodeAnalysis;
 using Highbyte.DotNet6502.Systems.Configuration;
 using Highbyte.DotNet6502.Utils;
 using Highbyte.DotNet6502.Systems.Vic20.Render;
@@ -42,8 +41,8 @@ public class Vic20SystemConfig : ISystemConfig
     [JsonPropertyName("RenderProviderType")]
     public string? RenderProviderTypeName
     {
-        get => RenderProviderType?.AssemblyQualifiedName;
-        set => SetRenderProviderType(ResolveConfiguredType(value));
+        get => ConfiguredTypeName.Format(RenderProviderType);
+        set => SetRenderProviderType(ConfiguredTypeName.Resolve(value));
     }
 
     [JsonIgnore]
@@ -52,13 +51,9 @@ public class Vic20SystemConfig : ISystemConfig
     [JsonPropertyName("RenderTargetType")]
     public string? RenderTargetTypeName
     {
-        get => RenderTargetType?.AssemblyQualifiedName;
-        set => SetRenderTargetType(ResolveConfiguredType(value));
+        get => ConfiguredTypeName.Format(RenderTargetType);
+        set => SetRenderTargetType(ConfiguredTypeName.Resolve(value));
     }
-
-    [UnconditionalSuppressMessage("Trimming", "IL2057", Justification = "Configured type names are persisted application types and are immediately validated by the receiving setters.")]
-    private static Type? ResolveConfiguredType(string? typeName)
-        => string.IsNullOrWhiteSpace(typeName) ? null : Type.GetType(typeName);
 
     public bool AudioEnabled { get; set; } = false;
 

--- a/src/libraries/Highbyte.DotNet6502.Systems/Configuration/ConfiguredTypeName.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Configuration/ConfiguredTypeName.cs
@@ -1,0 +1,60 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Highbyte.DotNet6502.Systems.Configuration;
+
+public static class ConfiguredTypeName
+{
+    public static string? Format(Type? type)
+    {
+        if (type == null)
+            return null;
+
+        var typeName = type.FullName;
+        var assemblyName = type.Assembly.GetName().Name;
+        if (string.IsNullOrWhiteSpace(typeName) || string.IsNullOrWhiteSpace(assemblyName))
+            return type.AssemblyQualifiedName;
+
+        return $"{typeName}, {assemblyName}";
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2057", Justification = "Configured type names are persisted application types and are immediately validated by the receiving setters.")]
+    public static Type? Resolve(string? typeName)
+    {
+        if (string.IsNullOrWhiteSpace(typeName))
+            return null;
+
+        var resolved = TryGetType(typeName);
+        if (resolved != null)
+            return resolved;
+
+        var formattedTypeName = RemoveAssemblyMetadata(typeName);
+        return formattedTypeName == typeName ? null : TryGetType(formattedTypeName);
+    }
+
+    private static string RemoveAssemblyMetadata(string typeName)
+    {
+        var typeNameSeparator = typeName.IndexOf(',');
+        if (typeNameSeparator < 0)
+            return typeName.Trim();
+
+        var typePart = typeName[..typeNameSeparator].Trim();
+        var assemblyPart = typeName[(typeNameSeparator + 1)..].Split(',')[0].Trim();
+        if (string.IsNullOrWhiteSpace(typePart) || string.IsNullOrWhiteSpace(assemblyPart))
+            return typeName;
+
+        return $"{typePart}, {assemblyPart}";
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2057", Justification = "Configured type names are persisted application types and are immediately validated by the receiving setters.")]
+    private static Type? TryGetType(string typeName)
+    {
+        try
+        {
+            return Type.GetType(typeName, throwOnError: false);
+        }
+        catch (Exception ex) when (ex is FileLoadException or FileNotFoundException or BadImageFormatException or TypeLoadException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Updates/AppVersion.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/AppVersion.cs
@@ -1,0 +1,50 @@
+using System.Reflection;
+
+namespace Highbyte.DotNet6502.Updates;
+
+/// <summary>
+/// Reads the running app's release version, stamped into the assembly at build time by CI
+/// (the release workflow passes <c>-p:Version=${TAG#v}</c> to each app's <c>publish.sh</c>).
+/// </summary>
+public static class AppVersion
+{
+    /// <summary>
+    /// The default assembly version when no <c>-p:Version</c> was passed. A locally built
+    /// (non-CI) app reports this, and the update checker treats it as "unknown → skip the update
+    /// check" so dev builds never nag.
+    /// </summary>
+    public static readonly SemanticVersion Unstamped = new(1, 0, 0);
+
+    /// <summary>
+    /// Reads the release version from the given (or entry) assembly's
+    /// <see cref="AssemblyInformationalVersionAttribute"/>, stripping any <c>+build</c> metadata
+    /// that SourceLink appends (e.g. <c>0.40.2-alpha+abc123</c> → <c>0.40.2-alpha</c>).
+    /// Returns null when the value is missing, unparseable, or the unstamped <c>1.0.0</c> default —
+    /// callers treat null as "unknown, skip the check".
+    /// </summary>
+    public static SemanticVersion? GetCurrent(Assembly? assembly = null)
+    {
+        assembly ??= Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+        var raw = assembly?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        return Parse(raw);
+    }
+
+    /// <summary>
+    /// Parses a raw informational-version string into a release version, or null when it is
+    /// missing, unparseable, or the unstamped <c>1.0.0</c> default. Exposed for testing.
+    /// </summary>
+    public static SemanticVersion? Parse(string? informationalVersion)
+    {
+        if (!SemanticVersion.TryParse(informationalVersion, out var version) || version is null)
+            return null;
+
+        // 1.0.0 (with or without +build metadata) means the app was not stamped by CI.
+        if (version.Equals(Unstamped))
+            return null;
+
+        // Drop the SourceLink +build metadata so the version displays cleanly (e.g. in the About dialog).
+        return version.BuildMetadata is null
+            ? version
+            : new SemanticVersion(version.Major, version.Minor, version.Patch, version.PrereleaseIdentifiers);
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Updates/ConsoleUpdateCli.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/ConsoleUpdateCli.cs
@@ -1,0 +1,127 @@
+namespace Highbyte.DotNet6502.Updates;
+
+/// <summary>
+/// Console-host glue for the update flow: the <c>--version</c> / <c>--check-update</c> / <c>--update</c>
+/// flags, and a quiet, gated one-line "update available" startup notice. Kept host-agnostic by writing
+/// to caller-supplied <see cref="TextWriter"/>s; suppression follows the npm <c>update-notifier</c>
+/// conventions (skip when non-interactive, in CI, or opted out).
+/// </summary>
+public static class ConsoleUpdateCli
+{
+    public const string OptOutEnvVar = "DOTNET6502_NO_UPDATE_CHECK";
+
+    private static readonly string[] HandledFlags = { "--version", "--check-update", "--update" };
+
+    /// <summary>True when args request the version or an explicit update check, so the host can early-return.</summary>
+    public static bool WantsHandling(string[] args) => args.Any(a => HandledFlags.Contains(a, StringComparer.Ordinal));
+
+    /// <summary>
+    /// Handles <c>--version</c> / <c>--check-update</c> / <c>--update</c> (explicit, so output goes to
+    /// <paramref name="output"/> = stdout) and returns the process exit code. Assumes
+    /// <see cref="WantsHandling"/> was true.
+    /// </summary>
+    public static async Task<int> RunAsync(string[] args, AppUpdateDescriptor descriptor, TextWriter output, CancellationToken cancellationToken = default)
+    {
+        if (args.Contains("--version", StringComparer.Ordinal))
+        {
+            var current = AppVersion.GetCurrent();
+            output.WriteLine(current is null ? "unknown (development build)" : $"v{current}");
+            return 0;
+        }
+
+        UpdateCheckResult result;
+        try
+        {
+            using var http = CreateHttpClient();
+            var checker = UpdateChecker.CreateDefault(descriptor, http);
+            result = await checker.CheckAsync(new UpdateCheckContext { ForceCheck = true }, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Update check failed: {ex.Message}");
+            return 0;
+        }
+
+        PrintVerbose(result, output);
+        return 0;
+    }
+
+    /// <summary>
+    /// Prints a single "update available" line to <paramref name="errorOutput"/> (stderr, so it never
+    /// pollutes machine-readable stdout) when appropriate. No-op when suppressed, not managed, or up to
+    /// date. Respects the daily cadence cache and never throws — a failed notice must not break startup.
+    /// </summary>
+    public static async Task NotifyOnStartupAsync(AppUpdateDescriptor descriptor, TextWriter errorOutput, CancellationToken cancellationToken = default)
+    {
+        if (IsSuppressed())
+            return;
+
+        try
+        {
+            using var http = CreateHttpClient();
+            var checker = UpdateChecker.CreateDefault(descriptor, http);
+            var result = await checker.CheckAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (result.IsUpdateAvailable)
+                errorOutput.WriteLine(FormatNoticeLine(result));
+        }
+        catch
+        {
+            // Best effort: never let the update notice break or delay-fail the host.
+        }
+    }
+
+    /// <summary>Standard suppressors: opt-out env var, CI, or a non-interactive (redirected) stderr.</summary>
+    public static bool IsSuppressed()
+    {
+        if (IsEnvFlagSet(OptOutEnvVar))
+            return true;
+        if (IsEnvFlagSet("CI"))
+            return true;
+        // The notice is written to stderr; if that's redirected we're likely scripted/piped.
+        if (Console.IsErrorRedirected)
+            return true;
+        return false;
+    }
+
+    private static bool IsEnvFlagSet(string name)
+    {
+        var value = Environment.GetEnvironmentVariable(name);
+        return !string.IsNullOrEmpty(value)
+            && !value.Equals("0", StringComparison.Ordinal)
+            && !value.Equals("false", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>The one-line "update available" message shared by the startup notice and verbose output.</summary>
+    public static string FormatNoticeLine(UpdateCheckResult result)
+        => $"A newer version v{result.LatestVersion} is available (you have v{result.CurrentVersion}). Run '{result.SuggestedCommand}' to update.";
+
+    private static void PrintVerbose(UpdateCheckResult result, TextWriter output)
+    {
+        switch (result.Status)
+        {
+            case UpdateCheckStatus.UpdateAvailable:
+                output.WriteLine(FormatNoticeLine(result));
+                if (!string.IsNullOrEmpty(result.ReleaseNotesUrl))
+                    output.WriteLine($"Release notes: {result.ReleaseNotesUrl}");
+                output.WriteLine("(Automatic in-app update isn't available yet — run the command above to update.)");
+                break;
+            case UpdateCheckStatus.UpToDate:
+                output.WriteLine($"You're on the latest version (v{result.CurrentVersion}).");
+                break;
+            case UpdateCheckStatus.NotManaged:
+                output.Write("This build isn't installed via Homebrew or Scoop, so there's no update check. ");
+                output.WriteLine(result.CurrentVersion is null
+                    ? "Version: unknown (development build)."
+                    : $"Current version: v{result.CurrentVersion}.");
+                break;
+            case UpdateCheckStatus.VersionUnknown:
+                output.WriteLine("Development build (version unknown); skipping update check.");
+                break;
+            case UpdateCheckStatus.Error:
+                output.WriteLine($"Update check failed: {result.Error}");
+                break;
+        }
+    }
+
+    private static HttpClient CreateHttpClient() => new() { Timeout = TimeSpan.FromSeconds(5) };
+}

--- a/src/libraries/Highbyte.DotNet6502.Updates/ConsoleUpdateCli.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/ConsoleUpdateCli.cs
@@ -1,10 +1,13 @@
+using Microsoft.Extensions.Logging;
+
 namespace Highbyte.DotNet6502.Updates;
 
 /// <summary>
-/// Console-host glue for the update flow: the <c>--version</c> / <c>--check-update</c> / <c>--update</c>
-/// flags, and a quiet, gated one-line "update available" startup notice. Kept host-agnostic by writing
-/// to caller-supplied <see cref="TextWriter"/>s; suppression follows the npm <c>update-notifier</c>
-/// conventions (skip when non-interactive, in CI, or opted out).
+/// Console-host glue for the update flow: the explicit <c>--version</c> / <c>--check-update</c> /
+/// <c>--update</c> flags (output to a caller-supplied <see cref="TextWriter"/> = stdout), and a gated
+/// automatic startup check that logs an "update available" line via <see cref="ILogger"/> (routing is
+/// the host's concern). Suppression of the automatic check follows the npm <c>update-notifier</c>
+/// conventions (skip in CI or when opted out).
 /// </summary>
 public static class ConsoleUpdateCli
 {
@@ -47,41 +50,39 @@ public static class ConsoleUpdateCli
     }
 
     /// <summary>
-    /// Prints a single "update available" line to <paramref name="errorOutput"/> (stderr, so it never
-    /// pollutes machine-readable stdout) when appropriate. No-op when suppressed, not managed, or up to
-    /// date. Respects the daily cadence cache and never throws — a failed notice must not break startup.
+    /// Runs the automatic (cadence-cached) startup update check and, if an update is available, logs one
+    /// <see cref="LogLevel.Information"/> line via <paramref name="logger"/> (the checker emits it — the
+    /// shared log point; the host decides where it's routed). Gated: a no-op when
+    /// <paramref name="updateCheckEnabled"/> is false or the environment suppresses it (CI / opt-out env
+    /// var). Never throws — a failed startup check must not disrupt the app.
     /// </summary>
-    public static async Task NotifyOnStartupAsync(AppUpdateDescriptor descriptor, TextWriter errorOutput, CancellationToken cancellationToken = default)
+    public static async Task CheckAndLogOnStartupAsync(
+        AppUpdateDescriptor descriptor,
+        ILogger logger,
+        bool updateCheckEnabled,
+        CancellationToken cancellationToken = default)
     {
-        if (IsSuppressed())
+        if (!updateCheckEnabled || IsSuppressedByEnvironment())
             return;
 
         try
         {
             using var http = CreateHttpClient();
-            var checker = UpdateChecker.CreateDefault(descriptor, http);
-            var result = await checker.CheckAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-            if (result.IsUpdateAvailable)
-                errorOutput.WriteLine(FormatNoticeLine(result));
+            var checker = UpdateChecker.CreateDefault(descriptor, http, logger);
+            await checker.CheckAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
         catch
         {
-            // Best effort: never let the update notice break or delay-fail the host.
+            // Best effort: never let the update check break or delay-fail startup.
         }
     }
 
-    /// <summary>Standard suppressors: opt-out env var, CI, or a non-interactive (redirected) stderr.</summary>
-    public static bool IsSuppressed()
-    {
-        if (IsEnvFlagSet(OptOutEnvVar))
-            return true;
-        if (IsEnvFlagSet("CI"))
-            return true;
-        // The notice is written to stderr; if that's redirected we're likely scripted/piped.
-        if (Console.IsErrorRedirected)
-            return true;
-        return false;
-    }
+    /// <summary>
+    /// Environmental suppressors for the <em>automatic</em> check: the opt-out env var
+    /// (<see cref="OptOutEnvVar"/>) or a CI environment. Explicit flags (<c>--check-update</c>) ignore these.
+    /// </summary>
+    public static bool IsSuppressedByEnvironment()
+        => IsEnvFlagSet(OptOutEnvVar) || IsEnvFlagSet("CI");
 
     private static bool IsEnvFlagSet(string name)
     {

--- a/src/libraries/Highbyte.DotNet6502.Updates/ConsoleUpdateCli.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/ConsoleUpdateCli.cs
@@ -45,6 +45,24 @@ public static class ConsoleUpdateCli
             return 0;
         }
 
+        // --update: actually run the package-manager upgrade in the foreground (this invocation is a
+        // short-lived flag handler, not the running app, so no quit/relaunch is needed).
+        if (args.Contains("--update", StringComparer.Ordinal)
+            && result.Status == UpdateCheckStatus.UpdateAvailable
+            && result.ManagerExecutablePath is not null)
+        {
+            output.WriteLine(FormatNoticeLine(result));
+            output.WriteLine($"Updating: {result.SuggestedCommand}");
+            output.WriteLine();
+            var succeeded = await UpdateApplier.RunUpgradeAsync(
+                result.ManagerExecutablePath, descriptor.UpgradeArgs(result.Channel), output, cancellationToken).ConfigureAwait(false);
+            output.WriteLine();
+            output.WriteLine(succeeded
+                ? "Update complete. Restart the app to use the new version."
+                : "Update failed. See the output above; you can run the command manually.");
+            return succeeded ? 0 : 1;
+        }
+
         PrintVerbose(result, output);
         return 0;
     }
@@ -104,7 +122,7 @@ public static class ConsoleUpdateCli
                 output.WriteLine(FormatNoticeLine(result));
                 if (!string.IsNullOrEmpty(result.ReleaseNotesUrl))
                     output.WriteLine($"Release notes: {result.ReleaseNotesUrl}");
-                output.WriteLine("(Automatic in-app update isn't available yet — run the command above to update.)");
+                output.WriteLine("(Run with --update to upgrade automatically, or run the command above yourself.)");
                 break;
             case UpdateCheckStatus.UpToDate:
                 output.WriteLine($"You're on the latest version (v{result.CurrentVersion}).");

--- a/src/libraries/Highbyte.DotNet6502.Updates/GitHubRelease.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/GitHubRelease.cs
@@ -1,0 +1,43 @@
+using System.Text.Json.Serialization;
+
+namespace Highbyte.DotNet6502.Updates;
+
+/// <summary>A GitHub release, as returned by <c>GET /repos/{owner}/{repo}/releases</c>.</summary>
+public sealed record GitHubRelease
+{
+    [JsonPropertyName("tag_name")]
+    public string TagName { get; init; } = "";
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("prerelease")]
+    public bool Prerelease { get; init; }
+
+    [JsonPropertyName("draft")]
+    public bool Draft { get; init; }
+
+    [JsonPropertyName("html_url")]
+    public string? HtmlUrl { get; init; }
+
+    [JsonPropertyName("published_at")]
+    public DateTimeOffset? PublishedAt { get; init; }
+}
+
+/// <summary>
+/// Outcome of a release query. <see cref="NotModified"/> is true when the server answered 304 to a
+/// conditional request (the caller should reuse its cached list); otherwise <see cref="Releases"/>
+/// holds the fresh list and <see cref="ETag"/> the value to send next time.
+/// </summary>
+public sealed record ReleaseQueryResult(
+    bool NotModified,
+    string? ETag,
+    IReadOnlyList<GitHubRelease> Releases);
+
+[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true, WriteIndented = true)]
+[JsonSerializable(typeof(GitHubRelease[]))]
+[JsonSerializable(typeof(List<GitHubRelease>))]
+[JsonSerializable(typeof(UpdateCheckCacheData))]
+internal partial class UpdatesJsonContext : JsonSerializerContext
+{
+}

--- a/src/libraries/Highbyte.DotNet6502.Updates/GitHubReleaseClient.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/GitHubReleaseClient.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using System.Text.Json;
+
+namespace Highbyte.DotNet6502.Updates;
+
+/// <summary>
+/// Queries the GitHub REST API for a repository's releases, with conditional-request (ETag) support
+/// to stay well under the 60 req/hr unauthenticated rate limit.
+/// </summary>
+/// <remarks>
+/// Uses <c>GET /releases</c> (not <c>/releases/latest</c>, which excludes prereleases — every release
+/// here is tagged <c>-alpha</c>). Sends a <c>User-Agent</c> as GitHub requires.
+/// </remarks>
+public sealed class GitHubReleaseClient : IReleaseSource
+{
+    public const string DefaultOwner = "highbyte";
+    public const string DefaultRepo = "dotnet-6502";
+    private const string UserAgent = "Highbyte.DotNet6502-UpdateChecker";
+
+    private readonly HttpClient _httpClient;
+    private readonly string _releasesUrl;
+
+    public GitHubReleaseClient(
+        HttpClient httpClient,
+        string owner = DefaultOwner,
+        string repo = DefaultRepo,
+        int perPage = 30)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _releasesUrl = $"https://api.github.com/repos/{owner}/{repo}/releases?per_page={perPage}";
+    }
+
+    public async Task<ReleaseQueryResult> GetReleasesAsync(string? etag, CancellationToken cancellationToken = default)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, _releasesUrl);
+        request.Headers.UserAgent.ParseAdd(UserAgent);
+        request.Headers.Accept.ParseAdd("application/vnd.github+json");
+        // GitHub returns weak ETags (e.g. W/"abc"); ParseAdd handles the W/ prefix that the
+        // EntityTagHeaderValue(string) constructor rejects. TryParseAdd keeps a malformed cached
+        // value from throwing — worst case we just do an unconditional request.
+        if (!string.IsNullOrEmpty(etag))
+            request.Headers.IfNoneMatch.TryParseAdd(etag);
+
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (response.StatusCode == HttpStatusCode.NotModified)
+            return new ReleaseQueryResult(NotModified: true, etag, Array.Empty<GitHubRelease>());
+
+        response.EnsureSuccessStatusCode();
+
+        var newEtag = response.Headers.ETag?.ToString() ?? etag;
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        var releases = await JsonSerializer.DeserializeAsync(
+            stream,
+            UpdatesJsonContext.Default.GitHubReleaseArray,
+            cancellationToken).ConfigureAwait(false);
+
+        return new ReleaseQueryResult(NotModified: false, newEtag, releases ?? Array.Empty<GitHubRelease>());
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Updates/Highbyte.DotNet6502.Updates.csproj
+++ b/src/libraries/Highbyte.DotNet6502.Updates/Highbyte.DotNet6502.Updates.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <!-- App-support library, consumed by the shipped apps via ProjectReference only.
+         Not published to NuGet, so its dependencies (HTTP, process spawning, semver)
+         stay out of the reusable Highbyte.DotNet6502.* emulator packages. -->
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Highbyte.DotNet6502.Systems\Highbyte.DotNet6502.Systems.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/libraries/Highbyte.DotNet6502.Updates/IInstallChannelProbe.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/IInstallChannelProbe.cs
@@ -1,0 +1,43 @@
+namespace Highbyte.DotNet6502.Updates;
+
+public enum OSPlatformKind
+{
+    Other = 0,
+    Windows,
+    MacOS,
+    Linux,
+}
+
+/// <summary>Outcome of running an external command (package-manager query).</summary>
+public sealed record ProcessRunResult(int ExitCode, string StandardOutput);
+
+/// <summary>
+/// The OS / filesystem / process operations <see cref="InstallChannelDetector"/> needs. Abstracted
+/// so channel detection — which shells out to <c>brew</c>/<c>scoop</c> and reads marker files — can
+/// be unit-tested with a fake, and driven for real by <see cref="SystemInstallChannelProbe"/>.
+/// </summary>
+public interface IInstallChannelProbe
+{
+    OSPlatformKind OS { get; }
+
+    /// <summary>Directory the app runs from (<see cref="AppContext.BaseDirectory"/> in production).</summary>
+    string BaseDirectory { get; }
+
+    string? HomeDirectory { get; }
+
+    string? GetEnvironmentVariable(string name);
+
+    bool DirectoryExists(string path);
+
+    /// <summary>First non-empty trimmed line of the file, or null if the file is missing/empty.</summary>
+    string? ReadFileFirstLine(string path);
+
+    /// <summary>
+    /// Resolves the full path to <paramref name="command"/>, checking <paramref name="preferredDirectories"/>
+    /// first (GUI apps don't inherit the shell PATH) and then PATH. Returns null if not found.
+    /// </summary>
+    string? ResolveExecutable(string command, IEnumerable<string> preferredDirectories);
+
+    /// <summary>Runs a command and captures its exit code + stdout; returns null if it couldn't be launched.</summary>
+    ProcessRunResult? RunCommand(string executablePath, IReadOnlyList<string> arguments, TimeSpan timeout);
+}

--- a/src/libraries/Highbyte.DotNet6502.Updates/IReleaseSource.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/IReleaseSource.cs
@@ -1,0 +1,11 @@
+namespace Highbyte.DotNet6502.Updates;
+
+/// <summary>Fetches the repository's releases. Abstracted so the update checker can be tested with a fake.</summary>
+public interface IReleaseSource
+{
+    /// <summary>
+    /// Fetches releases, sending <paramref name="etag"/> as a conditional request when non-null.
+    /// Returns <see cref="ReleaseQueryResult.NotModified"/> when the server answers 304.
+    /// </summary>
+    Task<ReleaseQueryResult> GetReleasesAsync(string? etag, CancellationToken cancellationToken = default);
+}

--- a/src/libraries/Highbyte.DotNet6502.Updates/InstallChannel.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/InstallChannel.cs
@@ -55,4 +55,13 @@ public sealed record AppUpdateDescriptor
         InstallChannel.Scoop => ScoopPackage,
         _ => throw new ArgumentOutOfRangeException(nameof(channel), channel, "No package name for a non-managed channel."),
     };
+
+    /// <summary>Argv (after the manager executable) that upgrades this app for the given channel.</summary>
+    public string[] UpgradeArgs(InstallChannel channel) => channel switch
+    {
+        InstallChannel.Homebrew when HomebrewIsCask => new[] { "upgrade", "--cask", HomebrewPackage },
+        InstallChannel.Homebrew => new[] { "upgrade", HomebrewPackage },
+        InstallChannel.Scoop => new[] { "update", ScoopPackage },
+        _ => throw new ArgumentOutOfRangeException(nameof(channel), channel, "No upgrade args for a non-managed channel."),
+    };
 }

--- a/src/libraries/Highbyte.DotNet6502.Updates/InstallChannel.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/InstallChannel.cs
@@ -1,0 +1,58 @@
+namespace Highbyte.DotNet6502.Updates;
+
+/// <summary>
+/// How this instance of the app was installed. Only package-manager installs get an update flow;
+/// everything else (portable zip, dev build, or any ambiguity) is <see cref="NotManaged"/> and does
+/// nothing.
+/// </summary>
+public enum InstallChannel
+{
+    /// <summary>Not installed via a supported package manager. No update check, no nudge.</summary>
+    NotManaged = 0,
+
+    /// <summary>Installed via Homebrew (cask on macOS GUI, formula for console apps / Linux).</summary>
+    Homebrew,
+
+    /// <summary>Installed via Scoop (Windows).</summary>
+    Scoop,
+}
+
+/// <summary>
+/// Result of install-channel detection. <see cref="ManagerExecutablePath"/> is the full resolved
+/// path to the package manager (GUI apps don't inherit the shell PATH), populated only once the
+/// channel is confirmed managed.
+/// </summary>
+public sealed record InstallChannelInfo(
+    InstallChannel Channel,
+    string? PackageName = null,
+    string? ManagerExecutablePath = null)
+{
+    public static readonly InstallChannelInfo NotManaged = new(InstallChannel.NotManaged);
+
+    public bool IsManaged => Channel is InstallChannel.Homebrew or InstallChannel.Scoop;
+}
+
+/// <summary>
+/// Per-app details the update flow needs but the shared detector can't know on its own: what this
+/// app is called in each package manager, and (for Homebrew) whether it's a cask or a formula —
+/// which changes both the confirmation query and the suggested <c>brew upgrade</c> command.
+/// </summary>
+public sealed record AppUpdateDescriptor
+{
+    /// <summary>Homebrew package name (cask token or formula name), e.g. <c>dotnet-6502-terminal</c>.</summary>
+    public required string HomebrewPackage { get; init; }
+
+    /// <summary>True for the macOS GUI cask; false for a formula (console apps / Linux GUI).</summary>
+    public bool HomebrewIsCask { get; init; }
+
+    /// <summary>Scoop app name, e.g. <c>dotnet-6502-terminal</c>.</summary>
+    public required string ScoopPackage { get; init; }
+
+    /// <summary>Package name for the currently detected/confirmed channel.</summary>
+    public string PackageNameFor(InstallChannel channel) => channel switch
+    {
+        InstallChannel.Homebrew => HomebrewPackage,
+        InstallChannel.Scoop => ScoopPackage,
+        _ => throw new ArgumentOutOfRangeException(nameof(channel), channel, "No package name for a non-managed channel."),
+    };
+}

--- a/src/libraries/Highbyte.DotNet6502.Updates/InstallChannelDetector.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/InstallChannelDetector.cs
@@ -1,0 +1,156 @@
+namespace Highbyte.DotNet6502.Updates;
+
+/// <summary>
+/// Detects whether this instance was installed via Homebrew or Scoop (vs. a portable zip of the
+/// same binary), which gates the entire update feature. Biases hard to
+/// <see cref="InstallChannel.NotManaged"/> on any ambiguity: a false "managed" would show a
+/// <c>brew</c>/<c>scoop</c> command that does nothing, whereas a false "not-managed" merely does
+/// nothing — the safe failure.
+///
+/// Three stages: (1) an authoritative <c>install-channel</c> marker file dropped by the manifest,
+/// (2) path-heuristic corroboration on the run directory, and (3) a runtime sanity check that the
+/// manager is actually resolvable and reports this package installed. Only stage 3 can *confirm*
+/// managed; anything short of it collapses to not-managed.
+/// </summary>
+public sealed class InstallChannelDetector
+{
+    /// <summary>Single-line sidecar naming the channel (<c>homebrew</c> / <c>scoop</c>), optionally <c>homebrew:&lt;pkg&gt;</c>.</summary>
+    public const string MarkerFileName = "install-channel";
+
+    private readonly IInstallChannelProbe _probe;
+    private readonly TimeSpan _commandTimeout;
+
+    public InstallChannelDetector(IInstallChannelProbe? probe = null, TimeSpan? commandTimeout = null)
+    {
+        _probe = probe ?? SystemInstallChannelProbe.Instance;
+        _commandTimeout = commandTimeout ?? TimeSpan.FromSeconds(5);
+    }
+
+    public InstallChannelInfo Detect(AppUpdateDescriptor descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        var candidate = ReadMarkerChannel();
+        if (candidate is null)
+            return InstallChannelInfo.NotManaged; // absent marker ⇒ not-managed (portable)
+
+        var channel = candidate.Value;
+        var packageName = descriptor.PackageNameFor(channel);
+
+        return channel switch
+        {
+            InstallChannel.Homebrew => ConfirmHomebrew(packageName, descriptor.HomebrewIsCask),
+            InstallChannel.Scoop => ConfirmScoop(packageName),
+            _ => InstallChannelInfo.NotManaged,
+        };
+    }
+
+    /// <summary>Reads the channel from the marker, checking the next-to-binary location then the macOS cask support dir.</summary>
+    private InstallChannel? ReadMarkerChannel()
+    {
+        foreach (var path in MarkerFilePaths())
+        {
+            var line = _probe.ReadFileFirstLine(path);
+            if (line is null)
+                continue;
+
+            // Format: "homebrew" | "scoop" | "homebrew:<pkg>" | "scoop:<pkg>". Only the channel is used here;
+            // per-app package names come from the AppUpdateDescriptor.
+            var channelToken = line.Split(':', 2)[0].Trim().ToLowerInvariant();
+            switch (channelToken)
+            {
+                case "homebrew":
+                case "brew":
+                    return InstallChannel.Homebrew;
+                case "scoop":
+                    return InstallChannel.Scoop;
+            }
+        }
+
+        return null;
+    }
+
+    private IEnumerable<string> MarkerFilePaths()
+    {
+        // 1. Next to the binary (Homebrew formula + Scoop write it into the install dir).
+        yield return Path.Combine(_probe.BaseDirectory, MarkerFileName);
+
+        // 2. macOS cask: the .app runs from /Applications and can't carry a marker cleanly, so the
+        //    cask writes it to a support dir instead (see CaskSupportDirMarkerPath).
+        var caskMarker = CaskSupportDirMarkerPath();
+        if (caskMarker != null)
+            yield return caskMarker;
+    }
+
+    /// <summary>
+    /// macOS support-dir marker path written by the Homebrew cask <c>postflight</c>:
+    /// <c>~/Library/Application Support/Highbyte/DotNet6502/install-channel</c>. Null on other OSes.
+    /// Kept in sync with the cask manifest.
+    /// </summary>
+    public string? CaskSupportDirMarkerPath()
+    {
+        if (_probe.OS != OSPlatformKind.MacOS)
+            return null;
+        var home = _probe.HomeDirectory;
+        if (string.IsNullOrWhiteSpace(home))
+            return null;
+        return Path.Combine(home, "Library", "Application Support", "Highbyte", "DotNet6502", MarkerFileName);
+    }
+
+    private InstallChannelInfo ConfirmHomebrew(string packageName, bool isCask)
+    {
+        var brew = _probe.ResolveExecutable("brew", HomebrewBinDirectories());
+        if (brew is null)
+            return InstallChannelInfo.NotManaged;
+
+        // `brew list --versions <pkg>` exits 0 and prints the package+version only when installed.
+        var args = isCask
+            ? new[] { "list", "--cask", "--versions", packageName }
+            : new[] { "list", "--versions", packageName };
+        var result = _probe.RunCommand(brew, args, _commandTimeout);
+        if (result is null || result.ExitCode != 0 || !result.StandardOutput.Contains(packageName, StringComparison.OrdinalIgnoreCase))
+            return InstallChannelInfo.NotManaged;
+
+        return new InstallChannelInfo(InstallChannel.Homebrew, packageName, brew);
+    }
+
+    private InstallChannelInfo ConfirmScoop(string packageName)
+    {
+        var scoop = _probe.ResolveExecutable("scoop", ScoopShimDirectories());
+        if (scoop is null)
+            return InstallChannelInfo.NotManaged;
+
+        // `scoop list <pkg>` lists the app row only when installed; the app name appears in stdout.
+        var result = _probe.RunCommand(scoop, new[] { "list", packageName }, _commandTimeout);
+        if (result is null || result.ExitCode != 0 || !result.StandardOutput.Contains(packageName, StringComparison.OrdinalIgnoreCase))
+            return InstallChannelInfo.NotManaged;
+
+        return new InstallChannelInfo(InstallChannel.Scoop, packageName, scoop);
+    }
+
+    private IEnumerable<string> HomebrewBinDirectories()
+    {
+        var prefix = _probe.GetEnvironmentVariable("HOMEBREW_PREFIX");
+        if (!string.IsNullOrWhiteSpace(prefix))
+            yield return Path.Combine(prefix, "bin");
+
+        yield return "/opt/homebrew/bin";        // Apple Silicon
+        yield return "/usr/local/bin";           // Intel macOS
+
+        var home = _probe.HomeDirectory;
+        if (!string.IsNullOrWhiteSpace(home))
+            yield return Path.Combine(home, ".linuxbrew", "bin");
+        yield return "/home/linuxbrew/.linuxbrew/bin"; // Linuxbrew default
+    }
+
+    private IEnumerable<string> ScoopShimDirectories()
+    {
+        var scoopHome = _probe.GetEnvironmentVariable("SCOOP");
+        if (!string.IsNullOrWhiteSpace(scoopHome))
+            yield return Path.Combine(scoopHome, "shims");
+
+        var home = _probe.HomeDirectory;
+        if (!string.IsNullOrWhiteSpace(home))
+            yield return Path.Combine(home, "scoop", "shims");
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Updates/ProcessLaunch.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/ProcessLaunch.cs
@@ -1,0 +1,83 @@
+using System.Diagnostics;
+
+namespace Highbyte.DotNet6502.Updates;
+
+/// <summary>
+/// Builds a <see cref="ProcessStartInfo"/> that launches an executable OR a Windows shell script
+/// correctly. This matters because Scoop is a PowerShell tool: the preferred shim is <c>scoop.ps1</c>
+/// (Scoop's <c>scoop.cmd</c> is just a trampoline to it). Scripts can't be started directly with
+/// <c>UseShellExecute=false</c> — a <c>.ps1</c> is run via a PowerShell host, and a <c>.cmd</c>/<c>.bat</c>
+/// via <c>cmd.exe /c</c>. For the PowerShell host it prefers <c>pwsh.exe</c> (PowerShell 7) when present
+/// and falls back to the always-installed <c>powershell.exe</c> (Windows PowerShell 5.1) — the same
+/// choice Scoop's own <c>scoop.cmd</c> makes. Homebrew's <c>brew</c> is a plain executable, so on Unix
+/// (and for real .exe files) this is a straight pass-through.
+/// </summary>
+public static class ProcessLaunch
+{
+    public static ProcessStartInfo BuildStartInfo(
+        string executablePath,
+        IReadOnlyList<string> args,
+        bool isWindows,
+        string powerShellExe = "powershell.exe")
+    {
+        var psi = new ProcessStartInfo { UseShellExecute = false, CreateNoWindow = true };
+
+        var extension = isWindows ? Path.GetExtension(executablePath).ToLowerInvariant() : string.Empty;
+        switch (extension)
+        {
+            case ".cmd":
+            case ".bat":
+                psi.FileName = "cmd.exe";
+                psi.ArgumentList.Add("/c");
+                psi.ArgumentList.Add(executablePath);
+                break;
+            case ".ps1":
+                psi.FileName = powerShellExe;
+                psi.ArgumentList.Add("-NoProfile");
+                psi.ArgumentList.Add("-ExecutionPolicy");
+                psi.ArgumentList.Add("Bypass");
+                psi.ArgumentList.Add("-File");
+                psi.ArgumentList.Add(executablePath);
+                break;
+            default:
+                psi.FileName = executablePath;
+                break;
+        }
+
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+        return psi;
+    }
+
+    /// <summary>
+    /// The PowerShell host to run <c>.ps1</c> scripts with: <c>pwsh.exe</c> (PowerShell 7) when it's on
+    /// PATH, else <c>powershell.exe</c> (Windows PowerShell 5.1, always present). Always
+    /// <c>powershell.exe</c> off Windows (irrelevant there). Mirrors Scoop's <c>scoop.cmd</c>.
+    /// </summary>
+    public static string ResolveWindowsPowerShellExe()
+    {
+        if (!OperatingSystem.IsWindows())
+            return "powershell.exe";
+        return IsExecutableOnPath("pwsh.exe") ? "pwsh.exe" : "powershell.exe";
+    }
+
+    private static bool IsExecutableOnPath(string fileName)
+    {
+        var pathEnv = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathEnv))
+            return false;
+        foreach (var dir in pathEnv.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            try
+            {
+                if (File.Exists(Path.Combine(dir, fileName)))
+                    return true;
+            }
+            catch (ArgumentException)
+            {
+                // A malformed PATH entry — skip it.
+            }
+        }
+        return false;
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Updates/SemanticVersion.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/SemanticVersion.cs
@@ -1,0 +1,185 @@
+using System.Globalization;
+using System.Numerics;
+
+namespace Highbyte.DotNet6502.Updates;
+
+/// <summary>
+/// Minimal Semantic Versioning 2.0.0 value type: parse + precedence comparison.
+///
+/// Exists instead of taking a NuGet dependency (NuGet.Versioning / Semver) so the update
+/// checker stays dependency-free and out of the published emulator packages. Only the subset the
+/// update flow needs is implemented: <c>MAJOR.MINOR.PATCH</c> with an optional <c>-prerelease</c>
+/// and an optional <c>+build</c> metadata part. A leading <c>v</c> (as in the git tag
+/// <c>v0.40.2-alpha</c>) is tolerated on parse. Build metadata is parsed but, per the spec, ignored
+/// for precedence, so <c>0.40.2-alpha</c> sorts below <c>0.40.2</c> and above <c>0.40.1-alpha</c>.
+/// </summary>
+public sealed class SemanticVersion : IComparable<SemanticVersion>, IEquatable<SemanticVersion>
+{
+    public int Major { get; }
+    public int Minor { get; }
+    public int Patch { get; }
+
+    /// <summary>Dot-separated prerelease identifiers; empty when this is a release version.</summary>
+    public IReadOnlyList<string> PrereleaseIdentifiers { get; }
+
+    /// <summary>The raw <c>+build</c> metadata (without the <c>+</c>), or null. Ignored for precedence.</summary>
+    public string? BuildMetadata { get; }
+
+    public bool IsPrerelease => PrereleaseIdentifiers.Count > 0;
+
+    public SemanticVersion(
+        int major,
+        int minor,
+        int patch,
+        IReadOnlyList<string>? prereleaseIdentifiers = null,
+        string? buildMetadata = null)
+    {
+        if (major < 0) throw new ArgumentOutOfRangeException(nameof(major));
+        if (minor < 0) throw new ArgumentOutOfRangeException(nameof(minor));
+        if (patch < 0) throw new ArgumentOutOfRangeException(nameof(patch));
+
+        Major = major;
+        Minor = minor;
+        Patch = patch;
+        PrereleaseIdentifiers = prereleaseIdentifiers ?? Array.Empty<string>();
+        BuildMetadata = buildMetadata;
+    }
+
+    public static bool TryParse(string? input, out SemanticVersion? version)
+    {
+        version = null;
+        if (string.IsNullOrWhiteSpace(input))
+            return false;
+
+        var s = input.Trim();
+        if (s.StartsWith('v') || s.StartsWith('V'))
+            s = s[1..];
+
+        // Peel off build metadata (+...), then the prerelease (-...), leaving the numeric core.
+        string? build = null;
+        var plus = s.IndexOf('+');
+        if (plus >= 0)
+        {
+            build = s[(plus + 1)..];
+            s = s[..plus];
+            if (build.Length == 0)
+                return false;
+        }
+
+        string? prerelease = null;
+        var dash = s.IndexOf('-');
+        if (dash >= 0)
+        {
+            prerelease = s[(dash + 1)..];
+            s = s[..dash];
+        }
+
+        var core = s.Split('.');
+        if (core.Length != 3)
+            return false;
+        if (!TryParseCoreNumber(core[0], out var major) ||
+            !TryParseCoreNumber(core[1], out var minor) ||
+            !TryParseCoreNumber(core[2], out var patch))
+            return false;
+
+        string[] prereleaseIds = Array.Empty<string>();
+        if (prerelease != null)
+        {
+            prereleaseIds = prerelease.Split('.');
+            foreach (var id in prereleaseIds)
+            {
+                if (id.Length == 0)
+                    return false; // empty identifier (e.g. trailing/leading/double dot) is invalid
+            }
+        }
+
+        version = new SemanticVersion(major, minor, patch, prereleaseIds, build);
+        return true;
+    }
+
+    private static bool TryParseCoreNumber(string s, out int value)
+        => int.TryParse(s, NumberStyles.None, CultureInfo.InvariantCulture, out value);
+
+    public int CompareTo(SemanticVersion? other)
+    {
+        if (other is null)
+            return 1;
+
+        var c = Major.CompareTo(other.Major);
+        if (c != 0) return c;
+        c = Minor.CompareTo(other.Minor);
+        if (c != 0) return c;
+        c = Patch.CompareTo(other.Patch);
+        if (c != 0) return c;
+
+        // A release version has higher precedence than a prerelease of the same core.
+        var thisPre = IsPrerelease;
+        var otherPre = other.IsPrerelease;
+        if (!thisPre && !otherPre) return 0;
+        if (!thisPre) return 1;
+        if (!otherPre) return -1;
+
+        var len = Math.Min(PrereleaseIdentifiers.Count, other.PrereleaseIdentifiers.Count);
+        for (var i = 0; i < len; i++)
+        {
+            var a = PrereleaseIdentifiers[i];
+            var b = other.PrereleaseIdentifiers[i];
+            var aNumeric = TryAsNumber(a, out var an);
+            var bNumeric = TryAsNumber(b, out var bn);
+
+            if (aNumeric && bNumeric)
+            {
+                c = an.CompareTo(bn);
+                if (c != 0) return c;
+            }
+            else if (aNumeric)
+            {
+                return -1; // numeric identifiers have lower precedence than alphanumeric
+            }
+            else if (bNumeric)
+            {
+                return 1;
+            }
+            else
+            {
+                c = string.CompareOrdinal(a, b);
+                if (c != 0) return c;
+            }
+        }
+
+        // All shared identifiers equal: the version with more identifiers has higher precedence.
+        return PrereleaseIdentifiers.Count.CompareTo(other.PrereleaseIdentifiers.Count);
+    }
+
+    private static bool TryAsNumber(string s, out BigInteger value)
+    {
+        value = default;
+        foreach (var ch in s)
+        {
+            if (ch is < '0' or > '9')
+                return false;
+        }
+        return BigInteger.TryParse(s, NumberStyles.None, CultureInfo.InvariantCulture, out value);
+    }
+
+    public bool Equals(SemanticVersion? other) => other is not null && CompareTo(other) == 0;
+    public override bool Equals(object? obj) => Equals(obj as SemanticVersion);
+    public override int GetHashCode() => HashCode.Combine(Major, Minor, Patch, IsPrerelease);
+
+    public static bool operator <(SemanticVersion a, SemanticVersion b) => a.CompareTo(b) < 0;
+    public static bool operator >(SemanticVersion a, SemanticVersion b) => a.CompareTo(b) > 0;
+    public static bool operator <=(SemanticVersion a, SemanticVersion b) => a.CompareTo(b) <= 0;
+    public static bool operator >=(SemanticVersion a, SemanticVersion b) => a.CompareTo(b) >= 0;
+    public static bool operator ==(SemanticVersion? a, SemanticVersion? b) => a is null ? b is null : a.Equals(b);
+    public static bool operator !=(SemanticVersion? a, SemanticVersion? b) => !(a == b);
+
+    public override string ToString()
+    {
+        var core = $"{Major}.{Minor}.{Patch}";
+        if (IsPrerelease)
+            core += "-" + string.Join('.', PrereleaseIdentifiers);
+        if (BuildMetadata != null)
+            core += "+" + BuildMetadata;
+        return core;
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Updates/SystemInstallChannelProbe.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/SystemInstallChannelProbe.cs
@@ -61,8 +61,11 @@ public sealed class SystemInstallChannelProbe : IInstallChannelProbe
     public string? ResolveExecutable(string command, IEnumerable<string> preferredDirectories)
     {
         var isWindows = OS == OSPlatformKind.Windows;
+        // Prefer a native .exe, then the PowerShell shim (.ps1) — Scoop is a PowerShell tool and its
+        // .cmd shim is just a trampoline to scoop.ps1, so running the .ps1 directly is more direct on
+        // modern Windows. Fall back to .cmd/.bat/bare for robustness.
         var candidateNames = isWindows
-            ? new[] { command + ".exe", command + ".cmd", command + ".bat", command }
+            ? new[] { command + ".exe", command + ".ps1", command + ".cmd", command + ".bat", command }
             : new[] { command };
 
         foreach (var dir in preferredDirectories)
@@ -98,16 +101,11 @@ public sealed class SystemInstallChannelProbe : IInstallChannelProbe
     {
         try
         {
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = executablePath,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-            };
-            foreach (var arg in arguments)
-                startInfo.ArgumentList.Add(arg);
+            // Launch .ps1/.cmd/.bat (e.g. the Scoop shim scoop.ps1) correctly on Windows, preferring pwsh 7.
+            var startInfo = ProcessLaunch.BuildStartInfo(
+                executablePath, arguments, OS == OSPlatformKind.Windows, ProcessLaunch.ResolveWindowsPowerShellExe());
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;
 
             using var process = Process.Start(startInfo);
             if (process is null)

--- a/src/libraries/Highbyte.DotNet6502.Updates/SystemInstallChannelProbe.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/SystemInstallChannelProbe.cs
@@ -1,0 +1,133 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Highbyte.DotNet6502.Updates;
+
+/// <summary>Production <see cref="IInstallChannelProbe"/> backed by the real OS, filesystem, and processes.</summary>
+public sealed class SystemInstallChannelProbe : IInstallChannelProbe
+{
+    public static readonly SystemInstallChannelProbe Instance = new();
+
+    public OSPlatformKind OS
+    {
+        get
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return OSPlatformKind.Windows;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return OSPlatformKind.MacOS;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return OSPlatformKind.Linux;
+            return OSPlatformKind.Other;
+        }
+    }
+
+    public string BaseDirectory => AppContext.BaseDirectory;
+
+    public string? HomeDirectory
+    {
+        get
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            return string.IsNullOrWhiteSpace(home) ? Environment.GetEnvironmentVariable("HOME") : home;
+        }
+    }
+
+    public string? GetEnvironmentVariable(string name) => Environment.GetEnvironmentVariable(name);
+
+    public bool DirectoryExists(string path) => Directory.Exists(path);
+
+    public string? ReadFileFirstLine(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+                return null;
+            foreach (var line in File.ReadLines(path))
+            {
+                var trimmed = line.Trim();
+                if (trimmed.Length > 0)
+                    return trimmed;
+            }
+            return null;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    public string? ResolveExecutable(string command, IEnumerable<string> preferredDirectories)
+    {
+        var isWindows = OS == OSPlatformKind.Windows;
+        var candidateNames = isWindows
+            ? new[] { command + ".exe", command + ".cmd", command + ".bat", command }
+            : new[] { command };
+
+        foreach (var dir in preferredDirectories)
+        {
+            if (string.IsNullOrWhiteSpace(dir))
+                continue;
+            foreach (var name in candidateNames)
+            {
+                var candidate = Path.Combine(dir, name);
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+        }
+
+        var pathEnv = Environment.GetEnvironmentVariable("PATH");
+        if (!string.IsNullOrEmpty(pathEnv))
+        {
+            foreach (var dir in pathEnv.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+            {
+                foreach (var name in candidateNames)
+                {
+                    var candidate = Path.Combine(dir, name);
+                    if (File.Exists(candidate))
+                        return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public ProcessRunResult? RunCommand(string executablePath, IReadOnlyList<string> arguments, TimeSpan timeout)
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = executablePath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            foreach (var arg in arguments)
+                startInfo.ArgumentList.Add(arg);
+
+            using var process = Process.Start(startInfo);
+            if (process is null)
+                return null;
+
+            var stdout = process.StandardOutput.ReadToEnd();
+            // Drain stderr too so a chatty manager can't fill the pipe and deadlock.
+            _ = process.StandardError.ReadToEnd();
+
+            if (!process.WaitForExit((int)timeout.TotalMilliseconds))
+            {
+                try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+                return null;
+            }
+
+            return new ProcessRunResult(process.ExitCode, stdout);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception or IOException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Updates/UpdateApplier.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/UpdateApplier.cs
@@ -1,0 +1,190 @@
+using System.Diagnostics;
+using System.Text;
+using Highbyte.DotNet6502.Systems.Configuration;
+
+namespace Highbyte.DotNet6502.Updates;
+
+/// <summary>How to relaunch the app after the upgrade: an executable plus its arguments.</summary>
+public sealed record RelaunchSpec(string Executable, IReadOnlyList<string> Arguments);
+
+/// <summary>
+/// Applies a delegated update by running the package manager (Phase B).
+///
+/// <see cref="RunUpgradeAsync"/> is the foreground path used by the console <c>--update</c> flag: that
+/// invocation is a short-lived flag handler, not the running app, so it can upgrade in place and just
+/// report — no quit/PID-wait/relaunch. The GUI's one-click button (where the <em>running</em> app
+/// updates itself) needs the detached wait-PID → upgrade → relaunch helper instead.
+/// </summary>
+public static class UpdateApplier
+{
+    /// <summary>
+    /// Runs <c>&lt;managerExecutablePath&gt; &lt;args&gt;</c> in the foreground, streaming its stdout and
+    /// stderr to <paramref name="output"/>. Returns true on exit code 0. Never throws for the expected
+    /// launch failures.
+    /// </summary>
+    public static async Task<bool> RunUpgradeAsync(
+        string managerExecutablePath,
+        IReadOnlyList<string> args,
+        TextWriter output,
+        CancellationToken cancellationToken = default)
+    {
+        // Launch .ps1/.cmd/.bat (e.g. the Scoop shim scoop.ps1) correctly on Windows, preferring pwsh 7.
+        var startInfo = ProcessLaunch.BuildStartInfo(
+            managerExecutablePath, args, OperatingSystem.IsWindows(), ProcessLaunch.ResolveWindowsPowerShellExe());
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+
+        Process? process;
+        try
+        {
+            process = Process.Start(startInfo);
+        }
+        catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or InvalidOperationException or IOException)
+        {
+            output.WriteLine($"Could not start the package manager: {ex.Message}");
+            return false;
+        }
+
+        if (process is null)
+        {
+            output.WriteLine("Could not start the package manager.");
+            return false;
+        }
+
+        using (process)
+        {
+            process.OutputDataReceived += (_, e) => { if (e.Data != null) output.WriteLine(e.Data); };
+            process.ErrorDataReceived += (_, e) => { if (e.Data != null) output.WriteLine(e.Data); };
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+            return process.ExitCode == 0;
+        }
+    }
+
+    /// <summary>
+    /// Spawns a DETACHED helper that waits for the app (<paramref name="appProcessId"/>) to exit, runs
+    /// the upgrade, then relaunches — the new version, or the old one if the upgrade failed (fail-safe).
+    /// For the GUI's one-click update: the caller spawns this and then quits the app. Returns false if
+    /// the helper couldn't be spawned (caller should fall back to showing the command). Not testable
+    /// without a real brew/scoop install.
+    /// </summary>
+    /// <summary>Log file the detached helper appends its upgrade output to, so a GUI update outcome (incl. failures) isn't lost.</summary>
+    public static string GetUpdateLogPath()
+        => Path.Combine(AppStoragePaths.GetCacheRoot(), "updates", "last-update.log");
+
+    public static bool TrySpawnDetachedRelaunch(
+        string managerExecutablePath,
+        IReadOnlyList<string> upgradeArgs,
+        int appProcessId,
+        RelaunchSpec relaunch,
+        string? logFilePath = null)
+    {
+        var logPath = logFilePath ?? GetUpdateLogPath();
+        try
+        {
+            return OperatingSystem.IsWindows()
+                ? TrySpawnDetachedWindows(managerExecutablePath, upgradeArgs, appProcessId, relaunch, logPath)
+                : TrySpawnDetachedUnix(managerExecutablePath, upgradeArgs, appProcessId, relaunch, logPath);
+        }
+        catch (Exception ex) when (ex is IOException or System.ComponentModel.Win32Exception or UnauthorizedAccessException or InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    // Unix (macOS/Linux): a bash script waits on the PID, upgrades, then relaunches. The app spawns
+    // /bin/bash and exits; the child reparents to init and survives (GUI apps have no controlling
+    // terminal). No elevation needed — brew installs to user-writable locations.
+    private static bool TrySpawnDetachedUnix(string manager, IReadOnlyList<string> upgradeArgs, int pid, RelaunchSpec relaunch, string logPath)
+    {
+        var script = new StringBuilder();
+        script.Append("#!/bin/bash\n");
+        // Capture everything (incl. the upgrade output/errors) so a failed update isn't lost.
+        script.Append("LOG=").Append(ShQuote(logPath)).Append('\n');
+        script.Append("mkdir -p \"$(dirname \"$LOG\")\" 2>/dev/null\n");
+        script.Append("exec >>\"$LOG\" 2>&1\n");
+        script.Append("echo \"=== update $(date) ===\"\n");
+        script.Append("APP_PID=\"$1\"\n");
+        script.Append("while kill -0 \"$APP_PID\" 2>/dev/null; do sleep 0.3; done\n");
+        // Upgrade; fail-safe means we relaunch regardless of the outcome (|| true).
+        script.Append(ShJoin(manager, upgradeArgs)).Append(" || true\n");
+        // Relaunch detached from this helper.
+        script.Append(ShJoin(relaunch.Executable, relaunch.Arguments)).Append(" &\n");
+        script.Append("exit 0\n");
+
+        var scriptPath = WriteTempScript(script.ToString(), ".sh");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "/bin/bash",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+        };
+        psi.ArgumentList.Add(scriptPath);
+        psi.ArgumentList.Add(pid.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        return Process.Start(psi) != null;
+    }
+
+    // Windows: a PowerShell script waits on the PID, upgrades, then relaunches. Launched via
+    // ShellExecute (UseShellExecute=true) so it isn't tied to the exiting app's lifetime.
+    private static bool TrySpawnDetachedWindows(string manager, IReadOnlyList<string> upgradeArgs, int pid, RelaunchSpec relaunch, string logPath)
+    {
+        var script = new StringBuilder();
+        script.Append("param([int]$AppPid)\n");
+        script.Append("$log = ").Append(PsQuote(logPath)).Append('\n');
+        script.Append("New-Item -ItemType Directory -Force -Path (Split-Path $log) *> $null\n");
+        script.Append("\"=== update $(Get-Date) ===\" | Out-File -FilePath $log -Append\n");
+        script.Append("try { Wait-Process -Id $AppPid -ErrorAction SilentlyContinue } catch {}\n");
+        // Capture the upgrade output/errors (all streams) so a failed update isn't lost.
+        script.Append("try { & ").Append(PsQuote(manager));
+        foreach (var a in upgradeArgs)
+            script.Append(' ').Append(PsQuote(a));
+        script.Append(" *>> $log } catch { $_ | Out-File -FilePath $log -Append }\n");
+        script.Append("Start-Process -FilePath ").Append(PsQuote(relaunch.Executable));
+        if (relaunch.Arguments.Count > 0)
+        {
+            script.Append(" -ArgumentList ");
+            script.Append(string.Join(",", relaunch.Arguments.Select(PsQuote)));
+        }
+        script.Append('\n');
+
+        var scriptPath = WriteTempScript(script.ToString(), ".ps1");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = ProcessLaunch.ResolveWindowsPowerShellExe(), // pwsh 7 if present, else Windows PowerShell 5.1
+            UseShellExecute = true,
+            WindowStyle = ProcessWindowStyle.Hidden,
+        };
+        psi.ArgumentList.Add("-NoProfile");
+        psi.ArgumentList.Add("-ExecutionPolicy");
+        psi.ArgumentList.Add("Bypass");
+        psi.ArgumentList.Add("-WindowStyle");
+        psi.ArgumentList.Add("Hidden");
+        psi.ArgumentList.Add("-File");
+        psi.ArgumentList.Add(scriptPath);
+        psi.ArgumentList.Add(pid.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        return Process.Start(psi) != null;
+    }
+
+    private static string WriteTempScript(string content, string extension)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"dotnet6502-update-{Guid.NewGuid():N}{extension}");
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private static string ShJoin(string exe, IReadOnlyList<string> args)
+    {
+        var sb = new StringBuilder(ShQuote(exe));
+        foreach (var a in args)
+            sb.Append(' ').Append(ShQuote(a));
+        return sb.ToString();
+    }
+
+    private static string ShQuote(string s) => "'" + s.Replace("'", "'\\''") + "'";
+
+    private static string PsQuote(string s) => "'" + s.Replace("'", "''") + "'";
+}

--- a/src/libraries/Highbyte.DotNet6502.Updates/UpdateCheckCache.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/UpdateCheckCache.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using Highbyte.DotNet6502.Systems.Configuration;
+
+namespace Highbyte.DotNet6502.Updates;
+
+/// <summary>Persisted state from the last update check: timestamp (for cadence), ETag, and the last seen release.</summary>
+public sealed record UpdateCheckCacheData
+{
+    public DateTimeOffset LastCheckUtc { get; init; }
+    public string? ETag { get; init; }
+    public string? LatestTag { get; init; }
+    public string? LatestReleaseUrl { get; init; }
+}
+
+/// <summary>
+/// Reads/writes the update-check cache as a small JSON file under the machine-local cache root
+/// (<see cref="AppStoragePaths.GetCacheRoot"/>), host-agnostic. Best-effort: any IO/parse failure
+/// is swallowed so a corrupt or unwritable cache never breaks the app or the check.
+/// </summary>
+public sealed class UpdateCheckCache
+{
+    private readonly string _filePath;
+
+    public UpdateCheckCache(string? filePath = null)
+    {
+        _filePath = filePath ?? DefaultFilePath();
+    }
+
+    public static string DefaultFilePath()
+        => Path.Combine(AppStoragePaths.GetCacheRoot(), "updates", "update-check.json");
+
+    public UpdateCheckCacheData? Load()
+    {
+        try
+        {
+            if (!File.Exists(_filePath))
+                return null;
+            var json = File.ReadAllText(_filePath);
+            if (string.IsNullOrWhiteSpace(json))
+                return null;
+            return JsonSerializer.Deserialize(json, UpdatesJsonContext.Default.UpdateCheckCacheData);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        {
+            return null;
+        }
+    }
+
+    public void Save(UpdateCheckCacheData data)
+    {
+        try
+        {
+            var directory = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
+            var json = JsonSerializer.Serialize(data, UpdatesJsonContext.Default.UpdateCheckCacheData);
+            File.WriteAllText(_filePath, json);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Best effort: a failed cache write must not surface to the user.
+        }
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Updates/UpdateCheckResult.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/UpdateCheckResult.cs
@@ -30,6 +30,9 @@ public sealed record UpdateCheckResult
     public string? ReleaseNotesUrl { get; init; }
     public string? Error { get; init; }
 
+    /// <summary>Full path to the resolved package manager (brew/scoop), for actually running the upgrade. Null when not managed.</summary>
+    public string? ManagerExecutablePath { get; init; }
+
     public bool IsUpdateAvailable => Status == UpdateCheckStatus.UpdateAvailable;
 
     public static UpdateCheckResult NotManaged(SemanticVersion? current = null) => new()

--- a/src/libraries/Highbyte.DotNet6502.Updates/UpdateCheckResult.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/UpdateCheckResult.cs
@@ -1,0 +1,54 @@
+namespace Highbyte.DotNet6502.Updates;
+
+public enum UpdateCheckStatus
+{
+    /// <summary>Not installed via a package manager (portable / dev / ambiguous). Nothing to do.</summary>
+    NotManaged = 0,
+
+    /// <summary>App assembly wasn't stamped by CI (a local/dev build); can't compare, skip.</summary>
+    VersionUnknown,
+
+    /// <summary>Managed install, already on the newest applicable release.</summary>
+    UpToDate,
+
+    /// <summary>Managed install, a newer release exists — see <see cref="UpdateCheckResult.SuggestedCommand"/>.</summary>
+    UpdateAvailable,
+
+    /// <summary>The check failed (offline, rate-limited, parse error). See <see cref="UpdateCheckResult.Error"/>.</summary>
+    Error,
+}
+
+/// <summary>Outcome of an update check. <see cref="SuggestedCommand"/> is populated only when an update is available.</summary>
+public sealed record UpdateCheckResult
+{
+    public required UpdateCheckStatus Status { get; init; }
+    public SemanticVersion? CurrentVersion { get; init; }
+    public SemanticVersion? LatestVersion { get; init; }
+    public InstallChannel Channel { get; init; }
+    public string? PackageName { get; init; }
+    public string? SuggestedCommand { get; init; }
+    public string? ReleaseNotesUrl { get; init; }
+    public string? Error { get; init; }
+
+    public bool IsUpdateAvailable => Status == UpdateCheckStatus.UpdateAvailable;
+
+    public static UpdateCheckResult NotManaged(SemanticVersion? current = null) => new()
+    {
+        Status = UpdateCheckStatus.NotManaged,
+        CurrentVersion = current,
+        Channel = InstallChannel.NotManaged,
+    };
+}
+
+/// <summary>Caller-supplied knobs for a single update check.</summary>
+public sealed record UpdateCheckContext
+{
+    /// <summary>Bypass the cadence window (and use of a cached result): a manual "Check now" / <c>--check-update</c>.</summary>
+    public bool ForceCheck { get; init; }
+
+    /// <summary>Minimum time between network checks; within it a cached result is reused. Default 24h.</summary>
+    public TimeSpan MinCheckInterval { get; init; } = TimeSpan.FromHours(24);
+
+    /// <summary>Consider prerelease (<c>-alpha</c>) releases. True here since every release is tagged <c>-alpha</c>.</summary>
+    public bool IncludePrereleases { get; init; } = true;
+}

--- a/src/libraries/Highbyte.DotNet6502.Updates/UpdateChecker.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/UpdateChecker.cs
@@ -111,6 +111,8 @@ public sealed class UpdateChecker
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or System.Text.Json.JsonException)
         {
+            _logger.LogWarning(ex, "Update check failed (offline, rate-limited, or unexpected response): {Message}", ex.Message);
+
             // Update the timestamp so a persistent failure doesn't hammer GitHub every launch,
             // but keep the previous ETag/latest so a later success is still conditional.
             if (cached is not null)
@@ -145,6 +147,7 @@ public sealed class UpdateChecker
             PackageName = channelInfo.PackageName,
             SuggestedCommand = updateAvailable ? BuildUpgradeCommand(channelInfo.Channel) : null,
             ReleaseNotesUrl = updateAvailable ? releaseUrl : null,
+            ManagerExecutablePath = channelInfo.ManagerExecutablePath,
         };
     }
 

--- a/src/libraries/Highbyte.DotNet6502.Updates/UpdateChecker.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/UpdateChecker.cs
@@ -1,0 +1,169 @@
+namespace Highbyte.DotNet6502.Updates;
+
+/// <summary>
+/// Host-agnostic update check: detect the install channel first (cheap, local, and gates
+/// everything), and only if managed query GitHub for a newer release, comparing by semver and
+/// caching the result. Returns a fully-formed <see cref="UpdateCheckResult"/> including the exact
+/// <c>brew</c>/<c>scoop</c> command to run — never throws for the expected failure modes
+/// (offline, rate-limited, not-managed, unstamped).
+/// </summary>
+public sealed class UpdateChecker
+{
+    private readonly AppUpdateDescriptor _descriptor;
+    private readonly InstallChannelDetector _channelDetector;
+    private readonly IReleaseSource _releaseSource;
+    private readonly UpdateCheckCache _cache;
+    private readonly Func<SemanticVersion?> _currentVersionProvider;
+    private readonly Func<DateTimeOffset> _utcNow;
+
+    /// <summary>Convenience factory wiring the production GitHub release source over the given <see cref="HttpClient"/>.</summary>
+    public static UpdateChecker CreateDefault(AppUpdateDescriptor descriptor, HttpClient httpClient)
+        => new(descriptor, new GitHubReleaseClient(httpClient));
+
+    public UpdateChecker(
+        AppUpdateDescriptor descriptor,
+        IReleaseSource releaseSource,
+        InstallChannelDetector? channelDetector = null,
+        UpdateCheckCache? cache = null,
+        Func<SemanticVersion?>? currentVersionProvider = null,
+        Func<DateTimeOffset>? utcNow = null)
+    {
+        _descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+        _releaseSource = releaseSource ?? throw new ArgumentNullException(nameof(releaseSource));
+        _channelDetector = channelDetector ?? new InstallChannelDetector();
+        _cache = cache ?? new UpdateCheckCache();
+        _currentVersionProvider = currentVersionProvider ?? (() => AppVersion.GetCurrent());
+        _utcNow = utcNow ?? (() => DateTimeOffset.UtcNow);
+    }
+
+    public async Task<UpdateCheckResult> CheckAsync(UpdateCheckContext? context = null, CancellationToken cancellationToken = default)
+    {
+        context ??= new UpdateCheckContext();
+
+        // 1. Channel first — if not managed, do nothing (not even the version read or network call).
+        var channelInfo = _channelDetector.Detect(_descriptor);
+        if (!channelInfo.IsManaged)
+            return UpdateCheckResult.NotManaged(_currentVersionProvider());
+
+        // 2. Current version — a local/dev build reports 1.0.0 (null here) → skip.
+        var current = _currentVersionProvider();
+        if (current is null)
+            return new UpdateCheckResult { Status = UpdateCheckStatus.VersionUnknown, Channel = channelInfo.Channel, PackageName = channelInfo.PackageName };
+
+        var cached = _cache.Load();
+
+        // 3. Within the cadence window (and not forced): decide from the cached latest, no network.
+        if (!context.ForceCheck && cached is { LatestTag: not null } &&
+            _utcNow() - cached.LastCheckUtc < context.MinCheckInterval)
+        {
+            if (SemanticVersion.TryParse(cached.LatestTag, out var cachedLatest) && cachedLatest is not null)
+                return BuildResult(current, cachedLatest, cached.LatestReleaseUrl, channelInfo);
+        }
+
+        // 4. Query GitHub (conditional on the cached ETag).
+        try
+        {
+            var query = await _releaseSource.GetReleasesAsync(cached?.ETag, cancellationToken).ConfigureAwait(false);
+
+            SemanticVersion? latest;
+            string? latestUrl;
+            string? latestTag;
+            string? etag;
+
+            if (query.NotModified && cached?.LatestTag != null)
+            {
+                SemanticVersion.TryParse(cached.LatestTag, out latest);
+                latestUrl = cached.LatestReleaseUrl;
+                latestTag = cached.LatestTag;
+                etag = cached.ETag;
+            }
+            else
+            {
+                var newest = SelectNewestRelease(query.Releases, context.IncludePrereleases);
+                latest = newest.Version;
+                latestUrl = newest.Release?.HtmlUrl;
+                latestTag = newest.Release?.TagName;
+                etag = query.ETag;
+            }
+
+            _cache.Save(new UpdateCheckCacheData
+            {
+                LastCheckUtc = _utcNow(),
+                ETag = etag,
+                LatestTag = latestTag,
+                LatestReleaseUrl = latestUrl,
+            });
+
+            if (latest is null)
+                return new UpdateCheckResult { Status = UpdateCheckStatus.UpToDate, CurrentVersion = current, Channel = channelInfo.Channel, PackageName = channelInfo.PackageName };
+
+            return BuildResult(current, latest, latestUrl, channelInfo);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or System.Text.Json.JsonException)
+        {
+            // Update the timestamp so a persistent failure doesn't hammer GitHub every launch,
+            // but keep the previous ETag/latest so a later success is still conditional.
+            if (cached is not null)
+                _cache.Save(cached with { LastCheckUtc = _utcNow() });
+
+            return new UpdateCheckResult
+            {
+                Status = UpdateCheckStatus.Error,
+                CurrentVersion = current,
+                Channel = channelInfo.Channel,
+                PackageName = channelInfo.PackageName,
+                Error = ex.Message,
+            };
+        }
+    }
+
+    private UpdateCheckResult BuildResult(SemanticVersion current, SemanticVersion latest, string? releaseUrl, InstallChannelInfo channelInfo)
+    {
+        var updateAvailable = latest > current;
+        return new UpdateCheckResult
+        {
+            Status = updateAvailable ? UpdateCheckStatus.UpdateAvailable : UpdateCheckStatus.UpToDate,
+            CurrentVersion = current,
+            LatestVersion = latest,
+            Channel = channelInfo.Channel,
+            PackageName = channelInfo.PackageName,
+            SuggestedCommand = updateAvailable ? BuildUpgradeCommand(channelInfo.Channel) : null,
+            ReleaseNotesUrl = updateAvailable ? releaseUrl : null,
+        };
+    }
+
+    /// <summary>Builds the exact upgrade command for the detected channel (Phase A: shown/copied, not auto-run).</summary>
+    public string BuildUpgradeCommand(InstallChannel channel) => channel switch
+    {
+        InstallChannel.Homebrew when _descriptor.HomebrewIsCask => $"brew upgrade --cask {_descriptor.HomebrewPackage}",
+        InstallChannel.Homebrew => $"brew upgrade {_descriptor.HomebrewPackage}",
+        InstallChannel.Scoop => $"scoop update {_descriptor.ScoopPackage}",
+        _ => throw new ArgumentOutOfRangeException(nameof(channel), channel, "No upgrade command for a non-managed channel."),
+    };
+
+    private static (SemanticVersion? Version, GitHubRelease? Release) SelectNewestRelease(
+        IReadOnlyList<GitHubRelease> releases,
+        bool includePrereleases)
+    {
+        SemanticVersion? bestVersion = null;
+        GitHubRelease? bestRelease = null;
+
+        foreach (var release in releases)
+        {
+            if (release.Draft)
+                continue;
+            if (release.Prerelease && !includePrereleases)
+                continue;
+            if (!SemanticVersion.TryParse(release.TagName, out var version) || version is null)
+                continue;
+
+            if (bestVersion is null || version > bestVersion)
+            {
+                bestVersion = version;
+                bestRelease = release;
+            }
+        }
+
+        return (bestVersion, bestRelease);
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Updates/UpdateChecker.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/UpdateChecker.cs
@@ -1,3 +1,6 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
 namespace Highbyte.DotNet6502.Updates;
 
 /// <summary>
@@ -6,6 +9,10 @@ namespace Highbyte.DotNet6502.Updates;
 /// caching the result. Returns a fully-formed <see cref="UpdateCheckResult"/> including the exact
 /// <c>brew</c>/<c>scoop</c> command to run — never throws for the expected failure modes
 /// (offline, rate-limited, not-managed, unstamped).
+///
+/// When an update is available it also logs one <see cref="LogLevel.Information"/> line via the
+/// supplied <see cref="ILogger"/>. This is the single shared log point so every host emits the same
+/// message; only where those logs are routed (in-app Logs pane, console, ...) differs per host.
 /// </summary>
 public sealed class UpdateChecker
 {
@@ -15,10 +22,11 @@ public sealed class UpdateChecker
     private readonly UpdateCheckCache _cache;
     private readonly Func<SemanticVersion?> _currentVersionProvider;
     private readonly Func<DateTimeOffset> _utcNow;
+    private readonly ILogger _logger;
 
     /// <summary>Convenience factory wiring the production GitHub release source over the given <see cref="HttpClient"/>.</summary>
-    public static UpdateChecker CreateDefault(AppUpdateDescriptor descriptor, HttpClient httpClient)
-        => new(descriptor, new GitHubReleaseClient(httpClient));
+    public static UpdateChecker CreateDefault(AppUpdateDescriptor descriptor, HttpClient httpClient, ILogger? logger = null)
+        => new(descriptor, new GitHubReleaseClient(httpClient), logger: logger);
 
     public UpdateChecker(
         AppUpdateDescriptor descriptor,
@@ -26,7 +34,8 @@ public sealed class UpdateChecker
         InstallChannelDetector? channelDetector = null,
         UpdateCheckCache? cache = null,
         Func<SemanticVersion?>? currentVersionProvider = null,
-        Func<DateTimeOffset>? utcNow = null)
+        Func<DateTimeOffset>? utcNow = null,
+        ILogger? logger = null)
     {
         _descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
         _releaseSource = releaseSource ?? throw new ArgumentNullException(nameof(releaseSource));
@@ -34,6 +43,7 @@ public sealed class UpdateChecker
         _cache = cache ?? new UpdateCheckCache();
         _currentVersionProvider = currentVersionProvider ?? (() => AppVersion.GetCurrent());
         _utcNow = utcNow ?? (() => DateTimeOffset.UtcNow);
+        _logger = logger ?? NullLogger.Instance;
     }
 
     public async Task<UpdateCheckResult> CheckAsync(UpdateCheckContext? context = null, CancellationToken cancellationToken = default)
@@ -120,6 +130,12 @@ public sealed class UpdateChecker
     private UpdateCheckResult BuildResult(SemanticVersion current, SemanticVersion latest, string? releaseUrl, InstallChannelInfo channelInfo)
     {
         var updateAvailable = latest > current;
+        if (updateAvailable)
+        {
+            _logger.LogInformation(
+                "A newer version v{LatestVersion} is available (you have v{CurrentVersion}). Run '{UpgradeCommand}' to update.",
+                latest, current, BuildUpgradeCommand(channelInfo.Channel));
+        }
         return new UpdateCheckResult
         {
             Status = updateAvailable ? UpdateCheckStatus.UpdateAvailable : UpdateCheckStatus.UpToDate,

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64SystemConfigTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64SystemConfigTests.cs
@@ -1,5 +1,8 @@
+using System.Text.Json;
+using Highbyte.DotNet6502.Systems.Commodore64.Audio.Sample;
 using Highbyte.DotNet6502.Systems.Commodore64.Cartridge.SwiftLink;
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Systems.Commodore64.Render.VideoCommands;
 
 namespace Highbyte.DotNet6502.Systems.Tests.Commodore64;
 
@@ -37,5 +40,64 @@ public class C64SystemConfigTests
         Assert.Contains(
             $"{nameof(C64SystemConfig.SwiftLink)}.{nameof(C64SwiftLinkConfig.InterruptMode)} has an invalid value.",
             validationErrors);
+    }
+
+    [Fact]
+    public void Serialize_Persists_Type_Names_Without_Assembly_Version_Metadata()
+    {
+        var config = new C64SystemConfig();
+        config.SetRenderProviderType(typeof(C64VideoCommandStream));
+        config.SetRenderTargetType(typeof(TestRenderTarget));
+        config.SetAudioProviderType(typeof(C64SidSampleProvider));
+        config.SetAudioTargetType(typeof(TestAudioTarget));
+
+        var json = JsonSerializer.Serialize(config);
+
+        AssertPersistedType(json, "RenderProviderType", typeof(C64VideoCommandStream));
+        AssertPersistedType(json, "RenderTargetType", typeof(TestRenderTarget));
+        AssertPersistedType(json, "AudioProviderType", typeof(C64SidSampleProvider));
+        AssertPersistedType(json, "AudioTargetType", typeof(TestAudioTarget));
+        Assert.DoesNotContain("Version=", json);
+        Assert.DoesNotContain("Culture=", json);
+        Assert.DoesNotContain("PublicKeyToken=", json);
+    }
+
+    [Fact]
+    public void Deserialize_Accepts_Legacy_Assembly_Qualified_Type_Names()
+    {
+        var json = $$"""
+            {
+              "RenderProviderType": "{{LegacyAssemblyQualifiedName(typeof(C64VideoCommandStream))}}",
+              "RenderTargetType": "{{LegacyAssemblyQualifiedName(typeof(TestRenderTarget))}}",
+              "AudioProviderType": "{{LegacyAssemblyQualifiedName(typeof(C64SidSampleProvider))}}",
+              "AudioTargetType": "{{LegacyAssemblyQualifiedName(typeof(TestAudioTarget))}}"
+            }
+            """;
+
+        var config = JsonSerializer.Deserialize<C64SystemConfig>(json)!;
+
+        Assert.Equal(typeof(C64VideoCommandStream), config.RenderProviderType);
+        Assert.Equal(typeof(TestRenderTarget), config.RenderTargetType);
+        Assert.Equal(typeof(C64SidSampleProvider), config.AudioProviderType);
+        Assert.Equal(typeof(TestAudioTarget), config.AudioTargetType);
+    }
+
+    private static string LegacyAssemblyQualifiedName(Type type)
+        => $"{type.FullName}, {type.Assembly.GetName().Name}, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
+
+    private static void AssertPersistedType(string json, string propertyName, Type expectedType)
+    {
+        using var document = JsonDocument.Parse(json);
+        var actual = document.RootElement.GetProperty(propertyName).GetString();
+
+        Assert.Equal($"{expectedType.FullName}, {expectedType.Assembly.GetName().Name}", actual);
+    }
+
+    private sealed class TestRenderTarget
+    {
+    }
+
+    private sealed class TestAudioTarget
+    {
     }
 }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Generic/GenericComputerSystemConfigTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Generic/GenericComputerSystemConfigTests.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using Highbyte.DotNet6502.Systems.Generic.Config;
+using Highbyte.DotNet6502.Systems.Generic.Render;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Generic;
+
+public class GenericComputerSystemConfigTests
+{
+    [Fact]
+    public void Serialize_Persists_Type_Names_Without_Assembly_Version_Metadata()
+    {
+        var config = new GenericComputerSystemConfig();
+        config.SetRenderProviderType(typeof(GenericVideoCommandStream));
+        config.SetRenderTargetType(typeof(TestRenderTarget));
+
+        var json = JsonSerializer.Serialize(config);
+
+        AssertPersistedType(json, "RenderProviderType", typeof(GenericVideoCommandStream));
+        AssertPersistedType(json, "RenderTargetType", typeof(TestRenderTarget));
+        Assert.DoesNotContain("Version=", json);
+        Assert.DoesNotContain("Culture=", json);
+        Assert.DoesNotContain("PublicKeyToken=", json);
+    }
+
+    [Fact]
+    public void Deserialize_Accepts_Legacy_Assembly_Qualified_Type_Names()
+    {
+        var json = $$"""
+            {
+              "RenderProviderType": "{{LegacyAssemblyQualifiedName(typeof(GenericVideoCommandStream))}}",
+              "RenderTargetType": "{{LegacyAssemblyQualifiedName(typeof(TestRenderTarget))}}"
+            }
+            """;
+
+        var config = JsonSerializer.Deserialize<GenericComputerSystemConfig>(json)!;
+
+        Assert.Equal(typeof(GenericVideoCommandStream), config.RenderProviderType);
+        Assert.Equal(typeof(TestRenderTarget), config.RenderTargetType);
+    }
+
+    private static string LegacyAssemblyQualifiedName(Type type)
+        => $"{type.FullName}, {type.Assembly.GetName().Name}, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
+
+    private static void AssertPersistedType(string json, string propertyName, Type expectedType)
+    {
+        using var document = JsonDocument.Parse(json);
+        var actual = document.RootElement.GetProperty(propertyName).GetString();
+
+        Assert.Equal($"{expectedType.FullName}, {expectedType.Assembly.GetName().Name}", actual);
+    }
+
+    private sealed class TestRenderTarget
+    {
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Vic20/Vic20SystemConfigTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Vic20/Vic20SystemConfigTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Highbyte.DotNet6502.Systems.Vic20.Config;
 using Highbyte.DotNet6502.Systems.Vic20;
 using Highbyte.DotNet6502.Systems.Vic20.Render;
@@ -51,6 +52,49 @@ public class Vic20SystemConfigTests
 
         Assert.Equal(renderProviderType, hostConfig.SystemConfig.RenderProviderType);
         Assert.Equal(renderTargetType, hostConfig.SystemConfig.RenderTargetType);
+    }
+
+    [Fact]
+    public void Serialize_Persists_Type_Names_Without_Assembly_Version_Metadata()
+    {
+        var config = new Vic20SystemConfig();
+        config.SetRenderProviderType(typeof(Vic20VideoCommandStream));
+        config.SetRenderTargetType(typeof(TestRenderTarget));
+
+        var json = JsonSerializer.Serialize(config);
+
+        AssertPersistedType(json, "RenderProviderType", typeof(Vic20VideoCommandStream));
+        AssertPersistedType(json, "RenderTargetType", typeof(TestRenderTarget));
+        Assert.DoesNotContain("Version=", json);
+        Assert.DoesNotContain("Culture=", json);
+        Assert.DoesNotContain("PublicKeyToken=", json);
+    }
+
+    [Fact]
+    public void Deserialize_Accepts_Legacy_Assembly_Qualified_Type_Names()
+    {
+        var json = $$"""
+            {
+              "RenderProviderType": "{{LegacyAssemblyQualifiedName(typeof(Vic20VideoCommandStream))}}",
+              "RenderTargetType": "{{LegacyAssemblyQualifiedName(typeof(TestRenderTarget))}}"
+            }
+            """;
+
+        var config = JsonSerializer.Deserialize<Vic20SystemConfig>(json)!;
+
+        Assert.Equal(typeof(Vic20VideoCommandStream), config.RenderProviderType);
+        Assert.Equal(typeof(TestRenderTarget), config.RenderTargetType);
+    }
+
+    private static string LegacyAssemblyQualifiedName(Type type)
+        => $"{type.FullName}, {type.Assembly.GetName().Name}, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
+
+    private static void AssertPersistedType(string json, string propertyName, Type expectedType)
+    {
+        using var document = JsonDocument.Parse(json);
+        var actual = document.RootElement.GetProperty(propertyName).GetString();
+
+        Assert.Equal($"{expectedType.FullName}, {expectedType.Assembly.GetName().Name}", actual);
     }
 
     private sealed class TestVic20HostConfig : HostSystemConfigBase<Vic20SystemConfig>

--- a/tests/Highbyte.DotNet6502.Updates.Tests/AppVersionTests.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/AppVersionTests.cs
@@ -1,0 +1,29 @@
+using Highbyte.DotNet6502.Updates;
+using Xunit;
+
+namespace Highbyte.DotNet6502.Updates.Tests;
+
+public class AppVersionTests
+{
+    [Theory]
+    [InlineData("0.40.2-alpha", "0.40.2-alpha")]
+    [InlineData("0.40.2-alpha+abc123", "0.40.2-alpha")] // SourceLink build metadata stripped
+    [InlineData("1.2.3", "1.2.3")]
+    public void Parse_ReturnsStampedVersion(string informational, string expected)
+    {
+        var v = AppVersion.Parse(informational);
+        Assert.NotNull(v);
+        Assert.Equal(expected, v!.ToString());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("1.0.0")]          // unstamped default
+    [InlineData("1.0.0+abc123")]   // unstamped + SourceLink hash
+    [InlineData("not-a-version")]
+    public void Parse_ReturnsNullForUnknownOrUnstamped(string? informational)
+    {
+        Assert.Null(AppVersion.Parse(informational));
+    }
+}

--- a/tests/Highbyte.DotNet6502.Updates.Tests/ConsoleUpdateCliTests.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/ConsoleUpdateCliTests.cs
@@ -1,0 +1,50 @@
+using Highbyte.DotNet6502.Updates;
+using Xunit;
+
+namespace Highbyte.DotNet6502.Updates.Tests;
+
+public class ConsoleUpdateCliTests
+{
+    [Theory]
+    [InlineData(new[] { "--version" }, true)]
+    [InlineData(new[] { "--check-update" }, true)]
+    [InlineData(new[] { "--update" }, true)]
+    [InlineData(new[] { "--start", "--check-update", "--system", "C64" }, true)]
+    [InlineData(new[] { "--start", "--system", "C64" }, false)]
+    [InlineData(new string[0], false)]
+    public void WantsHandling_DetectsFlags(string[] args, bool expected)
+        => Assert.Equal(expected, ConsoleUpdateCli.WantsHandling(args));
+
+    [Fact]
+    public void FormatNoticeLine_MatchesSpecWording()
+    {
+        SemanticVersion.TryParse("0.40.2-alpha", out var latest);
+        SemanticVersion.TryParse("0.39.3-alpha", out var current);
+        var result = new UpdateCheckResult
+        {
+            Status = UpdateCheckStatus.UpdateAvailable,
+            CurrentVersion = current,
+            LatestVersion = latest,
+            SuggestedCommand = "brew upgrade dotnet-6502-terminal",
+        };
+
+        Assert.Equal(
+            "A newer version v0.40.2-alpha is available (you have v0.39.3-alpha). Run 'brew upgrade dotnet-6502-terminal' to update.",
+            ConsoleUpdateCli.FormatNoticeLine(result));
+    }
+
+    [Fact]
+    public void IsSuppressed_WhenOptOutEnvSet()
+    {
+        var previous = Environment.GetEnvironmentVariable(ConsoleUpdateCli.OptOutEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(ConsoleUpdateCli.OptOutEnvVar, "1");
+            Assert.True(ConsoleUpdateCli.IsSuppressed());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(ConsoleUpdateCli.OptOutEnvVar, previous);
+        }
+    }
+}

--- a/tests/Highbyte.DotNet6502.Updates.Tests/ConsoleUpdateCliTests.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/ConsoleUpdateCliTests.cs
@@ -34,13 +34,13 @@ public class ConsoleUpdateCliTests
     }
 
     [Fact]
-    public void IsSuppressed_WhenOptOutEnvSet()
+    public void IsSuppressedByEnvironment_WhenOptOutEnvSet()
     {
         var previous = Environment.GetEnvironmentVariable(ConsoleUpdateCli.OptOutEnvVar);
         try
         {
             Environment.SetEnvironmentVariable(ConsoleUpdateCli.OptOutEnvVar, "1");
-            Assert.True(ConsoleUpdateCli.IsSuppressed());
+            Assert.True(ConsoleUpdateCli.IsSuppressedByEnvironment());
         }
         finally
         {

--- a/tests/Highbyte.DotNet6502.Updates.Tests/FakeInstallChannelProbe.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/FakeInstallChannelProbe.cs
@@ -20,9 +20,18 @@ internal sealed class FakeInstallChannelProbe : IInstallChannelProbe
     public string? GetEnvironmentVariable(string name)
         => EnvironmentVariables.TryGetValue(name, out var v) ? v : null;
 
-    public bool DirectoryExists(string path) => Directories.Contains(path);
+    public bool DirectoryExists(string path)
+        => Directories.Contains(path)
+           || Directories.Any(x => PathEquals(x, path));
 
-    public string? ReadFileFirstLine(string path) => Files.TryGetValue(path, out var v) ? v : null;
+    public string? ReadFileFirstLine(string path)
+    {
+        if (Files.TryGetValue(path, out var value))
+            return value;
+
+        var matchingPath = Files.Keys.FirstOrDefault(x => PathEquals(x, path));
+        return matchingPath is null ? null : Files[matchingPath];
+    }
 
     public string? ResolveExecutable(string command, IEnumerable<string> preferredDirectories)
         => ResolvableExecutables.TryGetValue(command, out var path) ? path : null;
@@ -32,4 +41,10 @@ internal sealed class FakeInstallChannelProbe : IInstallChannelProbe
         var key = executablePath + " " + string.Join(' ', arguments);
         return CommandResults.TryGetValue(key, out var result) ? result : null;
     }
+
+    private static bool PathEquals(string left, string right)
+        => string.Equals(NormalizePath(left), NormalizePath(right), StringComparison.Ordinal);
+
+    private static string NormalizePath(string path)
+        => path.Replace('\\', '/');
 }

--- a/tests/Highbyte.DotNet6502.Updates.Tests/FakeInstallChannelProbe.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/FakeInstallChannelProbe.cs
@@ -1,0 +1,35 @@
+using Highbyte.DotNet6502.Updates;
+
+namespace Highbyte.DotNet6502.Updates.Tests;
+
+/// <summary>In-memory <see cref="IInstallChannelProbe"/> for exercising <see cref="InstallChannelDetector"/>.</summary>
+internal sealed class FakeInstallChannelProbe : IInstallChannelProbe
+{
+    public OSPlatformKind OS { get; set; } = OSPlatformKind.MacOS;
+    public string BaseDirectory { get; set; } = "/app";
+    public string? HomeDirectory { get; set; } = "/home/user";
+
+    public Dictionary<string, string?> EnvironmentVariables { get; } = new();
+    public Dictionary<string, string> Files { get; } = new();           // path -> first line
+    public HashSet<string> Directories { get; } = new();
+    public Dictionary<string, string> ResolvableExecutables { get; } = new(); // command -> full path
+
+    /// <summary>(executablePath, joined args) -> result. Missing entry ⇒ command could not be launched (null).</summary>
+    public Dictionary<string, ProcessRunResult> CommandResults { get; } = new();
+
+    public string? GetEnvironmentVariable(string name)
+        => EnvironmentVariables.TryGetValue(name, out var v) ? v : null;
+
+    public bool DirectoryExists(string path) => Directories.Contains(path);
+
+    public string? ReadFileFirstLine(string path) => Files.TryGetValue(path, out var v) ? v : null;
+
+    public string? ResolveExecutable(string command, IEnumerable<string> preferredDirectories)
+        => ResolvableExecutables.TryGetValue(command, out var path) ? path : null;
+
+    public ProcessRunResult? RunCommand(string executablePath, IReadOnlyList<string> arguments, TimeSpan timeout)
+    {
+        var key = executablePath + " " + string.Join(' ', arguments);
+        return CommandResults.TryGetValue(key, out var result) ? result : null;
+    }
+}

--- a/tests/Highbyte.DotNet6502.Updates.Tests/GitHubReleaseClientTests.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/GitHubReleaseClientTests.cs
@@ -1,0 +1,58 @@
+using System.Net;
+using System.Text;
+using Highbyte.DotNet6502.Updates;
+using Xunit;
+
+namespace Highbyte.DotNet6502.Updates.Tests;
+
+public class GitHubReleaseClientTests
+{
+    /// <summary>Scripted handler capturing each request's If-None-Match and returning queued responses.</summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses;
+        public List<string?> ReceivedIfNoneMatch { get; } = new();
+
+        public StubHandler(params HttpResponseMessage[] responses) => _responses = new Queue<HttpResponseMessage>(responses);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            ReceivedIfNoneMatch.Add(request.Headers.IfNoneMatch.ToString());
+            return Task.FromResult(_responses.Dequeue());
+        }
+    }
+
+    private static HttpResponseMessage Ok(string weakEtag, string body)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+        response.Headers.TryAddWithoutValidation("ETag", weakEtag);
+        return response;
+    }
+
+    [Fact]
+    public async Task WeakETag_IsStoredThenSentAsConditionalRequest()
+    {
+        const string weakEtag = "W/\"7084393f0b2cf3b5ca133bafbbcd6135\"";
+        const string body = "[{\"tag_name\":\"v0.40.2-alpha\",\"prerelease\":true,\"html_url\":\"https://example/x\"}]";
+
+        var handler = new StubHandler(
+            Ok(weakEtag, body),
+            new HttpResponseMessage(HttpStatusCode.NotModified));
+        var client = new GitHubReleaseClient(new HttpClient(handler));
+
+        // 1st call: no ETag sent, gets the weak ETag back.
+        var first = await client.GetReleasesAsync(null);
+        Assert.False(first.NotModified);
+        Assert.Equal(weakEtag, first.ETag);
+        Assert.Single(first.Releases);
+        Assert.Equal("v0.40.2-alpha", first.Releases[0].TagName);
+
+        // 2nd call: sends the weak ETag back (must not throw), server answers 304.
+        var second = await client.GetReleasesAsync(first.ETag);
+        Assert.True(second.NotModified);
+        Assert.Equal(weakEtag, handler.ReceivedIfNoneMatch[1]);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Updates.Tests/Highbyte.DotNet6502.Updates.Tests.csproj
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/Highbyte.DotNet6502.Updates.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\libraries\Highbyte.DotNet6502.Updates\Highbyte.DotNet6502.Updates.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Highbyte.DotNet6502.Updates.Tests/InstallChannelDetectorTests.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/InstallChannelDetectorTests.cs
@@ -1,0 +1,115 @@
+using Highbyte.DotNet6502.Updates;
+using Xunit;
+
+namespace Highbyte.DotNet6502.Updates.Tests;
+
+public class InstallChannelDetectorTests
+{
+    private static readonly AppUpdateDescriptor TerminalDescriptor = new()
+    {
+        HomebrewPackage = "dotnet-6502-terminal",
+        HomebrewIsCask = false,
+        ScoopPackage = "dotnet-6502-terminal",
+    };
+
+    private static readonly AppUpdateDescriptor CaskDescriptor = new()
+    {
+        HomebrewPackage = "dotnet-6502",
+        HomebrewIsCask = true,
+        ScoopPackage = "dotnet-6502",
+    };
+
+    [Fact]
+    public void NoMarker_IsNotManaged()
+    {
+        var probe = new FakeInstallChannelProbe();
+        var detector = new InstallChannelDetector(probe);
+
+        var info = detector.Detect(TerminalDescriptor);
+
+        Assert.Equal(InstallChannel.NotManaged, info.Channel);
+        Assert.False(info.IsManaged);
+    }
+
+    [Fact]
+    public void HomebrewMarker_ManagerResolvesAndReportsInstalled_IsManaged()
+    {
+        var probe = new FakeInstallChannelProbe { OS = OSPlatformKind.Linux };
+        probe.Files["/app/install-channel"] = "homebrew";
+        probe.ResolvableExecutables["brew"] = "/home/linuxbrew/.linuxbrew/bin/brew";
+        probe.CommandResults["/home/linuxbrew/.linuxbrew/bin/brew list --versions dotnet-6502-terminal"] =
+            new ProcessRunResult(0, "dotnet-6502-terminal 0.40.2\n");
+
+        var info = new InstallChannelDetector(probe).Detect(TerminalDescriptor);
+
+        Assert.Equal(InstallChannel.Homebrew, info.Channel);
+        Assert.Equal("dotnet-6502-terminal", info.PackageName);
+        Assert.Equal("/home/linuxbrew/.linuxbrew/bin/brew", info.ManagerExecutablePath);
+    }
+
+    [Fact]
+    public void HomebrewMarker_ManagerNotOnPath_IsNotManaged()
+    {
+        var probe = new FakeInstallChannelProbe { OS = OSPlatformKind.Linux };
+        probe.Files["/app/install-channel"] = "homebrew";
+        // No brew resolvable.
+
+        var info = new InstallChannelDetector(probe).Detect(TerminalDescriptor);
+
+        Assert.Equal(InstallChannel.NotManaged, info.Channel);
+    }
+
+    [Fact]
+    public void HomebrewMarker_ManagerReportsNotInstalled_IsNotManaged()
+    {
+        // Stale marker on a portable copy: manager exists but the package isn't installed → safe fallback.
+        var probe = new FakeInstallChannelProbe { OS = OSPlatformKind.Linux };
+        probe.Files["/app/install-channel"] = "homebrew";
+        probe.ResolvableExecutables["brew"] = "/opt/homebrew/bin/brew";
+        probe.CommandResults["/opt/homebrew/bin/brew list --versions dotnet-6502-terminal"] =
+            new ProcessRunResult(1, "Error: No such keg\n");
+
+        var info = new InstallChannelDetector(probe).Detect(TerminalDescriptor);
+
+        Assert.Equal(InstallChannel.NotManaged, info.Channel);
+    }
+
+    [Fact]
+    public void CaskMarker_InSupportDir_ConfirmedViaCaskQuery_IsManaged()
+    {
+        var probe = new FakeInstallChannelProbe { OS = OSPlatformKind.MacOS, HomeDirectory = "/Users/me" };
+        var markerPath = "/Users/me/Library/Application Support/Highbyte/DotNet6502/install-channel";
+        probe.Files[markerPath] = "homebrew:dotnet-6502";
+        probe.ResolvableExecutables["brew"] = "/opt/homebrew/bin/brew";
+        probe.CommandResults["/opt/homebrew/bin/brew list --cask --versions dotnet-6502"] =
+            new ProcessRunResult(0, "dotnet-6502 0.40.2\n");
+
+        var info = new InstallChannelDetector(probe).Detect(CaskDescriptor);
+
+        Assert.Equal(InstallChannel.Homebrew, info.Channel);
+        Assert.Equal("dotnet-6502", info.PackageName);
+    }
+
+    [Fact]
+    public void ScoopMarker_ManagerResolvesAndReportsInstalled_IsManaged()
+    {
+        var probe = new FakeInstallChannelProbe { OS = OSPlatformKind.Windows, HomeDirectory = @"C:\Users\me" };
+        probe.Files[@"/app/install-channel".Replace('/', Path.DirectorySeparatorChar)] = "scoop";
+        probe.BaseDirectory = "/app".Replace('/', Path.DirectorySeparatorChar);
+        probe.ResolvableExecutables["scoop"] = @"C:\Users\me\scoop\shims\scoop";
+        probe.CommandResults[@"C:\Users\me\scoop\shims\scoop list dotnet-6502-terminal"] =
+            new ProcessRunResult(0, "Installed apps:\n\ndotnet-6502-terminal 0.40.2\n");
+
+        var info = new InstallChannelDetector(probe).Detect(TerminalDescriptor);
+
+        Assert.Equal(InstallChannel.Scoop, info.Channel);
+        Assert.Equal("dotnet-6502-terminal", info.PackageName);
+    }
+
+    [Fact]
+    public void CaskSupportDirMarkerPath_NullOnNonMac()
+    {
+        var probe = new FakeInstallChannelProbe { OS = OSPlatformKind.Windows };
+        Assert.Null(new InstallChannelDetector(probe).CaskSupportDirMarkerPath());
+    }
+}

--- a/tests/Highbyte.DotNet6502.Updates.Tests/ProcessLaunchTests.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/ProcessLaunchTests.cs
@@ -1,0 +1,66 @@
+using Highbyte.DotNet6502.Updates;
+using Xunit;
+
+namespace Highbyte.DotNet6502.Updates.Tests;
+
+public class ProcessLaunchTests
+{
+    [Fact]
+    public void Windows_CmdShim_IsRunViaCmdExe()
+    {
+        // The Scoop shim: C:\Users\me\scoop\shims\scoop.cmd list dotnet-6502
+        var psi = ProcessLaunch.BuildStartInfo(@"C:\Users\me\scoop\shims\scoop.cmd", new[] { "list", "dotnet-6502" }, isWindows: true);
+
+        Assert.Equal("cmd.exe", psi.FileName);
+        Assert.Equal(new[] { "/c", @"C:\Users\me\scoop\shims\scoop.cmd", "list", "dotnet-6502" }, psi.ArgumentList);
+        Assert.False(psi.UseShellExecute);
+    }
+
+    [Fact]
+    public void Windows_Ps1Shim_IsRunViaPowerShellFile_DefaultsToWindowsPowerShell()
+    {
+        var psi = ProcessLaunch.BuildStartInfo(@"C:\scoop\shims\scoop.ps1", new[] { "update", "dotnet-6502" }, isWindows: true);
+
+        Assert.Equal("powershell.exe", psi.FileName);
+        Assert.Contains("-File", psi.ArgumentList);
+        Assert.Contains(@"C:\scoop\shims\scoop.ps1", psi.ArgumentList);
+        Assert.Contains("update", psi.ArgumentList);
+    }
+
+    [Fact]
+    public void Windows_Ps1Shim_UsesGivenPowerShellHost()
+    {
+        var psi = ProcessLaunch.BuildStartInfo(@"C:\scoop\shims\scoop.ps1", new[] { "update", "x" }, isWindows: true, powerShellExe: "pwsh.exe");
+
+        Assert.Equal("pwsh.exe", psi.FileName);
+        Assert.Contains("-File", psi.ArgumentList);
+    }
+
+    [Fact]
+    public void ResolveWindowsPowerShellExe_IsWindowsPowerShell_OffWindows()
+    {
+        // Off Windows the host is irrelevant; must return the always-present powershell.exe (no probing).
+        if (OperatingSystem.IsWindows())
+            return;
+        Assert.Equal("powershell.exe", ProcessLaunch.ResolveWindowsPowerShellExe());
+    }
+
+    [Fact]
+    public void Windows_Exe_IsRunDirectly()
+    {
+        var psi = ProcessLaunch.BuildStartInfo(@"C:\tools\brew.exe", new[] { "upgrade", "x" }, isWindows: true);
+
+        Assert.Equal(@"C:\tools\brew.exe", psi.FileName);
+        Assert.Equal(new[] { "upgrade", "x" }, psi.ArgumentList);
+    }
+
+    [Fact]
+    public void Unix_ManagerPath_IsRunDirectly()
+    {
+        // brew has no extension; on Unix nothing is wrapped even for a .cmd-looking name.
+        var psi = ProcessLaunch.BuildStartInfo("/opt/homebrew/bin/brew", new[] { "list", "--versions", "dotnet-6502-terminal" }, isWindows: false);
+
+        Assert.Equal("/opt/homebrew/bin/brew", psi.FileName);
+        Assert.Equal(new[] { "list", "--versions", "dotnet-6502-terminal" }, psi.ArgumentList);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Updates.Tests/SemanticVersionTests.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/SemanticVersionTests.cs
@@ -1,0 +1,82 @@
+using Highbyte.DotNet6502.Updates;
+using Xunit;
+
+namespace Highbyte.DotNet6502.Updates.Tests;
+
+public class SemanticVersionTests
+{
+    [Theory]
+    [InlineData("0.40.2", 0, 40, 2, false)]
+    [InlineData("1.2.3-alpha", 1, 2, 3, true)]
+    [InlineData("v0.40.2-alpha", 0, 40, 2, true)]       // leading v tolerated (git tag form)
+    [InlineData("0.40.2-alpha+abc123", 0, 40, 2, true)] // build metadata stripped
+    [InlineData("10.20.30", 10, 20, 30, false)]
+    public void TryParse_ParsesValidVersions(string input, int major, int minor, int patch, bool isPrerelease)
+    {
+        Assert.True(SemanticVersion.TryParse(input, out var v));
+        Assert.NotNull(v);
+        Assert.Equal(major, v!.Major);
+        Assert.Equal(minor, v.Minor);
+        Assert.Equal(patch, v.Patch);
+        Assert.Equal(isPrerelease, v.IsPrerelease);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("1.2")]
+    [InlineData("1.2.3.4")]
+    [InlineData("1.2.x")]
+    [InlineData("1.2.3-")]        // empty prerelease
+    [InlineData("1.2.3-alpha..1")] // empty identifier
+    [InlineData("1.2.3+")]        // empty build metadata
+    public void TryParse_RejectsInvalidVersions(string? input)
+    {
+        Assert.False(SemanticVersion.TryParse(input, out var v));
+        Assert.Null(v);
+    }
+
+    [Theory]
+    // Core precedence.
+    [InlineData("0.40.1", "0.40.2", -1)]
+    [InlineData("0.41.0", "0.40.9", 1)]
+    [InlineData("1.0.0", "1.0.0", 0)]
+    // Release outranks prerelease of same core.
+    [InlineData("0.40.2-alpha", "0.40.2", -1)]
+    [InlineData("0.40.2", "0.40.2-alpha", 1)]
+    // Prerelease ordering (from the feature spec's examples).
+    [InlineData("0.40.1-alpha", "0.40.2-alpha", -1)]
+    [InlineData("0.40.2-alpha", "0.40.2-alpha.1", -1)] // more identifiers = higher
+    [InlineData("0.40.2-alpha.1", "0.40.2-alpha.2", -1)]
+    [InlineData("0.40.2-alpha.2", "0.40.2-alpha.10", -1)] // numeric identifiers compared numerically
+    [InlineData("0.40.2-alpha", "0.40.2-beta", -1)]       // lexical
+    [InlineData("0.40.2-1", "0.40.2-alpha", -1)]          // numeric < alphanumeric
+    public void CompareTo_OrdersBySemverPrecedence(string a, string b, int expectedSign)
+    {
+        Assert.True(SemanticVersion.TryParse(a, out var va));
+        Assert.True(SemanticVersion.TryParse(b, out var vb));
+        Assert.Equal(expectedSign, Math.Sign(va!.CompareTo(vb!)));
+        Assert.Equal(-expectedSign, Math.Sign(vb!.CompareTo(va!)));
+    }
+
+    [Fact]
+    public void BuildMetadata_IgnoredForPrecedence()
+    {
+        Assert.True(SemanticVersion.TryParse("0.40.2-alpha+build1", out var a));
+        Assert.True(SemanticVersion.TryParse("0.40.2-alpha+build2", out var b));
+        Assert.Equal(0, a!.CompareTo(b!));
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void Operators_Work()
+    {
+        SemanticVersion.TryParse("0.40.2-alpha", out var older);
+        SemanticVersion.TryParse("0.40.2-alpha", out var olderCopy);
+        SemanticVersion.TryParse("0.41.0-alpha", out var newer);
+        Assert.True(newer! > older!);
+        Assert.True(older! < newer!);
+        Assert.True(older! <= olderCopy!);
+        Assert.False(older! > newer!);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Updates.Tests/UpdateApplierTests.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/UpdateApplierTests.cs
@@ -1,0 +1,121 @@
+using System.Diagnostics;
+using Highbyte.DotNet6502.Updates;
+using Xunit;
+
+namespace Highbyte.DotNet6502.Updates.Tests;
+
+public class UpdateApplierTests
+{
+    /// <summary>
+    /// The detached relauncher's real Unix path, end-to-end: it must wait for the target process to
+    /// exit, then run the upgrade, then relaunch. (The Windows PowerShell path can only run on Windows.)
+    /// </summary>
+    [Fact]
+    public async Task TrySpawnDetachedRelaunch_WaitsForApp_RunsUpgrade_ThenRelaunches()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var (ranBeforeExit, upgraded, relaunched) = await RunDetachedScenarioAsync(managerExitCode: 0);
+
+        Assert.False(ranBeforeExit, "upgrade ran before the app exited");
+        Assert.True(upgraded, "upgrade did not run");
+        Assert.True(relaunched, "relaunch did not run");
+    }
+
+    /// <summary>
+    /// Fail-safe: if the upgrade fails (manager exits non-zero), the helper must STILL relaunch — so the
+    /// user is left with the (old) app running, not nothing.
+    /// </summary>
+    [Fact]
+    public async Task TrySpawnDetachedRelaunch_StillRelaunches_WhenUpgradeFails()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var (_, upgraded, relaunched) = await RunDetachedScenarioAsync(managerExitCode: 1);
+
+        Assert.True(upgraded, "upgrade step did not run");
+        Assert.True(relaunched, "relaunch did not run after a failed upgrade (fail-safe broken)");
+    }
+
+    // Runs the full detached scenario with a fake manager that touches a marker then exits with the
+    // given code, and a fake relaunch that touches another marker. Returns whether the upgrade ran
+    // before the app exited (should be false), and whether the upgrade + relaunch markers appeared.
+    private static async Task<(bool ranBeforeExit, bool upgraded, bool relaunched)> RunDetachedScenarioAsync(int managerExitCode)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "d6502-relaunch-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        Process? app = null;
+        try
+        {
+            var upgradeMarker = Path.Combine(dir, "upgraded");
+            var relaunchMarker = Path.Combine(dir, "relaunched");
+
+            var manager = Path.Combine(dir, "manager.sh");
+            await File.WriteAllTextAsync(manager, $"#!/bin/bash\ntouch '{upgradeMarker}'\nexit {managerExitCode}\n");
+            var relaunchScript = Path.Combine(dir, "relaunch.sh");
+            await File.WriteAllTextAsync(relaunchScript, $"#!/bin/bash\ntouch '{relaunchMarker}'\n");
+            MakeExecutable(manager);
+            MakeExecutable(relaunchScript);
+
+            app = Process.Start(new ProcessStartInfo { FileName = "/bin/bash", UseShellExecute = false }
+                .WithArgs("-c", "sleep 30"))!;
+
+            var spawned = UpdateApplier.TrySpawnDetachedRelaunch(
+                manager,
+                Array.Empty<string>(),
+                app.Id,
+                new RelaunchSpec("/bin/bash", new[] { relaunchScript }),
+                logFilePath: Path.Combine(dir, "update.log")); // keep test output out of the real cache
+            Assert.True(spawned, "helper was not spawned");
+
+            // The helper should still be waiting for the app to exit.
+            await Task.Delay(500);
+            var ranBeforeExit = File.Exists(upgradeMarker);
+
+            app.Kill(entireProcessTree: true);
+            await app.WaitForExitAsync();
+
+            var relaunched = await WaitForFileAsync(relaunchMarker, TimeSpan.FromSeconds(15));
+            return (ranBeforeExit, File.Exists(upgradeMarker), relaunched);
+        }
+        finally
+        {
+            try { if (app is { HasExited: false }) app.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    private static void MakeExecutable(string path)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+        File.SetUnixFileMode(
+            path,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+            UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+    }
+
+    private static async Task<bool> WaitForFileAsync(string path, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (File.Exists(path))
+                return true;
+            await Task.Delay(100);
+        }
+        return File.Exists(path);
+    }
+}
+
+internal static class ProcessStartInfoExtensions
+{
+    public static ProcessStartInfo WithArgs(this ProcessStartInfo psi, params string[] args)
+    {
+        foreach (var a in args)
+            psi.ArgumentList.Add(a);
+        return psi;
+    }
+}

--- a/tests/Highbyte.DotNet6502.Updates.Tests/UpdateCheckerTests.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/UpdateCheckerTests.cs
@@ -71,10 +71,14 @@ public class UpdateCheckerTests : IDisposable
     private sealed class CapturingLogger : ILogger
     {
         public List<string> Messages { get; } = new();
+        public List<LogLevel> Levels { get; } = new();
         public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullDisposable.Instance;
         public bool IsEnabled(LogLevel logLevel) => true;
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-            => Messages.Add(formatter(state, exception));
+        {
+            Messages.Add(formatter(state, exception));
+            Levels.Add(logLevel);
+        }
 
         private sealed class NullDisposable : IDisposable
         {
@@ -92,6 +96,19 @@ public class UpdateCheckerTests : IDisposable
         await checker.CheckAsync();
 
         Assert.Contains(logger.Messages, m => m.Contains("v0.40.2-alpha") && m.Contains("brew upgrade dotnet-6502-terminal"));
+    }
+
+    [Fact]
+    public async Task LogsWarning_WhenCheckFails()
+    {
+        var logger = new CapturingLogger();
+        var checker = MakeChecker(new FakeReleaseSource(new HttpRequestException("offline")), ManagedHomebrewDetector(), "0.40.1-alpha", logger);
+
+        var result = await checker.CheckAsync();
+
+        Assert.Equal(UpdateCheckStatus.Error, result.Status);
+        Assert.Contains(logger.Messages, m => m.Contains("Update check failed"));
+        Assert.Contains(LogLevel.Warning, logger.Levels);
     }
 
     [Fact]

--- a/tests/Highbyte.DotNet6502.Updates.Tests/UpdateCheckerTests.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/UpdateCheckerTests.cs
@@ -1,0 +1,172 @@
+using Highbyte.DotNet6502.Updates;
+using Xunit;
+
+namespace Highbyte.DotNet6502.Updates.Tests;
+
+public class UpdateCheckerTests : IDisposable
+{
+    private static readonly AppUpdateDescriptor Descriptor = new()
+    {
+        HomebrewPackage = "dotnet-6502-terminal",
+        HomebrewIsCask = false,
+        ScoopPackage = "dotnet-6502-terminal",
+    };
+
+    private readonly string _cacheFile = Path.Combine(Path.GetTempPath(), $"update-check-test-{Guid.NewGuid():N}.json");
+
+    public void Dispose()
+    {
+        if (File.Exists(_cacheFile))
+            File.Delete(_cacheFile);
+    }
+
+    private sealed class FakeReleaseSource : IReleaseSource
+    {
+        private readonly ReleaseQueryResult _result;
+        private readonly Exception? _throw;
+        public int CallCount { get; private set; }
+
+        public FakeReleaseSource(ReleaseQueryResult result) => _result = result;
+        public FakeReleaseSource(Exception toThrow) { _throw = toThrow; _result = null!; }
+
+        public Task<ReleaseQueryResult> GetReleasesAsync(string? etag, CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            if (_throw != null)
+                throw _throw;
+            return Task.FromResult(_result);
+        }
+    }
+
+    private static ReleaseQueryResult Releases(params string[] tags)
+    {
+        var list = tags.Select(t => new GitHubRelease { TagName = t, Prerelease = t.Contains('-'), HtmlUrl = $"https://example/releases/{t}" }).ToList();
+        return new ReleaseQueryResult(NotModified: false, ETag: "\"etag1\"", Releases: list);
+    }
+
+    private InstallChannelDetector ManagedHomebrewDetector()
+    {
+        var probe = new FakeInstallChannelProbe { OS = OSPlatformKind.Linux };
+        probe.Files["/app/install-channel"] = "homebrew";
+        probe.ResolvableExecutables["brew"] = "/opt/homebrew/bin/brew";
+        probe.CommandResults["/opt/homebrew/bin/brew list --versions dotnet-6502-terminal"] =
+            new ProcessRunResult(0, "dotnet-6502-terminal 0.40.1\n");
+        return new InstallChannelDetector(probe);
+    }
+
+    private InstallChannelDetector NotManagedDetector()
+        => new(new FakeInstallChannelProbe { OS = OSPlatformKind.Linux }); // no marker
+
+    private UpdateChecker MakeChecker(IReleaseSource source, InstallChannelDetector detector, string currentVersion)
+        => new(
+            Descriptor,
+            source,
+            detector,
+            new UpdateCheckCache(_cacheFile),
+            currentVersionProvider: () => AppVersion.Parse(currentVersion),
+            utcNow: () => DateTimeOffset.UnixEpoch + TimeSpan.FromDays(1000));
+
+    [Fact]
+    public async Task UpdateAvailable_BuildsCommandAndReleaseUrl()
+    {
+        var checker = MakeChecker(new FakeReleaseSource(Releases("v0.40.1-alpha", "v0.40.2-alpha")), ManagedHomebrewDetector(), "0.40.1-alpha");
+
+        var result = await checker.CheckAsync();
+
+        Assert.Equal(UpdateCheckStatus.UpdateAvailable, result.Status);
+        Assert.True(result.IsUpdateAvailable);
+        Assert.Equal("0.40.2-alpha", result.LatestVersion!.ToString());
+        Assert.Equal("brew upgrade dotnet-6502-terminal", result.SuggestedCommand);
+        Assert.Equal("https://example/releases/v0.40.2-alpha", result.ReleaseNotesUrl);
+    }
+
+    [Fact]
+    public async Task UpToDate_WhenOnNewestRelease()
+    {
+        var checker = MakeChecker(new FakeReleaseSource(Releases("v0.40.1-alpha", "v0.40.2-alpha")), ManagedHomebrewDetector(), "0.40.2-alpha");
+
+        var result = await checker.CheckAsync();
+
+        Assert.Equal(UpdateCheckStatus.UpToDate, result.Status);
+        Assert.Null(result.SuggestedCommand);
+    }
+
+    [Fact]
+    public async Task NotManaged_ShortCircuits_NoNetwork()
+    {
+        var source = new FakeReleaseSource(Releases("v0.40.2-alpha"));
+        var checker = MakeChecker(source, NotManagedDetector(), "0.40.1-alpha");
+
+        var result = await checker.CheckAsync();
+
+        Assert.Equal(UpdateCheckStatus.NotManaged, result.Status);
+        Assert.Equal(0, source.CallCount);
+    }
+
+    [Fact]
+    public async Task VersionUnknown_WhenAppNotStamped()
+    {
+        var source = new FakeReleaseSource(Releases("v0.40.2-alpha"));
+        var checker = MakeChecker(source, ManagedHomebrewDetector(), "1.0.0"); // unstamped
+
+        var result = await checker.CheckAsync();
+
+        Assert.Equal(UpdateCheckStatus.VersionUnknown, result.Status);
+        Assert.Equal(0, source.CallCount);
+    }
+
+    [Fact]
+    public async Task CadenceWindow_ReusesCache_NoSecondNetworkCall()
+    {
+        var source = new FakeReleaseSource(Releases("v0.40.1-alpha", "v0.40.2-alpha"));
+        var detector = ManagedHomebrewDetector();
+
+        var first = await MakeChecker(source, detector, "0.40.1-alpha").CheckAsync();
+        Assert.Equal(UpdateCheckStatus.UpdateAvailable, first.Status);
+        Assert.Equal(1, source.CallCount);
+
+        // Second check within the 24h window reuses the cache written by the first.
+        var second = await MakeChecker(source, detector, "0.40.1-alpha").CheckAsync();
+        Assert.Equal(UpdateCheckStatus.UpdateAvailable, second.Status);
+        Assert.Equal("brew upgrade dotnet-6502-terminal", second.SuggestedCommand);
+        Assert.Equal(1, source.CallCount); // no new network call
+    }
+
+    [Fact]
+    public async Task ForceCheck_BypassesCadenceCache()
+    {
+        var source = new FakeReleaseSource(Releases("v0.40.2-alpha"));
+        var detector = ManagedHomebrewDetector();
+
+        await MakeChecker(source, detector, "0.40.1-alpha").CheckAsync();
+        await MakeChecker(source, detector, "0.40.1-alpha").CheckAsync(new UpdateCheckContext { ForceCheck = true });
+
+        Assert.Equal(2, source.CallCount);
+    }
+
+    [Fact]
+    public async Task NetworkFailure_ReturnsErrorStatus()
+    {
+        var checker = MakeChecker(new FakeReleaseSource(new HttpRequestException("offline")), ManagedHomebrewDetector(), "0.40.1-alpha");
+
+        var result = await checker.CheckAsync();
+
+        Assert.Equal(UpdateCheckStatus.Error, result.Status);
+        Assert.False(result.IsUpdateAvailable);
+    }
+
+    [Fact]
+    public async Task IgnoresDraftsAndPrereleasesWhenExcluded()
+    {
+        var releases = new ReleaseQueryResult(false, "\"e\"", new[]
+        {
+            new GitHubRelease { TagName = "v0.41.0-alpha", Prerelease = true, HtmlUrl = "u1" },
+            new GitHubRelease { TagName = "v0.40.2", Prerelease = false, HtmlUrl = "u2" },
+        });
+        var checker = MakeChecker(new FakeReleaseSource(releases), ManagedHomebrewDetector(), "0.40.1");
+
+        var result = await checker.CheckAsync(new UpdateCheckContext { IncludePrereleases = false });
+
+        Assert.Equal("0.40.2", result.LatestVersion!.ToString()); // prerelease 0.41.0-alpha excluded
+    }
+}

--- a/tests/Highbyte.DotNet6502.Updates.Tests/UpdateCheckerTests.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/UpdateCheckerTests.cs
@@ -1,4 +1,5 @@
 using Highbyte.DotNet6502.Updates;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Highbyte.DotNet6502.Updates.Tests;
@@ -57,14 +58,52 @@ public class UpdateCheckerTests : IDisposable
     private InstallChannelDetector NotManagedDetector()
         => new(new FakeInstallChannelProbe { OS = OSPlatformKind.Linux }); // no marker
 
-    private UpdateChecker MakeChecker(IReleaseSource source, InstallChannelDetector detector, string currentVersion)
+    private UpdateChecker MakeChecker(IReleaseSource source, InstallChannelDetector detector, string currentVersion, ILogger? logger = null)
         => new(
             Descriptor,
             source,
             detector,
             new UpdateCheckCache(_cacheFile),
             currentVersionProvider: () => AppVersion.Parse(currentVersion),
-            utcNow: () => DateTimeOffset.UnixEpoch + TimeSpan.FromDays(1000));
+            utcNow: () => DateTimeOffset.UnixEpoch + TimeSpan.FromDays(1000),
+            logger: logger);
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<string> Messages { get; } = new();
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullDisposable.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Messages.Add(formatter(state, exception));
+
+        private sealed class NullDisposable : IDisposable
+        {
+            public static readonly NullDisposable Instance = new();
+            public void Dispose() { }
+        }
+    }
+
+    [Fact]
+    public async Task LogsInformation_WhenUpdateAvailable()
+    {
+        var logger = new CapturingLogger();
+        var checker = MakeChecker(new FakeReleaseSource(Releases("v0.40.1-alpha", "v0.40.2-alpha")), ManagedHomebrewDetector(), "0.40.1-alpha", logger);
+
+        await checker.CheckAsync();
+
+        Assert.Contains(logger.Messages, m => m.Contains("v0.40.2-alpha") && m.Contains("brew upgrade dotnet-6502-terminal"));
+    }
+
+    [Fact]
+    public async Task DoesNotLog_WhenUpToDate()
+    {
+        var logger = new CapturingLogger();
+        var checker = MakeChecker(new FakeReleaseSource(Releases("v0.40.2-alpha")), ManagedHomebrewDetector(), "0.40.2-alpha", logger);
+
+        await checker.CheckAsync();
+
+        Assert.Empty(logger.Messages);
+    }
 
     [Fact]
     public async Task UpdateAvailable_BuildsCommandAndReleaseUrl()

--- a/tools/update/_common.ps1
+++ b/tools/update/_common.ps1
@@ -1,0 +1,115 @@
+# Shared helpers for the tools/update/trigger-*.ps1 dev scripts (Windows / Scoop).
+#
+# Windows analog of _common.sh: makes the "a newer version is available" behavior fire locally for one
+# of the Scoop-distributed apps WITHOUT a real Scoop install, by faking the two things a managed install
+# provides:
+#   1. a version stamp OLDER than the latest GitHub release (so an update looks available), and
+#   2. a managed-install signal: an `install-channel` marker next to the binary + a fake `scoop.ps1`
+#      shim that "confirms" the package is installed ($env:SCOOP points at it).
+# The real shared Highbyte.DotNet6502.Updates checker then runs exactly as on a real Scoop install; only
+# the version stamp, marker, and scoop are simulated.
+#
+# A sourcing trigger-<app>.ps1 must, AFTER dot-sourcing this file:
+#   - set $AppLabel     (human name, e.g. "Avalonia Desktop")
+#   - set $ProjectDir   (path to the app project dir; build from $RepoRoot)
+#   - set $DllName      (built dll filename)
+#   - define Invoke-App ($BinDir param; launches/observes the app; $env:SCOOP already set)
+#   - call  Invoke-UpdateTrigger @args
+#
+# Run from a PowerShell prompt (Windows PowerShell 5.1 or PowerShell 7). Env overrides:
+#   OLD_VERSION (default 0.1.0-alpha), FAKE_UPGRADE_EXIT=1 (make the fake upgrade fail).
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot      = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$OldVersion    = if ($env:OLD_VERSION) { $env:OLD_VERSION } else { '0.1.0-alpha' }
+$FakeScoopRoot = Join-Path $env:TEMP 'dotnet6502-dev-fakescoop'
+
+# Update-checker storage lives under .NET's LocalApplicationData = %LOCALAPPDATA% on Windows.
+$UpdatesDir    = Join-Path $env:LOCALAPPDATA 'Highbyte\DotNet6502\cache\updates'
+$CheckCache    = Join-Path $UpdatesDir 'update-check.json'
+$DismissedFile = Join-Path $UpdatesDir 'dismissed-version.txt'
+$PendingFile   = Join-Path $UpdatesDir 'pending-update.txt'
+$ApplyLog      = Join-Path $UpdatesDir 'last-update.log'
+
+function Get-ProjectFile {
+    Get-ChildItem -Path $ProjectDir -Filter '*.csproj' | Select-Object -First 1 -ExpandProperty FullName
+}
+
+function Get-BinaryDir {
+    # The stamped binary's directory is the app's AppContext.BaseDirectory, where the marker must live.
+    $dll = Get-ChildItem -Path (Join-Path $ProjectDir 'bin') -Recurse -Filter $DllName -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($dll) { return $dll.Directory.FullName }
+    return $null
+}
+
+function Reset-UpdateSim {
+    Write-Host "Removing update simulation and restoring a plain dev build for $AppLabel..."
+    $binDir = Get-BinaryDir
+    if ($binDir) { Remove-Item -Force -ErrorAction SilentlyContinue (Join-Path $binDir 'install-channel') }
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $FakeScoopRoot
+    Remove-Item -Force -ErrorAction SilentlyContinue $CheckCache, $DismissedFile, $PendingFile, $ApplyLog
+    dotnet build (Get-ProjectFile) -v quiet | Out-Null
+    Write-Host "Done. $AppLabel is back to normal (unstamped, not managed)."
+}
+
+function Initialize-UpdateSim {
+    Write-Host "Building $AppLabel stamped with old version v$OldVersion..."
+    dotnet build (Get-ProjectFile) -p:Version=$OldVersion -v quiet | Out-Null
+    if ($LASTEXITCODE -ne 0) { Write-Error "Build failed."; exit 1 }
+
+    $script:BinDir = Get-BinaryDir
+    if (-not $script:BinDir) { Write-Error "Could not locate the built binary ($DllName)."; exit 1 }
+
+    # 1. Marker next to the binary - the "managed" signal Scoop's post_install emits.
+    Set-Content -Path (Join-Path $script:BinDir 'install-channel') -Value 'scoop' -Encoding ascii
+
+    # 2. Fake scoop.ps1 shim (Scoop is a PowerShell tool). Confirms the package on `scoop list <pkg>`
+    #    and fakes `scoop update <pkg>`. Set FAKE_UPGRADE_EXIT=1 to make the upgrade FAIL.
+    $shims = Join-Path $FakeScoopRoot 'shims'
+    New-Item -ItemType Directory -Force -Path $shims | Out-Null
+    $upgradeExit = if ($env:FAKE_UPGRADE_EXIT) { $env:FAKE_UPGRADE_EXIT } else { '0' }
+    $fakeScoop = @"
+`$cmd = if (`$args.Count -gt 0) { `$args[0] } else { '' }
+switch (`$cmd) {
+    'list'   { `$args -join ' '; exit 0 }
+    'update' { "==> (fake) scoop `$(`$args -join ' ')"; "Upgrade finished (exit $upgradeExit)."; exit $upgradeExit }
+    default  { exit 1 }
+}
+"@
+    Set-Content -Path (Join-Path $shims 'scoop.ps1') -Value $fakeScoop -Encoding ascii
+
+    # 3. Clear the update-check cache + dismissed/pending memory so the check definitely reports available.
+    Remove-Item -Force -ErrorAction SilentlyContinue $CheckCache, $DismissedFile, $PendingFile, $ApplyLog
+}
+
+function Invoke-UpdateTrigger {
+    param([string]$Mode)
+
+    if ($Mode -eq '--reset') { Reset-UpdateSim; return }
+
+    if ($Mode -eq '--relaunch') {
+        # Reuse the existing stamped build + marker + fake scoop, and DO NOT clear the pending-update
+        # memory - so you can confirm a dismissed banner stays hidden / the amber notice appears.
+        $script:BinDir = Get-BinaryDir
+        if ((-not $script:BinDir) -or
+            (-not (Test-Path (Join-Path $script:BinDir 'install-channel'))) -or
+            (-not (Test-Path (Join-Path $FakeScoopRoot 'shims\scoop.ps1')))) {
+            Write-Error "Nothing set up yet - run without --relaunch first."; exit 1
+        }
+        $env:SCOOP = $FakeScoopRoot
+        Invoke-App $script:BinDir
+        return
+    }
+
+    if ($Mode) { Write-Error "Unknown option: $Mode`nUsage: <script> [--relaunch | --reset]"; exit 2 }
+
+    Initialize-UpdateSim
+    $env:SCOOP = $FakeScoopRoot
+    Invoke-App $script:BinDir
+
+    Write-Host ''
+    Write-Host 'Tip: run this script with --reset to restore a normal dev build.'
+}

--- a/tools/update/_common.ps1
+++ b/tools/update/_common.ps1
@@ -46,17 +46,17 @@ function Get-BinaryDir {
 }
 
 function Reset-UpdateSim {
-    Write-Host "Removing update simulation and restoring a plain dev build for $AppLabel..."
+    Write-Output "Removing update simulation and restoring a plain dev build for $AppLabel..."
     $binDir = Get-BinaryDir
     if ($binDir) { Remove-Item -Force -ErrorAction SilentlyContinue (Join-Path $binDir 'install-channel') }
     Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $FakeScoopRoot
     Remove-Item -Force -ErrorAction SilentlyContinue $CheckCache, $DismissedFile, $PendingFile, $ApplyLog
     dotnet build (Get-ProjectFile) -v quiet | Out-Null
-    Write-Host "Done. $AppLabel is back to normal (unstamped, not managed)."
+    Write-Output "Done. $AppLabel is back to normal (unstamped, not managed)."
 }
 
 function Initialize-UpdateSim {
-    Write-Host "Building $AppLabel stamped with old version v$OldVersion..."
+    Write-Output "Building $AppLabel stamped with old version v$OldVersion..."
     dotnet build (Get-ProjectFile) -p:Version=$OldVersion -v quiet | Out-Null
     if ($LASTEXITCODE -ne 0) { Write-Error "Build failed."; exit 1 }
 
@@ -110,6 +110,6 @@ function Invoke-UpdateTrigger {
     $env:SCOOP = $FakeScoopRoot
     Invoke-App $script:BinDir
 
-    Write-Host ''
-    Write-Host 'Tip: run this script with --reset to restore a normal dev build.'
+    Write-Output ''
+    Write-Output 'Tip: run this script with --reset to restore a normal dev build.'
 }

--- a/tools/update/_common.ps1
+++ b/tools/update/_common.ps1
@@ -33,6 +33,32 @@ $DismissedFile = Join-Path $UpdatesDir 'dismissed-version.txt'
 $PendingFile   = Join-Path $UpdatesDir 'pending-update.txt'
 $ApplyLog      = Join-Path $UpdatesDir 'last-update.log'
 
+function Test-IsFakeScoopRoot {
+    param([string]$Path)
+
+    if (-not $Path) { return $false }
+
+    return [System.IO.Path]::GetFullPath($Path).TrimEnd('\') -ieq [System.IO.Path]::GetFullPath($FakeScoopRoot).TrimEnd('\')
+}
+
+function Invoke-WithFakeScoop {
+    param([scriptblock]$Action)
+
+    $previousScoop = $env:SCOOP
+    try {
+        $env:SCOOP = $FakeScoopRoot
+        & $Action
+    }
+    finally {
+        if ([string]::IsNullOrEmpty($previousScoop)) {
+            Remove-Item Env:SCOOP -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:SCOOP = $previousScoop
+        }
+    }
+}
+
 function Get-ProjectFile {
     Get-ChildItem -Path $ProjectDir -Filter '*.csproj' | Select-Object -First 1 -ExpandProperty FullName
 }
@@ -50,6 +76,9 @@ function Reset-UpdateSim {
     $binDir = Get-BinaryDir
     if ($binDir) { Remove-Item -Force -ErrorAction SilentlyContinue (Join-Path $binDir 'install-channel') }
     Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $FakeScoopRoot
+    if (Test-IsFakeScoopRoot $env:SCOOP) {
+        Remove-Item Env:SCOOP -ErrorAction SilentlyContinue
+    }
     Remove-Item -Force -ErrorAction SilentlyContinue $CheckCache, $DismissedFile, $PendingFile, $ApplyLog
     dotnet build (Get-ProjectFile) -v quiet | Out-Null
     Write-Output "Done. $AppLabel is back to normal (unstamped, not managed)."
@@ -99,16 +128,14 @@ function Invoke-UpdateTrigger {
             (-not (Test-Path (Join-Path $FakeScoopRoot 'shims\scoop.ps1')))) {
             Write-Error "Nothing set up yet - run without --relaunch first."; exit 1
         }
-        $env:SCOOP = $FakeScoopRoot
-        Invoke-App $script:BinDir
+        Invoke-WithFakeScoop { Invoke-App $script:BinDir }
         return
     }
 
     if ($Mode) { Write-Error "Unknown option: $Mode`nUsage: <script> [--relaunch | --reset]"; exit 2 }
 
     Initialize-UpdateSim
-    $env:SCOOP = $FakeScoopRoot
-    Invoke-App $script:BinDir
+    Invoke-WithFakeScoop { Invoke-App $script:BinDir }
 
     Write-Output ''
     Write-Output 'Tip: run this script with --reset to restore a normal dev build.'

--- a/tools/update/_common.sh
+++ b/tools/update/_common.sh
@@ -91,7 +91,9 @@ FAKEBREW
 }
 
 update_main() {
-    case "${1:-}" in
+    local mode="${1:-}"
+
+    case "$mode" in
         --reset)
             update_reset
             exit 0
@@ -111,7 +113,7 @@ update_main() {
         "")
             ;;
         *)
-            echo "Unknown option: $1" >&2
+            echo "Unknown option: $mode" >&2
             echo "Usage: $0 [--relaunch | --reset]" >&2
             exit 2
             ;;

--- a/tools/update/_common.sh
+++ b/tools/update/_common.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Shared helpers for the tools/update/trigger-*.sh dev scripts.
+#
+# These scripts make the "a newer version is available" behavior fire locally for one of the
+# brew/scoop-distributed apps, WITHOUT a real Homebrew/Scoop install, by faking the two things a
+# managed install provides:
+#   1. a version stamp OLDER than the latest GitHub release (so an update looks available), and
+#   2. a managed-install signal: an `install-channel` marker next to the binary + a fake `brew`
+#      that "confirms" the package is installed (HOMEBREW_PREFIX points at it).
+# The real shared Highbyte.DotNet6502.Updates checker then runs exactly as on a real install; only
+# the version stamp, marker, and brew are simulated.
+#
+# A sourcing trigger-<app>.sh must, AFTER sourcing this file:
+#   - set APP_LABEL     (human name, e.g. "Avalonia Desktop")
+#   - set PROJECT_DIR   (absolute path to the app project dir; build from $REPO_ROOT)
+#   - set DLL_NAME      (built dll filename)
+#   - define run_app()  (launches/observes the app; $1 = bin dir; HOMEBREW_PREFIX already exported)
+#   - call update_main "$@"
+#
+# ASCII-only on purpose (a multibyte char next to a $var mis-parses under LC_CTYPE=C). Run from a
+# real terminal (GUI/TUI apps need a window server / TTY).
+#
+# Env overrides: OLD_VERSION (default 0.1.0-alpha).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OLD_VERSION="${OLD_VERSION:-0.1.0-alpha}"
+FAKEBREW_ROOT="${TMPDIR:-/tmp}/dotnet6502-dev-fakebrew"
+
+# Update-checker storage lives under .NET's LocalApplicationData (see AppStoragePaths).
+case "$(uname -s)" in
+    Darwin) UPDATES_DIR="$HOME/Library/Application Support/Highbyte/DotNet6502/cache/updates" ;;
+    *)      UPDATES_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/Highbyte/DotNet6502/cache/updates" ;;
+esac
+CHECK_CACHE="$UPDATES_DIR/update-check.json"
+DISMISSED_FILE="$UPDATES_DIR/dismissed-version.txt"
+
+_project_file() { ls "$PROJECT_DIR"/*.csproj 2>/dev/null | head -1; }
+
+_find_binary_dir() {
+    # The stamped binary's directory is the app's AppContext.BaseDirectory, where the marker must live.
+    find "$PROJECT_DIR/bin" -name "$DLL_NAME" 2>/dev/null | head -1 | xargs -I{} dirname {}
+}
+
+update_reset() {
+    echo "Removing update simulation and restoring a plain dev build for ${APP_LABEL}..."
+    local bin_dir
+    bin_dir="$(_find_binary_dir || true)"
+    [[ -n "${bin_dir:-}" ]] && rm -f "${bin_dir}/install-channel"
+    rm -rf "$FAKEBREW_ROOT"
+    rm -f "$CHECK_CACHE" "$DISMISSED_FILE"
+    dotnet build "$(_project_file)" -v quiet >/dev/null
+    echo "Done. ${APP_LABEL} is back to normal (unstamped, not managed)."
+}
+
+update_setup() {
+    echo "Building ${APP_LABEL} stamped with old version v${OLD_VERSION}..."
+    dotnet build "$(_project_file)" -p:Version="$OLD_VERSION" -v quiet >/dev/null
+    BIN_DIR="$(_find_binary_dir)"
+    if [[ -z "$BIN_DIR" ]]; then
+        echo "Could not locate the built binary (${DLL_NAME})." >&2
+        exit 1
+    fi
+
+    # 1. Marker next to the binary - the "managed" signal the Homebrew formula/Scoop emit.
+    printf 'homebrew\n' > "${BIN_DIR}/install-channel"
+
+    # 2. Fake `brew` that confirms the package on `brew list [--cask] --versions <pkg>`. Echoing all
+    #    args guarantees the package name is present regardless of formula/cask arg position.
+    mkdir -p "$FAKEBREW_ROOT/bin"
+    printf '#!/bin/bash\n[[ "$1" == "list" ]] && echo "$@" && exit 0\nexit 1\n' > "$FAKEBREW_ROOT/bin/brew"
+    chmod +x "$FAKEBREW_ROOT/bin/brew"
+
+    # 3. Clear the update-check cache AND dismissed-version memory so the check definitely reports available.
+    rm -f "$CHECK_CACHE" "$DISMISSED_FILE"
+}
+
+update_main() {
+    case "${1:-}" in
+        --reset)
+            update_reset
+            exit 0
+            ;;
+        --relaunch)
+            # Reuse the existing stamped build + marker + fake brew, and DO NOT clear the
+            # dismissed-version memory (relevant to the Avalonia banner's per-version dismissal).
+            BIN_DIR="$(_find_binary_dir || true)"
+            if [[ -z "${BIN_DIR:-}" || ! -f "${BIN_DIR}/install-channel" || ! -x "$FAKEBREW_ROOT/bin/brew" ]]; then
+                echo "Nothing set up yet - run without --relaunch first." >&2
+                exit 1
+            fi
+            export HOMEBREW_PREFIX="$FAKEBREW_ROOT"
+            run_app "$BIN_DIR"
+            exit 0
+            ;;
+        "")
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            echo "Usage: $0 [--relaunch | --reset]" >&2
+            exit 2
+            ;;
+    esac
+
+    update_setup
+    export HOMEBREW_PREFIX="$FAKEBREW_ROOT"
+    run_app "$BIN_DIR"
+
+    echo
+    echo "Tip: run '$0 --reset' to restore a normal dev build."
+}

--- a/tools/update/_common.sh
+++ b/tools/update/_common.sh
@@ -35,6 +35,8 @@ case "$(uname -s)" in
 esac
 CHECK_CACHE="$UPDATES_DIR/update-check.json"
 DISMISSED_FILE="$UPDATES_DIR/dismissed-version.txt"
+PENDING_FILE="$UPDATES_DIR/pending-update.txt"
+APPLY_LOG="$UPDATES_DIR/last-update.log"
 
 _project_file() { ls "$PROJECT_DIR"/*.csproj 2>/dev/null | head -1; }
 
@@ -49,7 +51,7 @@ update_reset() {
     bin_dir="$(_find_binary_dir || true)"
     [[ -n "${bin_dir:-}" ]] && rm -f "${bin_dir}/install-channel"
     rm -rf "$FAKEBREW_ROOT"
-    rm -f "$CHECK_CACHE" "$DISMISSED_FILE"
+    rm -f "$CHECK_CACHE" "$DISMISSED_FILE" "$PENDING_FILE" "$APPLY_LOG"
     dotnet build "$(_project_file)" -v quiet >/dev/null
     echo "Done. ${APP_LABEL} is back to normal (unstamped, not managed)."
 }
@@ -68,12 +70,24 @@ update_setup() {
 
     # 2. Fake `brew` that confirms the package on `brew list [--cask] --versions <pkg>`. Echoing all
     #    args guarantees the package name is present regardless of formula/cask arg position.
+    #    Also fakes `upgrade` so --update / the GUI one-click can exercise the upgrade step. Set
+    #    FAKE_UPGRADE_EXIT=1 to make the upgrade FAIL (to test --update failure / the amber
+    #    "update didn't complete" banner on next launch).
     mkdir -p "$FAKEBREW_ROOT/bin"
-    printf '#!/bin/bash\n[[ "$1" == "list" ]] && echo "$@" && exit 0\nexit 1\n' > "$FAKEBREW_ROOT/bin/brew"
+    local upgrade_exit="${FAKE_UPGRADE_EXIT:-0}"
+    cat > "$FAKEBREW_ROOT/bin/brew" <<FAKEBREW
+#!/bin/bash
+# Throwaway fake brew for the dev update scripts.
+case "\$1" in
+    list)    echo "\$@"; exit 0 ;;                                 # detection: confirm the package is installed
+    upgrade) echo "==> (fake) brew \$*"; echo "Upgrade finished (exit ${upgrade_exit})."; exit ${upgrade_exit} ;;
+    *)       exit 1 ;;
+esac
+FAKEBREW
     chmod +x "$FAKEBREW_ROOT/bin/brew"
 
     # 3. Clear the update-check cache AND dismissed-version memory so the check definitely reports available.
-    rm -f "$CHECK_CACHE" "$DISMISSED_FILE"
+    rm -f "$CHECK_CACHE" "$DISMISSED_FILE" "$PENDING_FILE" "$APPLY_LOG"
 }
 
 update_main() {

--- a/tools/update/_common.sh
+++ b/tools/update/_common.sh
@@ -38,6 +38,24 @@ DISMISSED_FILE="$UPDATES_DIR/dismissed-version.txt"
 PENDING_FILE="$UPDATES_DIR/pending-update.txt"
 APPLY_LOG="$UPDATES_DIR/last-update.log"
 
+is_fakebrew_root() {
+    [[ -n "${1:-}" && "$1" == "$FAKEBREW_ROOT" ]]
+}
+
+run_with_fakebrew() {
+    local had_homebrew_prefix="${HOMEBREW_PREFIX+set}"
+    local previous_homebrew_prefix="${HOMEBREW_PREFIX:-}"
+
+    export HOMEBREW_PREFIX="$FAKEBREW_ROOT"
+    "$@"
+
+    if [[ -n "$had_homebrew_prefix" ]]; then
+        export HOMEBREW_PREFIX="$previous_homebrew_prefix"
+    else
+        unset HOMEBREW_PREFIX
+    fi
+}
+
 _project_file() { ls "$PROJECT_DIR"/*.csproj 2>/dev/null | head -1; }
 
 _find_binary_dir() {
@@ -51,6 +69,9 @@ update_reset() {
     bin_dir="$(_find_binary_dir || true)"
     [[ -n "${bin_dir:-}" ]] && rm -f "${bin_dir}/install-channel"
     rm -rf "$FAKEBREW_ROOT"
+    if is_fakebrew_root "${HOMEBREW_PREFIX:-}"; then
+        unset HOMEBREW_PREFIX
+    fi
     rm -f "$CHECK_CACHE" "$DISMISSED_FILE" "$PENDING_FILE" "$APPLY_LOG"
     dotnet build "$(_project_file)" -v quiet >/dev/null
     echo "Done. ${APP_LABEL} is back to normal (unstamped, not managed)."
@@ -106,8 +127,7 @@ update_main() {
                 echo "Nothing set up yet - run without --relaunch first." >&2
                 exit 1
             fi
-            export HOMEBREW_PREFIX="$FAKEBREW_ROOT"
-            run_app "$BIN_DIR"
+            run_with_fakebrew run_app "$BIN_DIR"
             exit 0
             ;;
         "")
@@ -120,8 +140,7 @@ update_main() {
     esac
 
     update_setup
-    export HOMEBREW_PREFIX="$FAKEBREW_ROOT"
-    run_app "$BIN_DIR"
+    run_with_fakebrew run_app "$BIN_DIR"
 
     echo
     echo "Tip: run '$0 --reset' to restore a normal dev build."

--- a/tools/update/trigger-avalonia-desktop.ps1
+++ b/tools/update/trigger-avalonia-desktop.ps1
@@ -22,8 +22,8 @@ $DllName    = 'Highbyte.DotNet6502.App.Avalonia.Desktop.dll'
 
 function Invoke-App {
     param($BinDir)
-    Write-Host "Launching $AppLabel. Expect a green top banner: 'Update available: v$OldVersion -> v<latest>'."
-    Write-Host "Click the left-panel 'About' button for the version, the scoop command, and What's new."
+    Write-Output "Launching $AppLabel. Expect a green top banner: 'Update available: v$OldVersion -> v<latest>'."
+    Write-Output "Click the left-panel 'About' button for the version, the scoop command, and What's new."
     dotnet (Join-Path $BinDir $DllName) -- --console-log
 }
 

--- a/tools/update/trigger-avalonia-desktop.ps1
+++ b/tools/update/trigger-avalonia-desktop.ps1
@@ -1,0 +1,30 @@
+# Trigger the "update available" banner + About dialog in the Avalonia DESKTOP app locally (Windows/Scoop).
+#
+#   App: src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop
+#        ("DotNet 6502 Emulator" GUI; on Windows distributed via Scoop).
+#
+# Observe: a green banner appears at the top of the window a moment after it opens; click the
+#          left-panel "About" button for the version, the `scoop update` command, and What's new.
+#          Click "Update now" to test the one-click self-update (quits -> fake scoop update -> relaunch).
+#
+# Usage:
+#   .\tools\update\trigger-avalonia-desktop.ps1              # set up + launch (banner shows)
+#   .\tools\update\trigger-avalonia-desktop.ps1 --relaunch   # relaunch keeping the pending-update memory
+#                                                            # (to see the amber "didn't complete" banner)
+#   .\tools\update\trigger-avalonia-desktop.ps1 --reset      # remove simulation + restore a normal build
+#   $env:FAKE_UPGRADE_EXIT=1; .\tools\update\trigger-avalonia-desktop.ps1   # make the fake upgrade fail
+
+. "$PSScriptRoot\_common.ps1"
+
+$AppLabel   = 'Avalonia Desktop'
+$ProjectDir = Join-Path $RepoRoot 'src\apps\Avalonia\Highbyte.DotNet6502.App.Avalonia.Desktop'
+$DllName    = 'Highbyte.DotNet6502.App.Avalonia.Desktop.dll'
+
+function Invoke-App {
+    param($BinDir)
+    Write-Host "Launching $AppLabel. Expect a green top banner: 'Update available: v$OldVersion -> v<latest>'."
+    Write-Host "Click the left-panel 'About' button for the version, the scoop command, and What's new."
+    dotnet (Join-Path $BinDir $DllName)
+}
+
+Invoke-UpdateTrigger @args

--- a/tools/update/trigger-avalonia-desktop.ps1
+++ b/tools/update/trigger-avalonia-desktop.ps1
@@ -24,7 +24,7 @@ function Invoke-App {
     param($BinDir)
     Write-Host "Launching $AppLabel. Expect a green top banner: 'Update available: v$OldVersion -> v<latest>'."
     Write-Host "Click the left-panel 'About' button for the version, the scoop command, and What's new."
-    dotnet (Join-Path $BinDir $DllName)
+    dotnet (Join-Path $BinDir $DllName) -- --console-log
 }
 
 Invoke-UpdateTrigger @args

--- a/tools/update/trigger-avalonia-desktop.sh
+++ b/tools/update/trigger-avalonia-desktop.sh
@@ -27,6 +27,7 @@ run_app() {
     echo "Launching ${APP_LABEL}. Expect a green top banner: 'Update available: v${OLD_VERSION} -> v<latest>'."
     echo "Click the left-panel 'About' button for the version, the brew command, and What's new."
     dotnet "${bin_dir}/${DLL_NAME}" -- --console-log
+    return 0
 }
 
 update_main "$@"

--- a/tools/update/trigger-avalonia-desktop.sh
+++ b/tools/update/trigger-avalonia-desktop.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Trigger the "update available" banner + About dialog in the Avalonia DESKTOP app locally.
+#
+#   App: src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop
+#        ("DotNet 6502 Emulator" GUI; Homebrew cask on macOS / formula on Linux; Scoop on Windows).
+#
+# Observe: a green banner appears at the top of the window a moment after it opens; click the
+#          left-panel "About" button for the version, the brew command, and the What's new link.
+#
+# Usage:
+#   tools/update/trigger-avalonia-desktop.sh              # set up + launch (banner shows)
+#   tools/update/trigger-avalonia-desktop.sh --relaunch   # relaunch keeping the dismissed-version
+#                                                          # memory, to verify a dismissed banner
+#                                                          # stays hidden across a restart
+#   tools/update/trigger-avalonia-desktop.sh --reset      # remove simulation + restore a normal build
+#
+# Run from a real GUI session (Terminal.app); Avalonia needs a window server.
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+
+APP_LABEL="Avalonia Desktop"
+PROJECT_DIR="$REPO_ROOT/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop"
+DLL_NAME="Highbyte.DotNet6502.App.Avalonia.Desktop.dll"
+
+run_app() {
+    local bin_dir="$1"
+    echo "Launching ${APP_LABEL}. Expect a green top banner: 'Update available: v${OLD_VERSION} -> v<latest>'."
+    echo "Click the left-panel 'About' button for the version, the brew command, and What's new."
+    dotnet "${bin_dir}/${DLL_NAME}" -- --console-log
+}
+
+update_main "$@"

--- a/tools/update/trigger-headless.ps1
+++ b/tools/update/trigger-headless.ps1
@@ -1,0 +1,29 @@
+# Trigger the "update available" log in the HEADLESS app locally (Windows/Scoop).
+#
+#   App: src/apps/Highbyte.DotNet6502.App.Headless (Scoop; CLI/automation host that logs to the console).
+#
+# Observe: launched here as a remote server (--remote-port) so it stays alive; the update line prints to
+#          the console log about a second after startup:
+#            info: UpdateCheck[0] A newer version ... Run 'scoop update dotnet-6502-headless' to update.
+#          Press Ctrl+C to stop. (A very short-lived headless run may exit before the async check
+#          finishes - by design, since the check is non-blocking; this keeps it alive to observe.)
+#
+# Usage:
+#   .\tools\update\trigger-headless.ps1              # set up + launch (remote server, logs to console)
+#   .\tools\update\trigger-headless.ps1 --relaunch   # relaunch reusing the existing setup
+#   .\tools\update\trigger-headless.ps1 --reset      # remove simulation + restore a normal build
+
+. "$PSScriptRoot\_common.ps1"
+
+$AppLabel   = 'Headless'
+$ProjectDir = Join-Path $RepoRoot 'src\apps\Highbyte.DotNet6502.App.Headless'
+$DllName    = 'Highbyte.DotNet6502.App.Headless.dll'
+
+function Invoke-App {
+    param($BinDir)
+    Write-Host "Launching $AppLabel as a remote server (stays alive). Watch the console for the"
+    Write-Host '  info: UpdateCheck[0] A newer version ... line. Press Ctrl+C to stop.'
+    dotnet (Join-Path $BinDir $DllName) --remote-port 6599
+}
+
+Invoke-UpdateTrigger @args

--- a/tools/update/trigger-headless.ps1
+++ b/tools/update/trigger-headless.ps1
@@ -21,8 +21,8 @@ $DllName    = 'Highbyte.DotNet6502.App.Headless.dll'
 
 function Invoke-App {
     param($BinDir)
-    Write-Host "Launching $AppLabel as a remote server (stays alive). Watch the console for the"
-    Write-Host '  info: UpdateCheck[0] A newer version ... line. Press Ctrl+C to stop.'
+    Write-Output "Launching $AppLabel as a remote server (stays alive). Watch the console for the"
+    Write-Output '  info: UpdateCheck[0] A newer version ... line. Press Ctrl+C to stop.'
     dotnet (Join-Path $BinDir $DllName) --remote-port 6599
 }
 

--- a/tools/update/trigger-headless.sh
+++ b/tools/update/trigger-headless.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Trigger the "update available" log in the HEADLESS app locally.
+#
+#   App: src/apps/Highbyte.DotNet6502.App.Headless
+#        (Homebrew formula / Scoop; CLI/automation host that logs to the console).
+#
+# Observe: launched here as a remote server (--remote-port) so it stays alive; the update line prints
+#          to the console log about a second after startup:
+#            info: UpdateCheck[0] A newer version ... Run 'brew upgrade dotnet-6502-headless' to update.
+#          Press Ctrl+C to stop. (A very short-lived headless run may exit before the async check
+#          finishes - by design, since the check is non-blocking; this keeps it alive to observe.)
+#
+# Usage:
+#   tools/update/trigger-headless.sh              # set up + launch (remote server, logs to console)
+#   tools/update/trigger-headless.sh --relaunch   # relaunch reusing the existing setup
+#   tools/update/trigger-headless.sh --reset      # remove simulation + restore a normal build
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+
+APP_LABEL="Headless"
+PROJECT_DIR="$REPO_ROOT/src/apps/Highbyte.DotNet6502.App.Headless"
+DLL_NAME="Highbyte.DotNet6502.App.Headless.dll"
+
+run_app() {
+    local bin_dir="$1"
+    echo "Launching ${APP_LABEL} as a remote server (stays alive). Watch the console for the"
+    echo "  info: UpdateCheck[0] A newer version ... line. Press Ctrl+C to stop."
+    dotnet "${bin_dir}/${DLL_NAME}" --remote-port 6599
+}
+
+update_main "$@"

--- a/tools/update/trigger-headless.sh
+++ b/tools/update/trigger-headless.sh
@@ -26,6 +26,7 @@ run_app() {
     echo "Launching ${APP_LABEL} as a remote server (stays alive). Watch the console for the"
     echo "  info: UpdateCheck[0] A newer version ... line. Press Ctrl+C to stop."
     dotnet "${bin_dir}/${DLL_NAME}" --remote-port 6599
+    return 0
 }
 
 update_main "$@"

--- a/tools/update/trigger-remoteclient.ps1
+++ b/tools/update/trigger-remoteclient.ps1
@@ -19,8 +19,8 @@ $DllName    = 'Highbyte.DotNet6502.App.RemoteClient.dll'
 
 function Invoke-App {
     param($BinDir)
-    Write-Host 'RemoteClient has no automatic check (explicit flags only). Running --check-update:'
-    Write-Host ''
+    Write-Output 'RemoteClient has no automatic check (explicit flags only). Running --check-update:'
+    Write-Output ''
     dotnet (Join-Path $BinDir $DllName) --check-update
 }
 

--- a/tools/update/trigger-remoteclient.ps1
+++ b/tools/update/trigger-remoteclient.ps1
@@ -1,0 +1,27 @@
+# Show the "update available" output for the REMOTECLIENT app locally (Windows/Scoop).
+#
+#   App: src/apps/Highbyte.DotNet6502.App.RemoteClient (Scoop; one-shot TCP client).
+#
+# NOTE: RemoteClient has NO automatic startup check/log - its stdout is the server response, kept clean
+#       for automation - so it only reports on the explicit flags. This sets up the managed simulation and
+#       runs `--check-update` so you can see the reported command. `--update` and `--version` also work
+#       (run the dll directly with those flags).
+#
+# Usage:
+#   .\tools\update\trigger-remoteclient.ps1          # set up + run --check-update
+#   .\tools\update\trigger-remoteclient.ps1 --reset  # remove simulation + restore a normal build
+
+. "$PSScriptRoot\_common.ps1"
+
+$AppLabel   = 'RemoteClient'
+$ProjectDir = Join-Path $RepoRoot 'src\apps\Highbyte.DotNet6502.App.RemoteClient'
+$DllName    = 'Highbyte.DotNet6502.App.RemoteClient.dll'
+
+function Invoke-App {
+    param($BinDir)
+    Write-Host 'RemoteClient has no automatic check (explicit flags only). Running --check-update:'
+    Write-Host ''
+    dotnet (Join-Path $BinDir $DllName) --check-update
+}
+
+Invoke-UpdateTrigger @args

--- a/tools/update/trigger-remoteclient.sh
+++ b/tools/update/trigger-remoteclient.sh
@@ -24,6 +24,7 @@ run_app() {
     echo "RemoteClient has no automatic check (explicit flags only). Running --check-update:"
     echo
     dotnet "${bin_dir}/${DLL_NAME}" --check-update
+    return 0
 }
 
 update_main "$@"

--- a/tools/update/trigger-remoteclient.sh
+++ b/tools/update/trigger-remoteclient.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Show the "update available" output for the REMOTECLIENT app locally.
+#
+#   App: src/apps/Highbyte.DotNet6502.App.RemoteClient
+#        (Homebrew formula / Scoop; one-shot TCP client for the remote-control server).
+#
+# NOTE: RemoteClient has NO automatic startup check/log - its stdout is the server response, kept
+#       clean for automation - so it only reports on the explicit flags. This sets up the managed
+#       simulation and runs `--check-update` so you can see the reported command. `--update` and
+#       `--version` also work (run the dll directly with those flags).
+#
+# Usage:
+#   tools/update/trigger-remoteclient.sh          # set up + run --check-update
+#   tools/update/trigger-remoteclient.sh --reset  # remove simulation + restore a normal build
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+
+APP_LABEL="RemoteClient"
+PROJECT_DIR="$REPO_ROOT/src/apps/Highbyte.DotNet6502.App.RemoteClient"
+DLL_NAME="Highbyte.DotNet6502.App.RemoteClient.dll"
+
+run_app() {
+    local bin_dir="$1"
+    echo "RemoteClient has no automatic check (explicit flags only). Running --check-update:"
+    echo
+    dotnet "${bin_dir}/${DLL_NAME}" --check-update
+}
+
+update_main "$@"

--- a/tools/update/trigger-terminal.ps1
+++ b/tools/update/trigger-terminal.ps1
@@ -1,0 +1,27 @@
+# Trigger the "update available" log in the TERMINAL (TUI) app locally (Windows/Scoop).
+#
+#   App: src/apps/Terminal/Highbyte.DotNet6502.App.Terminal (Scoop; Terminal.Gui TUI host).
+#
+# Observe: the update line is logged to the in-app "Logs" pane about a second after startup (not to
+#          stdout - the TUI owns the screen). Open the Logs pane to see it. The explicit flags also work
+#          and print to stdout before the TUI starts, e.g. `dotnet <dll> --check-update`.
+#
+# Usage:
+#   .\tools\update\trigger-terminal.ps1              # set up + launch the TUI
+#   .\tools\update\trigger-terminal.ps1 --relaunch   # relaunch reusing the existing setup
+#   .\tools\update\trigger-terminal.ps1 --reset      # remove simulation + restore a normal build
+
+. "$PSScriptRoot\_common.ps1"
+
+$AppLabel   = 'Terminal (TUI)'
+$ProjectDir = Join-Path $RepoRoot 'src\apps\Terminal\Highbyte.DotNet6502.App.Terminal'
+$DllName    = 'Highbyte.DotNet6502.App.Terminal.dll'
+
+function Invoke-App {
+    param($BinDir)
+    Write-Host "Launching $AppLabel. The 'update available' line appears in the in-app Logs pane after ~1s."
+    Write-Host 'Open the Logs pane to see it.'
+    dotnet (Join-Path $BinDir $DllName)
+}
+
+Invoke-UpdateTrigger @args

--- a/tools/update/trigger-terminal.ps1
+++ b/tools/update/trigger-terminal.ps1
@@ -19,8 +19,8 @@ $DllName    = 'Highbyte.DotNet6502.App.Terminal.dll'
 
 function Invoke-App {
     param($BinDir)
-    Write-Host "Launching $AppLabel. The 'update available' line appears in the in-app Logs pane after ~1s."
-    Write-Host 'Open the Logs pane to see it.'
+    Write-Output "Launching $AppLabel. The 'update available' line appears in the in-app Logs pane after ~1s."
+    Write-Output 'Open the Logs pane to see it.'
     dotnet (Join-Path $BinDir $DllName)
 }
 

--- a/tools/update/trigger-terminal.sh
+++ b/tools/update/trigger-terminal.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Trigger the "update available" log in the TERMINAL (TUI) app locally.
+#
+#   App: src/apps/Terminal/Highbyte.DotNet6502.App.Terminal
+#        (Homebrew formula / Scoop; Terminal.Gui TUI host).
+#
+# Observe: the update line is logged to the in-app "Logs" pane about a second after startup (not to
+#          stdout - the TUI owns the screen). Open the Logs pane to see it. The explicit flags also
+#          work and print to stdout before the TUI starts, e.g.:
+#            dotnet <dll> --check-update
+#
+# Usage:
+#   tools/update/trigger-terminal.sh              # set up + launch the TUI
+#   tools/update/trigger-terminal.sh --relaunch   # relaunch reusing the existing setup
+#   tools/update/trigger-terminal.sh --reset      # remove simulation + restore a normal build
+#
+# Run from a real terminal (the TUI needs a TTY).
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+
+APP_LABEL="Terminal (TUI)"
+PROJECT_DIR="$REPO_ROOT/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal"
+DLL_NAME="Highbyte.DotNet6502.App.Terminal.dll"
+
+run_app() {
+    local bin_dir="$1"
+    echo "Launching ${APP_LABEL}. The 'update available' line appears in the in-app Logs pane after ~1s."
+    echo "Open the Logs pane to see it."
+    dotnet "${bin_dir}/${DLL_NAME}"
+}
+
+update_main "$@"

--- a/tools/update/trigger-terminal.sh
+++ b/tools/update/trigger-terminal.sh
@@ -27,6 +27,7 @@ run_app() {
     echo "Launching ${APP_LABEL}. The 'update available' line appears in the in-app Logs pane after ~1s."
     echo "Open the Logs pane to see it."
     dotnet "${bin_dir}/${DLL_NAME}"
+    return 0
 }
 
 update_main "$@"


### PR DESCRIPTION
## Summary

Adds in-app update checking for brew/scoop-distributed apps, using release-stamped app assembly versions to compare against GitHub releases.

- Adds a shared `Highbyte.DotNet6502.Updates` library for app version parsing, brew/scoop install-channel detection, GitHub release checks, caching, and package-manager upgrade execution.
- Wires update commands into desktop/console apps via `--check-update` and `--update`, with automatic update notices where appropriate and opt-out configuration.
- Adds Avalonia Desktop update UI: About dialog version/status, update banner, one-click update, relaunch handling, and failure logging.
- Updates release/publish scripts to stamp app versions during release builds.
- Persists configured .NET type names without assembly version/culture/public key metadata so user settings survive app version changes.

## Testing

- Adds unit coverage for version parsing, channel detection, update checking/caching, update execution helpers, CLI behavior, and config type-name persistence.
- Builds the Avalonia Desktop update path and keeps update logic out of the browser/WASM app graph.
