### PR TITLE
Add Apple II lo-res and hi-res graphics rendering

### DIFF
--- a/docs/systems/apple2/overview.md
+++ b/docs/systems/apple2/overview.md
@@ -24,8 +24,8 @@ there is no CIA/VIA equivalent to emulate and no keyboard matrix to scan.
 - Soft switches at `$C000`–`$C0FF`, decoded on bits 7-4 so each switch covers 16 addresses:
     - `$C000` keyboard data (ASCII in bits 6-0) + strobe (bit 7).
     - `$C010` clears the strobe.
-    - `$C050`–`$C057` display-mode switches tracked as state (text/graphics, mixed, page 1/2,
-      lo-res/hi-res).
+    - `$C050`–`$C057` display-mode switches (text/graphics, mixed, page 1/2, lo-res/hi-res),
+      honored by the rasterizer render path.
     - `$C030` speaker toggle counted but silent.
 - Empty peripheral slots at `$C100`–`$CFFF` read as `$FF`, which makes the Autostart ROM's disk
   scan fail cleanly so it falls through to BASIC.
@@ -37,13 +37,21 @@ there is no CIA/VIA equivalent to emulate and no keyboard matrix to scan.
     - Normal (`$80`–`$FF`), inverse (`$00`–`$3F`) and flashing (`$40`–`$7F`) video; flashing
       alternates at roughly 2 Hz.
     - Uppercase-only 64-glyph character set, matching the Apple II / II Plus character generator.
-- Monochrome display with a selectable phosphor colour (green, white, amber).
-- Pixel-exact render path (`Apple2Rasterizer`, the default): draws every cell from the real 5&times;7
-  dot patterns in the character generator ROM, in two compositing layers.
+- Lo-res graphics (GR): the active text page reinterpreted as 40&times;48 colour blocks (two
+  stacked 4-bit colours per screen byte), rendered with the 16-colour lo-res palette.
+- Hi-res graphics (HGR): 280&times;192 monochrome dot pattern from page 1 (`$2000`) or page 2
+  (`$4000`), with the same interleaved line addressing as real hardware
+  (`offset = (y % 8) * $400 + ((y / 8) % 8) * $80 + (y / 64) * $28`). Bit 7 of each byte (the
+  NTSC colour-shift bit) is ignored — no colour model yet.
+- Mixed mode: graphics with the bottom 4 text rows, for both lo-res and hi-res.
+- Monochrome text/hi-res display with a selectable phosphor colour (green, white, amber).
+- Pixel-exact render path (`Apple2Rasterizer`, the default): draws text cells from the real 5&times;7
+  dot patterns in the character generator ROM and all graphics modes, in two compositing layers.
 - Lightweight glyph command-stream render path (`Apple2VideoCommandStream`) for hosts that draw
   characters rather than pixels. It renders on an 8-pixel grid using a host font, so on a host
-  with fixed 8&times;8 cells it overflows the 280-pixel display slightly — prefer the rasterizer
-  for a faithful picture.
+  with fixed 8&times;8 cells it overflows the 280-pixel display slightly — and its glyph command
+  vocabulary cannot express pixel graphics, so it always shows the text page. Prefer the
+  rasterizer for a faithful picture and for graphics modes.
 - Host-agnostic input handling — host key to ASCII with Shift and Control, plus typematic
   auto-repeat.
 - CTRL-RESET (warm reset through the reset vector, like the RESET key on the real keyboard)
@@ -76,8 +84,8 @@ For general monitor commands, see [Monitor library](../../libraries/core/dotnet6
 
 ## Not yet implemented
 
-- Graphics modes. The lo-res (GR) and hi-res (HGR) soft switches are tracked but the display
-  always renders the text page.
+- Hi-res colour. Hi-res renders as the monochrome dot pattern in the configured phosphor
+  colour; the NTSC artifact colours (bit 7 + column parity) are not modelled.
 - Audio. `$C030` speaker toggles are counted but not turned into sound.
 - Disk II — the controller is software-driven and is a large, separate effort.
 - Peripheral slots, cassette, paddles and game-port input, light pen.

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2Config.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2Config.cs
@@ -22,6 +22,14 @@ public class Apple2Config
     public const int DrawableAreaHeight = Rows * CharacterHeight;  // 192
 
     /// <summary>
+    /// In mixed mode ($C053) the bottom 4 text rows stay text while graphics fill the area above
+    /// them (160 scan lines).
+    /// </summary>
+    public const int MixedModeTextRows = 4;
+    public const int MixedModeFirstTextRow = Rows - MixedModeTextRows;                  // 20
+    public const int MixedModeGraphicsHeight = MixedModeFirstTextRow * CharacterHeight; // 160
+
+    /// <summary>
     /// The Apple II video signal has no separately coloured border area like the VIC-I or
     /// VIC-II — the text field fills the active display.
     /// </summary>

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2SoftSwitches.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2SoftSwitches.cs
@@ -9,8 +9,8 @@ namespace Highbyte.DotNet6502.Systems.Apple2.Peripherals;
 /// $C000-$C07F are decoded on bits 7-4 only (each switch occupies 16 consecutive addresses),
 /// which is why software may equivalently use e.g. $C010 or $C01F to clear the keyboard strobe.
 ///
-/// v1 scope: keyboard ($C000 / $C010), display-mode switches tracked as state, everything else
-/// answering as unconnected. Nothing here generates an interrupt — the machine has no timer.
+/// Scope: keyboard ($C000 / $C010), display-mode switches, everything else answering as
+/// unconnected. Nothing here generates an interrupt — the machine has no timer.
 /// </summary>
 public class Apple2SoftSwitches
 {
@@ -50,7 +50,7 @@ public class Apple2SoftSwitches
         _keyboard = keyboard;
     }
 
-    /// <summary>Text mode ($C051) vs. graphics mode ($C050). v1 always renders the text page.</summary>
+    /// <summary>Text mode ($C051) vs. graphics mode ($C050).</summary>
     public bool TextMode { get; private set; } = true;
 
     /// <summary>Mixed text/graphics ($C053) vs. full screen ($C052).</summary>
@@ -59,7 +59,7 @@ public class Apple2SoftSwitches
     /// <summary>Display page 2 ($C055) vs. page 1 ($C054).</summary>
     public bool Page2 { get; private set; }
 
-    /// <summary>Hi-res ($C057) vs. lo-res ($C056) graphics. Tracked only; no graphics in v1.</summary>
+    /// <summary>Hi-res ($C057) vs. lo-res ($C056) graphics.</summary>
     public bool HiRes { get; private set; }
 
     /// <summary>Number of $C030 accesses. A speaker/audio provider would consume this.</summary>
@@ -69,6 +69,11 @@ public class Apple2SoftSwitches
     public ushort ActiveTextPageBaseAddress => Page2
         ? Video.Apple2TextScreen.TextPage2BaseAddress
         : Video.Apple2TextScreen.TextPage1BaseAddress;
+
+    /// <summary>Base address of the hi-res page the display switches currently select.</summary>
+    public ushort ActiveHiResPageBaseAddress => Page2
+        ? Video.Apple2HiResScreen.HiResPage2BaseAddress
+        : Video.Apple2HiResScreen.HiResPage1BaseAddress;
 
     /// <summary>Wires the I/O page and slot space into the memory map.</summary>
     public void MapIOLocations(Memory mem)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Render/Apple2Rasterizer.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Render/Apple2Rasterizer.cs
@@ -9,14 +9,19 @@ using Apple2System = Highbyte.DotNet6502.Systems.Apple2.Apple2;
 namespace Highbyte.DotNet6502.Systems.Apple2.Render;
 
 /// <summary>
-/// Pixel-exact Apple II text renderer: draws each character cell from the real 5x7 dot patterns
-/// in the character generator ROM, into the hardware's 7x8 cell and 280x192 display.
+/// Pixel-exact Apple II renderer for the 280x192 display, honoring the display soft switches:
+/// 40x24 text (each cell drawn from the real 5x7 dot patterns in the character generator ROM),
+/// lo-res 40x48 color blocks, hi-res 280x192 monochrome with page flipping ($2000/$4000), and
+/// mixed mode (graphics with the bottom 4 text rows).
+///
+/// Hi-res is rendered as the monochrome dot pattern (bit 7, the NTSC color-shift bit, is
+/// ignored) in the configured monitor color; lo-res uses the 16-color lo-res palette.
 ///
 /// Two layers, matching the VIC-20 rasterizer: layer 0 is the background, layer 1 the lit
 /// pixels (transparent where unlit) so hosts can composite them.
 /// </summary>
 [DisplayName("Rasterizer")]
-[HelpText("Renders the Apple II text screen as exact pixels using the character generator ROM.")]
+[HelpText("Renders the Apple II text and graphics modes as exact pixels.")]
 public sealed class Apple2Rasterizer : IRenderProvider, IVideoFrameLayerProvider
 {
     private readonly Apple2System _apple2;
@@ -140,15 +145,34 @@ public sealed class Apple2Rasterizer : IRenderProvider, IVideoFrameLayerProvider
         Array.Fill(_backBackground, background);
         Array.Clear(_backForeground);
 
+        var switches = _apple2.SoftSwitches;
+        if (switches.TextMode)
+        {
+            RasterizeTextRows(0, Apple2Config.Rows, foreground, background);
+            return;
+        }
+
+        var graphicsHeight = switches.MixedMode ? Apple2Config.MixedModeGraphicsHeight : NativeSize.Height;
+        if (switches.HiRes)
+            RasterizeHiRes(graphicsHeight, foreground, background);
+        else
+            RasterizeLoRes(graphicsHeight, background);
+
+        if (switches.MixedMode)
+            RasterizeTextRows(Apple2Config.MixedModeFirstTextRow, Apple2Config.Rows, foreground, background);
+    }
+
+    private void RasterizeTextRows(int firstRow, int rowsEnd, uint foreground, uint background)
+    {
         var characterRom = _apple2.CharacterRom;
         if (characterRom == null)
-            return;   // No character generator: a blank screen rather than garbage.
+            return;   // No character generator: blank text rows rather than garbage.
 
         var mem = _apple2.Mem;
         var pageBaseAddress = _apple2.SoftSwitches.ActiveTextPageBaseAddress;
         var flashInverted = FlashPhaseInverted;
 
-        for (var row = 0; row < Apple2Config.Rows; row++)
+        for (var row = firstRow; row < rowsEnd; row++)
         {
             var rowStartAddress = Apple2TextScreen.GetRowStartAddress(row, pageBaseAddress);
             var cellPixelY = row * Apple2Config.CharacterHeight;
@@ -185,6 +209,65 @@ public sealed class Apple2Rasterizer : IRenderProvider, IVideoFrameLayerProvider
                     }
                 }
             }
+        }
+    }
+
+    private void RasterizeHiRes(int lines, uint foreground, uint background)
+    {
+        var mem = _apple2.Mem;
+        var pageBaseAddress = _apple2.SoftSwitches.ActiveHiResPageBaseAddress;
+
+        for (var y = 0; y < lines; y++)
+        {
+            var lineStartAddress = Apple2HiResScreen.GetLineStartAddress(y, pageBaseAddress);
+            var rowOffset = y * NativeSize.Width;
+
+            for (var byteIndex = 0; byteIndex < Apple2HiResScreen.BytesPerLine; byteIndex++)
+            {
+                var screenByte = mem[(ushort)(lineStartAddress + byteIndex)];
+                var pixelX = byteIndex * Apple2HiResScreen.PixelsPerByte;
+
+                for (var bit = 0; bit < Apple2HiResScreen.PixelsPerByte; bit++)
+                {
+                    var lit = ((screenByte >> bit) & 0x01) != 0;
+                    SetRasterPixel(rowOffset + pixelX + bit, background, lit ? foreground : background);
+                }
+            }
+        }
+    }
+
+    private void RasterizeLoRes(int graphicsHeight, uint background)
+    {
+        var mem = _apple2.Mem;
+        var pageBaseAddress = _apple2.SoftSwitches.ActiveTextPageBaseAddress;
+        var textRows = graphicsHeight / Apple2Config.CharacterHeight;
+
+        for (var row = 0; row < textRows; row++)
+        {
+            var rowStartAddress = Apple2TextScreen.GetRowStartAddress(row, pageBaseAddress);
+            var cellPixelY = row * Apple2Config.CharacterHeight;
+
+            for (var col = 0; col < Apple2Config.Cols; col++)
+            {
+                var screenByte = mem[(ushort)(rowStartAddress + col)];
+                var cellPixelX = col * Apple2LoResScreen.BlockPixelWidth;
+
+                RasterizeLoResBlock(screenByte, upperBlock: true, cellPixelX, cellPixelY, background);
+                RasterizeLoResBlock(screenByte, upperBlock: false, cellPixelX, cellPixelY + Apple2LoResScreen.BlockPixelHeight, background);
+            }
+        }
+    }
+
+    private void RasterizeLoResBlock(byte screenByte, bool upperBlock, int pixelX, int pixelY, uint background)
+    {
+        var color = Apple2LoResScreen.Palette[Apple2LoResScreen.GetColorIndex(screenByte, upperBlock)];
+        var packedColor = PackBgra(color.B, color.G, color.R, color.A);
+
+        for (var y = 0; y < Apple2LoResScreen.BlockPixelHeight; y++)
+        {
+            var rowOffset = (pixelY + y) * NativeSize.Width;
+            for (var x = 0; x < Apple2LoResScreen.BlockPixelWidth; x++)
+                SetRasterPixel(rowOffset + pixelX + x, background, packedColor);
         }
     }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Render/Apple2VideoCommandStream.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Render/Apple2VideoCommandStream.cs
@@ -12,8 +12,9 @@ namespace Highbyte.DotNet6502.Systems.Apple2.Render;
 /// of the active 40x24 text page, resolving the interleaved row addressing and the
 /// inverse/flash attributes carried in bits 7-6 of each screen byte.
 ///
-/// v1 always renders the text page, even while the display soft switches select a graphics
-/// mode — the graphics modes themselves are not emulated yet.
+/// The glyph command vocabulary cannot express pixel graphics, so this path always renders the
+/// text page, even while the display soft switches select a graphics mode. Graphics modes are
+/// rendered by the default <see cref="Apple2Rasterizer"/> provider.
 /// </summary>
 [DisplayName("Text Commands")]
 [HelpText("Emits the Apple II 40x24 text page as DrawGlyph video commands.")]

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Video/Apple2HiResScreen.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Video/Apple2HiResScreen.cs
@@ -1,0 +1,56 @@
+namespace Highbyte.DotNet6502.Systems.Apple2.Video;
+
+/// <summary>
+/// Apple II hi-res page addressing.
+///
+/// Like the text page, hi-res scan lines are not laid out linearly. A line's offset from the
+/// page base is <c>(y % 8) * $400 + ((y / 8) % 8) * $80 + (y / 64) * $28</c>: consecutive
+/// scan lines of a character-cell row sit $400 apart, cell rows within a band sit $80 apart,
+/// and the three 64-line bands sit $28 apart. Each 128-byte block ends with 8 unused
+/// "screen hole" bytes, exactly as on the text page.
+///
+/// Each of the 40 bytes on a line carries 7 pixels in bits 0-6, bit 0 leftmost. Bit 7 is the
+/// NTSC color-shift bit and does not affect which pixels are lit.
+/// </summary>
+public static class Apple2HiResScreen
+{
+    public const int BytesPerLine = 40;
+    public const int Lines = 192;
+    public const int PixelsPerByte = 7;
+
+    /// <summary>Hi-res page 1 base address ($2000-$3FFF).</summary>
+    public const ushort HiResPage1BaseAddress = 0x2000;
+
+    /// <summary>Hi-res page 2 base address ($4000-$5FFF).</summary>
+    public const ushort HiResPage2BaseAddress = 0x4000;
+
+    /// <summary>Size of a hi-res page, including the unused screen-hole bytes.</summary>
+    public const int HiResPageSize = 0x2000;
+
+    private static readonly ushort[] s_lineOffsets = BuildLineOffsets();
+
+    private static ushort[] BuildLineOffsets()
+    {
+        var offsets = new ushort[Lines];
+        for (var y = 0; y < Lines; y++)
+            offsets[y] = (ushort)(((y % 8) * 0x400) + (((y / 8) % 8) * 0x80) + ((y / 64) * 0x28));
+        return offsets;
+    }
+
+    /// <summary>Offset of a scan line from the start of its hi-res page.</summary>
+    public static ushort GetLineOffset(int y)
+    {
+        ValidateLine(y);
+        return s_lineOffsets[y];
+    }
+
+    /// <summary>Address of the first byte of a scan line.</summary>
+    public static ushort GetLineStartAddress(int y, ushort pageBaseAddress = HiResPage1BaseAddress)
+        => (ushort)(pageBaseAddress + GetLineOffset(y));
+
+    private static void ValidateLine(int y)
+    {
+        if (y < 0 || y >= Lines)
+            throw new ArgumentOutOfRangeException(nameof(y), y, $"Hi-res scan line must be 0-{Lines - 1}.");
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Video/Apple2LoResScreen.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Video/Apple2LoResScreen.cs
@@ -1,0 +1,46 @@
+using System.Drawing;
+
+namespace Highbyte.DotNet6502.Systems.Apple2.Video;
+
+/// <summary>
+/// Apple II lo-res (GR) geometry and colors.
+///
+/// Lo-res reinterprets the active <em>text</em> page: each of the 40x24 screen bytes holds two
+/// vertically stacked 4-bit color blocks — the low nibble is the upper block (even lo-res row),
+/// the high nibble the lower block (odd row) — giving 40x48 blocks of 7x4 display pixels.
+/// </summary>
+public static class Apple2LoResScreen
+{
+    public const int BlockColumns = Apple2TextScreen.Columns;      // 40
+    public const int BlockRows = Apple2TextScreen.Rows * 2;        // 48
+    public const int BlockPixelWidth = 7;
+    public const int BlockPixelHeight = 4;
+
+    /// <summary>
+    /// The 16 lo-res colors, indexed by nibble value. Simplified composite palette (the common
+    /// NTSC-derived RGB approximation); colors 5 and 10 are the same grey on real hardware too.
+    /// </summary>
+    public static readonly Color[] Palette =
+    {
+        Color.FromArgb(255, 0, 0, 0),         //  0 black
+        Color.FromArgb(255, 227, 30, 96),     //  1 magenta
+        Color.FromArgb(255, 96, 78, 189),     //  2 dark blue
+        Color.FromArgb(255, 255, 68, 253),    //  3 purple
+        Color.FromArgb(255, 0, 163, 96),      //  4 dark green
+        Color.FromArgb(255, 156, 156, 156),   //  5 grey 1
+        Color.FromArgb(255, 20, 207, 253),    //  6 medium blue
+        Color.FromArgb(255, 208, 195, 255),   //  7 light blue
+        Color.FromArgb(255, 96, 114, 3),      //  8 brown
+        Color.FromArgb(255, 255, 106, 60),    //  9 orange
+        Color.FromArgb(255, 156, 156, 156),   // 10 grey 2
+        Color.FromArgb(255, 255, 160, 208),   // 11 pink
+        Color.FromArgb(255, 20, 245, 60),     // 12 light green
+        Color.FromArgb(255, 208, 221, 141),   // 13 yellow
+        Color.FromArgb(255, 114, 255, 208),   // 14 aquamarine
+        Color.FromArgb(255, 255, 255, 255),   // 15 white
+    };
+
+    /// <summary>Color index of one of the two blocks in a screen byte.</summary>
+    public static int GetColorIndex(byte screenByte, bool upperBlock)
+        => upperBlock ? screenByte & 0x0F : (screenByte >> 4) & 0x0F;
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2HiResScreenTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2HiResScreenTests.cs
@@ -1,0 +1,48 @@
+using Highbyte.DotNet6502.Systems.Apple2.Video;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
+
+public class Apple2HiResScreenTests
+{
+    [Theory]
+    [InlineData(0, 0x0000)]
+    [InlineData(1, 0x0400)]    // consecutive scan lines of a cell row sit $400 apart
+    [InlineData(7, 0x1C00)]
+    [InlineData(8, 0x0080)]    // next cell row within the band
+    [InlineData(63, 0x1F80)]
+    [InlineData(64, 0x0028)]   // second band
+    [InlineData(128, 0x0050)]  // third band
+    [InlineData(191, 0x1FD0)]  // last line
+    public void Line_Offsets_Follow_The_HiRes_Interleave(int y, int expectedOffset)
+    {
+        Assert.Equal(expectedOffset, Apple2HiResScreen.GetLineOffset(y));
+    }
+
+    [Fact]
+    public void Line_Addresses_Are_Relative_To_The_Page_Base()
+    {
+        Assert.Equal(0x2000, Apple2HiResScreen.GetLineStartAddress(0));
+        Assert.Equal(0x2400, Apple2HiResScreen.GetLineStartAddress(1));
+        Assert.Equal(0x4000, Apple2HiResScreen.GetLineStartAddress(0, Apple2HiResScreen.HiResPage2BaseAddress));
+    }
+
+    [Fact]
+    public void All_Line_Offsets_Are_Distinct_And_Inside_The_Page()
+    {
+        var offsets = Enumerable.Range(0, Apple2HiResScreen.Lines)
+            .Select(Apple2HiResScreen.GetLineOffset)
+            .ToArray();
+
+        Assert.Equal(offsets.Length, offsets.Distinct().Count());
+        Assert.All(offsets, offset =>
+            Assert.InRange(offset, 0, Apple2HiResScreen.HiResPageSize - Apple2HiResScreen.BytesPerLine));
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(192)]
+    public void An_Invalid_Line_Is_Rejected(int y)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Apple2HiResScreen.GetLineOffset(y));
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2LoResScreenTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2LoResScreenTests.cs
@@ -1,0 +1,28 @@
+using Highbyte.DotNet6502.Systems.Apple2.Video;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
+
+public class Apple2LoResScreenTests
+{
+    [Fact]
+    public void The_Low_Nibble_Is_The_Upper_Block_And_The_High_Nibble_The_Lower()
+    {
+        Assert.Equal(0x01, Apple2LoResScreen.GetColorIndex(0xF1, upperBlock: true));
+        Assert.Equal(0x0F, Apple2LoResScreen.GetColorIndex(0xF1, upperBlock: false));
+    }
+
+    [Fact]
+    public void The_Block_Grid_Covers_The_280_By_192_Display()
+    {
+        Assert.Equal(280, Apple2LoResScreen.BlockColumns * Apple2LoResScreen.BlockPixelWidth);
+        Assert.Equal(192, Apple2LoResScreen.BlockRows * Apple2LoResScreen.BlockPixelHeight);
+    }
+
+    [Fact]
+    public void The_Palette_Has_16_Colors_With_Black_First_And_White_Last()
+    {
+        Assert.Equal(16, Apple2LoResScreen.Palette.Length);
+        Assert.Equal(System.Drawing.Color.FromArgb(255, 0, 0, 0), Apple2LoResScreen.Palette[0]);
+        Assert.Equal(System.Drawing.Color.FromArgb(255, 255, 255, 255), Apple2LoResScreen.Palette[15]);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RasterizerGraphicsTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RasterizerGraphicsTests.cs
@@ -1,0 +1,241 @@
+using Highbyte.DotNet6502.Systems.Apple2.Config;
+using Highbyte.DotNet6502.Systems.Apple2.Peripherals;
+using Highbyte.DotNet6502.Systems.Apple2.Render;
+using Highbyte.DotNet6502.Systems.Apple2.Video;
+using Microsoft.Extensions.Logging.Abstractions;
+using Apple2System = Highbyte.DotNet6502.Systems.Apple2.Apple2;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
+
+/// <summary>
+/// Rasterizer tests for the graphics modes (lo-res, hi-res, mixed) selected by the display
+/// soft switches. Text-mode rendering itself is covered by <see cref="Apple2RasterizerTests"/>.
+/// </summary>
+public class Apple2RasterizerGraphicsTests
+{
+    private static Apple2System BuildApple2()
+    {
+        // An all-zero character generator: text cells render blank except inverse video, which
+        // lights the whole 7x8 cell — handy for asserting where text rows land in mixed mode.
+        var romData = new Dictionary<string, byte[]>
+        {
+            { Apple2SystemConfig.CHARGEN_ROM_NAME, new byte[Apple2CharSet.CharacterRomSize] },
+        };
+        return new Apple2System(new Apple2Config(), NullLoggerFactory.Instance, romData);
+    }
+
+    private static Apple2Rasterizer GetRasterizer(Apple2System apple2)
+        => (Apple2Rasterizer)apple2.RenderProvider!;
+
+    /// <summary>
+    /// Fills the text page with normal-video spaces. Unwritten RAM reads as $00, which is an
+    /// <em>inverse</em> '@' — a lit cell — so tests that render text rows must clear first.
+    /// </summary>
+    private static void ClearTextScreen(Apple2System apple2)
+    {
+        var space = Apple2CharSet.FromAscii((byte)' ');
+        for (var row = 0; row < Apple2Config.Rows; row++)
+            for (var col = 0; col < Apple2Config.Cols; col++)
+                apple2.Mem[Apple2TextScreen.GetAddress(row, col)] = space;
+    }
+
+    private static uint PixelAt(Apple2Rasterizer rasterizer, int x, int y)
+        => rasterizer.CurrentFrontLayerBuffers[1].Span[(y * rasterizer.NativeSize.Width) + x];
+
+    private static uint Packed(System.Drawing.Color color)
+        => Apple2Rasterizer.PackBgra(color.B, color.G, color.R, color.A);
+
+    private static uint Foreground(Apple2System apple2)
+        => Packed(Apple2Colors.GetForeground(apple2.Apple2Config.MonitorColor));
+
+    private static void SelectMode(Apple2System apple2, bool text, bool hiRes = false, bool mixed = false, bool page2 = false)
+    {
+        _ = apple2.Mem[text ? Apple2SoftSwitches.TextModeAddress : Apple2SoftSwitches.GraphicsModeAddress];
+        _ = apple2.Mem[hiRes ? Apple2SoftSwitches.HiResModeAddress : Apple2SoftSwitches.LoResModeAddress];
+        _ = apple2.Mem[mixed ? Apple2SoftSwitches.MixedModeOnAddress : Apple2SoftSwitches.MixedModeOffAddress];
+        _ = apple2.Mem[page2 ? Apple2SoftSwitches.TextPage2Address : Apple2SoftSwitches.TextPage1Address];
+    }
+
+    [Fact]
+    public void HiRes_Bits_0_To_6_Map_To_Pixels_Left_To_Right()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = GetRasterizer(apple2);
+        SelectMode(apple2, text: false, hiRes: true);
+
+        apple2.Mem[Apple2HiResScreen.HiResPage1BaseAddress] = 0b0100_0001;   // pixels 0 and 6
+        rasterizer.OnEndFrame();
+
+        var foreground = Foreground(apple2);
+        Assert.Equal(foreground, PixelAt(rasterizer, 0, 0));
+        Assert.Equal(0u, PixelAt(rasterizer, 1, 0));
+        Assert.Equal(0u, PixelAt(rasterizer, 5, 0));
+        Assert.Equal(foreground, PixelAt(rasterizer, 6, 0));
+    }
+
+    [Fact]
+    public void HiRes_Bit_7_Does_Not_Light_Any_Pixel()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = GetRasterizer(apple2);
+        SelectMode(apple2, text: false, hiRes: true);
+
+        apple2.Mem[Apple2HiResScreen.HiResPage1BaseAddress] = 0x80;
+        rasterizer.OnEndFrame();
+
+        for (var x = 0; x < Apple2HiResScreen.PixelsPerByte; x++)
+            Assert.Equal(0u, PixelAt(rasterizer, x, 0));
+    }
+
+    [Fact]
+    public void HiRes_Interleaved_Lines_Land_On_The_Right_Scan_Lines()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = GetRasterizer(apple2);
+        SelectMode(apple2, text: false, hiRes: true);
+
+        // Line 1 lives at $2400, not 40 bytes into the page.
+        apple2.Mem[Apple2HiResScreen.GetLineStartAddress(1)] = 0x01;
+        rasterizer.OnEndFrame();
+
+        Assert.NotEqual(0u, PixelAt(rasterizer, 0, 1));
+        for (var y = 0; y < Apple2HiResScreen.Lines; y++)
+            if (y != 1)
+                Assert.Equal(0u, PixelAt(rasterizer, 0, y));
+    }
+
+    [Fact]
+    public void HiRes_Second_Byte_Of_A_Line_Starts_At_Pixel_7()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = GetRasterizer(apple2);
+        SelectMode(apple2, text: false, hiRes: true);
+
+        apple2.Mem[Apple2HiResScreen.HiResPage1BaseAddress + 1] = 0x01;
+        rasterizer.OnEndFrame();
+
+        Assert.Equal(0u, PixelAt(rasterizer, 6, 0));
+        Assert.NotEqual(0u, PixelAt(rasterizer, 7, 0));
+    }
+
+    [Fact]
+    public void The_Page2_Soft_Switch_Flips_Between_The_HiRes_Pages()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = GetRasterizer(apple2);
+        SelectMode(apple2, text: false, hiRes: true);
+
+        apple2.Mem[Apple2HiResScreen.HiResPage2BaseAddress] = 0x01;
+        rasterizer.OnEndFrame();
+        Assert.Equal(0u, PixelAt(rasterizer, 0, 0));   // page 1 is blank
+
+        _ = apple2.Mem[Apple2SoftSwitches.TextPage2Address];
+        rasterizer.OnEndFrame();
+        Assert.NotEqual(0u, PixelAt(rasterizer, 0, 0));
+
+        _ = apple2.Mem[Apple2SoftSwitches.TextPage1Address];
+        rasterizer.OnEndFrame();
+        Assert.Equal(0u, PixelAt(rasterizer, 0, 0));
+    }
+
+    [Fact]
+    public void LoRes_Renders_Both_Nibbles_As_Stacked_7x4_Color_Blocks()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = GetRasterizer(apple2);
+        SelectMode(apple2, text: false, hiRes: false);
+
+        // Upper block magenta (1), lower block white (15).
+        apple2.Mem[Apple2TextScreen.GetAddress(0, 0)] = 0xF1;
+        rasterizer.OnEndFrame();
+
+        var magenta = Packed(Apple2LoResScreen.Palette[1]);
+        var white = Packed(Apple2LoResScreen.Palette[15]);
+        for (var x = 0; x < Apple2LoResScreen.BlockPixelWidth; x++)
+        {
+            for (var y = 0; y < Apple2LoResScreen.BlockPixelHeight; y++)
+            {
+                Assert.Equal(magenta, PixelAt(rasterizer, x, y));
+                Assert.Equal(white, PixelAt(rasterizer, x, y + Apple2LoResScreen.BlockPixelHeight));
+            }
+        }
+
+        // The neighbouring cell is black (memory reads 0), i.e. transparent foreground.
+        Assert.Equal(0u, PixelAt(rasterizer, Apple2LoResScreen.BlockPixelWidth, 0));
+    }
+
+    [Fact]
+    public void LoRes_Black_Blocks_Leave_The_Foreground_Transparent()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = GetRasterizer(apple2);
+        SelectMode(apple2, text: false, hiRes: false);
+
+        apple2.Mem[Apple2TextScreen.GetAddress(0, 0)] = 0x00;
+        rasterizer.OnEndFrame();
+
+        Assert.Equal(0u, PixelAt(rasterizer, 0, 0));
+        Assert.Equal(Packed(Apple2Colors.Background),
+            rasterizer.CurrentFrontLayerBuffers[0].Span[0]);
+    }
+
+    [Fact]
+    public void Mixed_Mode_Renders_Graphics_Above_The_Bottom_Four_Text_Rows()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = GetRasterizer(apple2);
+        SelectMode(apple2, text: false, hiRes: true, mixed: true);
+        ClearTextScreen(apple2);
+
+        // Hi-res data on the last graphics line and on the first line of the text area.
+        apple2.Mem[Apple2HiResScreen.GetLineStartAddress(Apple2Config.MixedModeGraphicsHeight - 1)] = 0x01;
+        apple2.Mem[Apple2HiResScreen.GetLineStartAddress(Apple2Config.MixedModeGraphicsHeight)] = 0x01;
+        // An inverse space in the first mixed text row lights its whole cell.
+        apple2.Mem[Apple2TextScreen.GetAddress(Apple2Config.MixedModeFirstTextRow, 0)] =
+            Apple2CharSet.FromAscii((byte)' ', Apple2TextAttribute.Inverse);
+
+        rasterizer.OnEndFrame();
+
+        Assert.NotEqual(0u, PixelAt(rasterizer, 0, Apple2Config.MixedModeGraphicsHeight - 1));
+        // The text area shows text, not the hi-res data behind it.
+        var textAreaTop = Apple2Config.MixedModeGraphicsHeight;
+        Assert.Equal(Foreground(apple2), PixelAt(rasterizer, 0, textAreaTop));
+        // A cell without text in the text area is blank even though hi-res memory has data there.
+        Assert.Equal(0u, PixelAt(rasterizer, 8, textAreaTop));
+    }
+
+    [Fact]
+    public void Mixed_LoRes_Stops_The_Blocks_At_The_Text_Area()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = GetRasterizer(apple2);
+        SelectMode(apple2, text: false, hiRes: false, mixed: true);
+
+        // White blocks in the last graphics row and in the first text row's cell.
+        apple2.Mem[Apple2TextScreen.GetAddress(Apple2Config.MixedModeFirstTextRow - 1, 0)] = 0xFF;
+        apple2.Mem[Apple2TextScreen.GetAddress(Apple2Config.MixedModeFirstTextRow, 0)] = 0xFF;
+
+        rasterizer.OnEndFrame();
+
+        Assert.NotEqual(0u, PixelAt(rasterizer, 0, Apple2Config.MixedModeGraphicsHeight - 1));
+        // $FF in the text area is a flashing '?' cell, not two white blocks; assert it is not
+        // rendered as the solid lo-res white the graphics area shows.
+        var white = Packed(Apple2LoResScreen.Palette[15]);
+        Assert.NotEqual(white, PixelAt(rasterizer, 0, Apple2Config.MixedModeGraphicsHeight));
+    }
+
+    [Fact]
+    public void Text_Mode_Ignores_Graphics_Memory()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = GetRasterizer(apple2);
+        SelectMode(apple2, text: true);
+        ClearTextScreen(apple2);
+
+        apple2.Mem[Apple2HiResScreen.HiResPage1BaseAddress] = 0x7F;
+        rasterizer.OnEndFrame();
+
+        for (var x = 0; x < Apple2HiResScreen.PixelsPerByte; x++)
+            Assert.Equal(0u, PixelAt(rasterizer, x, 0));
+    }
+}


### PR DESCRIPTION
## Summary

Makes the Apple II renderer honor the display soft switches, so graphics-mode software is visible. Until now the lo-res (GR) and hi-res (HGR) switches were tracked but the display always rendered the text page.

- **Hi-res (HGR)**: 280x192 monochrome dot pattern in the configured phosphor colour, page 1 (`$2000`) / page 2 (`$4000`) flipping via the PAGE2 soft switch, real interleaved line addressing. Bit 7 (NTSC colour-shift) is ignored — no colour model yet.
- **Lo-res (GR)**: the active text page reinterpreted as 40x48 colour blocks (two stacked 4-bit colours per byte) with the 16-colour lo-res palette.
- **Mixed mode**: graphics with the bottom 4 text rows, for both modes.
- New `Apple2HiResScreen` (line interleave) and `Apple2LoResScreen` (geometry + palette) helpers; `ActiveHiResPageBaseAddress` on the soft switches.
- All rendering is in `Apple2Rasterizer` (the default provider). `Apple2VideoCommandStream` stays text-only — its glyph command vocabulary cannot express pixel graphics (doc comment updated).
- `docs/systems/apple2/overview.md` updated.

## Testing

- 25 new unit tests (hi-res line interleave, lo-res mapping/palette, mode-matrix rasterizer output incl. page flipping and mixed mode); 689 tests pass, solution builds with 0 warnings.
- Live-verified in the Avalonia Desktop app: Applesoft `GR`/`COLOR`/`PLOT`/`HLIN`/`VLIN`, `HGR`/`HPLOT`, `HGR2`, `TEXT` — all render correctly at 60 fps.
- Milestone game verified: **Apple Panic** (Broderbund) is fully playable — binary extracted from a DOS 3.3 `.dsk` with CiderPress II and injected via the remote control server (`mem.loadbin` + `cpu.set`), hi-res gameplay with the mixed-mode score row, keyboard controls working.

Note for existing users: graphics render only with the default **Rasterizer** render provider. A previously saved "Text Commands" provider selection in the Apple II config keeps the display text-only.