### PR TITLE
Fix managed self-update: refresh metadata and unlock Scoop's install dir

### DIFF
--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/DesktopAppUpdateService.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/DesktopAppUpdateService.cs
@@ -81,7 +81,7 @@ public sealed class DesktopAppUpdateService : IAppUpdateService
 
         var spawned = UpdateApplier.TrySpawnDetachedRelaunch(
             result.ManagerExecutablePath,
-            CreateDescriptor().UpgradeArgs(result.Channel),
+            CreateDescriptor().UpgradeCommandArgs(result.Channel),
             Environment.ProcessId,
             BuildRelaunchSpec());
 

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Core/TerminalUpdateService.cs
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Core/TerminalUpdateService.cs
@@ -78,7 +78,7 @@ public sealed class TerminalUpdateService
         if (!PendingUpdateRequested || Latest?.ManagerExecutablePath is null)
             return false;
 
-        return await UpdateApplier.RunUpgradeAsync(
-            Latest.ManagerExecutablePath, _descriptor.UpgradeArgs(Latest.Channel), output, cancellationToken).ConfigureAwait(false);
+        return await UpdateApplier.RunUpgradeCommandsAsync(
+            Latest.ManagerExecutablePath, _descriptor.UpgradeCommandArgs(Latest.Channel), output, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Updates/ConsoleUpdateCli.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/ConsoleUpdateCli.cs
@@ -54,8 +54,8 @@ public static class ConsoleUpdateCli
             output.WriteLine(FormatNoticeLine(result));
             output.WriteLine($"Updating: {result.SuggestedCommand}");
             output.WriteLine();
-            var succeeded = await UpdateApplier.RunUpgradeAsync(
-                result.ManagerExecutablePath, descriptor.UpgradeArgs(result.Channel), output, cancellationToken).ConfigureAwait(false);
+            var succeeded = await UpdateApplier.RunUpgradeCommandsAsync(
+                result.ManagerExecutablePath, descriptor.UpgradeCommandArgs(result.Channel), output, cancellationToken).ConfigureAwait(false);
             output.WriteLine();
             output.WriteLine(succeeded
                 ? "Update complete. Restart the app to use the new version."

--- a/src/libraries/Highbyte.DotNet6502.Updates/InstallChannel.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/InstallChannel.cs
@@ -64,4 +64,27 @@ public sealed record AppUpdateDescriptor
         InstallChannel.Scoop => new[] { "update", ScoopPackage },
         _ => throw new ArgumentOutOfRangeException(nameof(channel), channel, "No upgrade args for a non-managed channel."),
     };
+
+    /// <summary>
+    /// Package-manager command arguments to run, in order, for an upgrade.
+    /// Both managers need a metadata refresh first so the automatic updater matches the documented
+    /// flows instead of using stale data: Homebrew's <c>brew update &amp;&amp; brew upgrade ...</c>, and
+    /// Scoop's <c>scoop update; scoop update ...</c> (bare <c>scoop update</c> git-pulls the bucket
+    /// manifests; without it <c>scoop update &lt;app&gt;</c> upgrades against a stale manifest and never
+    /// sees a freshly published version).
+    /// </summary>
+    public IReadOnlyList<IReadOnlyList<string>> UpgradeCommandArgs(InstallChannel channel) => channel switch
+    {
+        InstallChannel.Homebrew => new IReadOnlyList<string>[]
+        {
+            new[] { "update" },
+            UpgradeArgs(channel),
+        },
+        InstallChannel.Scoop => new IReadOnlyList<string>[]
+        {
+            new[] { "update" },
+            UpgradeArgs(channel),
+        },
+        _ => throw new ArgumentOutOfRangeException(nameof(channel), channel, "No upgrade command args for a non-managed channel."),
+    };
 }

--- a/src/libraries/Highbyte.DotNet6502.Updates/UpdateApplier.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/UpdateApplier.cs
@@ -27,39 +27,52 @@ public static class UpdateApplier
         IReadOnlyList<string> args,
         TextWriter output,
         CancellationToken cancellationToken = default)
+        => await RunUpgradeCommandsAsync(managerExecutablePath, new[] { args }, output, cancellationToken).ConfigureAwait(false);
+
+    public static async Task<bool> RunUpgradeCommandsAsync(
+        string managerExecutablePath,
+        IReadOnlyList<IReadOnlyList<string>> commandArgs,
+        TextWriter output,
+        CancellationToken cancellationToken = default)
     {
-        // Launch .ps1/.cmd/.bat (e.g. the Scoop shim scoop.ps1) correctly on Windows, preferring pwsh 7.
-        var startInfo = ProcessLaunch.BuildStartInfo(
-            managerExecutablePath, args, OperatingSystem.IsWindows(), ProcessLaunch.ResolveWindowsPowerShellExe());
-        startInfo.RedirectStandardOutput = true;
-        startInfo.RedirectStandardError = true;
+        foreach (var args in commandArgs)
+        {
+            // Launch .ps1/.cmd/.bat (e.g. the Scoop shim scoop.ps1) correctly on Windows, preferring pwsh 7.
+            var startInfo = ProcessLaunch.BuildStartInfo(
+                managerExecutablePath, args, OperatingSystem.IsWindows(), ProcessLaunch.ResolveWindowsPowerShellExe());
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;
 
-        Process? process;
-        try
-        {
-            process = Process.Start(startInfo);
-        }
-        catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or InvalidOperationException or IOException)
-        {
-            output.WriteLine($"Could not start the package manager: {ex.Message}");
-            return false;
+            Process? process;
+            try
+            {
+                process = Process.Start(startInfo);
+            }
+            catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or InvalidOperationException or IOException)
+            {
+                output.WriteLine($"Could not start the package manager: {ex.Message}");
+                return false;
+            }
+
+            if (process is null)
+            {
+                output.WriteLine("Could not start the package manager.");
+                return false;
+            }
+
+            using (process)
+            {
+                process.OutputDataReceived += (_, e) => { if (e.Data != null) output.WriteLine(e.Data); };
+                process.ErrorDataReceived += (_, e) => { if (e.Data != null) output.WriteLine(e.Data); };
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+                await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+                if (process.ExitCode != 0)
+                    return false;
+            }
         }
 
-        if (process is null)
-        {
-            output.WriteLine("Could not start the package manager.");
-            return false;
-        }
-
-        using (process)
-        {
-            process.OutputDataReceived += (_, e) => { if (e.Data != null) output.WriteLine(e.Data); };
-            process.ErrorDataReceived += (_, e) => { if (e.Data != null) output.WriteLine(e.Data); };
-            process.BeginOutputReadLine();
-            process.BeginErrorReadLine();
-            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-            return process.ExitCode == 0;
-        }
+        return true;
     }
 
     /// <summary>
@@ -79,13 +92,22 @@ public static class UpdateApplier
         int appProcessId,
         RelaunchSpec relaunch,
         string? logFilePath = null)
+        => TrySpawnDetachedRelaunch(
+            managerExecutablePath, new[] { upgradeArgs }, appProcessId, relaunch, logFilePath);
+
+    public static bool TrySpawnDetachedRelaunch(
+        string managerExecutablePath,
+        IReadOnlyList<IReadOnlyList<string>> upgradeCommandArgs,
+        int appProcessId,
+        RelaunchSpec relaunch,
+        string? logFilePath = null)
     {
         var logPath = logFilePath ?? GetUpdateLogPath();
         try
         {
             return OperatingSystem.IsWindows()
-                ? TrySpawnDetachedWindows(managerExecutablePath, upgradeArgs, appProcessId, relaunch, logPath)
-                : TrySpawnDetachedUnix(managerExecutablePath, upgradeArgs, appProcessId, relaunch, logPath);
+                ? TrySpawnDetachedWindows(managerExecutablePath, upgradeCommandArgs, appProcessId, relaunch, logPath)
+                : TrySpawnDetachedUnix(managerExecutablePath, upgradeCommandArgs, appProcessId, relaunch, logPath);
         }
         catch (Exception ex) when (ex is IOException or System.ComponentModel.Win32Exception or UnauthorizedAccessException or InvalidOperationException)
         {
@@ -96,7 +118,7 @@ public static class UpdateApplier
     // Unix (macOS/Linux): a bash script waits on the PID, upgrades, then relaunches. The app spawns
     // /bin/bash and exits; the child reparents to init and survives (GUI apps have no controlling
     // terminal). No elevation needed — brew installs to user-writable locations.
-    private static bool TrySpawnDetachedUnix(string manager, IReadOnlyList<string> upgradeArgs, int pid, RelaunchSpec relaunch, string logPath)
+    private static bool TrySpawnDetachedUnix(string manager, IReadOnlyList<IReadOnlyList<string>> upgradeCommandArgs, int pid, RelaunchSpec relaunch, string logPath)
     {
         var script = new StringBuilder();
         script.Append("#!/bin/bash\n");
@@ -107,8 +129,16 @@ public static class UpdateApplier
         script.Append("echo \"=== update $(date) ===\"\n");
         script.Append("APP_PID=\"$1\"\n");
         script.Append("while kill -0 \"$APP_PID\" 2>/dev/null; do sleep 0.3; done\n");
-        // Upgrade; fail-safe means we relaunch regardless of the outcome (|| true).
-        script.Append(ShJoin(manager, upgradeArgs)).Append(" || true\n");
+        // Upgrade; fail-safe means we relaunch regardless of the outcome.
+        script.Append("STATUS=0\n");
+        foreach (var args in upgradeCommandArgs)
+        {
+            script.Append("if [ \"$STATUS\" -eq 0 ]; then\n");
+            script.Append("  ").Append(ShJoin(manager, args)).Append('\n');
+            script.Append("  STATUS=$?\n");
+            script.Append("  if [ \"$STATUS\" -ne 0 ]; then echo \"Package manager command failed with exit code $STATUS\"; fi\n");
+            script.Append("fi\n");
+        }
         // Relaunch detached from this helper.
         script.Append(ShJoin(relaunch.Executable, relaunch.Arguments)).Append(" &\n");
         script.Append("exit 0\n");
@@ -129,7 +159,7 @@ public static class UpdateApplier
 
     // Windows: a PowerShell script waits on the PID, upgrades, then relaunches. Launched via
     // ShellExecute (UseShellExecute=true) so it isn't tied to the exiting app's lifetime.
-    private static bool TrySpawnDetachedWindows(string manager, IReadOnlyList<string> upgradeArgs, int pid, RelaunchSpec relaunch, string logPath)
+    private static bool TrySpawnDetachedWindows(string manager, IReadOnlyList<IReadOnlyList<string>> upgradeCommandArgs, int pid, RelaunchSpec relaunch, string logPath)
     {
         var script = new StringBuilder();
         script.Append("param([int]$AppPid)\n");
@@ -138,10 +168,17 @@ public static class UpdateApplier
         script.Append("\"=== update $(Get-Date) ===\" | Out-File -FilePath $log -Append\n");
         script.Append("try { Wait-Process -Id $AppPid -ErrorAction SilentlyContinue } catch {}\n");
         // Capture the upgrade output/errors (all streams) so a failed update isn't lost.
-        script.Append("try { & ").Append(PsQuote(manager));
-        foreach (var a in upgradeArgs)
-            script.Append(' ').Append(PsQuote(a));
-        script.Append(" *>> $log } catch { $_ | Out-File -FilePath $log -Append }\n");
+        script.Append("$status = 0\n");
+        foreach (var args in upgradeCommandArgs)
+        {
+            script.Append("if ($status -eq 0) {\n");
+            script.Append("  try { & ").Append(PsQuote(manager));
+            foreach (var a in args)
+                script.Append(' ').Append(PsQuote(a));
+            script.Append(" *>> $log; $status = $LASTEXITCODE } catch { $_ | Out-File -FilePath $log -Append; $status = 1 }\n");
+            script.Append("  if ($status -ne 0) { \"Package manager command failed with exit code $status\" | Out-File -FilePath $log -Append }\n");
+            script.Append("}\n");
+        }
         script.Append("Start-Process -FilePath ").Append(PsQuote(relaunch.Executable));
         if (relaunch.Arguments.Count > 0)
         {
@@ -157,6 +194,12 @@ public static class UpdateApplier
             FileName = ProcessLaunch.ResolveWindowsPowerShellExe(), // pwsh 7 if present, else Windows PowerShell 5.1
             UseShellExecute = true,
             WindowStyle = ProcessWindowStyle.Hidden,
+            // Run the helper from a neutral directory, NOT the app's inherited working directory. A
+            // Scoop-installed GUI app's working directory is its own install dir (...\apps\<pkg>\current);
+            // if the helper inherits that, Scoop's `scoop update` can't remove/repoint the `current`
+            // junction ("Cannot remove the item ... because it is in use") because this process is sitting
+            // in it. TempPath is always writable and is never the package dir being replaced.
+            WorkingDirectory = Path.GetTempPath(),
         };
         psi.ArgumentList.Add("-NoProfile");
         psi.ArgumentList.Add("-ExecutionPolicy");

--- a/src/libraries/Highbyte.DotNet6502.Updates/UpdateChecker.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/UpdateChecker.cs
@@ -154,9 +154,11 @@ public sealed class UpdateChecker
     /// <summary>Builds the exact upgrade command for the detected channel (Phase A: shown/copied, not auto-run).</summary>
     public string BuildUpgradeCommand(InstallChannel channel) => channel switch
     {
-        InstallChannel.Homebrew when _descriptor.HomebrewIsCask => $"brew upgrade --cask {_descriptor.HomebrewPackage}",
-        InstallChannel.Homebrew => $"brew upgrade {_descriptor.HomebrewPackage}",
-        InstallChannel.Scoop => $"scoop update {_descriptor.ScoopPackage}",
+        InstallChannel.Homebrew when _descriptor.HomebrewIsCask => $"brew update && brew upgrade --cask {_descriptor.HomebrewPackage}",
+        InstallChannel.Homebrew => $"brew update && brew upgrade {_descriptor.HomebrewPackage}",
+        // ';' (not '&&') separates the metadata refresh from the app upgrade: Scoop runs under
+        // PowerShell, where ';' is the portable statement separator ('&&' is PowerShell 7+ only).
+        InstallChannel.Scoop => $"scoop update; scoop update {_descriptor.ScoopPackage}",
         _ => throw new ArgumentOutOfRangeException(nameof(channel), channel, "No upgrade command for a non-managed channel."),
     };
 

--- a/tests/Highbyte.DotNet6502.Updates.Tests/AppUpdateDescriptorTests.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/AppUpdateDescriptorTests.cs
@@ -1,0 +1,44 @@
+using Highbyte.DotNet6502.Updates;
+using Xunit;
+
+namespace Highbyte.DotNet6502.Updates.Tests;
+
+public class AppUpdateDescriptorTests
+{
+    [Fact]
+    public void HomebrewCaskUpgradeCommandArgs_UpdateTapBeforeUpgrade()
+    {
+        var descriptor = new AppUpdateDescriptor
+        {
+            HomebrewPackage = "dotnet-6502",
+            HomebrewIsCask = true,
+            ScoopPackage = "dotnet-6502",
+        };
+
+        var commands = descriptor.UpgradeCommandArgs(InstallChannel.Homebrew);
+
+        Assert.Collection(
+            commands,
+            command => Assert.Equal(new[] { "update" }, command),
+            command => Assert.Equal(new[] { "upgrade", "--cask", "dotnet-6502" }, command));
+    }
+
+    [Fact]
+    public void ScoopUpgradeCommandArgs_RefreshesBucketsBeforeUpgrade()
+    {
+        var descriptor = new AppUpdateDescriptor
+        {
+            HomebrewPackage = "dotnet-6502",
+            ScoopPackage = "dotnet-6502",
+        };
+
+        var commands = descriptor.UpgradeCommandArgs(InstallChannel.Scoop);
+
+        // Bare `scoop update` git-pulls the bucket manifests first; without it `scoop update <app>`
+        // upgrades against a stale manifest and never sees a freshly published version.
+        Assert.Collection(
+            commands,
+            command => Assert.Equal(new[] { "update" }, command),
+            command => Assert.Equal(new[] { "update", "dotnet-6502" }, command));
+    }
+}

--- a/tests/Highbyte.DotNet6502.Updates.Tests/ConsoleUpdateCliTests.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/ConsoleUpdateCliTests.cs
@@ -25,11 +25,11 @@ public class ConsoleUpdateCliTests
             Status = UpdateCheckStatus.UpdateAvailable,
             CurrentVersion = current,
             LatestVersion = latest,
-            SuggestedCommand = "brew upgrade dotnet-6502-terminal",
+            SuggestedCommand = "brew update && brew upgrade dotnet-6502-terminal",
         };
 
         Assert.Equal(
-            "A newer version v0.40.2-alpha is available (you have v0.39.3-alpha). Run 'brew upgrade dotnet-6502-terminal' to update.",
+            "A newer version v0.40.2-alpha is available (you have v0.39.3-alpha). Run 'brew update && brew upgrade dotnet-6502-terminal' to update.",
             ConsoleUpdateCli.FormatNoticeLine(result));
     }
 

--- a/tests/Highbyte.DotNet6502.Updates.Tests/UpdateApplierTests.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/UpdateApplierTests.cs
@@ -39,6 +39,52 @@ public class UpdateApplierTests
         Assert.True(relaunched, "relaunch did not run after a failed upgrade (fail-safe broken)");
     }
 
+    [Fact]
+    public async Task TrySpawnDetachedRelaunch_RunsUpgradeCommands_InOrder()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var dir = Path.Combine(Path.GetTempPath(), "d6502-relaunch-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        Process? app = null;
+        try
+        {
+            var log = Path.Combine(dir, "commands.log");
+            var relaunchMarker = Path.Combine(dir, "relaunched");
+            var manager = Path.Combine(dir, "manager.sh");
+            await File.WriteAllTextAsync(manager, $"#!/bin/bash\necho \"$*\" >> '{log}'\nexit 0\n");
+            var relaunchScript = Path.Combine(dir, "relaunch.sh");
+            await File.WriteAllTextAsync(relaunchScript, $"#!/bin/bash\ntouch '{relaunchMarker}'\n");
+            MakeExecutable(manager);
+            MakeExecutable(relaunchScript);
+
+            app = Process.Start(new ProcessStartInfo { FileName = "/bin/bash", UseShellExecute = false }
+                .WithArgs("-c", "sleep 30"))!;
+
+            var spawned = UpdateApplier.TrySpawnDetachedRelaunch(
+                manager,
+                new IReadOnlyList<string>[] { new[] { "update" }, new[] { "upgrade", "--cask", "dotnet-6502" } },
+                app.Id,
+                new RelaunchSpec("/bin/bash", new[] { relaunchScript }),
+                logFilePath: Path.Combine(dir, "update.log"));
+            Assert.True(spawned, "helper was not spawned");
+
+            app.Kill(entireProcessTree: true);
+            await app.WaitForExitAsync();
+
+            Assert.True(await WaitForFileAsync(relaunchMarker, TimeSpan.FromSeconds(15)), "relaunch did not run");
+            var commandLogAppeared = await WaitForFileAsync(log, TimeSpan.FromSeconds(5));
+            Assert.True(commandLogAppeared, "manager command log was not written");
+            Assert.Equal(new[] { "update", "upgrade --cask dotnet-6502" }, await File.ReadAllLinesAsync(log));
+        }
+        finally
+        {
+            try { if (app is { HasExited: false }) app.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     // Runs the full detached scenario with a fake manager that touches a marker then exits with the
     // given code, and a fake relaunch that touches another marker. Returns whether the upgrade ran
     // before the app exited (should be false), and whether the upgrade + relaunch markers appeared.

--- a/tests/Highbyte.DotNet6502.Updates.Tests/UpdateCheckerTests.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/UpdateCheckerTests.cs
@@ -95,7 +95,7 @@ public class UpdateCheckerTests : IDisposable
 
         await checker.CheckAsync();
 
-        Assert.Contains(logger.Messages, m => m.Contains("v0.40.2-alpha") && m.Contains("brew upgrade dotnet-6502-terminal"));
+        Assert.Contains(logger.Messages, m => m.Contains("v0.40.2-alpha") && m.Contains("brew update && brew upgrade dotnet-6502-terminal"));
     }
 
     [Fact]
@@ -132,7 +132,7 @@ public class UpdateCheckerTests : IDisposable
         Assert.Equal(UpdateCheckStatus.UpdateAvailable, result.Status);
         Assert.True(result.IsUpdateAvailable);
         Assert.Equal("0.40.2-alpha", result.LatestVersion!.ToString());
-        Assert.Equal("brew upgrade dotnet-6502-terminal", result.SuggestedCommand);
+        Assert.Equal("brew update && brew upgrade dotnet-6502-terminal", result.SuggestedCommand);
         Assert.Equal("https://example/releases/v0.40.2-alpha", result.ReleaseNotesUrl);
     }
 
@@ -184,7 +184,7 @@ public class UpdateCheckerTests : IDisposable
         // Second check within the 24h window reuses the cache written by the first.
         var second = await MakeChecker(source, detector, "0.40.1-alpha").CheckAsync();
         Assert.Equal(UpdateCheckStatus.UpdateAvailable, second.Status);
-        Assert.Equal("brew upgrade dotnet-6502-terminal", second.SuggestedCommand);
+        Assert.Equal("brew update && brew upgrade dotnet-6502-terminal", second.SuggestedCommand);
         Assert.Equal(1, source.CallCount); // no new network call
     }
 


### PR DESCRIPTION
Self-update ran the upgrade command against stale metadata, so new versions weren't found. Run an ordered two-step flow instead — refresh then upgrade (`brew update && brew upgrade …`, `scoop update; scoop update …`) — gated so a failed refresh aborts the upgrade, in both the GUI helper and console --update.

Also fix the Windows helper failing with "…\current is in use": it inherited the app's own Scoop install dir as working directory. Launch it from TempPath.

Update Updates unit tests for the new sequences.