### PR TITLE
Fix lo-res ignoring the monitor, and make opt-in ROM tests skip visibly

### DIFF
--- a/docs/systems/apple2/overview.md
+++ b/docs/systems/apple2/overview.md
@@ -41,7 +41,10 @@ there is no CIA/VIA equivalent to emulate and no keyboard matrix to scan.
       alternates at roughly 2 Hz.
     - Uppercase-only 64-glyph character set, matching the Apple II / II Plus character generator.
 - Lo-res graphics (GR): the active text page reinterpreted as 40&times;48 colour blocks (two
-  stacked 4-bit colours per screen byte), rendered with the 16-colour lo-res palette.
+  stacked 4-bit colours per screen byte), rendered with the 16-colour lo-res palette on a colour
+  monitor. A phosphor monitor has no chroma to show, so the same blocks arrive as shades of its
+  phosphor — which means colours of equal brightness become indistinguishable, exactly as on the
+  hardware.
 - Hi-res graphics (HGR): 280&times;192 from page 1 (`$2000`) or page 2 (`$4000`), with the same
   interleaved line addressing as real hardware
   (`offset = (y % 8) * $400 + ((y / 8) % 8) * $80 + (y / 64) * $28`).
@@ -54,7 +57,9 @@ there is no CIA/VIA equivalent to emulate and no keyboard matrix to scan.
   same dots render as the plain monochrome pattern at the full 280 instead.
 - Mixed mode: graphics with the bottom 4 text rows, for both lo-res and hi-res.
 - Selectable monitor: a composite colour monitor (the default) or a green, white or amber
-  phosphor monitor. Text is monochrome either way — a colour monitor renders it white.
+  phosphor monitor. The choice applies to every mode, not just hi-res: text is monochrome either
+  way (a colour monitor renders it white), and lo-res is full colour on a colour monitor and
+  phosphor-tinted luminance on a monochrome one.
 - Pixel-exact render path (`Apple2Rasterizer`, the default): draws text cells from the real 5&times;7
   dot patterns in the character generator ROM and all graphics modes, in two compositing layers.
 - Lightweight glyph command-stream render path (`Apple2VideoCommandStream`) for hosts that draw

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Render/Apple2Rasterizer.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Render/Apple2Rasterizer.cs
@@ -17,7 +17,8 @@ namespace Highbyte.DotNet6502.Systems.Apple2.Render;
 /// How hi-res is drawn follows the configured monitor: the three phosphor settings render the
 /// raw dot pattern in that phosphor's color (bit 7, the NTSC color-shift bit, is ignored), while
 /// <see cref="Apple2MonitorColor.Color"/> decodes the dots as artifact colors — see
-/// <see cref="Apple2HiResColors"/>. Lo-res uses the 16-color lo-res palette either way.
+/// <see cref="Apple2HiResColors"/>. Lo-res uses the 16-color palette on a color monitor and the
+/// same colors reduced to phosphor-tinted luminance on a monochrome one.
 ///
 /// Two layers, matching the VIC-20 rasterizer: layer 0 is the background, layer 1 the lit
 /// pixels (transparent where unlit) so hosts can composite them.
@@ -39,6 +40,9 @@ public sealed class Apple2Rasterizer : IRenderProvider, IVideoFrameLayerProvider
     // neighbors, which cross byte boundaries, so the whole line is expanded before it is drawn.
     private readonly bool[] _hiResLineLit = new bool[Apple2Config.DrawableAreaWidth];
     private readonly bool[] _hiResLineHighBit = new bool[Apple2Config.DrawableAreaWidth];
+
+    // The lo-res palette as the configured monitor displays it, rebuilt per frame.
+    private readonly uint[] _loResPalette = new uint[16];
 
     private int _frameCounter;
 
@@ -321,6 +325,10 @@ public sealed class Apple2Rasterizer : IRenderProvider, IVideoFrameLayerProvider
 
     private void RasterizeLoRes(int graphicsHeight, uint background)
     {
+        var monitorColor = _apple2.Apple2Config.MonitorColor;
+        for (var i = 0; i < _loResPalette.Length; i++)
+            _loResPalette[i] = PackColor(Apple2Colors.ApplyMonitor(Apple2LoResScreen.Palette[i], monitorColor));
+
         var mem = _apple2.Mem;
         var pageBaseAddress = _apple2.SoftSwitches.ActiveTextPageBaseAddress;
         var textRows = graphicsHeight / Apple2Config.CharacterHeight;
@@ -343,7 +351,7 @@ public sealed class Apple2Rasterizer : IRenderProvider, IVideoFrameLayerProvider
 
     private void RasterizeLoResBlock(byte screenByte, bool upperBlock, int pixelX, int pixelY, uint background)
     {
-        var packedColor = PackColor(Apple2LoResScreen.Palette[Apple2LoResScreen.GetColorIndex(screenByte, upperBlock)]);
+        var packedColor = _loResPalette[Apple2LoResScreen.GetColorIndex(screenByte, upperBlock)];
 
         for (var y = 0; y < Apple2LoResScreen.BlockPixelHeight; y++)
         {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Video/Apple2MonitorColor.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Video/Apple2MonitorColor.cs
@@ -27,6 +27,26 @@ public static class Apple2Colors
     public static bool IsColorMonitor(Apple2MonitorColor monitorColor)
         => monitorColor == Apple2MonitorColor.Color;
 
+    /// <summary>
+    /// What the monitor makes of a colour signal. A colour monitor shows it as-is; a monochrome
+    /// monitor has no chroma to show, so it displays the signal's luminance in its phosphor's
+    /// colour — which is why lo-res on a green screen is shades of green, not 16 colours.
+    /// </summary>
+    public static Color ApplyMonitor(Color signalColor, Apple2MonitorColor monitorColor)
+    {
+        if (IsColorMonitor(monitorColor))
+            return signalColor;
+
+        // Rec. 601 luma, the weighting composite video's luminance channel carries.
+        var luma = ((0.299 * signalColor.R) + (0.587 * signalColor.G) + (0.114 * signalColor.B)) / 255.0;
+        var phosphor = GetForeground(monitorColor);
+        return Color.FromArgb(
+            signalColor.A,
+            (byte)Math.Round(phosphor.R * luma),
+            (byte)Math.Round(phosphor.G * luma),
+            (byte)Math.Round(phosphor.B * luma));
+    }
+
     public static Color GetForeground(Apple2MonitorColor monitorColor) => monitorColor switch
     {
         Apple2MonitorColor.White => Color.FromArgb(255, 255, 255, 255),

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2LoResMonitorColorTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2LoResMonitorColorTests.cs
@@ -1,0 +1,115 @@
+using Highbyte.DotNet6502.Systems.Apple2.Config;
+using Highbyte.DotNet6502.Systems.Apple2.Peripherals;
+using Highbyte.DotNet6502.Systems.Apple2.Render;
+using Highbyte.DotNet6502.Systems.Apple2.Video;
+using Microsoft.Extensions.Logging.Abstractions;
+using Apple2System = Highbyte.DotNet6502.Systems.Apple2.Apple2;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
+
+/// <summary>
+/// Lo-res through the monitor. A monochrome monitor has no chroma to show, so the 16 lo-res
+/// colors arrive as shades of its phosphor rather than as colors.
+/// </summary>
+public class Apple2LoResMonitorColorTests
+{
+    private static Apple2System BuildApple2(Apple2MonitorColor monitorColor)
+    {
+        var romData = new Dictionary<string, byte[]>
+        {
+            { Apple2SystemConfig.CHARGEN_ROM_NAME, new byte[Apple2CharSet.CharacterRomSize] },
+        };
+        return new Apple2System(
+            new Apple2Config { MonitorColor = monitorColor },
+            NullLoggerFactory.Instance,
+            romData);
+    }
+
+    private static Apple2Rasterizer RenderLoResCell(Apple2System apple2, byte screenByte)
+    {
+        var rasterizer = (Apple2Rasterizer)apple2.RenderProvider!;
+        _ = apple2.Mem[Apple2SoftSwitches.GraphicsModeAddress];
+        _ = apple2.Mem[Apple2SoftSwitches.LoResModeAddress];
+        _ = apple2.Mem[Apple2SoftSwitches.MixedModeOffAddress];
+        _ = apple2.Mem[Apple2SoftSwitches.TextPage1Address];
+        apple2.Mem[Apple2TextScreen.GetAddress(0, 0)] = screenByte;
+        rasterizer.OnEndFrame();
+        return rasterizer;
+    }
+
+    private static uint PixelAt(Apple2Rasterizer rasterizer, int x, int y)
+        => rasterizer.CurrentFrontLayerBuffers[1].Span[(y * rasterizer.NativeSize.Width) + x];
+
+    private static uint Packed(System.Drawing.Color color)
+        => Apple2Rasterizer.PackBgra(color.B, color.G, color.R, color.A);
+
+    [Fact]
+    public void A_Color_Monitor_Shows_The_Full_LoRes_Palette()
+    {
+        var apple2 = BuildApple2(Apple2MonitorColor.Color);
+        var rasterizer = RenderLoResCell(apple2, 0x01);   // upper block magenta (1)
+
+        Assert.Equal(Packed(Apple2LoResScreen.Palette[1]), PixelAt(rasterizer, 0, 0));
+    }
+
+    [Theory]
+    [InlineData(Apple2MonitorColor.Green)]
+    [InlineData(Apple2MonitorColor.White)]
+    [InlineData(Apple2MonitorColor.Amber)]
+    public void A_Phosphor_Monitor_Shows_LoRes_As_Shades_Of_Its_Phosphor(Apple2MonitorColor monitorColor)
+    {
+        var apple2 = BuildApple2(monitorColor);
+        var rasterizer = RenderLoResCell(apple2, 0x01);   // magenta on a colour monitor
+
+        var rendered = PixelAt(rasterizer, 0, 0);
+        Assert.NotEqual(Packed(Apple2LoResScreen.Palette[1]), rendered);
+        Assert.Equal(Packed(Apple2Colors.ApplyMonitor(Apple2LoResScreen.Palette[1], monitorColor)), rendered);
+    }
+
+    /// <summary>
+    /// The point of the luminance model: colours that differ only in hue must stay distinguishable
+    /// by brightness, and a brighter colour must stay brighter.
+    /// </summary>
+    [Fact]
+    public void Phosphor_Shades_Preserve_The_Brightness_Order_Of_The_Palette()
+    {
+        var black = Apple2Colors.ApplyMonitor(Apple2LoResScreen.Palette[0], Apple2MonitorColor.Green);
+        var darkBlue = Apple2Colors.ApplyMonitor(Apple2LoResScreen.Palette[2], Apple2MonitorColor.Green);
+        var grey = Apple2Colors.ApplyMonitor(Apple2LoResScreen.Palette[5], Apple2MonitorColor.Green);
+        var white = Apple2Colors.ApplyMonitor(Apple2LoResScreen.Palette[15], Apple2MonitorColor.Green);
+
+        Assert.True(black.G < darkBlue.G, "black must be darker than dark blue");
+        Assert.True(darkBlue.G < grey.G, "dark blue must be darker than grey");
+        Assert.True(grey.G < white.G, "grey must be darker than white");
+    }
+
+    [Fact]
+    public void Black_Stays_Black_And_White_Reaches_Full_Phosphor()
+    {
+        Assert.Equal(
+            System.Drawing.Color.FromArgb(255, 0, 0, 0),
+            Apple2Colors.ApplyMonitor(Apple2LoResScreen.Palette[0], Apple2MonitorColor.Amber));
+
+        // Palette entry 15 is pure white, so it maps to the phosphor at full intensity.
+        Assert.Equal(
+            Apple2Colors.GetForeground(Apple2MonitorColor.Amber),
+            Apple2Colors.ApplyMonitor(Apple2LoResScreen.Palette[15], Apple2MonitorColor.Amber));
+    }
+
+    [Fact]
+    public void A_Color_Monitor_Passes_The_Signal_Through_Unchanged()
+    {
+        foreach (var color in Apple2LoResScreen.Palette)
+            Assert.Equal(color, Apple2Colors.ApplyMonitor(color, Apple2MonitorColor.Color));
+    }
+
+    /// <summary>Two colours with the same luminance are genuinely indistinguishable in mono —
+    /// that is the hardware's behaviour, not a defect in the mapping.</summary>
+    [Fact]
+    public void The_Two_Identical_Greys_Stay_Identical()
+    {
+        Assert.Equal(
+            Apple2Colors.ApplyMonitor(Apple2LoResScreen.Palette[5], Apple2MonitorColor.Green),
+            Apple2Colors.ApplyMonitor(Apple2LoResScreen.Palette[10], Apple2MonitorColor.Green));
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RasterizerGraphicsTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RasterizerGraphicsTests.cs
@@ -149,7 +149,10 @@ public class Apple2RasterizerGraphicsTests
     [Fact]
     public void LoRes_Renders_Both_Nibbles_As_Stacked_7x4_Color_Blocks()
     {
-        var apple2 = BuildApple2();
+        // A colour monitor, so the palette arrives unchanged and this stays a test of the block
+        // geometry. What a phosphor monitor does to those colours is
+        // Apple2LoResMonitorColorTests' subject.
+        var apple2 = BuildApple2(Apple2MonitorColor.Color);
         var rasterizer = GetRasterizer(apple2);
         SelectMode(apple2, text: false, hiRes: false);
 

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RealRomBootTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RealRomBootTests.cs
@@ -13,8 +13,9 @@ namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
 /// <summary>
 /// Boot-to-BASIC verification against a genuine Apple II Plus ROM.
 ///
-/// The ROM is copyrighted and cannot be checked in, so these tests are opt-in: they skip unless
-/// an image is found. Put the ROMs in the Apple II ROM directory
+/// The ROM is copyrighted and cannot be checked in, so these tests are opt-in: without one they
+/// report as <em>skipped</em>, with the reason, rather than silently passing — see
+/// <see cref="Apple2TestRoms"/>. Put the ROMs in the Apple II ROM directory
 /// (<see cref="Apple2SystemConfig.DefaultROMDirectory"/>) under the names the archive publishes
 /// them with — which is exactly what the app's own ROM download writes — or point
 /// <c>DOTNET6502_APPLE2_ROM</c> at a file, then run:
@@ -25,16 +26,6 @@ namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
 [Trait("TestType", "Integration")]
 public class Apple2RealRomBootTests
 {
-    private const string RomPathEnvironmentVariable = "DOTNET6502_APPLE2_ROM";
-    private const string CharacterRomPathEnvironmentVariable = "DOTNET6502_APPLE2_CHARGEN_ROM";
-    /// <summary>
-    /// The archive publishes the system ROM as the bare 12 KB image and in the 20 KB layout;
-    /// the loader accepts either. These are also the names the app's ROM download writes.
-    /// </summary>
-    private static readonly string[] s_systemRomFileNames = ["apple.rom", "APPLE2_.ROM"];
-
-    private const string DefaultCharacterRomFileName = "3410036.BIN";
-
     /// <summary>Frames to run before the Autostart ROM has reached the Applesoft prompt.</summary>
     private const int BootFrames = 180;
 
@@ -42,12 +33,10 @@ public class Apple2RealRomBootTests
 
     public Apple2RealRomBootTests(ITestOutputHelper output) => _output = output;
 
-    [Fact]
+    [RequiresApple2RomFact]
     public void Boots_To_The_Applesoft_Prompt()
     {
         var apple2 = BootRealRom();
-        if (apple2 == null)
-            return;
 
         Assert.True(apple2.HasBasicStarted());
 
@@ -56,12 +45,10 @@ public class Apple2RealRomBootTests
         Assert.StartsWith("]", screen[2]);     // the Applesoft prompt
     }
 
-    [Fact]
+    [RequiresApple2RomFact]
     public void Reset_Vector_Points_At_The_Autostart_Monitor()
     {
         var apple2 = BootRealRom(runFrames: 0);
-        if (apple2 == null)
-            return;
 
         Assert.Equal(0xFA62, apple2.CPU.PC);
     }
@@ -80,12 +67,10 @@ public class Apple2RealRomBootTests
         0x00, 0x00,     // end of program
     };
 
-    [Fact]
+    [RequiresApple2RomFact]
     public void Injected_Basic_Program_Runs_And_Lists()
     {
         var apple2 = BootRealRom();
-        if (apple2 == null)
-            return;
 
         // Inject the tokenized program the way any external loader would: place the bytes at
         // $0801 and initialise the Applesoft zero-page pointers.
@@ -115,16 +100,23 @@ public class Apple2RealRomBootTests
         screen = ReadScreen(apple2);
         var listRow = Array.FindIndex(screen, row => row.TrimEnd() == "]LIST");
         Assert.True(listRow >= 0, "LIST was not echoed to the screen.");
-        Assert.Contains("10", screen[listRow + 1]);
-        Assert.Contains("PRINT 3", screen[listRow + 1]);
+
+        // Applesoft's LIST starts with a carriage return, so the listing is not on the row
+        // immediately below the echoed command — unlike ordinary output such as PRINT. Find the
+        // listing rather than assuming a fixed offset. Applesoft renders it "10  PRINT 3", with
+        // two spaces, so match on the parts rather than the exact spacing.
+        var listing = screen.Skip(listRow + 1)
+            .Select(row => row.TrimEnd())
+            .FirstOrDefault(row => row.Length > 0 && row != "]");
+        Assert.NotNull(listing);
+        Assert.Contains("10", listing);
+        Assert.Contains("PRINT 3", listing);
     }
 
-    [Fact]
+    [RequiresApple2RomFact]
     public void Typed_Input_Reaches_Applesoft_And_Is_Evaluated()
     {
         var apple2 = BootRealRom();
-        if (apple2 == null)
-            return;
 
         var inputState = new ScriptedHostInputState();
         var inputHandler = new Apple2InputHandler(apple2, NullLoggerFactory.Instance);
@@ -148,15 +140,11 @@ public class Apple2RealRomBootTests
         Assert.Equal("5", screen[3].TrimEnd());
     }
 
-    [Fact]
+    [RequiresApple2RomAndCharacterRomFact]
     public void The_Rasterizer_Draws_The_Banner_From_The_Real_Character_Generator()
     {
         var apple2 = BootRealRom();
-        if (apple2 == null || apple2.CharacterRom == null)
-        {
-            _output.WriteLine("SKIPPED: no character generator ROM available.");
-            return;
-        }
+        Assert.NotNull(apple2.CharacterRom);
 
         var rasterizer = (Apple2Rasterizer)apple2.RenderProviders.Single(p => p is Apple2Rasterizer);
         rasterizer.OnEndFrame();
@@ -197,20 +185,14 @@ public class Apple2RealRomBootTests
     }
 
     /// <summary>
-    /// Boots the machine on a real ROM, or returns <c>null</c> when no ROM is available so the
-    /// test can bow out. xUnit v2 has no run-time skip, so the reason is written to the test
-    /// output instead of failing a build that legitimately has no ROM to test with.
+    /// Boots the machine on a real ROM. Callers are guarded by
+    /// <see cref="RequiresApple2RomFactAttribute"/>, so a missing ROM is a skipped test rather
+    /// than something to handle here.
     /// </summary>
-    private Apple2System? BootRealRom(int runFrames = BootFrames)
+    private Apple2System BootRealRom(int runFrames = BootFrames)
     {
-        var romPath = ResolveRomPath();
-        if (romPath == null)
-        {
-            _output.WriteLine(
-                $"SKIPPED: no Apple II ROM found. Set {RomPathEnvironmentVariable}, or place one of " +
-                $"[{string.Join(", ", s_systemRomFileNames)}] in {Apple2SystemConfig.DefaultROMDirectory}.");
-            return null;
-        }
+        var romPath = Apple2TestRoms.ResolveSystemRomPath();
+        Assert.NotNull(romPath);
 
         _output.WriteLine($"Using Apple II ROM: {romPath}");
 
@@ -219,7 +201,7 @@ public class Apple2RealRomBootTests
             { Apple2SystemConfig.SYSTEM_ROM_NAME, File.ReadAllBytes(romPath) },
         };
 
-        var characterRomPath = ResolveCharacterRomPath();
+        var characterRomPath = Apple2TestRoms.ResolveCharacterRomPath();
         if (characterRomPath != null)
         {
             _output.WriteLine($"Using Apple II character generator ROM: {characterRomPath}");
@@ -234,26 +216,7 @@ public class Apple2RealRomBootTests
         return apple2;
     }
 
-    private static string? ResolveRomPath()
-    {
-        var fromEnvironment = Environment.GetEnvironmentVariable(RomPathEnvironmentVariable);
-        if (!string.IsNullOrWhiteSpace(fromEnvironment) && File.Exists(fromEnvironment))
-            return fromEnvironment;
 
-        return s_systemRomFileNames
-            .Select(name => Path.Combine(Apple2SystemConfig.DefaultROMDirectory, name))
-            .FirstOrDefault(File.Exists);
-    }
-
-    private static string? ResolveCharacterRomPath()
-    {
-        var fromEnvironment = Environment.GetEnvironmentVariable(CharacterRomPathEnvironmentVariable);
-        if (!string.IsNullOrWhiteSpace(fromEnvironment) && File.Exists(fromEnvironment))
-            return fromEnvironment;
-
-        var fromRomDirectory = Path.Combine(Apple2SystemConfig.DefaultROMDirectory, DefaultCharacterRomFileName);
-        return File.Exists(fromRomDirectory) ? fromRomDirectory : null;
-    }
 
     private static void TypeKey(
         Apple2System apple2,

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RealRomDisk2BootTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RealRomDisk2BootTests.cs
@@ -13,8 +13,9 @@ namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
 /// via RWTS reading the nibble streams.
 ///
 /// Like <see cref="Apple2RealRomBootTests"/> these are opt-in, because the system ROM, the
-/// Disk II boot ROM, and any real disk image are copyrighted. They skip unless all three are
-/// available:
+/// Disk II boot ROM, and any real disk image are copyrighted. Without all three they report as
+/// <em>skipped</em>, with the reason, rather than silently passing — see
+/// <see cref="Apple2TestRoms"/>. They need:
 /// <list type="bullet">
 /// <item>The system and Disk II ROMs in the Apple II ROM directory under the file names the
 /// archive publishes them with (the same names the app's ROM download writes), or the
@@ -30,19 +31,6 @@ namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
 [Trait("TestType", "Integration")]
 public class Apple2RealRomDisk2BootTests
 {
-    private const string RomPathEnvironmentVariable = "DOTNET6502_APPLE2_ROM";
-    private const string Disk2RomPathEnvironmentVariable = "DOTNET6502_APPLE2_DISK2_ROM";
-    private const string BootDskPathEnvironmentVariable = "DOTNET6502_APPLE2_BOOT_DSK";
-    /// <summary>
-    /// File names as published by the ROM archive — the same names the app's ROM download writes
-    /// into the ROM directory. The system ROM is published both as the bare 12 KB image and in
-    /// the 20 KB layout, and the loader accepts either.
-    /// </summary>
-    private static readonly string[] s_systemRomFileNames = ["apple.rom", "APPLE2_.ROM"];
-
-    private static readonly string[] s_disk2RomFileNames =
-        ["Apple Disk II 16 Sector Interface Card ROM P5 - 341-0027.bin-with-D4-D7 data bits swapped.bin"];
-
     /// <summary>
     /// Frames to allow for the whole boot. A System Master boot measures ~42 M cycles (~2475
     /// frames), most of it DOS's own motor spin-up waits — see the timing-model limitation
@@ -54,12 +42,10 @@ public class Apple2RealRomDisk2BootTests
 
     public Apple2RealRomDisk2BootTests(ITestOutputHelper output) => _output = output;
 
-    [Fact]
+    [RequiresApple2Disk2BootFact]
     public void Boots_Dos33_From_An_Inserted_Disk_Image()
     {
         var apple2 = BootFromDisk();
-        if (apple2 == null)
-            return;
 
         // DOS 3.3 turns the drive off once booted and leaves a prompt on screen.
         var screen = ReadScreen(apple2);
@@ -78,16 +64,14 @@ public class Apple2RealRomDisk2BootTests
     /// when the user inserts a disk. A plain reset warm-starts back to the prompt without
     /// scanning the slots, so the power-up byte must be invalidated to force a cold start.
     /// </summary>
-    [Fact]
+    [RequiresApple2Disk2BootFact]
     public void Booting_A_Disk_Works_From_An_Already_Running_Basic_Prompt()
     {
         var apple2 = BootFromDisk(insertDisk: false, runFrames: 200);
-        if (apple2 == null)
-            return;
 
         Assert.True(apple2.HasBasicStarted(), "Precondition: the machine reached the BASIC prompt.");
 
-        var dskPath = ResolveBootDsk()!;
+        var dskPath = Apple2TestRoms.ResolveBootDskPath()!;
         apple2.DiskController.InsertDiskImage(File.ReadAllBytes(dskPath));
         apple2.InvalidatePowerUpByte();
         apple2.Reset();
@@ -105,18 +89,16 @@ public class Apple2RealRomDisk2BootTests
     /// must not disturb the running machine — Applesoft itself has no disk commands, so losing
     /// resident DOS would leave the user unable to read the disk they just inserted.
     /// </summary>
-    [Fact]
+    [RequiresApple2Disk2BootFact]
     public void Inserting_A_Disk_Does_Not_Disturb_A_Running_Dos()
     {
         var apple2 = BootFromDisk();
-        if (apple2 == null)
-            return;
 
         var screenBefore = string.Join('\n', ReadScreen(apple2));
         Assert.Contains("DOS VERSION 3.3", screenBefore, StringComparison.Ordinal);
 
         // Swap in another diskette (the same image again is enough to prove the point).
-        apple2.DiskController.InsertDiskImage(File.ReadAllBytes(ResolveBootDsk()!));
+        apple2.DiskController.InsertDiskImage(File.ReadAllBytes(Apple2TestRoms.ResolveBootDskPath()!));
         for (var frame = 0; frame < 60; frame++)
             apple2.ExecuteOneFrame();
 
@@ -126,14 +108,12 @@ public class Apple2RealRomDisk2BootTests
     }
 
     /// <summary>Without the cold-start fix a reset just returns to the BASIC prompt.</summary>
-    [Fact]
+    [RequiresApple2Disk2BootFact]
     public void A_Plain_Reset_From_The_Basic_Prompt_Does_Not_Scan_The_Slots()
     {
         var apple2 = BootFromDisk(insertDisk: false, runFrames: 200);
-        if (apple2 == null)
-            return;
 
-        var dskPath = ResolveBootDsk()!;
+        var dskPath = Apple2TestRoms.ResolveBootDskPath()!;
         apple2.DiskController.InsertDiskImage(File.ReadAllBytes(dskPath));
         apple2.Reset();   // warm start: no power-up byte invalidation
 
@@ -143,31 +123,26 @@ public class Apple2RealRomDisk2BootTests
         Assert.DoesNotContain("DOS VERSION 3.3", string.Join('\n', ReadScreen(apple2)), StringComparison.Ordinal);
     }
 
-    [Fact]
+    [RequiresApple2Disk2BootFact]
     public void Without_A_Disk_The_Machine_Still_Boots_To_Basic()
     {
         var apple2 = BootFromDisk(insertDisk: false);
-        if (apple2 == null)
-            return;
 
         Assert.True(apple2.HasBasicStarted(), "The Autostart slot scan must fall through to BASIC.");
     }
 
-    private Apple2System? BootFromDisk(bool insertDisk = true, int? runFrames = null)
+    /// <summary>
+    /// Callers are guarded by <see cref="RequiresApple2Disk2BootFactAttribute"/>, so missing ROMs
+    /// or disk image are a skipped test rather than something to handle here.
+    /// </summary>
+    private Apple2System BootFromDisk(bool insertDisk = true, int? runFrames = null)
     {
-        var romPath = Resolve(RomPathEnvironmentVariable, s_systemRomFileNames);
-        var disk2RomPath = Resolve(Disk2RomPathEnvironmentVariable, s_disk2RomFileNames);
-        var dskPath = ResolveBootDsk();
-
-        if (romPath == null || disk2RomPath == null || dskPath == null)
-        {
-            _output.WriteLine(
-                $"SKIPPED: needs the system and Disk II ROMs in {Apple2SystemConfig.DefaultROMDirectory} " +
-                $"(under their published names, as written by the app's ROM download) or in " +
-                $"{RomPathEnvironmentVariable} / {Disk2RomPathEnvironmentVariable}, and a bootable " +
-                $"DOS 3.3 image in {BootDskPathEnvironmentVariable}.");
-            return null;
-        }
+        var romPath = Apple2TestRoms.ResolveSystemRomPath();
+        var disk2RomPath = Apple2TestRoms.ResolveDisk2RomPath();
+        var dskPath = Apple2TestRoms.ResolveBootDskPath();
+        Assert.NotNull(romPath);
+        Assert.NotNull(disk2RomPath);
+        Assert.NotNull(dskPath);
 
         _output.WriteLine($"System ROM: {romPath}");
         _output.WriteLine($"Disk II boot ROM: {disk2RomPath}");
@@ -193,29 +168,7 @@ public class Apple2RealRomDisk2BootTests
         return apple2;
     }
 
-    /// <summary>ROMs have a managed directory, so fall back to it.</summary>
-    private static string? Resolve(string environmentVariable, string[] publishedFileNames)
-    {
-        var fromEnvironment = Environment.GetEnvironmentVariable(environmentVariable);
-        if (!string.IsNullOrWhiteSpace(fromEnvironment) && File.Exists(fromEnvironment))
-            return fromEnvironment;
 
-        return publishedFileNames
-            .Select(name => Path.Combine(Apple2SystemConfig.DefaultROMDirectory, name))
-            .FirstOrDefault(File.Exists);
-    }
-
-    /// <summary>
-    /// Disk images have no managed directory — they are user content kept wherever the user
-    /// keeps it — so the environment variable is the only way to supply one.
-    /// </summary>
-    private static string? ResolveBootDsk()
-    {
-        var fromEnvironment = Environment.GetEnvironmentVariable(BootDskPathEnvironmentVariable);
-        return !string.IsNullOrWhiteSpace(fromEnvironment) && File.Exists(fromEnvironment)
-            ? fromEnvironment
-            : null;
-    }
 
     private static string[] ReadScreen(Apple2System apple2)
     {

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2TestRoms.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2TestRoms.cs
@@ -1,0 +1,125 @@
+using Highbyte.DotNet6502.Systems.Apple2.Config;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
+
+/// <summary>
+/// Locates the copyrighted files the Apple II integration tests need. None of them can be checked
+/// in, so those tests are opt-in — but they must announce that they did not run.
+///
+/// A test that quietly returns early reports as <em>passed</em>, which is how
+/// <c>Injected_Basic_Program_Runs_And_Lists</c> shipped broken: CI has no ROMs, so it was green
+/// from the day it was written without ever executing a line, and the bad assertion only surfaced
+/// once a ROM happened to be present locally. The attributes below set <see cref="FactAttribute.Skip"/>
+/// at discovery instead, so a missing ROM reads as "skipped, here is why" rather than as coverage.
+/// </summary>
+internal static class Apple2TestRoms
+{
+    public const string SystemRomPathEnvironmentVariable = "DOTNET6502_APPLE2_ROM";
+    public const string CharacterRomPathEnvironmentVariable = "DOTNET6502_APPLE2_CHARGEN_ROM";
+    public const string Disk2RomPathEnvironmentVariable = "DOTNET6502_APPLE2_DISK2_ROM";
+    public const string BootDskPathEnvironmentVariable = "DOTNET6502_APPLE2_BOOT_DSK";
+
+    /// <summary>
+    /// File names as published by the ROM archive — the same names the app's ROM download writes
+    /// into the ROM directory. The system ROM is published both as the bare 12 KB image and in the
+    /// 20 KB layout, and the loader accepts either.
+    /// </summary>
+    public static readonly string[] SystemRomFileNames = ["apple.rom", "APPLE2_.ROM"];
+
+    public const string CharacterRomFileName = "3410036.BIN";
+
+    public static readonly string[] Disk2RomFileNames =
+        ["Apple Disk II 16 Sector Interface Card ROM P5 - 341-0027.bin-with-D4-D7 data bits swapped.bin"];
+
+    public static string? ResolveSystemRomPath()
+        => Resolve(SystemRomPathEnvironmentVariable, SystemRomFileNames);
+
+    public static string? ResolveCharacterRomPath()
+        => Resolve(CharacterRomPathEnvironmentVariable, [CharacterRomFileName]);
+
+    public static string? ResolveDisk2RomPath()
+        => Resolve(Disk2RomPathEnvironmentVariable, Disk2RomFileNames);
+
+    /// <summary>
+    /// Disk images have no default location on purpose: they are user content kept wherever the
+    /// user likes (the host picks them with a file dialog), unlike ROMs which the config manages
+    /// in a known directory.
+    /// </summary>
+    public static string? ResolveBootDskPath()
+    {
+        var fromEnvironment = Environment.GetEnvironmentVariable(BootDskPathEnvironmentVariable);
+        return !string.IsNullOrWhiteSpace(fromEnvironment) && File.Exists(fromEnvironment)
+            ? fromEnvironment
+            : null;
+    }
+
+    private static string? Resolve(string environmentVariable, IEnumerable<string> fileNames)
+    {
+        var fromEnvironment = Environment.GetEnvironmentVariable(environmentVariable);
+        if (!string.IsNullOrWhiteSpace(fromEnvironment) && File.Exists(fromEnvironment))
+            return fromEnvironment;
+
+        return fileNames
+            .Select(name => Path.Combine(Apple2SystemConfig.DefaultROMDirectory, name))
+            .FirstOrDefault(File.Exists);
+    }
+
+    public static string MissingFileReason(string what, string environmentVariable, IEnumerable<string> fileNames)
+        => $"No {what} found. Set {environmentVariable}, or place one of " +
+           $"[{string.Join(", ", fileNames)}] in {Apple2SystemConfig.DefaultROMDirectory}.";
+}
+
+/// <summary>A test needing the genuine Apple II system ROM. Skips, visibly, when it is absent.</summary>
+public sealed class RequiresApple2RomFactAttribute : FactAttribute
+{
+    public RequiresApple2RomFactAttribute()
+    {
+        if (Apple2TestRoms.ResolveSystemRomPath() == null)
+            Skip = Apple2TestRoms.MissingFileReason(
+                "Apple II system ROM",
+                Apple2TestRoms.SystemRomPathEnvironmentVariable,
+                Apple2TestRoms.SystemRomFileNames);
+    }
+}
+
+/// <summary>A test needing the system ROM <em>and</em> the character generator ROM.</summary>
+public sealed class RequiresApple2RomAndCharacterRomFactAttribute : FactAttribute
+{
+    public RequiresApple2RomAndCharacterRomFactAttribute()
+    {
+        if (Apple2TestRoms.ResolveSystemRomPath() == null)
+            Skip = Apple2TestRoms.MissingFileReason(
+                "Apple II system ROM",
+                Apple2TestRoms.SystemRomPathEnvironmentVariable,
+                Apple2TestRoms.SystemRomFileNames);
+        else if (Apple2TestRoms.ResolveCharacterRomPath() == null)
+            Skip = Apple2TestRoms.MissingFileReason(
+                "Apple II character generator ROM",
+                Apple2TestRoms.CharacterRomPathEnvironmentVariable,
+                [Apple2TestRoms.CharacterRomFileName]);
+    }
+}
+
+/// <summary>
+/// A test that boots a real disk: needs the system ROM, the Disk II boot ROM, and a bootable
+/// DOS 3.3 image.
+/// </summary>
+public sealed class RequiresApple2Disk2BootFactAttribute : FactAttribute
+{
+    public RequiresApple2Disk2BootFactAttribute()
+    {
+        if (Apple2TestRoms.ResolveSystemRomPath() == null)
+            Skip = Apple2TestRoms.MissingFileReason(
+                "Apple II system ROM",
+                Apple2TestRoms.SystemRomPathEnvironmentVariable,
+                Apple2TestRoms.SystemRomFileNames);
+        else if (Apple2TestRoms.ResolveDisk2RomPath() == null)
+            Skip = Apple2TestRoms.MissingFileReason(
+                "Disk II boot ROM",
+                Apple2TestRoms.Disk2RomPathEnvironmentVariable,
+                Apple2TestRoms.Disk2RomFileNames);
+        else if (Apple2TestRoms.ResolveBootDskPath() == null)
+            Skip = $"No bootable DOS 3.3 disk image. Set {Apple2TestRoms.BootDskPathEnvironmentVariable} " +
+                   "to a .dsk path (there is deliberately no default location for disk images).";
+    }
+}


### PR DESCRIPTION
Three defects found reviewing what was left over after the hi-res artifact colour work (#269).

## 1. Lo-res ignored the monitor setting

`RasterizeLoRes` used the 16-colour palette unconditionally, so a machine configured with a green, white or amber phosphor monitor still showed lo-res in full colour. Wrong on hardware — a monochrome monitor has no chroma to display — and newly conspicuous now that a working colour monitor sits beside it.

New `Apple2Colors.ApplyMonitor` models what the screen does to a colour signal: pass-through on a colour monitor, Rec. 601 luminance in the phosphor's colour otherwise. The rasterizer rebuilds the lo-res palette through it per frame.

**One consequence reads as a defect but is not:** 16 colours collapse to about 10 distinguishable shades, because colours of equal luminance genuinely are indistinguishable in mono. That is the hardware's behaviour. It is documented, and pinned by a test so it is not mistaken for a regression later.

## 2. `Injected_Basic_Program_Runs_And_Lists` asserted the wrong row

Applesoft's `LIST` starts with a carriage return, so the listing is two rows below the echoed `]LIST`, not one.

**This is a test bug, not an emulator bug.** Diagnosed by dumping the text page: after injection the pointers are exactly right (`TXTTAB $0801`, `VARTAB`/`ARYTAB`/`STREND`/`PRGEND` all `$080A`), `RUN` prints `3`, and `LIST` prints `10  PRINT 3` with authentic Applesoft spacing. That the blank line is authentic rather than an emulator artifact is settled two ways: the sibling test passes with `]PRINT 2+3` and `5` on *adjacent* rows, so ordinary output has no such gap — only `LIST` does; and the emulator does not implement `LIST` at all, so that spacing came from executing the genuine ROM. Running 300 extra frames changes nothing, so it is not timing either.

The test now locates the listing instead of assuming an offset.

## 3. The opt-in ROM tests reported as passed when they skipped — the root cause of #2

Every ROM-dependent test guarded with `if (apple2 == null) return;`, which xunit counts as **passed**. CI has no ROMs (they are copyrighted), so all ten were green from the day they were written without executing a line. Defect #2 shipped in #264 precisely because of this: the bad assertion could not fail anywhere it was actually run, and only surfaced later when the Disk II work happened to put ROMs in the default directory.

A test that silently skips is worse than no test — it reports as coverage while providing none.

`RequiresApple2RomFact`, `RequiresApple2RomAndCharacterRomFact` and `RequiresApple2Disk2BootFact` now set `FactAttribute.Skip` at discovery, with the reason. ROM presence is a static environment property, so discovery is the right moment — and no new dependency is needed: xunit 2.9 has no runtime `Assert.Skip`, but `Skip` is settable and this is exactly what it is for.

| | before | after |
|---|---|---|
| CI (no ROMs) | 10 "passed" | **10 skipped, 0 passed** |
| Local (ROMs present) | 10 passed, 1 failing | 5 passed, 5 skipped |

The 5 skipped locally are the Disk II tests, which also want a bootable image via `DOTNET6502_APPLE2_BOOT_DSK`.

## Verification

**785 pass, 0 fail, 5 skip** — the pre-existing failure is gone and this is the first fully clean run. Build is clean with 0 warnings.

Lo-res verified live in the Avalonia app on the emulator's native 280x192 framebuffer, plotting all 16 lo-res colours as bars:

- **Colour monitor:** 16 distinct colours.
- **Green monitor:** every bar an exact luminance scaling of the phosphor `(51,255,51)`, white reaching full intensity, black staying black.