### PR TITLE
Fix backward branches being charged a page-crossing cycle

### DIFF
--- a/docs/systems/apple2/disk2.md
+++ b/docs/systems/apple2/disk2.md
@@ -72,8 +72,8 @@ polling paces the data and a reader can never miss a byte regardless of how slow
 them. That robustness is deliberate: the machine has no cycle-accurate bus for a rotational model
 to key off.
 
-**Known limitation:** booting the DOS 3.3 System Master takes about 41 emulated seconds, roughly
-30 s of which is DOS's *own* one-second motor spin-up wait, entered 31 times. RWTS decides whether
+**Known limitation:** booting the DOS 3.3 System Master takes about 35 emulated seconds, most of
+it DOS's *own* one-second motor spin-up wait, entered 31 times. RWTS decides whether
 the drive is spinning by comparing successive reads of the data register, and that decision
 depends on real read timing this model does not reproduce. Everything loads correctly, just slower
 than a real machine (~7 s). Two alternatives were implemented and measured, and both are worse: a

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Disk2/Disk2Controller.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Disk2/Disk2Controller.cs
@@ -23,8 +23,8 @@ namespace Highbyte.DotNet6502.Systems.Apple2.Disk2;
 /// byte (any N from 12 to 17 tried): the boot never reached the DOS banner at all.</item>
 /// </list>
 ///
-/// <para><b>Known limitation.</b> Booting the System Master takes ~41 emulated seconds, of which
-/// ~30 s is DOS's own one-second motor spin-up wait, entered 31 times: RWTS decides the drive
+/// <para><b>Known limitation.</b> Booting the System Master takes ~35 emulated seconds, most of it
+/// DOS's own one-second motor spin-up wait, entered 31 times: RWTS decides the drive
 /// is stopped by comparing successive reads of the data register, and that decision depends on
 /// real read timing this model does not reproduce. Everything loads correctly, just slower than
 /// a real machine (~7 s). Nibblizer sync-gap sizes were swept (20/5, 16/16, 12/12, 10/10, 9/9)

--- a/src/libraries/Highbyte.DotNet6502/BranchHelper.cs
+++ b/src/libraries/Highbyte.DotNet6502/BranchHelper.cs
@@ -21,32 +21,20 @@ public static class BranchHelper
     /// <returns></returns>
     public static ushort CalculateNewAbsoluteBranchAddress(ushort PC, sbyte branchOffset, out ulong cyclesConsumed, out bool addressCalculationCrossedPageBoundary)
     {
-        cyclesConsumed = 0;
-        addressCalculationCrossedPageBoundary = false;
-        // Check if adding offset to current address will cross page boundary. If so, one more cycle is consumed
-        // TODO: Can smarter logic be written to handle positive vs negative branchOffset?
-        if (branchOffset >= 0)
-        {
-            if ((PC & 0x00ff) + branchOffset > 0xff)
-            {
-                cyclesConsumed++;
-                addressCalculationCrossedPageBoundary = true;
-            }
-        }
-        else
-        {
-            // Abs(-128) = 128 which leads to Exception:
-            //'System.OverflowException' occurred in System.Private.CoreLib.dll: 'Negating the minimum value of a twos complement number is invalid.'
-            // Must cast to ushort first
-            if ((PC & 0x00ff) < Math.Abs((ushort)branchOffset))
-            {
-                cyclesConsumed++;
-                addressCalculationCrossedPageBoundary = true;
-            }
-        }
-
-        cyclesConsumed++;
-        return (ushort)(PC + branchOffset);
+        // PC is already past the instruction, which is what the offset is relative to. A taken
+        // branch costs one cycle, plus one more when the target lands in a different page — and
+        // "different page" is simply a different high byte, whichever direction the branch goes.
+        //
+        // This used to be computed from the offset in separate positive and negative cases. The
+        // negative case read `Math.Abs((ushort)branchOffset)`, and casting a negative sbyte to
+        // ushort gives its two's-complement value — 65528 for -8, not 8 — so the comparison was
+        // always true and every backward branch was charged a page crossing it never made. Since
+        // loops branch backwards, that was an extra cycle on essentially every loop iteration in
+        // every emulated program.
+        var target = (ushort)(PC + branchOffset);
+        addressCalculationCrossedPageBoundary = (PC & 0xFF00) != (target & 0xFF00);
+        cyclesConsumed = addressCalculationCrossedPageBoundary ? 2UL : 1UL;
+        return target;
     }
 
 }

--- a/tests/Highbyte.DotNet6502.Tests/BranchHelperTest.cs
+++ b/tests/Highbyte.DotNet6502.Tests/BranchHelperTest.cs
@@ -1,0 +1,66 @@
+namespace Highbyte.DotNet6502.Tests;
+
+/// <summary>
+/// Page-crossing detection for relative branches, which decides whether a taken branch costs 3
+/// cycles or 4.
+///
+/// Covered exhaustively in both directions: the rule is symmetric, but the implementation used to
+/// treat forwards and backwards separately and only the forward half was ever asserted.
+/// </summary>
+public class BranchHelperTest
+{
+    [Theory]
+    // Forwards, staying inside the page.
+    [InlineData(0x2002, 0x20, 0x2022, false)]
+    // Forwards, over the top of the page.
+    [InlineData(0x20F2, 0x20, 0x2112, true)]
+    // Backwards, staying inside the page — the loop case, and the one that used to be wrong.
+    [InlineData(0x2052, -16, 0x2042, false)]
+    [InlineData(0x10F2, -8, 0x10EA, false)]
+    [InlineData(0x2002, -2, 0x2000, false)]
+    // Backwards, under the bottom of the page.
+    [InlineData(0x2007, -16, 0x1FF7, true)]
+    [InlineData(0x2000, -1, 0x1FFF, true)]
+    // The extremes of the signed offset range.
+    [InlineData(0x2080, 127, 0x20FF, false)]
+    [InlineData(0x2081, 127, 0x2100, true)]
+    [InlineData(0x2080, -128, 0x2000, false)]
+    [InlineData(0x207F, -128, 0x1FFF, true)]
+    public void Page_Crossing_Is_Whether_The_Target_Lands_In_A_Different_Page(
+        ushort pc, int offset, ushort expectedTarget, bool expectedCrossed)
+    {
+        var target = BranchHelper.CalculateNewAbsoluteBranchAddress(
+            pc, (sbyte)offset, out var cyclesConsumed, out var crossed);
+
+        Assert.Equal(expectedTarget, target);
+        Assert.Equal(expectedCrossed, crossed);
+
+        // Cross-check against the definition, so the table above cannot drift from the rule.
+        Assert.Equal((pc & 0xFF00) != (target & 0xFF00), crossed);
+
+        // A taken branch costs one cycle, and one more when it crosses.
+        Assert.Equal(expectedCrossed ? 2UL : 1UL, cyclesConsumed);
+    }
+
+    /// <summary>
+    /// -128 is the offset that cannot be negated inside a signed byte, and the reason the old
+    /// implementation reached for a cast in the first place.
+    /// </summary>
+    [Fact]
+    public void The_Most_Negative_Offset_Does_Not_Throw()
+    {
+        var target = BranchHelper.CalculateNewAbsoluteBranchAddress(0x2080, -128, out _, out var crossed);
+
+        Assert.Equal(0x2000, target);
+        Assert.False(crossed);
+    }
+
+    [Fact]
+    public void Wrapping_Below_Zero_Stays_Within_The_Address_Space()
+    {
+        var target = BranchHelper.CalculateNewAbsoluteBranchAddress(0x0000, -1, out _, out var crossed);
+
+        Assert.Equal(0xFFFF, target);
+        Assert.True(crossed);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/BNE_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/BNE_test.cs
@@ -73,6 +73,39 @@ public class BNE_test
         test.Execute_And_Verify(AddrMode.Relative);
     }
 
+    /// <summary>
+    /// Backward branches are how loops are written, so this is the common case at run time — but
+    /// it was the one case with no cycle assertion, which is how an extra cycle went unnoticed
+    /// here for so long. The negative-offset tests below check the destination only.
+    /// </summary>
+    [Fact]
+    public void BNE_I_Takes_3_Cycles_Branching_Backwards_Within_Same_Page()
+    {
+        var test = new TestSpec()
+        {
+            PC             = 0x2050,
+            Z              = false, // BNE branches if Zero flag is clear.
+            OpCode         = OpCodeId.BNE,
+            FinalValue     = 0xf0, // - 16, so $2052 - $10 = $2042: same page.
+            ExpectedCycles = 3,
+        };
+        test.Execute_And_Verify(AddrMode.Relative);
+    }
+
+    [Fact]
+    public void BNE_I_Takes_4_Cycles_Branching_Backwards_Across_A_Page_Boundary()
+    {
+        var test = new TestSpec()
+        {
+            PC             = 0x2005,
+            Z              = false, // BNE branches if Zero flag is clear.
+            OpCode         = OpCodeId.BNE,
+            FinalValue     = 0xf0, // - 16, so $2007 - $10 = $1FF7: crosses into the page below.
+            ExpectedCycles = 4,
+        };
+        test.Execute_And_Verify(AddrMode.Relative);
+    }
+
     [Fact]
     public void BNE_I_Jumps_To_Correct_Location_When_Offset_Is_Negative()
     {


### PR DESCRIPTION
Every taken **backward** branch consumed one cycle too many. Since loops branch backwards, that was an extra cycle on essentially every loop iteration in every emulated program, on every system.

Found while implementing Apple II paddles, where the ROM's `PREAD` routine measures a duration by counting loop iterations — so the error showed up directly as wrong paddle positions.

## The bug

`BranchHelper` computed the page-crossing penalty from the branch *offset*, in separate positive and negative cases. The negative case read:

```csharp
Math.Abs((ushort)branchOffset)
```

`branchOffset` is an `sbyte`. Casting `-8` to `ushort` yields its two's-complement value — **65528**, not 8 — so `(PC & 0x00ff) < 65528` was always true and the branch was always reported as crossing a page. Forward branches were unaffected.

Probing all four cases directly:

```
backward, same page  ($10F2 -> $10EA)  reported=True   actual=False   <-- WRONG
backward, crosses    ($1007 -> $0FFF)  reported=True   actual=True    ok
forward,  same page  ($10F2 -> $10FA)  reported=False  actual=False   ok
forward,  crosses    ($10FA -> $1102)  reported=True   actual=True    ok
```

## The fix

Replaced the offset arithmetic with the rule itself: a branch crosses a page when the target's high byte differs from PC's. That is direction-agnostic, so both the positive/negative split and the `-128` negation hazard the cast was reaching for disappear.

## Why it survived

The branch instructions *do* have cycle tests — but every one uses a forward offset. The negative-offset tests assert only `ExpectedPC` and never `ExpectedCycles`, so the wrong case was the single case never checked.

Added backward same-page and backward page-crossing cycle tests to `BNE`, plus a `BranchHelperTest` covering both directions against both page outcomes and the signed-offset extremes (`+127`, `-128`, and wrapping below `$0000`). **Six of the new assertions fail against the old code** — verified by reverting the fix and re-running.

## Measured effect

Booting the DOS 3.3 System Master to its "DOS VERSION 3.3" banner:

| | boot completes | disk reads |
|---|---|---|
| master today | frame 2480 = **41.4 emulated seconds** | 64,036 |
| with this fix | frame 2120 = **35.4 emulated seconds** | 64,036 |

The identical read count is the useful part: RWTS takes exactly the same path and does exactly the same work — it was simply being charged too many cycles. The Disk II timing notes quoted the old 41 s figure and are updated here; the 31 spin-up waits are unchanged for the same reason.

Anything else timing-sensitive that was characterised against the old behaviour (C64 raster effects, VIC-20) is worth a fresh look, though nothing in the suite depended on it.

## Verification

All **1,631** tests pass across the solution, including the 742 core CPU tests. No existing test changed behaviour — the fix only removes a cycle that was never earned.