### PR TITLE
Add Apple II hi-res NTSC artifact colour

### DIFF
--- a/docs/systems/apple2/overview.md
+++ b/docs/systems/apple2/overview.md
@@ -42,12 +42,19 @@ there is no CIA/VIA equivalent to emulate and no keyboard matrix to scan.
     - Uppercase-only 64-glyph character set, matching the Apple II / II Plus character generator.
 - Lo-res graphics (GR): the active text page reinterpreted as 40&times;48 colour blocks (two
   stacked 4-bit colours per screen byte), rendered with the 16-colour lo-res palette.
-- Hi-res graphics (HGR): 280&times;192 monochrome dot pattern from page 1 (`$2000`) or page 2
-  (`$4000`), with the same interleaved line addressing as real hardware
-  (`offset = (y % 8) * $400 + ((y / 8) % 8) * $80 + (y / 64) * $28`). Bit 7 of each byte (the
-  NTSC colour-shift bit) is ignored — no colour model yet.
+- Hi-res graphics (HGR): 280&times;192 from page 1 (`$2000`) or page 2 (`$4000`), with the same
+  interleaved line addressing as real hardware
+  (`offset = (y % 8) * $400 + ((y / 8) % 8) * $80 + (y / 64) * $28`).
+- Hi-res NTSC artifact colour on a colour monitor: an isolated lit dot takes its colour from the
+  parity of its column across the scan line (violet or green) shifted by bit 7 of its byte (blue
+  or orange), and a dot with a lit neighbour reads as white. These are the six colours Applesoft
+  exposes through `HCOLOR`. The unit of colour is the two-dot colour cycle, so one lit dot tints
+  both of its columns and colour resolution is 140 across rather than 280 — as on the hardware,
+  where the monitor cannot resolve the dots inside a cycle. On the phosphor monitor settings the
+  same dots render as the plain monochrome pattern at the full 280 instead.
 - Mixed mode: graphics with the bottom 4 text rows, for both lo-res and hi-res.
-- Monochrome text/hi-res display with a selectable phosphor colour (green, white, amber).
+- Selectable monitor: a composite colour monitor (the default) or a green, white or amber
+  phosphor monitor. Text is monochrome either way — a colour monitor renders it white.
 - Pixel-exact render path (`Apple2Rasterizer`, the default): draws text cells from the real 5&times;7
   dot patterns in the character generator ROM and all graphics modes, in two compositing layers.
 - Lightweight glyph command-stream render path (`Apple2VideoCommandStream`) for hosts that draw
@@ -104,8 +111,9 @@ For general monitor commands, see [Monitor library](../../libraries/core/dotnet6
 
 ## Not yet implemented
 
-- Hi-res colour. Hi-res renders as the monochrome dot pattern in the configured phosphor
-  colour; the NTSC artifact colours (bit 7 + column parity) are not modelled.
+- NTSC-accurate hi-res colour. The six artifact colours are modelled, but the underlying
+  half-dot shift is not: bit 7 selects a colour rather than moving the dots half a pixel, so
+  colour fringing at black/white boundaries does not appear.
 - Audio. `$C030` speaker toggles are counted but not turned into sound.
 - Disk II writing (the drive is always write-protected), a second drive, ProDOS-ordered `.po`
   images, and nibble/flux (`.nib`/`.woz`) media. See [Disk II](disk2.md) for what is supported.

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/ViewModels/Apple2ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/ViewModels/Apple2ConfigDialogViewModel.cs
@@ -846,11 +846,13 @@ public record RenderProviderOption(Type Type, string DisplayName, string HelpTex
 
 public record RenderTargetOption(Type Type, string DisplayName, string HelpText);
 
-/// <summary>Selectable monitor phosphor colour — a property of the screen, not the machine.</summary>
+/// <summary>Selectable monitor type — a property of the screen, not the machine.</summary>
 public record MonitorColorOption(Apple2MonitorColor MonitorColor, string DisplayName, string HelpText)
 {
     public static readonly IReadOnlyList<MonitorColorOption> All = new[]
     {
+        new MonitorColorOption(Apple2MonitorColor.Color, "Color",
+            "Composite colour monitor: hi-res graphics show NTSC artifact colours."),
         new MonitorColorOption(Apple2MonitorColor.Green, "Green", "Classic green phosphor monitor."),
         new MonitorColorOption(Apple2MonitorColor.White, "White", "White phosphor / composite monochrome monitor."),
         new MonitorColorOption(Apple2MonitorColor.Amber, "Amber", "Amber phosphor monitor."),

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2Config.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2Config.cs
@@ -45,7 +45,7 @@ public class Apple2Config
 
     public float ScreenRefreshFrequencyHz { get; set; } = 59.92f;
 
-    public Apple2MonitorColor MonitorColor { get; set; } = Apple2MonitorColor.Green;
+    public Apple2MonitorColor MonitorColor { get; set; } = Apple2MonitorColor.Color;
 
     public CpuCompatibilityProfile CpuCompatibilityProfile { get; set; } = CpuCompatibilityProfile.StableUnofficial;
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2SystemConfig.cs
@@ -113,7 +113,7 @@ public class Apple2SystemConfig : ISystemConfig
     /// <summary>The Apple II speaker is not emulated yet.</summary>
     public bool AudioEnabled { get; set; } = false;
 
-    private Apple2MonitorColor _monitorColor = Apple2MonitorColor.Green;
+    private Apple2MonitorColor _monitorColor = Apple2MonitorColor.Color;
     public Apple2MonitorColor MonitorColor
     {
         get => _monitorColor;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Render/Apple2Rasterizer.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Render/Apple2Rasterizer.cs
@@ -14,8 +14,10 @@ namespace Highbyte.DotNet6502.Systems.Apple2.Render;
 /// lo-res 40x48 color blocks, hi-res 280x192 monochrome with page flipping ($2000/$4000), and
 /// mixed mode (graphics with the bottom 4 text rows).
 ///
-/// Hi-res is rendered as the monochrome dot pattern (bit 7, the NTSC color-shift bit, is
-/// ignored) in the configured monitor color; lo-res uses the 16-color lo-res palette.
+/// How hi-res is drawn follows the configured monitor: the three phosphor settings render the
+/// raw dot pattern in that phosphor's color (bit 7, the NTSC color-shift bit, is ignored), while
+/// <see cref="Apple2MonitorColor.Color"/> decodes the dots as artifact colors — see
+/// <see cref="Apple2HiResColors"/>. Lo-res uses the 16-color lo-res palette either way.
 ///
 /// Two layers, matching the VIC-20 rasterizer: layer 0 is the background, layer 1 the lit
 /// pixels (transparent where unlit) so hosts can composite them.
@@ -32,6 +34,11 @@ public sealed class Apple2Rasterizer : IRenderProvider, IVideoFrameLayerProvider
     private uint[] _backBackground;
     private uint[] _backForeground;
     private readonly ReadOnlyMemory<uint>[] _cachedLayerBuffers;
+
+    // One hi-res scan line's dot stream, reused per line. Artifact color needs a pixel's
+    // neighbors, which cross byte boundaries, so the whole line is expanded before it is drawn.
+    private readonly bool[] _hiResLineLit = new bool[Apple2Config.DrawableAreaWidth];
+    private readonly bool[] _hiResLineHighBit = new bool[Apple2Config.DrawableAreaWidth];
 
     private int _frameCounter;
 
@@ -135,6 +142,9 @@ public sealed class Apple2Rasterizer : IRenderProvider, IVideoFrameLayerProvider
     public static uint PackBgra(byte b, byte g, byte r, byte a)
         => (uint)(b | (g << 8) | (r << 16) | (a << 24));
 
+    private static uint PackColor(System.Drawing.Color color)
+        => PackBgra(color.B, color.G, color.R, color.A);
+
     private void RasterizeFrame()
     {
         var foregroundArgb = Apple2Colors.GetForeground(_apple2.Apple2Config.MonitorColor);
@@ -214,6 +224,14 @@ public sealed class Apple2Rasterizer : IRenderProvider, IVideoFrameLayerProvider
 
     private void RasterizeHiRes(int lines, uint foreground, uint background)
     {
+        if (Apple2Colors.IsColorMonitor(_apple2.Apple2Config.MonitorColor))
+            RasterizeHiResColor(lines, background);
+        else
+            RasterizeHiResMonochrome(lines, foreground, background);
+    }
+
+    private void RasterizeHiResMonochrome(int lines, uint foreground, uint background)
+    {
         var mem = _apple2.Mem;
         var pageBaseAddress = _apple2.SoftSwitches.ActiveHiResPageBaseAddress;
 
@@ -232,6 +250,71 @@ public sealed class Apple2Rasterizer : IRenderProvider, IVideoFrameLayerProvider
                     var lit = ((screenByte >> bit) & 0x01) != 0;
                     SetRasterPixel(rowOffset + pixelX + bit, background, lit ? foreground : background);
                 }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Draws hi-res as a color monitor decodes it. The unit is the color cycle — two dots — not
+    /// the dot, because a monitor's chroma bandwidth is far below the 7.16 MHz dot rate and it
+    /// cannot resolve the dots inside a cycle. So a lit dot colors both columns of its cycle,
+    /// which is what makes a colored area continuous instead of a comb of dots and black gaps,
+    /// and why color resolution is 140 across rather than 280.
+    ///
+    /// White is still decided per dot: two adjacent lit dots cover a whole cycle and read as a
+    /// white blob two columns wide, rather than widening to the four columns of both cycles they
+    /// happen to straddle.
+    /// </summary>
+    private void RasterizeHiResColor(int lines, uint background)
+    {
+        var mem = _apple2.Mem;
+        var pageBaseAddress = _apple2.SoftSwitches.ActiveHiResPageBaseAddress;
+
+        var white = PackColor(Apple2HiResColors.White);
+        Span<uint> artifactColors = stackalloc uint[4];
+        for (var i = 0; i < artifactColors.Length; i++)
+            artifactColors[i] = PackColor(Apple2HiResColors.GetArtifactColor(column: i & 1, highBitSet: i >= 2));
+
+        var lit = _hiResLineLit;
+        var highBit = _hiResLineHighBit;
+        var width = lit.Length;
+
+        for (var y = 0; y < lines; y++)
+        {
+            var lineStartAddress = Apple2HiResScreen.GetLineStartAddress(y, pageBaseAddress);
+
+            for (var byteIndex = 0; byteIndex < Apple2HiResScreen.BytesPerLine; byteIndex++)
+            {
+                var screenByte = mem[(ushort)(lineStartAddress + byteIndex)];
+                var byteHighBit = (screenByte & 0x80) != 0;
+                var pixelX = byteIndex * Apple2HiResScreen.PixelsPerByte;
+
+                for (var bit = 0; bit < Apple2HiResScreen.PixelsPerByte; bit++)
+                {
+                    lit[pixelX + bit] = ((screenByte >> bit) & 0x01) != 0;
+                    highBit[pixelX + bit] = byteHighBit;
+                }
+            }
+
+            var rowOffset = y * NativeSize.Width;
+            for (var even = 0; even < width; even += 2)
+            {
+                var odd = even + 1;
+
+                // A lit dot next to another lit dot covers a whole cycle on its own: white.
+                var evenIsWhite = lit[even] && ((even > 0 && lit[even - 1]) || lit[odd]);
+                var oddIsWhite = lit[odd] && (lit[even] || (odd + 1 < width && lit[odd + 1]));
+
+                // Otherwise one lit dot tints the entire cycle. Both dots of a cycle can never be
+                // lit here — that makes them adjacent, so both took the white branch above.
+                var cycleColor = background;
+                if (lit[even] && !evenIsWhite)
+                    cycleColor = artifactColors[highBit[even] ? 2 : 0];
+                else if (lit[odd] && !oddIsWhite)
+                    cycleColor = artifactColors[(highBit[odd] ? 2 : 0) | 1];
+
+                SetRasterPixel(rowOffset + even, background, evenIsWhite ? white : cycleColor);
+                SetRasterPixel(rowOffset + odd, background, oddIsWhite ? white : cycleColor);
             }
         }
     }
@@ -260,8 +343,7 @@ public sealed class Apple2Rasterizer : IRenderProvider, IVideoFrameLayerProvider
 
     private void RasterizeLoResBlock(byte screenByte, bool upperBlock, int pixelX, int pixelY, uint background)
     {
-        var color = Apple2LoResScreen.Palette[Apple2LoResScreen.GetColorIndex(screenByte, upperBlock)];
-        var packedColor = PackBgra(color.B, color.G, color.R, color.A);
+        var packedColor = PackColor(Apple2LoResScreen.Palette[Apple2LoResScreen.GetColorIndex(screenByte, upperBlock)]);
 
         for (var y = 0; y < Apple2LoResScreen.BlockPixelHeight; y++)
         {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Video/Apple2HiResColors.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Video/Apple2HiResColors.cs
@@ -1,0 +1,68 @@
+using System.Drawing;
+
+namespace Highbyte.DotNet6502.Systems.Apple2.Video;
+
+/// <summary>
+/// Hi-res NTSC artifact colors.
+///
+/// The Apple II has no color hi-res mode. It shifts out one dot per pixel at 7.16 MHz, exactly
+/// twice the NTSC color subcarrier, so a repeating dot pattern is indistinguishable from a
+/// chroma signal and a color monitor decodes it as a hue. Which hue depends on where the lit
+/// dot falls in the color cycle, which is the parity of its column across the whole scan line —
+/// not its position within the byte. Because a byte carries 7 pixels and 7 is odd, the same bit
+/// position alternates parity from one byte to the next, which is why a solid violet line is
+/// written as alternating $55 / $2A bytes rather than a run of one value.
+///
+/// Bit 7 of each byte delays that byte's dots by half a dot, moving them into the opposite half
+/// of the color cycle and swapping the pair to blue/orange. Two adjacent lit dots span a full
+/// cycle and read as white regardless of parity.
+///
+/// The six colors are the same signals lo-res produces, so they are taken from the lo-res
+/// palette rather than duplicated — the two cannot drift apart.
+///
+/// A monitor cannot resolve the two dots inside a cycle — its chroma bandwidth is roughly a tenth
+/// of the dot rate — so one lit dot tints its whole cycle and colored areas come out continuous.
+/// Color resolution is therefore 140 across, not 280, which is true of the hardware as well.
+///
+/// This is the simplified model: bit 7 selects the color of a dot rather than actually moving it
+/// half a pixel, so cycles stay aligned to fixed column pairs and the color fringing a real
+/// monitor shows at black/white boundaries does not appear.
+/// </summary>
+public static class Apple2HiResColors
+{
+    // Lo-res palette entries that carry the same chroma phases the hi-res dot patterns generate.
+    private const int LoResBlackIndex = 0;
+    private const int LoResVioletIndex = 3;
+    private const int LoResBlueIndex = 6;
+    private const int LoResOrangeIndex = 9;
+    private const int LoResGreenIndex = 12;
+    private const int LoResWhiteIndex = 15;
+
+    public static Color Black => Apple2LoResScreen.Palette[LoResBlackIndex];
+    public static Color Violet => Apple2LoResScreen.Palette[LoResVioletIndex];
+    public static Color Blue => Apple2LoResScreen.Palette[LoResBlueIndex];
+    public static Color Orange => Apple2LoResScreen.Palette[LoResOrangeIndex];
+    public static Color Green => Apple2LoResScreen.Palette[LoResGreenIndex];
+    public static Color White => Apple2LoResScreen.Palette[LoResWhiteIndex];
+
+    /// <summary>
+    /// Color of an isolated lit dot, indexed by <c>(highBitSet ? 2 : 0) | (oddColumn ? 1 : 0)</c>.
+    /// These are the four colors Applesoft exposes as HCOLOR 1/2 (green/violet) and 5/6
+    /// (orange/blue).
+    /// </summary>
+    private static readonly Color[] s_artifactColors =
+    {
+        Violet,   // even column, bit 7 clear  (HCOLOR=2)
+        Green,    // odd column,  bit 7 clear  (HCOLOR=1)
+        Blue,     // even column, bit 7 set    (HCOLOR=6)
+        Orange,   // odd column,  bit 7 set    (HCOLOR=5)
+    };
+
+    /// <summary>
+    /// Color a lit dot tints its cycle, from its column across the scan line and the color-shift
+    /// bit of the byte it came from. Only meaningful for a dot with no lit neighbor — one that
+    /// has a neighbor covers the cycle by itself and reads as white.
+    /// </summary>
+    public static Color GetArtifactColor(int column, bool highBitSet)
+        => s_artifactColors[(highBitSet ? 2 : 0) | (column & 1)];
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Video/Apple2MonitorColor.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Video/Apple2MonitorColor.cs
@@ -3,25 +3,36 @@ using System.Drawing;
 namespace Highbyte.DotNet6502.Systems.Apple2.Video;
 
 /// <summary>
-/// Phosphor colour of the emulated monitor. The Apple II text display is monochrome — the
-/// colour is a property of the screen it was plugged into, not of the machine.
+/// The kind of display the Apple II is plugged into. The machine emits one composite signal;
+/// what you see depends on the monitor. On a monochrome monitor the hi-res bit stream is just
+/// a dot pattern in the phosphor's color, while a color monitor decodes the same dots as
+/// NTSC artifact colors (see <see cref="Apple2HiResColors"/>).
+///
+/// Serialized numerically, so new members must be appended to keep saved settings stable.
 /// </summary>
 public enum Apple2MonitorColor
 {
     Green,
     White,
     Amber,
+    Color,
 }
 
-/// <summary>Foreground/background colours for the monochrome Apple II text display.</summary>
+/// <summary>Foreground/background colors for the Apple II text display.</summary>
 public static class Apple2Colors
 {
     public static readonly Color Background = Color.FromArgb(255, 0, 0, 0);
+
+    /// <summary>Whether the monitor decodes hi-res dots as NTSC artifact colors.</summary>
+    public static bool IsColorMonitor(Apple2MonitorColor monitorColor)
+        => monitorColor == Apple2MonitorColor.Color;
 
     public static Color GetForeground(Apple2MonitorColor monitorColor) => monitorColor switch
     {
         Apple2MonitorColor.White => Color.FromArgb(255, 255, 255, 255),
         Apple2MonitorColor.Amber => Color.FromArgb(255, 255, 176, 0),
+        // Text has no artifact color of its own — a color monitor renders it white.
+        Apple2MonitorColor.Color => Color.FromArgb(255, 255, 255, 255),
         _ => Color.FromArgb(255, 51, 255, 51),
     };
 }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RasterizerGraphicsTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RasterizerGraphicsTests.cs
@@ -13,7 +13,12 @@ namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
 /// </summary>
 public class Apple2RasterizerGraphicsTests
 {
-    private static Apple2System BuildApple2()
+    /// <summary>
+    /// Defaults to a phosphor monitor so the hi-res tests below see the raw dot pattern. Artifact
+    /// colour, which reinterprets those same dots, is covered by
+    /// <see cref="Apple2RasterizerHiResColorTests"/>.
+    /// </summary>
+    private static Apple2System BuildApple2(Apple2MonitorColor monitorColor = Apple2MonitorColor.Green)
     {
         // An all-zero character generator: text cells render blank except inverse video, which
         // lights the whole 7x8 cell — handy for asserting where text rows land in mixed mode.
@@ -21,7 +26,10 @@ public class Apple2RasterizerGraphicsTests
         {
             { Apple2SystemConfig.CHARGEN_ROM_NAME, new byte[Apple2CharSet.CharacterRomSize] },
         };
-        return new Apple2System(new Apple2Config(), NullLoggerFactory.Instance, romData);
+        return new Apple2System(
+            new Apple2Config { MonitorColor = monitorColor },
+            NullLoggerFactory.Instance,
+            romData);
     }
 
     private static Apple2Rasterizer GetRasterizer(Apple2System apple2)

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RasterizerHiResColorTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RasterizerHiResColorTests.cs
@@ -1,0 +1,306 @@
+using Highbyte.DotNet6502.Systems.Apple2.Config;
+using Highbyte.DotNet6502.Systems.Apple2.Peripherals;
+using Highbyte.DotNet6502.Systems.Apple2.Render;
+using Highbyte.DotNet6502.Systems.Apple2.Video;
+using Microsoft.Extensions.Logging.Abstractions;
+using Apple2System = Highbyte.DotNet6502.Systems.Apple2.Apple2;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
+
+/// <summary>
+/// Hi-res NTSC artifact colour, as decoded by <see cref="Apple2MonitorColor.Color"/>. The
+/// monochrome dot mapping the phosphor monitors use is covered by
+/// <see cref="Apple2RasterizerGraphicsTests"/>.
+/// </summary>
+public class Apple2RasterizerHiResColorTests
+{
+    private static Apple2System BuildApple2(Apple2MonitorColor monitorColor = Apple2MonitorColor.Color)
+    {
+        var romData = new Dictionary<string, byte[]>
+        {
+            { Apple2SystemConfig.CHARGEN_ROM_NAME, new byte[Apple2CharSet.CharacterRomSize] },
+        };
+        return new Apple2System(
+            new Apple2Config { MonitorColor = monitorColor },
+            NullLoggerFactory.Instance,
+            romData);
+    }
+
+    private static Apple2Rasterizer GetRasterizer(Apple2System apple2)
+        => (Apple2Rasterizer)apple2.RenderProvider!;
+
+    private static uint PixelAt(Apple2Rasterizer rasterizer, int x, int y = 0)
+        => rasterizer.CurrentFrontLayerBuffers[1].Span[(y * rasterizer.NativeSize.Width) + x];
+
+    private static uint Packed(System.Drawing.Color color)
+        => Apple2Rasterizer.PackBgra(color.B, color.G, color.R, color.A);
+
+    private static void SelectHiRes(Apple2System apple2, bool mixed = false)
+    {
+        _ = apple2.Mem[Apple2SoftSwitches.GraphicsModeAddress];
+        _ = apple2.Mem[Apple2SoftSwitches.HiResModeAddress];
+        _ = apple2.Mem[mixed ? Apple2SoftSwitches.MixedModeOnAddress : Apple2SoftSwitches.MixedModeOffAddress];
+        _ = apple2.Mem[Apple2SoftSwitches.TextPage1Address];
+    }
+
+    /// <summary>Writes bytes to the start of hi-res line 0 and renders one frame.</summary>
+    private static Apple2Rasterizer RenderLine(Apple2System apple2, params byte[] lineBytes)
+    {
+        var rasterizer = GetRasterizer(apple2);
+        SelectHiRes(apple2);
+        for (var i = 0; i < lineBytes.Length; i++)
+            apple2.Mem[(ushort)(Apple2HiResScreen.HiResPage1BaseAddress + i)] = lineBytes[i];
+        rasterizer.OnEndFrame();
+        return rasterizer;
+    }
+
+    [Fact]
+    public void Isolated_Dots_On_Even_Columns_Are_Violet()
+    {
+        var apple2 = BuildApple2();
+        // $55 lights bits 0,2,4,6 -> columns 0,2,4,6, each with unlit neighbours.
+        var rasterizer = RenderLine(apple2, 0x55);
+
+        var violet = Packed(Apple2HiResColors.Violet);
+        // Each lit dot tints its whole colour cycle, so columns 0-7 are a continuous violet run
+        // rather than violet dots separated by black.
+        for (var x = 0; x <= 7; x++)
+            Assert.Equal(violet, PixelAt(rasterizer, x));
+    }
+
+    [Fact]
+    public void Isolated_Dots_On_Odd_Columns_Are_Green()
+    {
+        var apple2 = BuildApple2();
+        // $2A lights bits 1,3,5 -> columns 1,3,5, tinting the cycles (0,1), (2,3) and (4,5).
+        var rasterizer = RenderLine(apple2, 0x2A);
+
+        var green = Packed(Apple2HiResColors.Green);
+        for (var x = 0; x <= 5; x++)
+            Assert.Equal(green, PixelAt(rasterizer, x));
+        // Nothing is lit in the cycle after it.
+        Assert.Equal(0u, PixelAt(rasterizer, 6));
+        Assert.Equal(0u, PixelAt(rasterizer, 7));
+    }
+
+    /// <summary>
+    /// The unit of colour is the two-dot colour cycle, not the dot — a monitor cannot resolve the
+    /// dots within a cycle. A single lit dot therefore paints two columns.
+    /// </summary>
+    [Fact]
+    public void A_Single_Lit_Dot_Fills_Both_Columns_Of_Its_Color_Cycle()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = RenderLine(apple2, 0x01);   // column 0 only
+
+        var violet = Packed(Apple2HiResColors.Violet);
+        Assert.Equal(violet, PixelAt(rasterizer, 0));
+        Assert.Equal(violet, PixelAt(rasterizer, 1));
+        Assert.Equal(0u, PixelAt(rasterizer, 2));
+    }
+
+    [Fact]
+    public void A_Single_Lit_Dot_On_An_Odd_Column_Fills_Its_Cycle_Backwards()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = RenderLine(apple2, 0x02);   // column 1 only
+
+        var green = Packed(Apple2HiResColors.Green);
+        // Column 1 belongs to the cycle (0,1), so the tint reaches back to column 0.
+        Assert.Equal(green, PixelAt(rasterizer, 0));
+        Assert.Equal(green, PixelAt(rasterizer, 1));
+        Assert.Equal(0u, PixelAt(rasterizer, 2));
+    }
+
+    [Fact]
+    public void Bit_7_Shifts_Violet_To_Blue()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = RenderLine(apple2, 0xD5);   // $55 with the colour-shift bit set
+
+        var blue = Packed(Apple2HiResColors.Blue);
+        for (var x = 0; x <= 7; x++)
+            Assert.Equal(blue, PixelAt(rasterizer, x));
+    }
+
+    [Fact]
+    public void Bit_7_Shifts_Green_To_Orange()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = RenderLine(apple2, 0xAA);   // $2A with the colour-shift bit set
+
+        var orange = Packed(Apple2HiResColors.Orange);
+        for (var x = 0; x <= 5; x++)
+            Assert.Equal(orange, PixelAt(rasterizer, x));
+    }
+
+    [Fact]
+    public void Bit_7_Alone_Still_Lights_Nothing()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = RenderLine(apple2, 0x80);
+
+        for (var x = 0; x < Apple2HiResScreen.PixelsPerByte; x++)
+            Assert.Equal(0u, PixelAt(rasterizer, x));
+    }
+
+    [Fact]
+    public void Adjacent_Dots_Read_As_White()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = RenderLine(apple2, 0x03);   // columns 0 and 1
+
+        var white = Packed(Apple2HiResColors.White);
+        Assert.Equal(white, PixelAt(rasterizer, 0));
+        Assert.Equal(white, PixelAt(rasterizer, 1));
+        Assert.Equal(0u, PixelAt(rasterizer, 2));
+    }
+
+    /// <summary>
+    /// A two-dot run straddling a cycle boundary stays two columns wide. White is decided per dot,
+    /// so it must not spread to all four columns of the two cycles the run touches.
+    /// </summary>
+    [Fact]
+    public void A_White_Run_Across_A_Cycle_Boundary_Does_Not_Widen()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = RenderLine(apple2, 0x06);   // columns 1 and 2
+
+        var white = Packed(Apple2HiResColors.White);
+        Assert.Equal(0u, PixelAt(rasterizer, 0));
+        Assert.Equal(white, PixelAt(rasterizer, 1));
+        Assert.Equal(white, PixelAt(rasterizer, 2));
+        Assert.Equal(0u, PixelAt(rasterizer, 3));
+    }
+
+    [Fact]
+    public void A_Run_Of_Dots_Is_White_All_The_Way_Through()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = RenderLine(apple2, 0x7F);   // all 7 pixels lit
+
+        var white = Packed(Apple2HiResColors.White);
+        for (var x = 0; x < Apple2HiResScreen.PixelsPerByte; x++)
+            Assert.Equal(white, PixelAt(rasterizer, x));
+    }
+
+    [Fact]
+    public void Dots_Adjacent_Across_A_Byte_Boundary_Read_As_White()
+    {
+        var apple2 = BuildApple2();
+        // Last pixel of byte 0 (column 6) and first of byte 1 (column 7).
+        var rasterizer = RenderLine(apple2, 0x40, 0x01);
+
+        var white = Packed(Apple2HiResColors.White);
+        Assert.Equal(white, PixelAt(rasterizer, 6));
+        Assert.Equal(white, PixelAt(rasterizer, 7));
+    }
+
+    /// <summary>
+    /// A byte carries 7 pixels, so the same bit position lands on the opposite column parity in
+    /// the next byte. Two identical bytes therefore produce violet followed by green — which is
+    /// why a solid violet line is written as alternating $55/$2A.
+    /// </summary>
+    [Fact]
+    public void Column_Parity_Continues_Across_Bytes_Rather_Than_Restarting()
+    {
+        var apple2 = BuildApple2();
+        // $15 lights bits 0,2,4 and leaves bit 6 clear, so column 6 stays unlit and the first dot
+        // of the next byte (column 7) has no lit neighbour to turn it white.
+        var rasterizer = RenderLine(apple2, 0x15, 0x15);
+
+        var violet = Packed(Apple2HiResColors.Violet);
+        var green = Packed(Apple2HiResColors.Green);
+        Assert.Equal(violet, PixelAt(rasterizer, 0));
+        // Byte 1 bit 0 is column 7 — odd, so green despite being the same byte value.
+        Assert.Equal(green, PixelAt(rasterizer, 7));
+    }
+
+    [Fact]
+    public void Alternating_55_2A_Bytes_Give_A_Continuous_Violet_Line()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = RenderLine(apple2, 0x55, 0x2A, 0x55, 0x2A);
+
+        var violet = Packed(Apple2HiResColors.Violet);
+        // Every lit dot in the first four bytes lands on an even column, so every colour cycle is
+        // tinted and the run is unbroken — no black gaps between the dots.
+        for (var x = 0; x < 4 * Apple2HiResScreen.PixelsPerByte; x++)
+            Assert.Equal(violet, PixelAt(rasterizer, x));
+    }
+
+    [Fact]
+    public void The_Last_Column_Of_The_Line_Renders_Without_A_Right_Neighbour()
+    {
+        var apple2 = BuildApple2();
+        var lastByte = new byte[Apple2HiResScreen.BytesPerLine];
+        lastByte[^1] = 0x40;   // bit 6 of the final byte == column 279
+        var rasterizer = RenderLine(apple2, lastByte);
+
+        var lastColumn = Apple2Config.DrawableAreaWidth - 1;
+        var green = Packed(Apple2HiResColors.Green);
+        Assert.Equal(green, PixelAt(rasterizer, lastColumn));       // 279 is odd
+        Assert.Equal(green, PixelAt(rasterizer, lastColumn - 1));   // its cycle partner
+    }
+
+    [Fact]
+    public void Unlit_Dots_Leave_The_Foreground_Transparent_Over_A_Black_Background()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = RenderLine(apple2, 0x00);
+
+        Assert.Equal(0u, PixelAt(rasterizer, 0));
+        Assert.Equal(Packed(Apple2Colors.Background), rasterizer.CurrentFrontLayerBuffers[0].Span[0]);
+    }
+
+    [Fact]
+    public void Mixed_Mode_Still_Stops_The_Graphics_At_The_Text_Area()
+    {
+        var apple2 = BuildApple2();
+        var rasterizer = GetRasterizer(apple2);
+        SelectHiRes(apple2, mixed: true);
+
+        apple2.Mem[Apple2HiResScreen.GetLineStartAddress(Apple2Config.MixedModeGraphicsHeight - 1)] = 0x55;
+        apple2.Mem[Apple2HiResScreen.GetLineStartAddress(Apple2Config.MixedModeGraphicsHeight)] = 0x55;
+        rasterizer.OnEndFrame();
+
+        var violet = Packed(Apple2HiResColors.Violet);
+        Assert.Equal(violet, PixelAt(rasterizer, 0, Apple2Config.MixedModeGraphicsHeight - 1));
+        Assert.NotEqual(violet, PixelAt(rasterizer, 0, Apple2Config.MixedModeGraphicsHeight));
+    }
+
+    [Theory]
+    [InlineData(Apple2MonitorColor.Green)]
+    [InlineData(Apple2MonitorColor.White)]
+    [InlineData(Apple2MonitorColor.Amber)]
+    public void Phosphor_Monitors_Keep_Rendering_The_Raw_Dot_Pattern(Apple2MonitorColor monitorColor)
+    {
+        var apple2 = BuildApple2(monitorColor);
+        var rasterizer = RenderLine(apple2, 0x55);
+
+        var foreground = Packed(Apple2Colors.GetForeground(monitorColor));
+        Assert.Equal(foreground, PixelAt(rasterizer, 0));
+        Assert.NotEqual(Packed(Apple2HiResColors.Violet), PixelAt(rasterizer, 0));
+    }
+
+    [Fact]
+    public void A_Color_Monitor_Renders_Text_White()
+    {
+        Assert.Equal(System.Drawing.Color.FromArgb(255, 255, 255, 255),
+            Apple2Colors.GetForeground(Apple2MonitorColor.Color));
+        Assert.True(Apple2Colors.IsColorMonitor(Apple2MonitorColor.Color));
+        Assert.False(Apple2Colors.IsColorMonitor(Apple2MonitorColor.Green));
+    }
+
+    [Fact]
+    public void The_Artifact_Colors_Come_From_The_LoRes_Palette()
+    {
+        // Hi-res artifact colours are the same signals lo-res generates directly.
+        Assert.Equal(Apple2LoResScreen.Palette[0], Apple2HiResColors.Black);
+        Assert.Equal(Apple2LoResScreen.Palette[3], Apple2HiResColors.Violet);
+        Assert.Equal(Apple2LoResScreen.Palette[6], Apple2HiResColors.Blue);
+        Assert.Equal(Apple2LoResScreen.Palette[9], Apple2HiResColors.Orange);
+        Assert.Equal(Apple2LoResScreen.Palette[12], Apple2HiResColors.Green);
+        Assert.Equal(Apple2LoResScreen.Palette[15], Apple2HiResColors.White);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RasterizerTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RasterizerTests.cs
@@ -48,7 +48,12 @@ public class Apple2RasterizerTests
         {
             { Apple2SystemConfig.CHARGEN_ROM_NAME, characterRom ?? BuildTestCharacterRom() },
         };
-        return new Apple2System(new Apple2Config(), NullLoggerFactory.Instance, romData);
+        // Pinned to a phosphor monitor: these tests assert green text, independently of whichever
+        // monitor the shipped config defaults to.
+        return new Apple2System(
+            new Apple2Config { MonitorColor = Apple2MonitorColor.Green },
+            NullLoggerFactory.Instance,
+            romData);
     }
 
     private static Apple2Rasterizer GetRasterizer(Apple2System apple2)

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2SyntheticRomTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2SyntheticRomTests.cs
@@ -22,7 +22,12 @@ public class Apple2SyntheticRomTests
         {
             { Apple2SystemConfig.SYSTEM_ROM_NAME, Apple2SyntheticRom.Build() },
         };
-        return new Apple2System(new Apple2Config(), NullLoggerFactory.Instance, romData);
+        // Pinned to a phosphor monitor so the colour assertions below stay independent of
+        // whichever monitor the shipped config defaults to.
+        return new Apple2System(
+            new Apple2Config { MonitorColor = Apple2MonitorColor.Green },
+            NullLoggerFactory.Instance,
+            romData);
     }
 
     /// <summary>The rasterizer is the default provider, so select the command stream explicitly.</summary>


### PR DESCRIPTION
Decodes the Apple II hi-res dot stream as colour on a composite monitor, so hi-res titles render in colour instead of monochrome. That is nearly the whole Apple II games library — including every entry in the Download & Run list (Apple Panic, Lode Runner, Choplifter, Bolo). Only lo-res titles, a thin slice of mostly 1979-80 BASIC games, had any colour before.

Monochrome hi-res is not simply a desaturated version of the colour image: Apple II green and violet are alternating-column dot patterns, so an object authored as solid colour rendered as a 50%-density dotted stripe.

Implements the colour work item deferred as optional when hi-res shipped in #265.

## What it does

- **`Apple2HiResColors`** — the six artifact colours, read from `Apple2LoResScreen.Palette` (indices 0/3/6/9/12/15) rather than duplicated. They are the same signals lo-res generates directly, so sourcing them from one place keeps the two palettes from drifting.
- **`Apple2Rasterizer`** — a colour path beside the unchanged monochrome one. The unit of colour is the two-dot **colour cycle**, not the dot: a monitor's chroma bandwidth is roughly a tenth of the 7.16 MHz dot rate and cannot resolve dots within a cycle, so one lit dot tints both of its columns and colour resolution is 140 across — as on the hardware. White stays per-dot, which keeps a two-dot run two columns wide instead of spreading over both cycles it straddles.
- **Colour parity is per scan line, not per byte.** A byte carries 7 pixels and 7 is odd, so the same bit position flips parity in the next byte — which is why a solid violet line is written as alternating `$55`/`$2A`. Pinned by a test, since a per-byte implementation looks correct on single-byte test data and wrong on real content.
- **Exposed as a fourth entry in the existing monitor-colour setting** rather than a new toggle, since that setting already models the screen rather than the machine. Colour is now the default; the enum serializes numerically, so the member is appended and existing saved settings are unaffected.

## Not modelled

The half-dot shift: bit 7 selects a colour rather than moving the dots half a pixel, so the colour fringing a real monitor shows at black/white boundaries does not appear. Reproducing it means expanding each scan line to a 560 half-dot bitstream, which changes `NativeSize` and would need per-host verification across Avalonia, Skia and browser.

Lo-res desaturation on the phosphor settings is also left alone — lo-res currently shows all 16 colours regardless of monitor, which is wrong on hardware and is made more visible by this change. Noted as a follow-up.

## Verification

Tests: 23 covering artifact colour; 781 of 782 pass in `Systems.Tests`. The one failure, `Injected_Basic_Program_Runs_And_Lists`, is pre-existing and fails identically on master at 38ef4897. Build is clean with 0 warnings.

Three existing fixtures needed their monitor pinned explicitly — they asserted green text or raw dot patterns while building machines from the default config, so changing the default broke them. That is the intended blast radius of a default change.

Verified against the running Avalonia app on the emulator's **native 280x192 framebuffer** (not a downscaled window capture, which blurs exactly the artifact this needs to show):

| Applesoft | rendered | black columns |
|---|---|---|
| `HCOLOR=1` | green `(20,245,60)` | 0 / 280 |
| `HCOLOR=2` | violet `(255,68,253)` | 0 / 280 |
| `HCOLOR=3` | white | 0 / 280 |
| `HCOLOR=5` | orange `(255,106,60)` | 0 / 280 |
| `HCOLOR=6` | blue `(20,207,253)` | 0 / 280 |

Matching the documented Applesoft `HCOLOR` mapping confirms the column parity is not inverted. On a real Lode Runner frame booted from disk: 1,563 non-white colour runs, none narrower than one colour cycle.