### PR TITLE
Fix Linux Homebrew self-update relaunch

### DIFF
--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/DesktopAppUpdateService.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/DesktopAppUpdateService.cs
@@ -79,11 +79,12 @@ public sealed class DesktopAppUpdateService : IAppUpdateService
             return false;
         }
 
+        var descriptor = CreateDescriptor();
         var spawned = UpdateApplier.TrySpawnDetachedRelaunch(
             result.ManagerExecutablePath,
-            CreateDescriptor().UpgradeCommandArgs(result.Channel),
+            descriptor.UpgradeCommandArgs(result.Channel),
             Environment.ProcessId,
-            BuildRelaunchSpec());
+            BuildRelaunchSpec(result.Channel, result.ManagerExecutablePath, descriptor.HomebrewPackage));
 
         if (spawned)
         {
@@ -151,13 +152,28 @@ public sealed class DesktopAppUpdateService : IAppUpdateService
     // How to relaunch the Avalonia GUI after the upgrade. If the app was started as
     // `dotnet <app>.dll` (the local dev/update-trigger flow), reconstruct that exact launch on every
     // OS. Otherwise macOS uses `open -a "<AppName>"` (robust across the cask replacing the bundle),
-    // while Windows/Linux relaunch the current executable — the Scoop `current` junction / brew shim
-    // path stays valid after the update.
-    private static RelaunchSpec BuildRelaunchSpec()
-    {
-        var processPath = Environment.ProcessPath ?? string.Empty;
-        var commandLineArgs = Environment.GetCommandLineArgs();
+    // Linux Homebrew relaunches via the stable bin symlink, and Windows relaunches the current
+    // executable path (Scoop's `current` junction stays valid after the update).
+    private static RelaunchSpec BuildRelaunchSpec(
+        InstallChannel channel,
+        string managerExecutablePath,
+        string homebrewLauncherName)
+        => BuildRelaunchSpec(
+            channel,
+            managerExecutablePath,
+            homebrewLauncherName,
+            Environment.ProcessPath ?? string.Empty,
+            Environment.GetCommandLineArgs(),
+            GetCurrentOS());
 
+    internal static RelaunchSpec BuildRelaunchSpec(
+        InstallChannel channel,
+        string? managerExecutablePath,
+        string homebrewLauncherName,
+        string processPath,
+        string[] commandLineArgs,
+        OSPlatformKind os)
+    {
         if (IsDotNetHost(processPath) && commandLineArgs.Length > 0)
         {
             var relaunchArgs = new List<string>(commandLineArgs.Length);
@@ -165,13 +181,36 @@ public sealed class DesktopAppUpdateService : IAppUpdateService
             return new RelaunchSpec(processPath, relaunchArgs);
         }
 
-        if (OperatingSystem.IsMacOS())
+        if (os == OSPlatformKind.MacOS)
             return new RelaunchSpec("/usr/bin/open", new[] { "-a", "DotNet 6502 Emulator" });
 
         var appArgs = commandLineArgs.Length > 1
             ? commandLineArgs[1..]
             : Array.Empty<string>();
+
+        if (os == OSPlatformKind.Linux && channel == InstallChannel.Homebrew)
+        {
+            var managerDirectory = string.IsNullOrWhiteSpace(managerExecutablePath)
+                ? null
+                : Path.GetDirectoryName(managerExecutablePath);
+            var launcher = string.IsNullOrWhiteSpace(managerDirectory)
+                ? homebrewLauncherName
+                : Path.Combine(managerDirectory, homebrewLauncherName);
+            return new RelaunchSpec(launcher, appArgs);
+        }
+
         return new RelaunchSpec(processPath, appArgs);
+    }
+
+    private static OSPlatformKind GetCurrentOS()
+    {
+        if (OperatingSystem.IsWindows())
+            return OSPlatformKind.Windows;
+        if (OperatingSystem.IsMacOS())
+            return OSPlatformKind.MacOS;
+        if (OperatingSystem.IsLinux())
+            return OSPlatformKind.Linux;
+        return OSPlatformKind.Other;
     }
 
     private static bool IsDotNetHost(string processPath)

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/DesktopAppUpdateService.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/DesktopAppUpdateService.cs
@@ -192,10 +192,10 @@ public sealed class DesktopAppUpdateService : IAppUpdateService
         {
             var managerDirectory = string.IsNullOrWhiteSpace(managerExecutablePath)
                 ? null
-                : Path.GetDirectoryName(managerExecutablePath);
+                : GetDirectoryName(managerExecutablePath, os);
             var launcher = string.IsNullOrWhiteSpace(managerDirectory)
                 ? homebrewLauncherName
-                : Path.Combine(managerDirectory, homebrewLauncherName);
+                : CombinePath(managerDirectory, homebrewLauncherName, os);
             return new RelaunchSpec(launcher, appArgs);
         }
 
@@ -213,12 +213,33 @@ public sealed class DesktopAppUpdateService : IAppUpdateService
         return OSPlatformKind.Other;
     }
 
+    private static string? GetDirectoryName(string path, OSPlatformKind os)
+    {
+        if (os is OSPlatformKind.Linux or OSPlatformKind.MacOS)
+        {
+            var normalized = path.Replace('\\', '/').TrimEnd('/');
+            var lastSlash = normalized.LastIndexOf('/');
+            return lastSlash > 0 ? normalized[..lastSlash] : null;
+        }
+
+        return Path.GetDirectoryName(path);
+    }
+
+    private static string CombinePath(string directory, string fileName, OSPlatformKind os)
+    {
+        if (os is OSPlatformKind.Linux or OSPlatformKind.MacOS)
+            return $"{directory.TrimEnd('/')}/{fileName.TrimStart('/')}";
+
+        return Path.Combine(directory, fileName);
+    }
+
     private static bool IsDotNetHost(string processPath)
     {
         if (string.IsNullOrWhiteSpace(processPath))
             return false;
 
-        var fileName = Path.GetFileName(processPath);
+        var pathParts = processPath.Replace('\\', '/').Split('/');
+        var fileName = pathParts[^1];
         return string.Equals(fileName, "dotnet", StringComparison.OrdinalIgnoreCase)
             || string.Equals(fileName, "dotnet.exe", StringComparison.OrdinalIgnoreCase);
     }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Properties/AssemblyInfo.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Highbyte.DotNet6502.Updates.Tests")]

--- a/src/libraries/Highbyte.DotNet6502.Updates/UpdateApplier.cs
+++ b/src/libraries/Highbyte.DotNet6502.Updates/UpdateApplier.cs
@@ -140,7 +140,16 @@ public static class UpdateApplier
             script.Append("fi\n");
         }
         // Relaunch detached from this helper.
-        script.Append(ShJoin(relaunch.Executable, relaunch.Arguments)).Append(" &\n");
+        var relaunchCommand = ShJoin(relaunch.Executable, relaunch.Arguments);
+        script.Append("echo ").Append(ShQuote("Relaunching: " + relaunchCommand)).Append('\n');
+        script.Append(relaunchCommand).Append(" &\n");
+        script.Append("RELAUNCH_PID=$!\n");
+        script.Append("sleep 1\n");
+        script.Append("if ! kill -0 \"$RELAUNCH_PID\" 2>/dev/null; then\n");
+        script.Append("  wait \"$RELAUNCH_PID\"\n");
+        script.Append("  RELAUNCH_STATUS=$?\n");
+        script.Append("  if [ \"$RELAUNCH_STATUS\" -ne 0 ]; then echo \"Relaunch command failed with exit code $RELAUNCH_STATUS\"; fi\n");
+        script.Append("fi\n");
         script.Append("exit 0\n");
 
         var scriptPath = WriteTempScript(script.ToString(), ".sh");
@@ -179,13 +188,17 @@ public static class UpdateApplier
             script.Append("  if ($status -ne 0) { \"Package manager command failed with exit code $status\" | Out-File -FilePath $log -Append }\n");
             script.Append("}\n");
         }
-        script.Append("Start-Process -FilePath ").Append(PsQuote(relaunch.Executable));
+        script.Append("$relaunchFile = ").Append(PsQuote(relaunch.Executable)).Append('\n');
+        script.Append("$relaunchArgs = @(").Append(string.Join(",", relaunch.Arguments.Select(PsQuote))).Append(")\n");
+        script.Append("\"Relaunching: $relaunchFile $($relaunchArgs -join ' ')\" | Out-File -FilePath $log -Append\n");
+        script.Append("try {\n");
+        script.Append("  $relaunchProcess = Start-Process -FilePath $relaunchFile");
         if (relaunch.Arguments.Count > 0)
-        {
-            script.Append(" -ArgumentList ");
-            script.Append(string.Join(",", relaunch.Arguments.Select(PsQuote)));
-        }
-        script.Append('\n');
+            script.Append(" -ArgumentList $relaunchArgs");
+        script.Append(" -PassThru -ErrorAction Stop\n");
+        script.Append("  Start-Sleep -Seconds 1\n");
+        script.Append("  if ($relaunchProcess.HasExited -and $relaunchProcess.ExitCode -ne 0) { \"Relaunch command failed with exit code $($relaunchProcess.ExitCode)\" | Out-File -FilePath $log -Append }\n");
+        script.Append("} catch { \"Relaunch command failed: $($_.Exception.Message)\" | Out-File -FilePath $log -Append }\n");
 
         var scriptPath = WriteTempScript(script.ToString(), ".ps1");
 

--- a/tests/Highbyte.DotNet6502.Updates.Tests/DesktopAppUpdateServiceTests.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/DesktopAppUpdateServiceTests.cs
@@ -1,0 +1,55 @@
+using Highbyte.DotNet6502.App.Avalonia.Desktop;
+using Highbyte.DotNet6502.Updates;
+using Xunit;
+
+namespace Highbyte.DotNet6502.Updates.Tests;
+
+public class DesktopAppUpdateServiceTests
+{
+    [Fact]
+    public void BuildRelaunchSpec_LinuxHomebrew_UsesStableBrewBinLauncher()
+    {
+        var spec = DesktopAppUpdateService.BuildRelaunchSpec(
+            InstallChannel.Homebrew,
+            "/home/linuxbrew/.linuxbrew/bin/brew",
+            "dotnet-6502",
+            "/home/linuxbrew/.linuxbrew/Cellar/dotnet-6502/0.41.4-alpha/bin/dotnet-6502",
+            new[] { "dotnet-6502", "--console-log" },
+            OSPlatformKind.Linux);
+
+        Assert.Equal("/home/linuxbrew/.linuxbrew/bin/dotnet-6502", spec.Executable);
+        Assert.Equal(new[] { "--console-log" }, spec.Arguments);
+    }
+
+    [Fact]
+    public void BuildRelaunchSpec_DotNetHost_ReconstructsOriginalLaunch()
+    {
+        var spec = DesktopAppUpdateService.BuildRelaunchSpec(
+            InstallChannel.Homebrew,
+            "/home/linuxbrew/.linuxbrew/bin/brew",
+            "dotnet-6502",
+            "/usr/bin/dotnet",
+            new[] { "/usr/bin/dotnet", "/tmp/app/Highbyte.DotNet6502.App.Avalonia.Desktop.dll", "--console-log" },
+            OSPlatformKind.Linux);
+
+        Assert.Equal("/usr/bin/dotnet", spec.Executable);
+        Assert.Equal(
+            new[] { "/usr/bin/dotnet", "/tmp/app/Highbyte.DotNet6502.App.Avalonia.Desktop.dll", "--console-log" },
+            spec.Arguments);
+    }
+
+    [Fact]
+    public void BuildRelaunchSpec_WindowsScoop_UsesCurrentProcessPath()
+    {
+        var spec = DesktopAppUpdateService.BuildRelaunchSpec(
+            InstallChannel.Scoop,
+            @"C:\Users\me\scoop\shims\scoop.ps1",
+            "dotnet-6502",
+            @"C:\Users\me\scoop\apps\dotnet-6502\current\dotnet-6502.exe",
+            new[] { "dotnet-6502", "--console-log" },
+            OSPlatformKind.Windows);
+
+        Assert.Equal(@"C:\Users\me\scoop\apps\dotnet-6502\current\dotnet-6502.exe", spec.Executable);
+        Assert.Equal(new[] { "--console-log" }, spec.Arguments);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Updates.Tests/Highbyte.DotNet6502.Updates.Tests.csproj
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/Highbyte.DotNet6502.Updates.Tests.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\apps\Avalonia\Highbyte.DotNet6502.App.Avalonia.Desktop\Highbyte.DotNet6502.App.Avalonia.Desktop.csproj" />
     <ProjectReference Include="..\..\src\libraries\Highbyte.DotNet6502.Updates\Highbyte.DotNet6502.Updates.csproj" />
   </ItemGroup>
 

--- a/tests/Highbyte.DotNet6502.Updates.Tests/UpdateApplierTests.cs
+++ b/tests/Highbyte.DotNet6502.Updates.Tests/UpdateApplierTests.cs
@@ -85,6 +85,53 @@ public class UpdateApplierTests
         }
     }
 
+    [Fact]
+    public async Task TrySpawnDetachedRelaunch_LogsUnixRelaunchCommandAndFailure()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var dir = Path.Combine(Path.GetTempPath(), "d6502-relaunch-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        Process? app = null;
+        try
+        {
+            var manager = Path.Combine(dir, "manager.sh");
+            await File.WriteAllTextAsync(manager, "#!/bin/bash\nexit 0\n");
+            MakeExecutable(manager);
+
+            app = Process.Start(new ProcessStartInfo { FileName = "/bin/bash", UseShellExecute = false }
+                .WithArgs("-c", "sleep 30"))!;
+
+            var logPath = Path.Combine(dir, "update.log");
+            var missingLauncher = Path.Combine(dir, "missing-dotnet-6502");
+            var spawned = UpdateApplier.TrySpawnDetachedRelaunch(
+                manager,
+                Array.Empty<string>(),
+                app.Id,
+                new RelaunchSpec(missingLauncher, new[] { "--console-log" }),
+                logFilePath: logPath);
+            Assert.True(spawned, "helper was not spawned");
+
+            app.Kill(entireProcessTree: true);
+            await app.WaitForExitAsync();
+
+            Assert.True(
+                await WaitForFileContainingAsync(logPath, "Relaunching:", TimeSpan.FromSeconds(15)),
+                "relaunch command was not logged");
+            Assert.True(
+                await WaitForFileContainingAsync(logPath, "Relaunch command failed with exit code", TimeSpan.FromSeconds(5)),
+                "relaunch failure was not logged");
+            var log = await File.ReadAllTextAsync(logPath);
+            Assert.Contains(missingLauncher, log);
+        }
+        finally
+        {
+            try { if (app is { HasExited: false }) app.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     // Runs the full detached scenario with a fake manager that touches a marker then exits with the
     // given code, and a fake relaunch that touches another marker. Returns whether the upgrade ran
     // before the app exited (should be false), and whether the upgrade + relaunch markers appeared.
@@ -153,6 +200,18 @@ public class UpdateApplierTests
             await Task.Delay(100);
         }
         return File.Exists(path);
+    }
+
+    private static async Task<bool> WaitForFileContainingAsync(string path, string text, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (File.Exists(path) && (await File.ReadAllTextAsync(path)).Contains(text, StringComparison.Ordinal))
+                return true;
+            await Task.Delay(100);
+        }
+        return File.Exists(path) && (await File.ReadAllTextAsync(path)).Contains(text, StringComparison.Ordinal);
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix Linux Homebrew self-update relaunch to use the stable `bin/dotnet-6502` launcher instead of the versioned Cellar executable path.
- Log relaunch attempts and immediate failures from the detached update helpers so future relaunch issues are diagnosable.
- Add regression coverage for Linux relaunch spec handling and relaunch failure logging.

