### PR TITLE
Feature/app update followups

### DIFF
--- a/docs/host-apps/installation.md
+++ b/docs/host-apps/installation.md
@@ -80,6 +80,30 @@ ROM details: [Systems / C64 / ROMs](../systems/c64/roms.md), [Systems / VIC-20 /
 
 ---
 
+## Staying up to date
+
+The package-manager `Update` commands above always work and are the manual way to update. In addition, the package-manager builds (Homebrew / Scoop) can **detect when a newer release is available** and surface it inside the app, and can hand the actual upgrade back to the package manager for you.
+
+- **How detection works** — an app installed via Homebrew or Scoop knows which package manager installed it (via an `install-channel` marker written at install time) and compares its own version against the latest GitHub release. Manual-download and development builds report *not managed* and do no update check. Detection is skipped in CI and can be turned off (see below); it never blocks or delays startup.
+- **The command shown is the manual command** — when an update is available the app shows the exact `brew upgrade …` / `scoop update …` command from the tables above. Running that yourself is always equivalent to letting the app do it.
+- **Delegated update** — where the app offers an in-app "update now" action (Avalonia Desktop, and the console hosts' `--update` flag) it simply runs that same package-manager command for you.
+
+The update surface differs per app:
+
+| Application | Update surface |
+|-------------|----------------|
+| **Avalonia** (GUI) | Automatic startup check with an in-window update banner and an About dialog offering a one-click **Update now**. |
+| **Terminal (TUI)** | Automatic startup check surfaced as a notice in the **Logs** pane. |
+| **Headless** | Automatic startup check surfaced via console logging. |
+| **Remote client** | No automatic check by design (keeps stdout script-friendly); update flags only. |
+
+All four also accept the `--version` / `--check-update` / `--update` command-line flags (see each app's CLI reference — for Avalonia Desktop and Headless these are in the [General parameters](avalonia/desktop.md#cli-arguments); for the Remote Client in its [Global options](../tools/remote-control/remote-client.md#global-options)).
+
+!!! note "Disabling the automatic check"
+    The automatic (startup) update check can be disabled per app — set `UpdateCheckEnabled` to `false` (Avalonia Desktop: the *Check for updates on startup* option / `appsettings.json`; Terminal and Headless: the top-level `UpdateCheckEnabled` key in `appsettings.json`). It is also suppressed for any app when the `DOTNET6502_NO_UPDATE_CHECK` environment variable is set (to anything other than `0`/`false`) or when `CI` is set. The explicit `--check-update` / `--update` flags ignore these and always run.
+
+---
+
 ## Install via manual download
 
 Download the latest release for your platform from the [Releases](https://github.com/highbyte/dotnet-6502/releases) page under Assets. Every application ships as its own zip; substitute `<platform>` with one of `win-x64`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-arm64` (macOS is Apple Silicon / ARM64 only).

--- a/docs/host-apps/terminal/overview.md
+++ b/docs/host-apps/terminal/overview.md
@@ -77,6 +77,7 @@ of direct host hotkeys. Instead, host commands hang off a single **leader key** 
 | `S` | Start / Stop toggle |
 | `M` | Toggle the **Monitor** |
 | `T` | Toggle the **Stats** (instrumentation) box |
+| `U` | Open the **Updates** dialog (see [Updates](#updates)) |
 | `Q` | Quit the app |
 | `Y` | Cycle the selected **System** (only while stopped) |
 | `V` | Cycle the selected **Variant** (only while stopped) |
@@ -158,6 +159,27 @@ the `ll <file>` / `llb <file>` variants take an explicit path. See
 
 Press the **Stats** button or `F9` `T` to show host instrumentation (FPS, per-frame timings, …) in the
 right-hand box while a system runs.
+
+## Updates
+
+On a package-manager install (Homebrew formula or Scoop) the app checks about once a day for a newer
+release. Because a full-screen TUI has no useful stdout, the result surfaces **inside** the TUI:
+
+- A one-line notice in the **Logs** tab (right-hand pane) when an update is available.
+- An **update-available indicator** appended to the window title and the bottom hint line
+  (e.g. `★ Update available (F9 U)`), so it never steals emulator keyboard focus.
+
+Press `F9` `U` to open the **Updates** dialog. It shows the current version and update status and, on a
+package-manager install with a newer release, the exact `brew`/`scoop` command plus:
+
+- **Check now** — force an immediate check (ignores the on/off setting).
+- **Update now** — quit the TUI and run the package-manager upgrade in the foreground (its output is
+  shown on the plain console); restart the app afterwards to use the new version.
+
+Manual-download and development builds report *not managed* and do no update check. The automatic check
+is controlled by the top-level `UpdateCheckEnabled` key in `appsettings.json` (default `true`) and is
+suppressed when `DOTNET6502_NO_UPDATE_CHECK` or `CI` is set; the CLI flags `--version` /
+`--check-update` / `--update` remain available (see [Staying up to date](../installation.md#staying-up-to-date)).
 
 ## How to run locally for development
 

--- a/docs/tools/remote-control/examples.md
+++ b/docs/tools/remote-control/examples.md
@@ -8,6 +8,19 @@ For the protocol and full command reference, see [TCP protocol](tcp-protocol.md)
 
 These show end-to-end patterns using the `dotnet-6502-remote` CLI. The same command sequence translates directly to JSON requests over the raw TCP connection.
 
+### Preflight: check the server version
+
+As a best practice, start a scripted control session by confirming the client and the emulator it drives are the same release. `--check-server-version` exits `0` on a match and `3` on a mismatch (printing the update commands to stderr), so a script can bail out early:
+
+```sh
+# Abort the script if the endpoint version doesn't match this client
+dotnet-6502-remote --port 6510 --check-server-version || exit 1
+
+# ... rest of the automation ...
+```
+
+This is a version-mismatch warning only, not full protocol compatibility handling. See [Server version preflight](remote-client.md#server-version-preflight).
+
 ### Typing a BASIC command and running it
 
 Poll `c64.isbasicstarted` before sending text — the C64 BASIC ROM takes several frames to initialize after `emu.start`.

--- a/docs/tools/remote-control/remote-client.md
+++ b/docs/tools/remote-control/remote-client.md
@@ -6,13 +6,18 @@ Pre-built binaries are available for Windows, Linux, and macOS. The remote clien
 
 ## Global options
 
-| Option          | Default     | Description                  |
-|-----------------|-------------|------------------------------|
-| `--host <host>` | `127.0.0.1` | Server hostname or IP        |
-| `--port <port>` | `6510`      | TCP port                     |
-| `--help`        |             | Print usage and exit         |
+| Option           | Default     | Description                  |
+|------------------|-------------|------------------------------|
+| `--host <host>`  | `127.0.0.1` | Server hostname or IP        |
+| `--port <port>`  | `6510`      | TCP port                     |
+| `--help`         |             | Print usage and exit         |
+| `--version`      |             | Print the client version and exit |
+| `--check-update` |             | Check for a newer release of `dotnet-6502-remote` and print the result (no automatic check otherwise). Package-manager installs only. |
+| `--update`       |             | Check and, if a newer release is available on a package-manager install, run the `brew`/`scoop` upgrade, then exit. |
 
 Exit codes: `0` = success, `1` = server returned an error or connection failed, `2` = bad arguments.
+
+The Remote Client never checks for updates automatically (its stdout stays script-friendly); the flags above are the only update surface. See [Staying up to date](../../host-apps/installation.md#staying-up-to-date).
 
 ## Usage examples
 

--- a/docs/tools/remote-control/remote-client.md
+++ b/docs/tools/remote-control/remote-client.md
@@ -14,10 +14,33 @@ Pre-built binaries are available for Windows, Linux, and macOS. The remote clien
 | `--version`      |             | Print the client version and exit |
 | `--check-update` |             | Check for a newer release of `dotnet-6502-remote` and print the result (no automatic check otherwise). Package-manager installs only. |
 | `--update`       |             | Check and, if a newer release is available on a package-manager install, run the `brew`/`scoop` upgrade, then exit. |
+| `--check-server-version` |     | Connect to the server, read its app version, and warn if it differs from this client's version (see [Server version preflight](#server-version-preflight)). |
 
-Exit codes: `0` = success, `1` = server returned an error or connection failed, `2` = bad arguments.
+Exit codes: `0` = success, `1` = server returned an error or connection failed, `2` = bad arguments, `3` = server/client version mismatch (from `--check-server-version`).
 
 The Remote Client never checks for updates automatically (its stdout stays script-friendly); the flags above are the only update surface. See [Staying up to date](../../host-apps/installation.md#staying-up-to-date).
+
+## Server version preflight
+
+`--check-server-version` is a recommended preflight before a scripted control session: it makes sure the `dotnet-6502-remote` client and the emulator it is about to drive are the same release. It sends one cheap, read-only `server.info` command (host app name + release-stamped version), compares that version with the client's own, and reports the result — it does **not** run any other command.
+
+- **Match** → prints an `OK: …` line to stdout and exits `0`.
+- **Mismatch** → prints a warning plus the `brew`/`scoop` commands to update both sides to stderr, and exits `3`. (Warnings go to stderr so normal command stdout stays script-friendly.)
+- **Can't verify** (either side is an unversioned development build, or the server is too old to answer `server.info`) → prints a note to stderr; a development build exits `0`, a too-old server is treated as a mismatch (`3`).
+
+```sh
+# Preflight: bail out of a script if the endpoint version doesn't match this client
+dotnet-6502-remote --port 6510 --check-server-version || exit 1
+```
+
+This is a version-mismatch **warning only** — it is not TCP protocol negotiation or full compatibility handling. Because the Homebrew tap and Scoop bucket normally track only the latest release, the fix for a mismatch is to bring both the client and the server app forward to the latest package-manager version rather than trying to install an older matching pair.
+
+You can also query the server directly:
+
+```sh
+# Print the server host app name and its release-stamped version
+dotnet-6502-remote --port 6510 server.info
+```
 
 ## Usage examples
 

--- a/docs/tools/remote-control/tcp-protocol.md
+++ b/docs/tools/remote-control/tcp-protocol.md
@@ -33,6 +33,29 @@ Null-valued fields are omitted from the response.
 
 ## Command Reference
 
+### `server.info`
+
+Cheap, read-only query returning the server's host app name and its release-stamped app version. Used by the client's `--check-server-version` preflight, but usable directly. Works in any emulator state.
+
+**Request**
+
+```json
+{"id": 1, "cmd": "server.info"}
+```
+
+**Response fields**
+
+| Field        | Type   | Description                                                                 |
+|--------------|--------|-----------------------------------------------------------------------------|
+| `app`        | string | Host app name, e.g. `Avalonia` or `Headless`                                |
+| `appversion` | string | Raw `AssemblyInformationalVersion` (e.g. `0.42.0-alpha+<hash>`); `1.0.0…` for an unstamped development build. Omitted if unavailable. The client normalizes and compares it. |
+
+**Response example**
+
+```json
+{"id": 1, "ok": true, "app": "Headless", "appversion": "0.42.0-alpha+abc1234"}
+```
+
 ### `emu.state`
 
 Returns the current emulator state and selected system name.

--- a/dotnet-6502.slnx
+++ b/dotnet-6502.slnx
@@ -93,6 +93,7 @@
     <Project Path="src/libraries/Highbyte.DotNet6502.Systems.Plugins/Highbyte.DotNet6502.Systems.Plugins.csproj" />
   </Folder>
   <Folder Name="/Tests/">
+    <Project Path="tests/Highbyte.DotNet6502.App.RemoteClient.Tests/Highbyte.DotNet6502.App.RemoteClient.Tests.csproj" />
     <Project Path="tests/Highbyte.DotNet6502.Monitor.Tests/Highbyte.DotNet6502.Monitor.Tests.csproj" />
     <Project Path="tests/Highbyte.DotNet6502.Systems.Tests/Highbyte.DotNet6502.Systems.Tests.csproj" />
     <Project Path="tests/Highbyte.DotNet6502.Tests/Highbyte.DotNet6502.Tests.csproj" />

--- a/includes/startup-params/cli-general.md
+++ b/includes/startup-params/cli-general.md
@@ -2,6 +2,23 @@
 
 These are interpreted by the shared startup pipeline and are valid for any system.
 
+#### Updates
+
+Handled before the emulator/UI starts; each prints its result and exits immediately. Update checks
+require a package-manager install (Homebrew / Scoop) — manual-download and development builds report
+*not managed*. For how detection works and the on/off setting, see
+[Staying up to date](../../host-apps/installation.md#staying-up-to-date).
+
+| Parameter | Description | Depends on | Example |
+|---|---|---|---|
+| `--version` | Print the app version and exit. | — | `--version` |
+| `--check-update` | Check for a newer release and print the result. Ignores the `UpdateCheckEnabled` setting and the CI / `DOTNET6502_NO_UPDATE_CHECK` suppression. | — | `--check-update` |
+| `--update` | Check and, if an update is available on a package-manager install, run the `brew`/`scoop` upgrade in the foreground, then exit. | — | `--update` |
+
+Host-specific notes: on **Avalonia Desktop** these flags run before the GUI window opens and, on
+Windows, attach to the invoking console so their output is visible. On **Headless** the output goes to
+stdout. The **Remote Client** exposes the same flags (see its [Global options](../../tools/remote-control/remote-client.md#global-options)) but never checks automatically.
+
 #### Scripting
 
 | Parameter | Description | Depends on | Example |

--- a/src/apps/Highbyte.DotNet6502.App.RemoteClient/Highbyte.DotNet6502.App.RemoteClient.csproj
+++ b/src/apps/Highbyte.DotNet6502.App.RemoteClient/Highbyte.DotNet6502.App.RemoteClient.csproj
@@ -9,4 +9,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\libraries\Highbyte.DotNet6502.Updates\Highbyte.DotNet6502.Updates.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Highbyte.DotNet6502.App.RemoteClient.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/apps/Highbyte.DotNet6502.App.RemoteClient/Program.cs
+++ b/src/apps/Highbyte.DotNet6502.App.RemoteClient/Program.cs
@@ -14,6 +14,7 @@ const string DefaultHost = "127.0.0.1";
 // Command definitions for --help output and self-description
 var commands = new[]
 {
+    ("server.info",      "",                              "Get the server host app name and release-stamped version"),
     ("emu.state",        "",                              "Get emulator state, system, and variant"),
     ("emu.start",        "",                              "Start (or resume from paused) the emulator"),
     ("emu.stop",         "",                              "Stop the emulator"),
@@ -100,6 +101,12 @@ if (cmdIndex >= args.Length)
 }
 
 var cmdArgs = args[cmdIndex..];
+
+// Preflight version check: connect, ask the server for its app version, and warn if it differs from
+// this client's version. Kept separate from the normal command path because it does its own compare.
+if (cmdArgs[0] == "--check-server-version")
+    return await CheckServerVersionAsync(host, port);
+
 var buildResult = RemoteClientRequestBuilder.Build(cmdArgs);
 if (buildResult.Error != null)
 {
@@ -176,6 +183,64 @@ catch (Exception ex)
     return 1;
 }
 
+async Task<int> CheckServerVersionAsync(string serverHost, int serverPort)
+{
+    try
+    {
+        using var tcp = new TcpClient();
+        await tcp.ConnectAsync(serverHost, serverPort);
+        using var stream = tcp.GetStream();
+        using var writer = new StreamWriter(stream, Encoding.UTF8, leaveOpen: true) { AutoFlush = true, NewLine = "\n" };
+        using var reader = new StreamReader(stream, Encoding.UTF8, leaveOpen: true);
+
+        await writer.WriteLineAsync("{\"id\":1,\"cmd\":\"server.info\"}");
+
+        var line = await reader.ReadLineAsync();
+        if (line == null)
+        {
+            Console.Error.WriteLine("No response from server.");
+            return 1;
+        }
+
+        using var doc = JsonDocument.Parse(line);
+        var root = doc.RootElement;
+
+        bool ok = root.TryGetProperty("ok", out var okProp) && okProp.GetBoolean();
+        if (!ok)
+        {
+            var error = root.TryGetProperty("error", out var errProp) ? errProp.GetString() : null;
+            // A server that predates this feature rejects the unknown command → it's older than the client.
+            if (error != null && error.Contains("Unknown command", StringComparison.OrdinalIgnoreCase))
+                return Emit(ServerVersionCheck.ServerTooOld(null));
+
+            Console.Error.WriteLine($"Error: {error ?? "Unknown error"}");
+            return 1;
+        }
+
+        var app = root.TryGetProperty("app", out var appProp) ? appProp.GetString() : null;
+        var appVersionRaw = root.TryGetProperty("appversion", out var verProp) ? verProp.GetString() : null;
+
+        return Emit(ServerVersionCheck.Evaluate(app, AppVersion.Parse(appVersionRaw), AppVersion.GetCurrent()));
+    }
+    catch (SocketException ex)
+    {
+        Console.Error.WriteLine($"Could not connect to {serverHost}:{serverPort} — {ex.Message}");
+        return 1;
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"Error: {ex.Message}");
+        return 1;
+    }
+
+    static int Emit(ServerVersionCheck.Result result)
+    {
+        foreach (var l in result.StdoutLines) Console.WriteLine(l);
+        foreach (var l in result.StderrLines) Console.Error.WriteLine(l);
+        return result.ExitCode;
+    }
+}
+
 void PrintHelp()
 {
     Console.WriteLine("dotnet-6502-remote — Remote control client for the DotNet 6502 Emulator");
@@ -187,6 +252,11 @@ void PrintHelp()
     Console.WriteLine("  --host <host>   Server hostname or IP (default: 127.0.0.1)");
     Console.WriteLine($"  --port <port>   TCP port (default: {DefaultPort})");
     Console.WriteLine("  --help          Show this help");
+    Console.WriteLine("  --version       Print the client version and exit");
+    Console.WriteLine("  --check-update  Check for a newer release of dotnet-6502-remote");
+    Console.WriteLine("  --update        Update dotnet-6502-remote via its package manager");
+    Console.WriteLine("  --check-server-version");
+    Console.WriteLine("                  Connect and warn if the server app version differs from this client");
     Console.WriteLine();
     Console.WriteLine("COMMANDS:");
     int maxCmd = commands.Max(c => c.Item1.Length);

--- a/src/apps/Highbyte.DotNet6502.App.RemoteClient/RemoteClientRequestBuilder.cs
+++ b/src/apps/Highbyte.DotNet6502.App.RemoteClient/RemoteClientRequestBuilder.cs
@@ -25,6 +25,7 @@ internal static class RemoteClientRequestBuilder
 
         switch (cmd)
         {
+            case "server.info":
             case "emu.state":
             case "emu.start":
             case "emu.stop":

--- a/src/apps/Highbyte.DotNet6502.App.RemoteClient/ServerVersionCheck.cs
+++ b/src/apps/Highbyte.DotNet6502.App.RemoteClient/ServerVersionCheck.cs
@@ -1,0 +1,91 @@
+using Highbyte.DotNet6502.Updates;
+
+namespace Highbyte.DotNet6502.App.RemoteClient;
+
+/// <summary>
+/// Pure evaluation for the <c>--check-server-version</c> preflight: compares the remote endpoint's
+/// release-stamped app version with this client's own version and produces the user-facing messages
+/// and process exit code. No I/O here so it can be unit-tested; <c>Program</c> does the TCP round-trip
+/// and prints the returned lines.
+/// </summary>
+internal static class ServerVersionCheck
+{
+    /// <summary>Distinct exit code for a version mismatch (0 = ok / can't-verify, 1 = connection error, 2 = bad args).</summary>
+    public const int MismatchExitCode = 3;
+
+    public sealed record Result(int ExitCode, IReadOnlyList<string> StdoutLines, IReadOnlyList<string> StderrLines);
+
+    /// <summary>
+    /// The remote client's own package name is fixed; the server package depends on which host app
+    /// answered (its <c>HostName</c>).
+    /// </summary>
+    private const string ClientPackageHint =
+        "dotnet-6502-remote (e.g. 'brew upgrade dotnet-6502-remote' or 'scoop update dotnet-6502-remote')";
+
+    private static string ServerPackageHint(string? serverApp) => serverApp switch
+    {
+        "Avalonia" => "dotnet-6502 (e.g. 'brew upgrade --cask dotnet-6502' on macOS, 'brew upgrade dotnet-6502' on Linux, or 'scoop update dotnet-6502')",
+        "Headless" => "dotnet-6502-headless (e.g. 'brew upgrade dotnet-6502-headless' or 'scoop update dotnet-6502-headless')",
+        _ => "the server app's package",
+    };
+
+    private static string Describe(string? serverApp) => string.IsNullOrEmpty(serverApp) ? "remote endpoint" : $"remote endpoint ({serverApp})";
+
+    private static string Show(SemanticVersion? v) => v is null ? "unknown" : $"v{v}";
+
+    /// <summary>
+    /// The server did not recognize the <c>server.info</c> command — it predates this feature, so it is
+    /// definitely older than the client. Treated as a mismatch.
+    /// </summary>
+    public static Result ServerTooOld(string? serverApp) => new(
+        MismatchExitCode,
+        StdoutLines: Array.Empty<string>(),
+        StderrLines: new[]
+        {
+            $"Warning: the {Describe(serverApp)} does not support the version check (it predates this feature), so it is older than dotnet-6502-remote.",
+            "Update the server app to the latest package-manager version:",
+            $"  Server:       {ServerPackageHint(serverApp)}",
+        });
+
+    /// <summary>
+    /// Compares the server's (already raw-parsed) version with the client's. Either being null means a
+    /// development/unstamped build that can't be compared → "can't verify" (exit 0). Equal → ok (exit 0).
+    /// Different → warning with update hints (exit <see cref="MismatchExitCode"/>).
+    /// </summary>
+    public static Result Evaluate(string? serverApp, SemanticVersion? serverVersion, SemanticVersion? clientVersion)
+    {
+        if (serverVersion is null || clientVersion is null)
+        {
+            var which = serverVersion is null && clientVersion is null
+                ? "both the server app and dotnet-6502-remote are development builds"
+                : serverVersion is null
+                    ? "the server app is a development build (or too old to report a version)"
+                    : "dotnet-6502-remote is a development build";
+            return new Result(
+                0,
+                StdoutLines: Array.Empty<string>(),
+                StderrLines: new[] { $"Cannot verify versions: {which}; development builds are unversioned." });
+        }
+
+        if (serverVersion.Equals(clientVersion))
+        {
+            return new Result(
+                0,
+                StdoutLines: new[] { $"OK: {Describe(serverApp)} {Show(serverVersion)} matches dotnet-6502-remote {Show(clientVersion)}." },
+                StderrLines: Array.Empty<string>());
+        }
+
+        var direction = serverVersion > clientVersion ? "newer than" : "older than";
+        return new Result(
+            MismatchExitCode,
+            StdoutLines: Array.Empty<string>(),
+            StderrLines: new[]
+            {
+                $"Warning: the {Describe(serverApp)} is {Show(serverVersion)} ({direction} dotnet-6502-remote {Show(clientVersion)}).",
+                "Bring both sides to the latest package-manager version:",
+                $"  RemoteClient: {ClientPackageHint}",
+                $"  Server:       {ServerPackageHint(serverApp)}",
+                "Note: Homebrew/Scoop normally offer only the latest version, so update both rather than trying to match an older one.",
+            });
+    }
+}

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Core/Highbyte.DotNet6502.App.Terminal.Core.csproj
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Core/Highbyte.DotNet6502.App.Terminal.Core.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\..\libraries\Highbyte.DotNet6502.Monitor\Highbyte.DotNet6502.Monitor.csproj" />
     <ProjectReference Include="..\..\..\libraries\Highbyte.DotNet6502.Systems\Highbyte.DotNet6502.Systems.csproj" />
     <ProjectReference Include="..\..\..\libraries\Highbyte.DotNet6502.Systems.Plugins\Highbyte.DotNet6502.Systems.Plugins.csproj" />
+    <ProjectReference Include="..\..\..\libraries\Highbyte.DotNet6502.Updates\Highbyte.DotNet6502.Updates.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Core/TerminalUpdateService.cs
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Core/TerminalUpdateService.cs
@@ -1,0 +1,84 @@
+using Highbyte.DotNet6502.Updates;
+using Microsoft.Extensions.Logging;
+
+namespace Highbyte.DotNet6502.App.Terminal;
+
+/// <summary>
+/// Terminal-host wrapper around the shared update flow. Runs the (gated) update check off the UI
+/// thread, holds the latest result for the in-TUI Updates dialog and the "update available" indicator,
+/// and — when the user picks "Update now" — records a pending upgrade that the app runs after the TUI
+/// has released the terminal (so the package manager's output is visible on a normal console).
+/// </summary>
+public sealed class TerminalUpdateService
+{
+    private readonly AppUpdateDescriptor _descriptor;
+    private readonly bool _updateCheckEnabled;
+    private readonly ILogger _logger;
+
+    public TerminalUpdateService(AppUpdateDescriptor descriptor, bool updateCheckEnabled, ILoggerFactory loggerFactory)
+    {
+        _descriptor = descriptor;
+        _updateCheckEnabled = updateCheckEnabled;
+        _logger = loggerFactory.CreateLogger("UpdateCheck");
+    }
+
+    /// <summary>Latest check result, or null until the first check has completed.</summary>
+    public UpdateCheckResult? Latest { get; private set; }
+
+    public bool IsUpdateAvailable => Latest?.IsUpdateAvailable == true;
+
+    /// <summary>Whether a one-click in-app update is possible right now (managed install + update available).</summary>
+    public bool CanUpdateNow => IsUpdateAvailable && Latest?.ManagerExecutablePath is not null;
+
+    /// <summary>True once "Update now" was chosen; the app runs the upgrade after the TUI exits.</summary>
+    public bool PendingUpdateRequested { get; private set; }
+
+    /// <summary>Raised (possibly off the UI thread) whenever <see cref="Latest"/> changes.</summary>
+    public event Action? Changed;
+
+    /// <summary>
+    /// Runs an update check. The automatic (non-forced) check is gated by the <c>UpdateCheckEnabled</c>
+    /// setting and the CI / opt-out env suppressors; a forced check (the dialog's "Check now") ignores
+    /// both. On update-available the underlying checker logs one line via the injected logger (routed to
+    /// the TUI's Logs pane). Never throws — a failed check must not disrupt the app.
+    /// </summary>
+    public async Task CheckAsync(bool force = false, CancellationToken cancellationToken = default)
+    {
+        if (!force && (!_updateCheckEnabled || ConsoleUpdateCli.IsSuppressedByEnvironment()))
+            return;
+
+        try
+        {
+            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+            var checker = UpdateChecker.CreateDefault(_descriptor, http, _logger);
+            Latest = await checker.CheckAsync(new UpdateCheckContext { ForceCheck = force }, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Update check failed.");
+        }
+
+        Changed?.Invoke();
+    }
+
+    /// <summary>Records that the user asked to update now (consumed by the app after the TUI exits).</summary>
+    public void RequestUpdateNow()
+    {
+        if (CanUpdateNow)
+            PendingUpdateRequested = true;
+    }
+
+    /// <summary>
+    /// Runs the recorded pending upgrade in the foreground; call only after the TUI has released the
+    /// terminal so the package manager's output is visible. Returns true on success, false if nothing
+    /// is pending or the upgrade failed.
+    /// </summary>
+    public async Task<bool> RunPendingUpdateAsync(TextWriter output, CancellationToken cancellationToken = default)
+    {
+        if (!PendingUpdateRequested || Latest?.ManagerExecutablePath is null)
+            return false;
+
+        return await UpdateApplier.RunUpgradeAsync(
+            Latest.ManagerExecutablePath, _descriptor.UpgradeArgs(Latest.Channel), output, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Core/TuiHostApp.cs
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Core/TuiHostApp.cs
@@ -126,13 +126,18 @@ public class TuiHostApp : HostApp
     // render target directly and dumps the rendered screen as text). Set by RunSelfTest.
     private bool _selfTestMode;
 
+    // Optional update service: drives the "Updates" dialog (leader-key U) and the "update available"
+    // window-title/hint indicator. Null when the host is created without one (e.g. self-test).
+    private readonly TerminalUpdateService? _updateService;
+
     public TuiHostApp(
         SystemList systemList,
         ILoggerFactory loggerFactory,
         EmulatorConfig emulatorConfig,
         DotNet6502InMemLogStore logStore,
         Func<string, ITerminalMenuContribution?>? resolveMenuContribution = null,
-        Func<string, ITerminalInfoContribution?>? resolveInfoContribution = null)
+        Func<string, ITerminalInfoContribution?>? resolveInfoContribution = null,
+        TerminalUpdateService? updateService = null)
         : base("Terminal", systemList, loggerFactory, useStatsNamePrefix: false)
     {
         _loggerFactory = loggerFactory;
@@ -141,6 +146,7 @@ public class TuiHostApp : HostApp
         _logStore = logStore;
         _resolveMenuContribution = resolveMenuContribution ?? (_ => null);
         _resolveInfoContribution = resolveInfoContribution ?? (_ => null);
+        _updateService = updateService;
     }
 
     public void Run()
@@ -172,6 +178,9 @@ public class TuiHostApp : HostApp
         // off F10/F11 (terminals bind those to their own menu/fullscreen). See OnGlobalKeyDown.
         _leaderKeyCode = ParseLeaderKey(_emulatorConfig.LeaderKey);
         Application.KeyDown += OnGlobalKeyDown;
+        // Reflect update-check results (they arrive from a background thread) in the title/hint indicator.
+        if (_updateService is not null)
+            _updateService.Changed += OnUpdateStatusChanged;
         try
         {
             BuildUi();
@@ -213,6 +222,8 @@ public class TuiHostApp : HostApp
         finally
         {
             Application.KeyDown -= OnGlobalKeyDown;
+            if (_updateService is not null)
+                _updateService.Changed -= OnUpdateStatusChanged;
             StopEmulatorLoop();
             RemoveTimer(ref _displayTimerToken);
             RemoveTimer(ref _statusTimerToken);
@@ -277,7 +288,7 @@ public class TuiHostApp : HostApp
     {
         _window = new Window
         {
-            Title = $"DotNet 6502 — Terminal Host   ({LeaderKeyName} = Menu)",
+            Title = BaseWindowTitle,
             BorderStyle = LineStyle.Single,
         };
 
@@ -625,6 +636,7 @@ public class TuiHostApp : HostApp
             case KeyCode.M: DoMonitor(); break;
             case KeyCode.P: ShowStoragePathsDialog(); break;
             case KeyCode.T: ToggleStats(); break;
+            case KeyCode.U: DoUpdates(); break;
             case KeyCode.Q: Application.RequestStop(_window); break;
             // Tab and F6 both toggle the keyboard between the emulator and the host UI. F6 is accepted
             // because it is the "move between areas" key in the UI, so reaching for it to leave the
@@ -698,15 +710,71 @@ public class TuiHostApp : HostApp
         // In UI mode also advertise the navigation keys (Tab within an area, F6 between areas).
         if (_hostModeActive)
             _hintLabel.Text =
-                $" HOST: S Start/Stop  M Monitor  P Paths  T Stats  Q Quit  Y System  V Variant  Tab/F6 Emu⇄UI";
+                $" HOST: S Start/Stop  M Monitor  P Paths  T Stats  U Updates  Q Quit  Y System  V Variant  Tab/F6 Emu⇄UI   (Esc cancels)";
         else if (InEmulatorMode)
-            _hintLabel.Text = $" [EMULATOR]  {LeaderKeyName} Menu";
+            _hintLabel.Text = $" [EMULATOR]  {LeaderKeyName} Menu{UpdateHintSuffix}";
         else
-            _hintLabel.Text = $" [UI NAV]  {LeaderKeyName} Menu   Tab move · F6 area";
+            _hintLabel.Text = $" [UI NAV]  {LeaderKeyName} Menu   Tab move · F6 area{UpdateHintSuffix}";
     }
+
+    /// <summary>Appended to the normal hint line when an update is available, pointing at the leader-key command.</summary>
+    private string UpdateHintSuffix =>
+        _updateService?.IsUpdateAvailable == true ? $"   ★ Update available ({LeaderKeyName} U)" : string.Empty;
 
     /// <summary>Display name of the configured leader key (e.g. "F9").</summary>
     private string LeaderKeyName => _leaderKeyCode.ToString();
+
+    /// <summary>Window title without the update marker (see <see cref="UpdateWindowTitleForUpdates"/>).</summary>
+    private string BaseWindowTitle => $"DotNet 6502 — Terminal Host   ({LeaderKeyName} = Menu)";
+
+    /// <summary>
+    /// Update-check results arrive from a background thread, so marshal to the UI thread before touching
+    /// Terminal.Gui state, then refresh the title + hint indicators.
+    /// </summary>
+    private void OnUpdateStatusChanged()
+    {
+        if (_selfTestMode)
+            return;
+        Application.Invoke(() =>
+        {
+            UpdateWindowTitleForUpdates();
+            UpdateHintLine();
+        });
+    }
+
+    /// <summary>Reflect update availability in the window title (a persistent, non-focus-stealing indicator).</summary>
+    private void UpdateWindowTitleForUpdates()
+    {
+        if (_window is null)
+            return;
+        _window.Title = _updateService?.IsUpdateAvailable == true
+            ? $"{BaseWindowTitle}   *** Update available: {LeaderKeyName} U ***"
+            : BaseWindowTitle;
+        _window.SetNeedsDraw();
+    }
+
+    /// <summary>
+    /// Open the modal Updates dialog (leader-key <c>U</c>). A no-op when the host was created without an
+    /// update service. Refreshes the indicators afterwards in case a "Check now" changed the status.
+    /// </summary>
+    private void DoUpdates()
+    {
+        if (_updateService is null)
+            return;
+        UpdatesDialog.Show(this, _updateService);
+
+        // "Update now" records a pending upgrade and closes the dialog; quit the TUI so the app can run
+        // the package-manager upgrade in the foreground (see Program).
+        if (_updateService.PendingUpdateRequested)
+        {
+            Application.RequestStop(_window);
+            return;
+        }
+
+        // Otherwise a "Check now" may have changed the status — refresh the indicators.
+        UpdateWindowTitleForUpdates();
+        UpdateHintLine();
+    }
 
     /// <summary>
     /// Parse the configured leader key name (e.g. "F9") into a <see cref="KeyCode"/>. Falls back to F9

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Core/UpdatesDialog.cs
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Core/UpdatesDialog.cs
@@ -1,0 +1,129 @@
+using Highbyte.DotNet6502.Updates;
+using Terminal.Gui.App;
+using Terminal.Gui.Drawing;
+using Terminal.Gui.Drivers;
+using Terminal.Gui.Input;
+using Terminal.Gui.ViewBase;
+using Terminal.Gui.Views;
+
+// Static Application API (Run for the modal dialog) is obsolete in Terminal.Gui 2.4.5 but functional.
+#pragma warning disable CS0618
+
+namespace Highbyte.DotNet6502.App.Terminal;
+
+/// <summary>
+/// Modal "Updates" dialog for the terminal host, opened with the leader-key <c>U</c> command. Shows the
+/// current version and update status, and — on a package-manager install with a newer release — the
+/// suggested <c>brew</c>/<c>scoop</c> command plus an "Update now" action. "Update now" records the
+/// request and quits the TUI; the app then runs the upgrade in the foreground. This keeps the update
+/// affordance inside the TUI (behind the leader key) so it never interferes with emulator keyboard focus.
+/// </summary>
+internal static class UpdatesDialog
+{
+    public static void Show(TuiHostApp host, TerminalUpdateService service)
+    {
+        var dialog = new Window
+        {
+            Title = "Updates  (Esc to close)",
+            X = Pos.Center(),
+            Y = Pos.Center(),
+            Width = 64,
+            Height = 12,
+            BorderStyle = LineStyle.Single,
+        };
+        host.ApplyUiScheme(dialog);
+
+        var versionLabel = new Label { X = 0, Y = 0, Width = Dim.Fill(), Text = "" };
+        var statusLabel = new Label { X = 0, Y = 1, Width = Dim.Fill(), Height = 2, Text = "" };
+
+        // Suggested upgrade command (read-only, selectable to copy), shown only when an update is available.
+        var commandField = new TextField { X = 0, Y = 3, Width = Dim.Fill(), ReadOnly = true, Visible = false };
+
+        var checkButton = new Button { X = 0, Y = Pos.AnchorEnd(1), Text = "Check now" };
+        var updateButton = new Button { X = Pos.Right(checkButton) + 1, Y = Pos.AnchorEnd(1), Text = "Update now", Visible = false };
+        var closeButton = new Button { X = Pos.AnchorEnd(9), Y = Pos.AnchorEnd(1), Text = "Close", IsDefault = true };
+
+        dialog.Add(versionLabel, statusLabel, commandField, checkButton, updateButton, closeButton);
+
+        var closed = false;
+
+        void Refresh()
+        {
+            var current = AppVersion.GetCurrent();
+            versionLabel.Text = $"Version: {(current is null ? "development build (unversioned)" : "v" + current)}";
+
+            var result = service.Latest;
+            statusLabel.Text = StatusText(result);
+
+            var hasCommand = result?.IsUpdateAvailable == true && !string.IsNullOrEmpty(result.SuggestedCommand);
+            commandField.Visible = hasCommand;
+            if (hasCommand)
+                commandField.Text = result!.SuggestedCommand ?? string.Empty;
+
+            // "Update now" only when the package manager was resolved (a one-click upgrade is possible).
+            updateButton.Visible = service.CanUpdateNow;
+
+            dialog.SetNeedsDraw();
+        }
+
+        // Refresh live when a background check (the automatic one, or "Check now") completes.
+        void OnChanged() => Application.Invoke(() => { if (!closed) Refresh(); });
+        service.Changed += OnChanged;
+
+        checkButton.Accepting += (_, e) =>
+        {
+            e.Handled = true;
+            statusLabel.Text = "Checking for updates…";
+            dialog.SetNeedsDraw();
+            // Fire-and-forget: OnChanged refreshes the dialog when it completes. Forced check ignores gating.
+            _ = service.CheckAsync(force: true);
+        };
+
+        updateButton.Accepting += (_, e) =>
+        {
+            e.Handled = true;
+            if (!service.CanUpdateNow)
+                return;
+            // Record the request and close the dialog. The caller (DoUpdates) sees the pending request
+            // and quits the TUI; the app then runs the upgrade in the foreground (see Program).
+            service.RequestUpdateNow();
+            Application.RequestStop(dialog);
+        };
+
+        closeButton.Accepting += (_, e) => { e.Handled = true; Application.RequestStop(dialog); };
+
+        dialog.KeyDown += (_, key) =>
+        {
+            var code = key.KeyCode & ~(KeyCode.ShiftMask | KeyCode.CtrlMask | KeyCode.AltMask);
+            if (code == KeyCode.Esc)
+            {
+                key.Handled = true;
+                Application.RequestStop(dialog);
+            }
+        };
+
+        Refresh();
+        checkButton.SetFocus();
+
+        try { Application.Run(dialog); }
+        finally
+        {
+            closed = true;
+            service.Changed -= OnChanged;
+            dialog.Dispose();
+        }
+    }
+
+    private static string StatusText(UpdateCheckResult? result) => result?.Status switch
+    {
+        null => "No update check has run yet. Choose \"Check now\" to check.",
+        UpdateCheckStatus.UpdateAvailable =>
+            $"A newer version v{result.LatestVersion} is available (you have v{result.CurrentVersion}).",
+        UpdateCheckStatus.UpToDate => $"You're on the latest version (v{result.CurrentVersion}).",
+        UpdateCheckStatus.NotManaged =>
+            "This build isn't installed via Homebrew or Scoop, so there's no update check.",
+        UpdateCheckStatus.VersionUnknown => "Development build (version unknown); update check skipped.",
+        UpdateCheckStatus.Error => $"Update check failed: {result.Error}",
+        _ => "",
+    };
+}

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/Program.cs
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/Program.cs
@@ -63,13 +63,14 @@ using var loggerFactory = LoggerFactory.Create(logBuilder =>
 
 var bootstrapLogger = loggerFactory.CreateLogger("Program");
 
-// Non-blocking startup update check. On a managed (brew/scoop) install with a newer release it logs
-// one Information line to the in-mem store shown in the "Logs" pane. Gated by the UpdateCheckEnabled
-// setting and the standard CI / DOTNET6502_NO_UPDATE_CHECK suppressors.
-_ = ConsoleUpdateCli.CheckAndLogOnStartupAsync(
+// Update service backing the in-TUI Updates dialog (leader-key U) and the "update available"
+// indicator. The startup check is fired below (interactive run only). Gated by the UpdateCheckEnabled
+// setting and the standard CI / DOTNET6502_NO_UPDATE_CHECK suppressors; on a managed (brew/scoop)
+// install with a newer release the checker logs one Information line to the "Logs" pane.
+var updateService = new TerminalUpdateService(
     new AppUpdateDescriptor { HomebrewPackage = "dotnet-6502-terminal", ScoopPackage = "dotnet-6502-terminal" },
-    loggerFactory.CreateLogger("UpdateCheck"),
-    configuration.GetValue("UpdateCheckEnabled", true));
+    configuration.GetValue("UpdateCheckEnabled", true),
+    loggerFactory);
 
 try
 {
@@ -141,7 +142,7 @@ try
     // Run the TUI host app (or the headless self-test that needs no TTY).
     // ----------
     var hostApp = new TuiHostApp(systemList, loggerFactory, emulatorConfig, logStore,
-        ResolveMenuContribution, ResolveInfoContribution);
+        ResolveMenuContribution, ResolveInfoContribution, updateService);
     hostAppHolder = hostApp;
 
     if (args.Contains("--selftest"))
@@ -161,7 +162,25 @@ try
     }
     else
     {
+        // Fire the non-blocking startup update check (interactive run only). Result surfaces in the
+        // Logs pane and the "update available" indicator; the Updates dialog (leader-key U) drives it.
+        _ = updateService.CheckAsync();
+
         hostApp.Run();
+
+        // The TUI has released the terminal. If the user chose "Update now", run the package-manager
+        // upgrade in the foreground now (its output is visible on the plain console).
+        if (updateService.PendingUpdateRequested)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"Updating: {updateService.Latest!.SuggestedCommand}");
+            Console.WriteLine();
+            var updated = await updateService.RunPendingUpdateAsync(Console.Out);
+            Console.WriteLine();
+            Console.WriteLine(updated
+                ? "Update complete. Restart dotnet-6502-terminal to use the new version."
+                : "Update failed. See the output above; you can run the command manually.");
+        }
     }
 }
 catch (Exception ex)

--- a/src/libraries/Highbyte.DotNet6502.Remoting/Protocol/RemoteCommandResult.cs
+++ b/src/libraries/Highbyte.DotNet6502.Remoting/Protocol/RemoteCommandResult.cs
@@ -32,6 +32,16 @@ public class RemoteCommandResult
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Variant { get; set; }
 
+    // server.info
+    [JsonPropertyName("app")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? App { get; set; }
+
+    // server.info — raw AssemblyInformationalVersion string (the client normalizes and compares it)
+    [JsonPropertyName("appversion")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AppVersion { get; set; }
+
     // mem.read / screenshot
     [JsonPropertyName("data")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/libraries/Highbyte.DotNet6502.Remoting/RemoteCommandDispatcher.cs
+++ b/src/libraries/Highbyte.DotNet6502.Remoting/RemoteCommandDispatcher.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.Json;
 using Highbyte.DotNet6502.Remoting.Protocol;
 using Highbyte.DotNet6502.Systems;
@@ -34,6 +35,7 @@ public class RemoteCommandDispatcher
             return cmd.Cmd switch
             {
                 "emu.state"    => HandleEmuState(cmd.Id),
+                "server.info"  => HandleServerInfo(cmd.Id),
                 "emu.start"    => await HandleUiAsync(cmd.Id, async hostApp => await hostApp.Start()),
                 "emu.stop"     => await HandleUiAsync(cmd.Id, hostApp => { hostApp.Stop();  return Task.CompletedTask; }),
                 "emu.pause"    => await HandleUiAsync(cmd.Id, hostApp => { hostApp.Pause(); return Task.CompletedTask; }),
@@ -86,6 +88,24 @@ public class RemoteCommandDispatcher
     }
 
     // --- Direct read handlers ---
+
+    /// <summary>
+    /// Cheap, read-only server-info query used by the remote client's <c>--check-server-version</c>
+    /// preflight. Returns the host app name and the raw release-stamped app version (the entry
+    /// assembly's <see cref="AssemblyInformationalVersionAttribute"/>); the client normalizes and
+    /// compares it against its own version. Works regardless of emulator state.
+    /// </summary>
+    private RemoteCommandResult HandleServerInfo(int? id)
+    {
+        var informationalVersion = Assembly.GetEntryAssembly()
+            ?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        return new RemoteCommandResult
+        {
+            Id = id, Ok = true,
+            App = _environment.GetHostApp()?.HostName,
+            AppVersion = informationalVersion,
+        };
+    }
 
     private RemoteCommandResult HandleEmuState(int? id)
     {

--- a/src/libraries/Highbyte.DotNet6502.Updates/InstallChannelDetector.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/InstallChannelDetector.cs
@@ -8,9 +8,10 @@ namespace Highbyte.DotNet6502.Updates;
 /// nothing — the safe failure.
 ///
 /// Three stages: (1) an authoritative <c>install-channel</c> marker file dropped by the manifest,
-/// (2) path-heuristic corroboration on the run directory, and (3) a runtime sanity check that the
-/// manager is actually resolvable and reports this package installed. Only stage 3 can *confirm*
-/// managed; anything short of it collapses to not-managed.
+/// (2) a conservative path heuristic on the run directory, used only as a fallback when the marker is
+/// absent (Scoop's <c>apps/&lt;pkg&gt;/current</c> layout, or a Homebrew formula's <c>Cellar</c> path),
+/// and (3) a runtime sanity check that the manager is actually resolvable and reports this package
+/// installed. Only stage 3 can *confirm* managed; anything short of it collapses to not-managed.
 /// </summary>
 public sealed class InstallChannelDetector
 {
@@ -30,9 +31,12 @@ public sealed class InstallChannelDetector
     {
         ArgumentNullException.ThrowIfNull(descriptor);
 
-        var candidate = ReadMarkerChannel();
+        // Authoritative marker first; if it's absent, fall back to a conservative path heuristic on the
+        // run directory. Either way the candidate is only a *guess* — stage 3 (ConfirmHomebrew /
+        // ConfirmScoop) still has to see the package manager report this package installed.
+        var candidate = ReadMarkerChannel() ?? InferChannelFromPath(descriptor);
         if (candidate is null)
-            return InstallChannelInfo.NotManaged; // absent marker ⇒ not-managed (portable)
+            return InstallChannelInfo.NotManaged; // no marker and no matching install path ⇒ not-managed (portable)
 
         var channel = candidate.Value;
         var packageName = descriptor.PackageNameFor(channel);
@@ -97,6 +101,67 @@ public sealed class InstallChannelDetector
         return Path.Combine(home, "Library", "Application Support", "Highbyte", "DotNet6502", MarkerFileName);
     }
 
+    /// <summary>
+    /// Fallback used only when no marker is present: guess a channel from the directory the app runs
+    /// from. Conservative and biased to not-managed — it recognises just the two unambiguous layouts,
+    /// and the guess is still confirmed by the package manager before anything is shown:
+    /// <list type="bullet">
+    ///   <item>Scoop installs the app under <c>&lt;scoop&gt;/apps/&lt;package&gt;/current</c>.</item>
+    ///   <item>A Homebrew <em>formula</em> installs under <c>&lt;prefix&gt;/Cellar/&lt;formula&gt;/&lt;version&gt;/…</c>.</item>
+    /// </list>
+    /// The Homebrew <em>cask</em> is deliberately excluded: the <c>.app</c> normally runs from
+    /// <c>/Applications</c> (not the Cellar), so it stays marker-driven.
+    /// </summary>
+    private InstallChannel? InferChannelFromPath(AppUpdateDescriptor descriptor)
+    {
+        var baseDir = _probe.BaseDirectory;
+        if (string.IsNullOrWhiteSpace(baseDir))
+            return null;
+
+        var normalized = baseDir.Replace('\\', '/');
+
+        if (LooksLikeScoopInstallPath(normalized, descriptor.ScoopPackage))
+            return InstallChannel.Scoop;
+
+        if (!descriptor.HomebrewIsCask && LooksLikeHomebrewCellarPath(normalized, descriptor.HomebrewPackage))
+            return InstallChannel.Homebrew;
+
+        return null;
+    }
+
+    /// <summary>True when the run directory sits under a Scoop <c>apps/&lt;package&gt;/current</c> tree.</summary>
+    private bool LooksLikeScoopInstallPath(string normalizedBaseDir, string package)
+    {
+        var haystack = normalizedBaseDir.ToLowerInvariant();
+        var suffix = $"/apps/{package}/current".ToLowerInvariant();
+
+        // Default install roots are literally named "scoop"; also honour a custom $SCOOP root.
+        if (haystack.Contains($"/scoop{suffix}", StringComparison.Ordinal))
+            return true;
+
+        foreach (var root in ScoopRoots())
+        {
+            var rootPrefix = root.Replace('\\', '/').TrimEnd('/').ToLowerInvariant();
+            if (haystack.Contains($"{rootPrefix}{suffix}", StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>True when the run directory is under a known Homebrew prefix's <c>Cellar/&lt;formula&gt;/…</c> tree.</summary>
+    private bool LooksLikeHomebrewCellarPath(string normalizedBaseDir, string formula)
+    {
+        foreach (var prefix in HomebrewPrefixes())
+        {
+            var cellarRoot = prefix.Replace('\\', '/').TrimEnd('/') + $"/Cellar/{formula}/";
+            if (normalizedBaseDir.StartsWith(cellarRoot, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
     private InstallChannelInfo ConfirmHomebrew(string packageName, bool isCask)
     {
         var brew = _probe.ResolveExecutable("brew", HomebrewBinDirectories());
@@ -129,28 +194,36 @@ public sealed class InstallChannelDetector
     }
 
     private IEnumerable<string> HomebrewBinDirectories()
+        => HomebrewPrefixes().Select(prefix => Path.Combine(prefix, "bin"));
+
+    /// <summary>Known Homebrew install prefixes (env override first, then the platform defaults).</summary>
+    private IEnumerable<string> HomebrewPrefixes()
     {
         var prefix = _probe.GetEnvironmentVariable("HOMEBREW_PREFIX");
         if (!string.IsNullOrWhiteSpace(prefix))
-            yield return Path.Combine(prefix, "bin");
+            yield return prefix;
 
-        yield return "/opt/homebrew/bin";        // Apple Silicon
-        yield return "/usr/local/bin";           // Intel macOS
+        yield return "/opt/homebrew";            // Apple Silicon
+        yield return "/usr/local";               // Intel macOS
 
         var home = _probe.HomeDirectory;
         if (!string.IsNullOrWhiteSpace(home))
-            yield return Path.Combine(home, ".linuxbrew", "bin");
-        yield return "/home/linuxbrew/.linuxbrew/bin"; // Linuxbrew default
+            yield return Path.Combine(home, ".linuxbrew");
+        yield return "/home/linuxbrew/.linuxbrew"; // Linuxbrew default
     }
 
     private IEnumerable<string> ScoopShimDirectories()
+        => ScoopRoots().Select(root => Path.Combine(root, "shims"));
+
+    /// <summary>Known Scoop install roots (env override first, then <c>~/scoop</c>).</summary>
+    private IEnumerable<string> ScoopRoots()
     {
         var scoopHome = _probe.GetEnvironmentVariable("SCOOP");
         if (!string.IsNullOrWhiteSpace(scoopHome))
-            yield return Path.Combine(scoopHome, "shims");
+            yield return scoopHome;
 
         var home = _probe.HomeDirectory;
         if (!string.IsNullOrWhiteSpace(home))
-            yield return Path.Combine(home, "scoop", "shims");
+            yield return Path.Combine(home, "scoop");
     }
 }

--- a/tests/Highbyte.DotNet6502.App.RemoteClient.Tests/Highbyte.DotNet6502.App.RemoteClient.Tests.csproj
+++ b/tests/Highbyte.DotNet6502.App.RemoteClient.Tests/Highbyte.DotNet6502.App.RemoteClient.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\apps\Highbyte.DotNet6502.App.RemoteClient\Highbyte.DotNet6502.App.RemoteClient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Highbyte.DotNet6502.App.RemoteClient.Tests/ServerVersionCheckTests.cs
+++ b/tests/Highbyte.DotNet6502.App.RemoteClient.Tests/ServerVersionCheckTests.cs
@@ -1,0 +1,70 @@
+using Highbyte.DotNet6502.App.RemoteClient;
+using Highbyte.DotNet6502.Updates;
+using Xunit;
+
+namespace Highbyte.DotNet6502.App.RemoteClient.Tests;
+
+public class ServerVersionCheckTests
+{
+    private static SemanticVersion V(string s)
+    {
+        Assert.True(SemanticVersion.TryParse(s, out var v) && v is not null, $"bad test version '{s}'");
+        return v!;
+    }
+
+    [Fact]
+    public void MatchingVersions_succeeds_and_reports_ok_on_stdout()
+    {
+        var result = ServerVersionCheck.Evaluate("Headless", V("0.41.0-alpha"), V("0.41.0-alpha"));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.StderrLines);
+        Assert.Contains(result.StdoutLines, l => l.Contains("OK") && l.Contains("matches"));
+    }
+
+    [Fact]
+    public void ServerNewer_warns_on_stderr_with_mismatch_exit_code_and_direction()
+    {
+        var result = ServerVersionCheck.Evaluate("Avalonia", V("0.42.0-alpha"), V("0.41.0-alpha"));
+
+        Assert.Equal(ServerVersionCheck.MismatchExitCode, result.ExitCode);
+        Assert.Empty(result.StdoutLines);
+        Assert.Contains(result.StderrLines, l => l.Contains("newer than"));
+        // Server package hint should be for the Avalonia app package, not the client package.
+        Assert.Contains(result.StderrLines, l => l.Contains("dotnet-6502 ") || l.Contains("--cask dotnet-6502"));
+    }
+
+    [Fact]
+    public void ServerOlder_warns_with_older_direction()
+    {
+        var result = ServerVersionCheck.Evaluate("Headless", V("0.40.0-alpha"), V("0.41.0-alpha"));
+
+        Assert.Equal(ServerVersionCheck.MismatchExitCode, result.ExitCode);
+        Assert.Contains(result.StderrLines, l => l.Contains("older than"));
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public void UnknownVersion_cannot_verify_and_exits_zero(bool serverUnknown, bool clientUnknown)
+    {
+        var server = serverUnknown ? null : V("0.41.0-alpha");
+        var client = clientUnknown ? null : V("0.41.0-alpha");
+
+        var result = ServerVersionCheck.Evaluate("Headless", server, client);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.StdoutLines);
+        Assert.Contains(result.StderrLines, l => l.Contains("Cannot verify"));
+    }
+
+    [Fact]
+    public void ServerTooOld_is_treated_as_mismatch()
+    {
+        var result = ServerVersionCheck.ServerTooOld("Headless");
+
+        Assert.Equal(ServerVersionCheck.MismatchExitCode, result.ExitCode);
+        Assert.Contains(result.StderrLines, l => l.Contains("predates"));
+    }
+}

--- a/tests/Highbyte.DotNet6502.Updates.Tests/InstallChannelDetectorTests.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/InstallChannelDetectorTests.cs
@@ -112,4 +112,136 @@ public class InstallChannelDetectorTests
         var probe = new FakeInstallChannelProbe { OS = OSPlatformKind.Windows };
         Assert.Null(new InstallChannelDetector(probe).CaskSupportDirMarkerPath());
     }
+
+    // --- Path fallback (no marker): still confirmed by the package manager, still biased to not-managed. ---
+
+    [Fact]
+    public void NoMarker_ScoopAppsCurrentPath_ConfirmedByManager_IsManaged()
+    {
+        var probe = new FakeInstallChannelProbe
+        {
+            OS = OSPlatformKind.Windows,
+            HomeDirectory = @"C:\Users\me",
+            BaseDirectory = @"C:\Users\me\scoop\apps\dotnet-6502-terminal\current",
+        };
+        // No marker file — the Scoop apps/<pkg>/current layout is the only signal.
+        probe.ResolvableExecutables["scoop"] = @"C:\Users\me\scoop\shims\scoop";
+        probe.CommandResults[@"C:\Users\me\scoop\shims\scoop list dotnet-6502-terminal"] =
+            new ProcessRunResult(0, "Installed apps:\n\ndotnet-6502-terminal 0.40.2\n");
+
+        var info = new InstallChannelDetector(probe).Detect(TerminalDescriptor);
+
+        Assert.Equal(InstallChannel.Scoop, info.Channel);
+        Assert.Equal("dotnet-6502-terminal", info.PackageName);
+    }
+
+    [Fact]
+    public void NoMarker_HomebrewCellarPath_ConfirmedByManager_IsManaged()
+    {
+        var probe = new FakeInstallChannelProbe
+        {
+            OS = OSPlatformKind.MacOS,
+            BaseDirectory = "/opt/homebrew/Cellar/dotnet-6502-terminal/0.40.2/libexec",
+        };
+        // No marker file — the Homebrew Cellar/<formula>/<version> layout is the only signal.
+        probe.ResolvableExecutables["brew"] = "/opt/homebrew/bin/brew";
+        probe.CommandResults["/opt/homebrew/bin/brew list --versions dotnet-6502-terminal"] =
+            new ProcessRunResult(0, "dotnet-6502-terminal 0.40.2\n");
+
+        var info = new InstallChannelDetector(probe).Detect(TerminalDescriptor);
+
+        Assert.Equal(InstallChannel.Homebrew, info.Channel);
+        Assert.Equal("dotnet-6502-terminal", info.PackageName);
+    }
+
+    [Fact]
+    public void NoMarker_ScoopPath_ButManagerReportsNotInstalled_IsNotManaged()
+    {
+        // A portable copy that merely happens to live under a scoop-shaped path: the manager query
+        // (the authoritative confirmation) must still veto it.
+        var probe = new FakeInstallChannelProbe
+        {
+            OS = OSPlatformKind.Windows,
+            HomeDirectory = @"C:\Users\me",
+            BaseDirectory = @"C:\Users\me\scoop\apps\dotnet-6502-terminal\current",
+        };
+        probe.ResolvableExecutables["scoop"] = @"C:\Users\me\scoop\shims\scoop";
+        probe.CommandResults[@"C:\Users\me\scoop\shims\scoop list dotnet-6502-terminal"] =
+            new ProcessRunResult(1, "");
+
+        var info = new InstallChannelDetector(probe).Detect(TerminalDescriptor);
+
+        Assert.Equal(InstallChannel.NotManaged, info.Channel);
+    }
+
+    [Fact]
+    public void NoMarker_HomebrewCellarPath_ButManagerNotResolvable_IsNotManaged()
+    {
+        var probe = new FakeInstallChannelProbe
+        {
+            OS = OSPlatformKind.MacOS,
+            BaseDirectory = "/opt/homebrew/Cellar/dotnet-6502-terminal/0.40.2/libexec",
+        };
+        // No brew resolvable ⇒ can't confirm ⇒ not-managed.
+
+        var info = new InstallChannelDetector(probe).Detect(TerminalDescriptor);
+
+        Assert.Equal(InstallChannel.NotManaged, info.Channel);
+    }
+
+    [Fact]
+    public void NoMarker_CaskAppInApplications_IsNotManaged()
+    {
+        // The cask stays marker-driven: the .app runs from /Applications, not a Cellar, so there is no
+        // path fallback for it even if brew is installed and would report it.
+        var probe = new FakeInstallChannelProbe
+        {
+            OS = OSPlatformKind.MacOS,
+            HomeDirectory = "/Users/me",
+            BaseDirectory = "/Applications/DotNet 6502 Emulator.app/Contents/MacOS",
+        };
+        probe.ResolvableExecutables["brew"] = "/opt/homebrew/bin/brew";
+        probe.CommandResults["/opt/homebrew/bin/brew list --cask --versions dotnet-6502"] =
+            new ProcessRunResult(0, "dotnet-6502 0.40.2\n");
+
+        var info = new InstallChannelDetector(probe).Detect(CaskDescriptor);
+
+        Assert.Equal(InstallChannel.NotManaged, info.Channel);
+    }
+
+    [Fact]
+    public void NoMarker_HomebrewCellarPath_ForADifferentFormula_IsNotManaged()
+    {
+        // The Cellar directory is named after the formula; a different formula's path must not match.
+        var probe = new FakeInstallChannelProbe
+        {
+            OS = OSPlatformKind.MacOS,
+            BaseDirectory = "/opt/homebrew/Cellar/some-other-tool/1.0.0/libexec",
+        };
+        probe.ResolvableExecutables["brew"] = "/opt/homebrew/bin/brew";
+
+        var info = new InstallChannelDetector(probe).Detect(TerminalDescriptor);
+
+        Assert.Equal(InstallChannel.NotManaged, info.Channel);
+    }
+
+    [Fact]
+    public void NoMarker_CustomScoopRootPath_ConfirmedByManager_IsManaged()
+    {
+        // A $SCOOP root that isn't literally named "scoop" is still recognised via the apps/<pkg>/current tail.
+        var probe = new FakeInstallChannelProbe
+        {
+            OS = OSPlatformKind.Windows,
+            HomeDirectory = @"C:\Users\me",
+            BaseDirectory = @"D:\tools\scooproot\apps\dotnet-6502-terminal\current",
+        };
+        probe.EnvironmentVariables["SCOOP"] = @"D:\tools\scooproot";
+        probe.ResolvableExecutables["scoop"] = @"D:\tools\scooproot\shims\scoop";
+        probe.CommandResults[@"D:\tools\scooproot\shims\scoop list dotnet-6502-terminal"] =
+            new ProcessRunResult(0, "dotnet-6502-terminal 0.40.2\n");
+
+        var info = new InstallChannelDetector(probe).Detect(TerminalDescriptor);
+
+        Assert.Equal(InstallChannel.Scoop, info.Channel);
+    }
 }


### PR DESCRIPTION
Follow-ups to the app update-detection / delegated-update feature (#251). Four independent items, one commit each.

### 1. Document the new update functionality
User-facing docs for the update behavior: a shared **Staying up to date** section in
`installation.md`, the `--version` / `--check-update` / `--update` flags folded into the shared
`cli-general.md` CLI reference (with host-specific notes), and a per-app "update surface" summary — no
duplication across the host-app pages.

### 2. RemoteClient `--check-server-version`
New read-only `server.info` remote command (host app name + release-stamped version).
`dotnet-6502-remote --check-server-version` connects, compares the endpoint's version with the
client's, and warns on mismatch (exit `3`) with the brew/scoop update commands. No automatic check and
no extra round-trip on the normal command path. Docs updated (remote-client, examples, tcp-protocol).

### 3. Terminal update UI
In-TUI update affordance for the Terminal host: a `TerminalUpdateService`, an **Updates** dialog reached
via the `F9 U` leader command (version/status, **Check now**, **Update now**), and an "update available"
indicator in the window title / hint line (behind the leader key, so it never steals emulator focus).
**Update now** quits the TUI and runs the package-manager upgrade in the foreground. The automatic
Logs-pane notice is retained.

### 4. Install-channel path fallback
When the `install-channel` marker is absent, infer the channel from the run directory (Scoop
`apps/<pkg>/current`; Homebrew *formula* `Cellar/<formula>/…`; the cask stays marker-only). Still
confirmed by the package manager and biased to not-managed.

### Testing
- Updates lib: 76 tests green; new `RemoteClient.Tests` project (7 tests) green.
- Full solution builds clean (0 warnings).
- Server version check verified end-to-end (match / dev-build "cannot verify" / mismatch exit `3`).
