### PR TITLE
Add Apple II joystick and game port support

### DIFF
--- a/docs/host-apps/avalonia/automation.md
+++ b/docs/host-apps/avalonia/automation.md
@@ -98,6 +98,8 @@ A non-exhaustive list of the most useful AutomationIds, grouped by view. All of 
 - **Disk drive section** (Disk II): `DiskToggleButton` (insert/eject, label bound to state like
   the C64's `DiskToggleButton`), `BootDiskButton` (only visible with a disk inserted),
   `DriveStatusText`
+- **Configuration section**: `OpenApple2ConfigButton` (only enabled while the emulator is
+  stopped — see the note below), `KeyboardJoystickCheckBox` (usable while running)
 - **Load/Save section**: `LoadBasicButton`, `SaveBasicButton`, `LoadBinaryButton`,
   `LoadFromDskButton`, `DskFileComboBox`, `RunDskFileButton`,
   `AssemblyExampleComboBox`, `LoadAssemblyExampleButton`, `BasicExampleComboBox`,
@@ -112,6 +114,14 @@ A non-exhaustive list of the most useful AutomationIds, grouped by view. All of 
 - **ROM actions**: `RomStatusSummaryText`, `RomDirectoryTextBox`, `LoadRomsButton`,
   `DownloadRomsToFilesButton`, `DownloadRomsToMemoryButton`, `ClearRomsButton`
 - **Display**: `MonitorColorComboBox`, `RenderProviderComboBox`, `RenderTargetComboBox`
+- **Input &amp; Joystick**: `KeyboardJoystickEnableCheckBox` — the persisted setting. Its live
+  counterpart is `KeyboardJoystickCheckBox` in the sidebar, needed because this dialog only opens
+  while the emulator is stopped. Both show the same setting and stay in step; the difference is
+  that only the dialog's OK writes it to disk. The sidebar checkbox is always enabled.
+  <br/>**Caveat:** `CheckBox` controls do not appear in the macOS accessibility tree in this app at
+  all — verified against this dialog, where every button and combobox enumerates but no checkbox
+  does. Their AutomationIds are set correctly and are right for other hosts, but on macOS a
+  checkbox has to be verified from a screenshot rather than from `inspect-ui`.
 - **CPU**: `CpuCompatibilityProfileComboBox`
 - **Messages**: `ConfigStatusMessageText` (non-error status), `ConfigErrorStatusMessageText`
   (error status), `ConfigValidationMessageText` (bulleted validation-error list)
@@ -223,6 +233,15 @@ peekaboo menu click --app "DotNet 6502 Emulator" --path "DotNet 6502 Emulator > 
 | Toggle Download & Run section    | `⌘⌥⇧D`         | `Ctrl+Alt+Shift+D`    |
 | Toggle Load/Save section         | `⌘⌥⇧L`         | `Ctrl+Alt+Shift+L`    |
 | Toggle Configuration section     | `⌘⌥⇧C`         | `Ctrl+Alt+Shift+C`    |
+| Toggle Joystick KB               | `⌘⌥K`           | `Ctrl+Alt+K`          |
+
+`Toggle Joystick KB` uses the same key as the C64's and VIC-20's, so the shortcut means the same
+thing whichever machine is loaded.
+
+**Testing the keyboard joystick from automation:** `apple2.type` will not do it. That command goes
+through the text-paste service, which writes ASCII straight to the keyboard latch and never becomes
+a `HostKey`, so the joystick mapping cannot see it. Use `keyboard.press --key w` and read back
+`PDL(1)` — 0 means the key steered, 128 means it did not.
 
 Sidebar sections behave as an accordion in both the C64 and Apple II menus (shared
 `AccordionSections` helper): expanding one section collapses the others. Automation

--- a/docs/systems/apple2/overview.md
+++ b/docs/systems/apple2/overview.md
@@ -56,6 +56,19 @@ there is no CIA/VIA equivalent to emulate and no keyboard matrix to scan.
   where the monitor cannot resolve the dots inside a cycle. On the phosphor monitor settings the
   same dots render as the plain monochrome pattern at the full 280 instead.
 - Mixed mode: graphics with the bottom 4 text rows, for both lo-res and hi-res.
+- Game port: the three pushbuttons at `$C061`-`$C063` and the analog paddles at `$C064`-`$C067`,
+  fired by the `$C070` strobe. There is no digital joystick on this machine — a stick is two
+  potentiometers, so a gamepad direction drives its axis to the end of its travel and `PDL(n)`
+  reads it back. Both stick buttons are wired — games do use the second, e.g. Choplifter turns the
+  helicopter with it. A host gamepad works out of the box (A and B are the two buttons); the
+  keyboard can drive it too, enabled by "Enable keyboard joystick controls" in the configuration
+  dialog, which is the only place the setting is saved. The "Joystick KB"
+  checkbox in the sidebar shows and changes that same setting without saving it — handy for trying
+  it mid-game — and takes effect immediately on a running machine. Entries in "Download &amp; Run
+  programs" can switch it on for themselves, as the C64 list does, so a title that needs the game
+  port arrives playable: `W`/`A`/`S`/`D` steer, Space is
+  button 0 and Left Shift is button 1. WASD rather than the arrows so the Apple II's own arrow keys
+  keep working, and Left Shift so Right Shift is still free for typing shifted characters.
 - Selectable monitor: a composite colour monitor (the default) or a green, white or amber
   phosphor monitor. The choice applies to every mode, not just hi-res: text is monochrome either
   way (a colour monitor renders it white), and lo-res is full colour on a colour monitor and
@@ -122,7 +135,7 @@ For general monitor commands, see [Monitor library](../../libraries/core/dotnet6
 - Audio. `$C030` speaker toggles are counted but not turned into sound.
 - Disk II writing (the drive is always write-protected), a second drive, ProDOS-ordered `.po`
   images, and nibble/flux (`.nib`/`.woz`) media. See [Disk II](disk2.md) for what is supported.
-- Peripheral slots other than slot 6, cassette, paddles and game-port input, light pen.
+- Peripheral slots other than slot 6, cassette, the second paddle pair (2 and 3), light pen.
 - The language card / 16 KB RAM expansion.
 - The original, non-Autostart Apple II with Integer BASIC. That is a different ROM set rather
   than different hardware, so it is a plausible later configuration variant.

--- a/docs/tools/remote-control/overview.md
+++ b/docs/tools/remote-control/overview.md
@@ -84,6 +84,8 @@ By default the server binds to `127.0.0.1`, so it is only reachable from the sam
 - **Loopback by default.** The server binds to `127.0.0.1` unless `--remote-bind-address` (or the **Bind** field in the Debug & Remoting tab) is set to a different interface. The wire protocol is unauthenticated — only bind to non-loopback addresses on trusted networks.
 - **`keyboard.press` holds a key until `keyboard.release` or `keyboard.releaseall`.** The client controls press duration by choosing when to release. Keys are applied at frame boundary and remain held until released.
 - **`joystick.press` holds joystick actions until `joystick.release` or `joystick.releaseall`.** Use this for ergonomic hold/release remote control.
+- **The Apple II has one game port**, so `--port` is accepted and ignored there rather than rejected, and scripts written for the C64's two ports keep working. Its stick is analog: a held direction drives that axis to the end of its travel, so `PDL(0)`/`PDL(1)` read 0 or 255 and return to 127 on release, and fire is button 0 at `$C061`. It also accepts `fire2` for the second game-port button at
+`$C062`, which the C64 has no equivalent of.
 - **`c64.type` and `c64.loadprg` are C64-specific; `apple2.type` is Apple II-specific.** Other systems do not implement these and will return an error. The text/PRG is applied at the next frame boundary.
 - **`c64.type` feeds text across frames** — if the C64 keyboard buffer is full the remaining characters wait until space is available.
 - **`apple2.type` feeds text across frames** — the Apple II has a single-key latch instead of a buffer, so each character waits until the program has consumed the previous one (at most one per frame).

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/ViewModels/Apple2ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/ViewModels/Apple2ConfigDialogViewModel.cs
@@ -295,6 +295,23 @@ public class Apple2ConfigDialogViewModel : ViewModelBase
 
     public string SelectedMonitorColorHelpText => SelectedMonitorColor?.HelpText ?? string.Empty;
 
+    /// <summary>
+    /// Whether host keys drive the game port. Edits the working copy like every other setting in
+    /// this dialog, so Cancel discards it; the sidebar checkbox is the live counterpart for
+    /// toggling it while a game is running.
+    /// </summary>
+    public bool KeyboardJoystickEnabled
+    {
+        get => _workingConfig.SystemConfig.KeyboardJoystickEnabled;
+        set
+        {
+            if (_workingConfig.SystemConfig.KeyboardJoystickEnabled == value)
+                return;
+            _workingConfig.SystemConfig.KeyboardJoystickEnabled = value;
+            this.RaisePropertyChanged();
+        }
+    }
+
     public string OkButtonText => IsRunningInWebAssembly ? "Save" : "Ok";
 
     /// <summary>
@@ -459,6 +476,7 @@ public class Apple2ConfigDialogViewModel : ViewModelBase
             _originalConfig.SystemConfig.ROMs = ROM.Clone(_workingConfig.SystemConfig.ROMs);
             _originalConfig.SystemConfig.CpuCompatibilityProfile = _workingConfig.SystemConfig.CpuCompatibilityProfile;
             _originalConfig.SystemConfig.MonitorColor = _workingConfig.SystemConfig.MonitorColor;
+            _originalConfig.SystemConfig.KeyboardJoystickEnabled = _workingConfig.SystemConfig.KeyboardJoystickEnabled;
 
             if (_workingConfig.SystemConfig.RenderProviderType != null)
                 _originalConfig.SystemConfig.SetRenderProviderType(_workingConfig.SystemConfig.RenderProviderType);

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/ViewModels/Apple2MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/ViewModels/Apple2MenuViewModel.cs
@@ -1,3 +1,5 @@
+using Highbyte.DotNet6502.Systems.Apple2.Input;
+using Highbyte.DotNet6502.Impl.Avalonia.Apple2;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -77,13 +79,15 @@ public class Apple2MenuViewModel : ViewModelBase, ISystemMenuContributor
             "Lode Runner",
             "https://mirrors.apple2.org.za/ftp.apple.asimov.net/images/games/action/lode_runner/Lode%20Runner%20%284am%20crack%29.zip",
             zipEntryName: "Lode Runner (4am crack)/Lode Runner (4am crack).dsk",
-            runMode: Apple2DownloadRunMode.BootDisk) },
+            runMode: Apple2DownloadRunMode.BootDisk,
+            keyboardJoystickEnabled: true) },
 
         { "choplifter", new Apple2DownloadProgramInfo(
             "Choplifter",
             "https://mirrors.apple2.org.za/ftp.apple.asimov.net/images/games/action/Choplifter%20%284am%20and%20san%20inc%20crack%29.zip",
             zipEntryName: "Choplifter (4am and san inc crack)/Choplifter (4am and san inc crack).dsk",
-            runMode: Apple2DownloadRunMode.BootDisk) },
+            runMode: Apple2DownloadRunMode.BootDisk,
+            keyboardJoystickEnabled: true) },
 
         { "bolo", new Apple2DownloadProgramInfo(
             "Bolo",
@@ -95,6 +99,7 @@ public class Apple2MenuViewModel : ViewModelBase, ISystemMenuContributor
     public AvaloniaHostApp HostApp => _hostApp;
 
     public ReactiveCommand<Unit, Unit> ToggleConfigSectionCommand { get; }
+    public ReactiveCommand<Unit, Unit> ToggleJoystickKeyboardCommand { get; }
     public ReactiveCommand<Unit, Unit> ToggleLoadSaveSectionCommand { get; }
     public ReactiveCommand<Unit, Unit> ToggleDownloadSectionCommand { get; }
     public ReactiveCommand<Unit, Unit> ToggleDiskSectionCommand { get; }
@@ -125,10 +130,24 @@ public class Apple2MenuViewModel : ViewModelBase, ISystemMenuContributor
             .WhenAnyValue(x => x.EmulatorState)
             .Subscribe(_ => RaiseEmulatorStateChanged());
 
+        // The config dialog's OK replaces the host system config, so the sidebar checkbox has to
+        // re-read; without this the two show different values until something else refreshes.
+        _hostApp
+            .WhenAnyValue(x => x.CurrentHostSystemConfig)
+            .Subscribe(_ => this.RaisePropertyChanged(nameof(KeyboardJoystickEnabled)));
+
         ToggleConfigSectionCommand = ReactiveCommandHelper.CreateSafeCommand(
             () =>
             {
                 _sections.Toggle(Apple2MenuSection.Config);
+                return Task.CompletedTask;
+            },
+            outputScheduler: RxSchedulers.MainThreadScheduler);
+
+        ToggleJoystickKeyboardCommand = ReactiveCommandHelper.CreateSafeCommand(
+            () =>
+            {
+                KeyboardJoystickEnabled = !KeyboardJoystickEnabled;
                 return Task.CompletedTask;
             },
             outputScheduler: RxSchedulers.MainThreadScheduler);
@@ -251,6 +270,42 @@ public class Apple2MenuViewModel : ViewModelBase, ISystemMenuContributor
     /// <summary>Configuration may only be edited while the emulator is not running.</summary>
     public bool IsApple2ConfigEnabled => _hostApp.EmulatorState == EmulatorState.Uninitialized;
 
+    /// <summary>
+    /// The running machine's input handler, or null when nothing is running.
+    /// </summary>
+    private Apple2InputHandler? RunningInputHandler
+        => _hostApp.CurrentRunningSystem is Apple2System { InputConsumer: Apple2InputHandler handler }
+            ? handler
+            : null;
+
+    /// <summary>
+    /// Whether host keys drive the game port — the same setting the configuration dialog shows, so
+    /// the two always agree, and usable whether or not a machine is running.
+    ///
+    /// Changing it here is not written to disk. It updates the in-memory config, so it applies to
+    /// the next start, and is pushed straight into a running machine so it takes effect at once;
+    /// saving stays the dialog's job, reached by pressing OK there.
+    /// </summary>
+    public bool KeyboardJoystickEnabled
+    {
+        get => _hostApp.CurrentHostSystemConfig is Apple2HostConfig config
+               && config.SystemConfig.KeyboardJoystickEnabled;
+        set
+        {
+            if (_hostApp.CurrentHostSystemConfig is not Apple2HostConfig config
+                || config.SystemConfig.KeyboardJoystickEnabled == value)
+                return;
+
+            config.SystemConfig.KeyboardJoystickEnabled = value;
+
+            // Apply to the machine already running, which took its copy when it started.
+            if (RunningInputHandler is { } handler)
+                handler.InputConfig.KeyboardJoystickEnabled = value;
+
+            this.RaisePropertyChanged();
+        }
+    }
+
     /// <summary>Load/save needs a started (running or paused) system to load into.</summary>
     public bool IsFileOperationEnabled => _hostApp.EmulatorState != EmulatorState.Uninitialized;
 
@@ -260,6 +315,9 @@ public class Apple2MenuViewModel : ViewModelBase, ISystemMenuContributor
     public void RaiseEmulatorStateChanged()
     {
         this.RaisePropertyChanged(nameof(IsApple2ConfigEnabled));
+        // Starting a machine applies the persisted setting, so the checkbox must re-read rather
+        // than keep whatever it last showed for the previous machine.
+        this.RaisePropertyChanged(nameof(KeyboardJoystickEnabled));
         this.RaisePropertyChanged(nameof(IsFileOperationEnabled));
         this.RaisePropertyChanged(nameof(IsCopyPasteEnabled));
         RaiseDriveStateChanged();   // stopping the emulator empties the drive
@@ -671,7 +729,19 @@ public class Apple2MenuViewModel : ViewModelBase, ISystemMenuContributor
                 corsProxyUrl: _hostApp.GetCorsProxyUrl(),
                 downloadCache: _hostApp.GetDownloadCache());
 
-            await _apple2AutoLoadAndRun.DownloadAndRunProgram(programInfo);
+            await _apple2AutoLoadAndRun.DownloadAndRunProgram(
+                programInfo,
+                setConfigCallback: info =>
+                {
+                    // Applied while the emulator is stopped so the machine starts with it. Only the
+                    // in-memory config is touched — as with the sidebar checkbox, launching a game
+                    // must not quietly rewrite the user's saved settings.
+                    if (_hostApp.CurrentHostSystemConfig is Apple2HostConfig apple2HostConfig)
+                        apple2HostConfig.SystemConfig.KeyboardJoystickEnabled = info.KeyboardJoystickEnabled;
+                    return Task.CompletedTask;
+                });
+
+            this.RaisePropertyChanged(nameof(KeyboardJoystickEnabled));
         }
         catch (Exception ex)
         {
@@ -756,6 +826,7 @@ public class Apple2MenuViewModel : ViewModelBase, ISystemMenuContributor
 
     public IReadOnlyList<NativeMenuItemBase> GetNativeMenuItems()
     {
+        const KeyModifiers macBase = KeyModifiers.Meta | KeyModifiers.Alt;
         const KeyModifiers macShift = KeyModifiers.Meta | KeyModifiers.Alt | KeyModifiers.Shift;
 
         return new NativeMenuItemBase[]
@@ -763,11 +834,16 @@ public class Apple2MenuViewModel : ViewModelBase, ISystemMenuContributor
             BuildMenuItem("Toggle Download & Run section", new KeyGesture(Key.D, macShift), ToggleDownloadSectionCommand),
             BuildMenuItem("Toggle Load/Save section", new KeyGesture(Key.L, macShift), ToggleLoadSaveSectionCommand),
             BuildMenuItem("Toggle Configuration section", new KeyGesture(Key.C, macShift), ToggleConfigSectionCommand),
+            new NativeMenuItemSeparator(),
+            // Same key as the C64's and VIC-20's, so the shortcut means the same thing whichever
+            // machine is loaded.
+            BuildMenuItem("Toggle Joystick KB", new KeyGesture(Key.K, macBase), ToggleJoystickKeyboardCommand),
         };
     }
 
     public IReadOnlyList<KeyBinding> GetKeyBindings()
     {
+        const KeyModifiers nonMacBase = KeyModifiers.Control | KeyModifiers.Alt;
         const KeyModifiers nonMacShift = KeyModifiers.Control | KeyModifiers.Alt | KeyModifiers.Shift;
 
         return new[]
@@ -775,6 +851,7 @@ public class Apple2MenuViewModel : ViewModelBase, ISystemMenuContributor
             BuildKeyBinding(new KeyGesture(Key.D, nonMacShift), ToggleDownloadSectionCommand),
             BuildKeyBinding(new KeyGesture(Key.L, nonMacShift), ToggleLoadSaveSectionCommand),
             BuildKeyBinding(new KeyGesture(Key.C, nonMacShift), ToggleConfigSectionCommand),
+            BuildKeyBinding(new KeyGesture(Key.K, nonMacBase), ToggleJoystickKeyboardCommand),
         };
     }
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/Views/Apple2ConfigDialogView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/Views/Apple2ConfigDialogView.axaml
@@ -214,6 +214,26 @@
                 </StackPanel>
             </Border>
         </StackPanel>
+
+        <!-- Input Section -->
+        <StackPanel Width="368" Classes="wrap-item">
+            <Border Classes="content-section">
+                <StackPanel Classes="spacing-tight">
+                <TextBlock Text="Input &amp; Joystick"
+                            Classes=""/>
+
+                <CheckBox AutomationProperties.AutomationId="KeyboardJoystickEnableCheckBox"
+                        AutomationProperties.Name="Enable keyboard joystick controls"
+                        Content="Enable keyboard joystick controls"
+                        IsChecked="{Binding KeyboardJoystickEnabled}"/>
+
+                <TextBlock Text="W A S D steer the game port, Space is button 1 and Left Shift is button 2. Those keys stop reaching the Apple II keyboard while this is on. A host gamepad always works and needs no setting."
+                            Classes="small secondary-text"
+                            TextWrapping="Wrap"/>
+
+                </StackPanel>
+            </Border>
+        </StackPanel>
       </WrapPanel>
     </ScrollViewer>
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/Views/Apple2MenuView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/Views/Apple2MenuView.axaml
@@ -319,6 +319,20 @@
                 <TextBlock Text="ROM files, monitor colour, render provider and CPU compatibility. Only editable while the emulator is stopped."
                            Classes="small secondary-text"
                            TextWrapping="Wrap"/>
+
+                <!-- Live counterpart of the dialog's "Enable keyboard joystick controls": the
+                     dialog only opens while the emulator is stopped, so this is the one that can be
+                     flipped mid-game. Both write the same persisted setting. -->
+                <CheckBox Content="Joystick KB"
+                          Name="KeyboardJoystickCheckBox"
+                          AutomationProperties.AutomationId="KeyboardJoystickCheckBox"
+                          AutomationProperties.Name="Use the keyboard as a joystick"
+                          Classes="small"
+                          IsChecked="{Binding KeyboardJoystickEnabled, Mode=TwoWay}"/>
+
+                <TextBlock Text="W A S D steer, Space is button 1 and Left Shift is button 2 (some games, e.g. Choplifter, turn with it). Those keys stop reaching the Apple II keyboard while this is on. Mirrors the configuration dialog setting, but changing it here is not saved — press OK in that dialog to keep it."
+                           Classes="small secondary-text"
+                           TextWrapping="Wrap"/>
             </StackPanel>
         </Border>
     </StackPanel>

--- a/src/apps/Highbyte.DotNet6502.App.RemoteClient/RemoteClientRequestBuilder.cs
+++ b/src/apps/Highbyte.DotNet6502.App.RemoteClient/RemoteClientRequestBuilder.cs
@@ -184,7 +184,7 @@ internal static class RemoteClientRequestBuilder
 
     private static string? ApplyJoystickState(Dictionary<string, string?> parameters, Dictionary<string, object?> request, bool allowExplicitFalse)
     {
-        foreach (var action in new[] { "up", "down", "left", "right", "fire" })
+        foreach (var action in new[] { "up", "down", "left", "right", "fire", "fire2" })
         {
             var parseResult = ParseJoystickState(parameters, action, allowExplicitFalse);
             if (parseResult.Error != null)

--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Apple2/Apple2HostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Apple2/Apple2HostConfig.cs
@@ -1,5 +1,6 @@
 using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Apple2.Config;
+using Highbyte.DotNet6502.Systems.Apple2.Input;
 
 namespace Highbyte.DotNet6502.Impl.Avalonia.Apple2;
 
@@ -10,5 +11,13 @@ public class Apple2HostConfig : HostSystemConfigBase<Apple2SystemConfig>
 
     public override bool AudioSupported => false;
 
-    public override object Clone() => (Apple2HostConfig)base.Clone();
+    /// <summary>Gamepad and keyboard-joystick mapping for the game port.</summary>
+    public Apple2InputConfig InputConfig { get; set; } = new();
+
+    public override object Clone()
+    {
+        var clone = (Apple2HostConfig)base.Clone();
+        clone.InputConfig = (Apple2InputConfig)InputConfig.Clone();
+        return clone;
+    }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Apple2/Apple2Setup.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Avalonia.Apple2/Apple2Setup.cs
@@ -43,7 +43,14 @@ public class Apple2Setup : Apple2SystemConfigurerCore
     public override Task<SystemRunner> BuildSystemRunner(ISystem system, IHostSystemConfig hostSystemConfig)
     {
         var apple2 = (Apple2System)system;
-        apple2.InputConsumer = new Apple2InputHandler(apple2, _loggerFactory);
+        var apple2HostConfig = (Apple2HostConfig)hostSystemConfig;
+
+        // The persisted setting is the source of truth; the mapping object carries it at runtime so
+        // the input handler has everything it needs in one place.
+        apple2HostConfig.InputConfig.KeyboardJoystickEnabled =
+            apple2HostConfig.SystemConfig.KeyboardJoystickEnabled;
+
+        apple2.InputConsumer = new Apple2InputHandler(apple2, _loggerFactory, apple2HostConfig.InputConfig);
         return Task.FromResult(new SystemRunner(apple2));
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Remoting/Protocol/RemoteCommand.cs
+++ b/src/libraries/Highbyte.DotNet6502.Remoting/Protocol/RemoteCommand.cs
@@ -44,6 +44,12 @@ public class RemoteCommand
     [JsonPropertyName("fire")]
     public bool? Fire { get; set; }
 
+    /// <summary>
+    /// The second joystick button. Only the Apple II game port has one; systems without it ignore
+    /// the field rather than erroring, so one script can drive either machine.
+    /// </summary>
+    public bool? Fire2 { get; set; }
+
     // keyboard.press / keyboard.release / keyboard.iskeydown
     [JsonPropertyName("key")]
     public string? Key { get; set; }

--- a/src/libraries/Highbyte.DotNet6502.Remoting/RemoteCommandDispatcher.cs
+++ b/src/libraries/Highbyte.DotNet6502.Remoting/RemoteCommandDispatcher.cs
@@ -374,6 +374,7 @@ public class RemoteCommandDispatcher
         SetJoystickBool(input, port, "Left",  cmd.Left);
         SetJoystickBool(input, port, "Right", cmd.Right);
         SetJoystickBool(input, port, "Fire",  cmd.Fire);
+        SetJoystickBool(input, port, "Fire2", cmd.Fire2);
     }
 
     private static void JoystickPressDirect(IRemotableHostApp hostApp, RemoteCommand cmd)
@@ -386,6 +387,7 @@ public class RemoteCommandDispatcher
         SetHeldJoystickBool(input, port, "Left", cmd.Left, pressed: true);
         SetHeldJoystickBool(input, port, "Right", cmd.Right, pressed: true);
         SetHeldJoystickBool(input, port, "Fire", cmd.Fire, pressed: true);
+        SetHeldJoystickBool(input, port, "Fire2", cmd.Fire2, pressed: true);
     }
 
     private static void JoystickReleaseDirect(IRemotableHostApp hostApp, RemoteCommand cmd)
@@ -398,6 +400,7 @@ public class RemoteCommandDispatcher
         SetHeldJoystickBool(input, port, "Left", cmd.Left, pressed: false);
         SetHeldJoystickBool(input, port, "Right", cmd.Right, pressed: false);
         SetHeldJoystickBool(input, port, "Fire", cmd.Fire, pressed: false);
+        SetHeldJoystickBool(input, port, "Fire2", cmd.Fire2, pressed: false);
     }
 
     private static void JoystickReleaseAllDirect(IRemotableHostApp hostApp, RemoteCommand cmd)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Apple2.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Apple2.cs
@@ -89,6 +89,9 @@ public class Apple2 : ISystem, ITextMode, IScreen, ISystemState, ISystemMonitor
     /// <summary>The Disk II controller card in slot 6 (read-only; boots when a disk is inserted).</summary>
     public Disk2Controller DiskController { get; }
 
+    /// <summary>The game port: pushbuttons and analog paddles. See <see cref="Apple2GamePort"/>.</summary>
+    public Apple2GamePort GamePort { get; }
+
     /// <summary>Types text into the machine by feeding the keyboard latch, one char per frame.</summary>
     public Apple2TextPaste TextPaste { get; }
 
@@ -125,7 +128,8 @@ public class Apple2 : ISystem, ITextMode, IScreen, ISystemState, ISystemMonitor
         CPU = new CPU(loggerFactory, config.CpuCompatibilityProfile);
         // The controller times its motor spin-down off the CPU's cumulative cycle count.
         DiskController = new Disk2Controller(() => CPU.ExecState.CyclesConsumed);
-        SoftSwitches = new Apple2SoftSwitches(Keyboard, DiskController);
+        GamePort = new Apple2GamePort(() => CPU.ExecState.CyclesConsumed);
+        SoftSwitches = new Apple2SoftSwitches(Keyboard, DiskController, GamePort);
         TextPaste = new Apple2TextPaste(this, loggerFactory);
         BasicTokenParser = new Apple2BasicTokenParser(this, loggerFactory);
         InputInjector = new Apple2InputInjector(this);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2SystemConfig.cs
@@ -120,6 +120,18 @@ public class Apple2SystemConfig : ISystemConfig
         set { _monitorColor = value; _isDirty = true; }
     }
 
+    /// <summary>
+    /// Whether host keys drive the game port. Lives here, on the persisted system config, rather
+    /// than on the runtime mapping — the same place the C64 keeps it, so there is one source of
+    /// truth that survives a restart and one place the config dialog and the sidebar both bind to.
+    /// </summary>
+    private bool _keyboardJoystickEnabled;
+    public bool KeyboardJoystickEnabled
+    {
+        get => _keyboardJoystickEnabled;
+        set { _keyboardJoystickEnabled = value; _isDirty = true; }
+    }
+
     private CpuCompatibilityProfile _cpuCompatibilityProfile = CpuCompatibilityProfile.StableUnofficial;
     public CpuCompatibilityProfile CpuCompatibilityProfile
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/DiskImage/Download/Apple2AutoLoadAndRun.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/DiskImage/Download/Apple2AutoLoadAndRun.cs
@@ -42,7 +42,13 @@ public class Apple2AutoLoadAndRun
     /// Downloads the program's disk image and runs it the way the entry asks for: either
     /// injecting a catalog file into RAM, or booting the disk in the emulated Disk II.
     /// </summary>
-    public async Task DownloadAndRunProgram(Apple2DownloadProgramInfo programInfo)
+    /// <param name="setConfigCallback">
+    /// Applies per-program emulator settings. Called while the emulator is stopped, so the machine
+    /// picks them up as it starts — the same hook the C64 flow uses.
+    /// </param>
+    public async Task DownloadAndRunProgram(
+        Apple2DownloadProgramInfo programInfo,
+        Func<Apple2DownloadProgramInfo, Task>? setConfigCallback = null)
     {
         // Restart for a clean machine state, like the C64 flow.
         if (_hostApp.EmulatorState is EmulatorState.Running or EmulatorState.Paused)
@@ -50,6 +56,9 @@ public class Apple2AutoLoadAndRun
             _logger.LogInformation("Stopping emulator before program download.");
             _hostApp.Stop();
         }
+
+        if (setConfigCallback != null)
+            await setConfigCallback(programInfo);
 
         await _hostApp.Start();
         var apple2 = (Apple2System)_hostApp.CurrentRunningSystem!;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/DiskImage/Download/Apple2DownloadProgramInfo.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/DiskImage/Download/Apple2DownloadProgramInfo.cs
@@ -30,13 +30,15 @@ public class Apple2DownloadProgramInfo
         string downloadUrl,
         string fileName = "*",
         string? zipEntryName = null,
-        Apple2DownloadRunMode runMode = Apple2DownloadRunMode.InjectFileIntoRam)
+        Apple2DownloadRunMode runMode = Apple2DownloadRunMode.InjectFileIntoRam,
+        bool keyboardJoystickEnabled = false)
     {
         DisplayName = displayName;
         DownloadUrl = downloadUrl;
         FileName = fileName;
         ZipEntryName = zipEntryName;
         RunMode = runMode;
+        KeyboardJoystickEnabled = keyboardJoystickEnabled;
     }
 
     public string DisplayName { get; }
@@ -59,4 +61,11 @@ public class Apple2DownloadProgramInfo
 
     /// <summary>Booting needs the optional Disk II boot ROM; injecting does not.</summary>
     public bool RequiresDisk2Rom => RunMode == Apple2DownloadRunMode.BootDisk;
+
+    /// <summary>
+    /// Whether to switch the keyboard joystick on for this program, as the C64 list does per entry.
+    /// Set it for titles that read the game port, so they are playable without the user first
+    /// having to work out that they need a joystick and where the setting lives.
+    /// </summary>
+    public bool KeyboardJoystickEnabled { get; }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Input/Apple2InputConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Input/Apple2InputConfig.cs
@@ -1,0 +1,52 @@
+using Highbyte.DotNet6502.Systems.Input;
+
+namespace Highbyte.DotNet6502.Systems.Apple2.Input;
+
+/// <summary>
+/// How host input drives the Apple II game port: which gamepad buttons and which host keys count
+/// as joystick directions.
+///
+/// The machine has a single game port, so unlike the C64 there is no port to choose between —
+/// paddles 0 and 1 are the one stick's axes.
+/// </summary>
+public class Apple2InputConfig : ICloneable
+{
+    /// <summary>
+    /// Whether host keys drive the joystick. Off by default, and deliberately opt-in: the mapped
+    /// keys are taken away from the keyboard while it is on.
+    /// </summary>
+    public bool KeyboardJoystickEnabled { get; set; }
+
+    /// <summary>
+    /// Which host key stands for which joystick action, when the keyboard joystick is on.
+    ///
+    /// WASD rather than the arrows, which keeps the Apple II's own left/right arrows — backspace
+    /// and retype — working while the stick is in use. Left Shift is the second button, so Right
+    /// Shift is still available for typing shifted characters.
+    /// </summary>
+    public Dictionary<HostKey, JoystickAction> KeyboardToJoystickMap = new()
+    {
+        { HostKey.KeyW, JoystickAction.Up },
+        { HostKey.KeyS, JoystickAction.Down },
+        { HostKey.KeyA, JoystickAction.Left },
+        { HostKey.KeyD, JoystickAction.Right },
+        { HostKey.Space, JoystickAction.Fire },
+        { HostKey.ShiftLeft, JoystickAction.Fire2 },
+    };
+
+    /// <summary>
+    /// Which gamepad button combination triggers which joystick action. Same shape as the C64's
+    /// map, and the same defaults, so a controller behaves identically across systems.
+    /// </summary>
+    public Dictionary<GamepadButton[], JoystickAction[]> GamePadToJoystickMap = new()
+    {
+        { new[] { GamepadButton.A }, new[] { JoystickAction.Fire } },
+        { new[] { GamepadButton.B }, new[] { JoystickAction.Fire2 } },
+        { new[] { GamepadButton.DPadUp }, new[] { JoystickAction.Up } },
+        { new[] { GamepadButton.DPadDown }, new[] { JoystickAction.Down } },
+        { new[] { GamepadButton.DPadLeft }, new[] { JoystickAction.Left } },
+        { new[] { GamepadButton.DPadRight }, new[] { JoystickAction.Right } },
+    };
+
+    public object Clone() => MemberwiseClone();
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Input/Apple2InputHandler.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Input/Apple2InputHandler.cs
@@ -24,6 +24,10 @@ public class Apple2InputHandler : IInputConsumer
 
     private readonly Apple2System _apple2;
     private readonly ILogger _logger;
+    private readonly Apple2InputConfig _inputConfig;
+
+    // Reused per frame so a held stick does not allocate 60 times a second.
+    private readonly HashSet<JoystickAction> _joystickActions = new();
 
     private IHostInputState _inputState = default!;
 
@@ -34,11 +38,15 @@ public class Apple2InputHandler : IInputConsumer
     public ISystem System => _apple2;
     public Instrumentations Instrumentations { get; } = new();
 
-    public Apple2InputHandler(Apple2System apple2, ILoggerFactory loggerFactory)
+    public Apple2InputHandler(Apple2System apple2, ILoggerFactory loggerFactory, Apple2InputConfig? inputConfig = null)
     {
         _apple2 = apple2;
         _logger = loggerFactory.CreateLogger(nameof(Apple2InputHandler));
+        _inputConfig = inputConfig ?? new Apple2InputConfig();
     }
+
+    /// <summary>The gamepad and keyboard-joystick mapping in force.</summary>
+    public Apple2InputConfig InputConfig => _inputConfig;
 
     public void Init(IHostInputState inputState)
     {
@@ -58,6 +66,8 @@ public class Apple2InputHandler : IInputConsumer
             _apple2.InputInjector.ApplyInjectedKeysTo(merged);
             keysDown = merged;
         }
+
+        keysDown = ApplyJoystick(keysDown);
 
         var shift = keysDown.Contains(HostKey.ShiftLeft) || keysDown.Contains(HostKey.ShiftRight);
         var control = keysDown.Contains(HostKey.ControlLeft) || keysDown.Contains(HostKey.ControlRight);
@@ -81,6 +91,50 @@ public class Apple2InputHandler : IInputConsumer
         _previousKeysDown.Clear();
         foreach (var k in keysDown)
             _previousKeysDown.Add(k);
+    }
+
+    /// <summary>
+    /// Turns the gamepad — and the host keyboard, when the keyboard joystick is enabled — into
+    /// game-port state, and returns the keys that are still the keyboard's to handle.
+    ///
+    /// Keys claimed by the joystick are withheld from the keyboard: a key cannot both steer and
+    /// type, and the arrow keys the joystick uses by default are real Apple II keys.
+    /// </summary>
+    private IReadOnlySet<HostKey> ApplyJoystick(IReadOnlySet<HostKey> keysDown)
+    {
+        _joystickActions.Clear();
+
+        foreach (var (buttons, actions) in _inputConfig.GamePadToJoystickMap)
+        {
+            if (buttons.All(_inputState.GamepadButtonsDown.Contains))
+            {
+                foreach (var action in actions)
+                    _joystickActions.Add(action);
+            }
+        }
+
+        var remainingKeys = keysDown;
+        if (_inputConfig.KeyboardJoystickEnabled)
+        {
+            HashSet<HostKey>? claimed = null;
+            foreach (var (key, action) in _inputConfig.KeyboardToJoystickMap)
+            {
+                if (!keysDown.Contains(key))
+                    continue;
+                _joystickActions.Add(action);
+                (claimed ??= new HashSet<HostKey>(keysDown)).Remove(key);
+            }
+            if (claimed != null)
+                remainingKeys = claimed;
+        }
+
+        // Remotely injected actions join the same set, so a script drives the port through the
+        // identical path a gamepad does.
+        _apple2.InputInjector.ApplyInjectedJoystickActionsTo(_joystickActions);
+        _apple2.InputInjector.ClearFrameInjectedJoystickActions();
+
+        _apple2.GamePort.ApplyJoystickActions(_joystickActions);
+        return remainingKeys;
     }
 
     public void Cleanup() { }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Input/Apple2InputInjector.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Input/Apple2InputInjector.cs
@@ -14,8 +14,12 @@ namespace Highbyte.DotNet6502.Systems.Apple2.Input;
 /// modifiers combining with other injected keys, exactly like the physical keyboard.
 ///
 /// The machine has no per-key state (only the single ASCII latch), so <see cref="IsKeyDown"/>
-/// reflects injected state only. There is no game/joystick port emulation yet, so no joystick
-/// actions are exposed.
+/// reflects injected state only.
+///
+/// Joystick actions are injected the same way and merged into the handler's action set, so they
+/// reach the analog game port through exactly the path a gamepad takes. There is one game port,
+/// so the port argument is accepted and ignored rather than rejected — scripts written against
+/// the C64's two ports keep working.
 /// </summary>
 public class Apple2InputInjector : IInputInjector
 {
@@ -23,6 +27,20 @@ public class Apple2InputInjector : IInputInjector
 
     private readonly HashSet<HostKey> _frameInjectedKeys = new();
     private readonly HashSet<HostKey> _heldKeys = new();
+
+    private readonly HashSet<JoystickAction> _frameInjectedJoystickActions = new();
+    private readonly HashSet<JoystickAction> _heldJoystickActions = new();
+
+    private static readonly Dictionary<string, JoystickAction> StringToJoystickAction =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["up"] = JoystickAction.Up,
+            ["down"] = JoystickAction.Down,
+            ["left"] = JoystickAction.Left,
+            ["right"] = JoystickAction.Right,
+            ["fire"] = JoystickAction.Fire,
+            ["fire2"] = JoystickAction.Fire2,
+        };
 
     private static readonly Dictionary<string, HostKey> StringToHostKey = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -101,10 +119,14 @@ public class Apple2InputInjector : IInputInjector
 
     public IReadOnlyList<string> GetAvailableJoystickActions()
     {
-        return Array.Empty<string>();
+        return StringToJoystickAction.Keys.ToList();
     }
 
-    public int JoystickPortCount => 0;
+    /// <summary>One game port, so one joystick.</summary>
+    public int JoystickPortCount => 1;
+
+    public bool HasInjectedJoystickActions
+        => _frameInjectedJoystickActions.Count > 0 || _heldJoystickActions.Count > 0;
 
     public void BeginFrame()
     {
@@ -152,15 +174,53 @@ public class Apple2InputInjector : IInputInjector
         return _heldKeys.Contains(hostKey) || _frameInjectedKeys.Contains(hostKey);
     }
 
-    public void SetJoystickAction(int port, string actionName, bool pressed) { }
+    public void SetJoystickAction(int port, string actionName, bool pressed)
+    {
+        if (!StringToJoystickAction.TryGetValue(actionName, out var action))
+            return;
 
-    public void HoldJoystickAction(int port, string actionName) { }
+        if (pressed)
+            _frameInjectedJoystickActions.Add(action);
+        else
+        {
+            _frameInjectedJoystickActions.Remove(action);
+            _heldJoystickActions.Remove(action);
+        }
+    }
 
-    public void ReleaseHeldJoystickAction(int port, string actionName) { }
+    public void HoldJoystickAction(int port, string actionName)
+    {
+        if (StringToJoystickAction.TryGetValue(actionName, out var action))
+            _heldJoystickActions.Add(action);
+    }
 
-    public void ReleaseAllHeldJoystickActions(int port) { }
+    public void ReleaseHeldJoystickAction(int port, string actionName)
+    {
+        if (StringToJoystickAction.TryGetValue(actionName, out var action))
+            _heldJoystickActions.Remove(action);
+    }
 
-    public bool IsJoystickActionDown(int port, string actionName) => false;
+    public void ReleaseAllHeldJoystickActions(int port) => _heldJoystickActions.Clear();
+
+    public bool IsJoystickActionDown(int port, string actionName)
+        => StringToJoystickAction.TryGetValue(actionName, out var action)
+           && (_heldJoystickActions.Contains(action) || _frameInjectedJoystickActions.Contains(action));
+
+    /// <summary>
+    /// Merges injected joystick actions into the set the handler is about to apply to the game
+    /// port. Held actions persist; one-frame ones are consumed by the handler clearing them.
+    /// </summary>
+    public void ApplyInjectedJoystickActionsTo(HashSet<JoystickAction> actions)
+    {
+        foreach (var action in _heldJoystickActions)
+            actions.Add(action);
+
+        foreach (var action in _frameInjectedJoystickActions)
+            actions.Add(action);
+    }
+
+    /// <summary>Drops the one-frame joystick actions, mirroring how injected keys are consumed.</summary>
+    public void ClearFrameInjectedJoystickActions() => _frameInjectedJoystickActions.Clear();
 
     public void Clear()
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2GamePort.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2GamePort.cs
@@ -1,0 +1,217 @@
+using Highbyte.DotNet6502.Systems.Input;
+namespace Highbyte.DotNet6502.Systems.Apple2.Peripherals;
+
+/// <summary>
+/// The Apple II game port: up to three pushbuttons and four analog paddles.
+///
+/// There is no digital joystick on this machine. A "joystick" is two 150k potentiometers — paddle
+/// 0 for X, paddle 1 for Y — and the software reads them by timing, not by reading a value. A
+/// strobe of <see cref="TriggerAddress"/> fires a 558 one-shot per paddle; bit 7 of that paddle's
+/// address then reads high until its timer expires, after a delay proportional to the pot's
+/// position. The ROM's PREAD counts loop iterations until the bit drops, and that count is the
+/// position.
+///
+/// <para>
+/// <b>Hold time.</b> PREAD's polling loop costs <see cref="PreadLoopCycles"/> cycles per
+/// iteration, so holding the bit for <c>position * PreadLoopCycles</c> makes PREAD count back
+/// exactly the position that was set, and <c>PDL(n)</c> round-trips. Real hardware is close to
+/// this by design but not exactly — the 558 runs on its own RC constant (~11 us per unit) rather
+/// than on CPU cycles, so the two only track because the machine was built that way. Deliberately
+/// modelling the loop cost instead of the RC curve keeps the round-trip exact and testable;
+/// nothing observed so far needs the analog behaviour, and the alternative is a model whose
+/// off-by-a-little errors would show up as games feeling subtly wrong rather than failing.
+/// </para>
+///
+/// <para>
+/// Not modelled: pot non-linearity, the interrupt sensitivity that makes PREAD unreliable on real
+/// hardware with interrupts enabled, and the shared-capacitor coupling between paddles.
+/// </para>
+/// </summary>
+public class Apple2GamePort
+{
+    /// <summary>$C061-$C063: pushbuttons 0-2, in bit 7.</summary>
+    public const ushort Button0Address = 0xC061;
+
+    /// <summary>$C064-$C067: paddle timer outputs, in bit 7.</summary>
+    public const ushort Paddle0Address = 0xC064;
+
+    /// <summary>$C070: strobing this restarts every paddle's one-shot.</summary>
+    public const ushort TriggerAddress = 0xC070;
+
+    public const int ButtonCount = 3;
+    public const int PaddleCount = 4;
+
+    /// <summary>
+    /// Neutral paddle position — a centred stick, and what a game reads at rest.
+    ///
+    /// The true midpoint of 0-255 is 127.5, so this has to round one way or the other, and the
+    /// choice is not cosmetic: Choplifter compares against 128 with no dead zone, so at 127 it
+    /// reads a centred stick as held left and the helicopter drifts. Verified by instrumenting
+    /// what the game actually computes — it read back exactly the value set, so the read model was
+    /// right and only the resting value was wrong. Rounding up suits real software better,
+    /// because a game that splits the range at 128 puts centre in the upper half.
+    /// </summary>
+    public const byte PaddleCentre = 128;
+
+    /// <summary>Ends of a paddle's travel, which a digital direction drives it straight to.</summary>
+    public const byte PaddleMin = 0;
+    public const byte PaddleMax = 255;
+
+    /// <summary>
+    /// Cycles per iteration of the ROM's PREAD polling loop
+    /// (<c>LDA $C064,X</c> 4, <c>BPL</c> 2, <c>INY</c> 2, <c>BNE</c> 3).
+    /// </summary>
+    public const int PreadLoopCycles = 11;
+
+    private readonly Func<ulong> _cpuCycleProvider;
+    private readonly byte[] _paddlePositions = new byte[PaddleCount];
+    private readonly bool[] _buttons = new bool[ButtonCount];
+    /// <summary>
+    /// When the one-shot was last fired, or null if it never has been. Null rather than 0: at
+    /// power-on the CPU cycle counter is also 0, so treating "never triggered" as "triggered at
+    /// cycle 0" would make an untouched game port read as though every paddle timer were running.
+    /// </summary>
+    private ulong? _triggeredAtCycle;
+
+    /// <summary>
+    /// How many times software has strobed $C070 to start a paddle read. A climbing count is the
+    /// only reliable way to tell whether a game actually uses the stick — the same role
+    /// <c>Disk2Controller.DataReadCount</c> plays for the drive.
+    /// </summary>
+    public ulong PaddleTriggerCount { get; private set; }
+
+    /// <summary>
+    /// How many times software has read each pushbutton at $C061-$C063. Per button rather than a
+    /// total, because which button a game polls is exactly the question worth asking — a game that
+    /// reads button 1 needs it mapped, and an aggregate count hides that.
+    /// </summary>
+    public readonly ulong[] ButtonReadCounts = new ulong[ButtonCount];
+
+    /// <summary>Reads across all buttons.</summary>
+    public ulong ButtonReadCount
+    {
+        get
+        {
+            ulong total = 0;
+            foreach (var count in ButtonReadCounts)
+                total += count;
+            return total;
+        }
+    }
+
+    public Apple2GamePort(Func<ulong> cpuCycleProvider)
+    {
+        _cpuCycleProvider = cpuCycleProvider;
+        for (var paddle = 0; paddle < PaddleCount; paddle++)
+            _paddlePositions[paddle] = PaddleCentre;
+    }
+
+    /// <summary>Position of a paddle, 0-255. Paddle 0 is a joystick's X axis, paddle 1 its Y.</summary>
+    public byte GetPaddlePosition(int paddle) => _paddlePositions[paddle];
+
+    public void SetPaddlePosition(int paddle, byte position)
+    {
+        ValidatePaddle(paddle);
+        _paddlePositions[paddle] = position;
+    }
+
+    public bool IsButtonPressed(int button)
+    {
+        ValidateButton(button);
+        return _buttons[button];
+    }
+
+    public void SetButton(int button, bool pressed)
+    {
+        ValidateButton(button);
+        _buttons[button] = pressed;
+    }
+
+    public void ClearAll()
+    {
+        for (var paddle = 0; paddle < PaddleCount; paddle++)
+            _paddlePositions[paddle] = PaddleCentre;
+        Array.Clear(_buttons);
+        _triggeredAtCycle = null;
+    }
+
+    /// <summary>Strobe of $C070: restarts every paddle's one-shot.</summary>
+    public void Trigger()
+    {
+        _triggeredAtCycle = _cpuCycleProvider();
+        PaddleTriggerCount++;
+    }
+
+    /// <summary>
+    /// Drives the port from a digital joystick. A held direction takes its axis to the end of its
+    /// travel and releasing returns it to centre, which is how a switch-type stick behaves on this
+    /// analog port — the pots are at their extremes, not at intermediate positions.
+    ///
+    /// Opposite directions held together cancel to centre: the stick cannot physically be at both
+    /// ends of an axis, and centring is what a real one would read as it passes through.
+    ///
+    /// Both buttons are wired, because games use both: Choplifter fires with button 0 and turns the
+    /// helicopter with button 1, and mapping only the first leaves the game half-playable in a way
+    /// that looks like a broken joystick rather than a missing mapping.
+    /// </summary>
+    public void ApplyJoystickActions(IReadOnlySet<JoystickAction> actions)
+    {
+        SetPaddlePosition(0, AxisPosition(
+            actions.Contains(JoystickAction.Left), actions.Contains(JoystickAction.Right)));
+        SetPaddlePosition(1, AxisPosition(
+            actions.Contains(JoystickAction.Up), actions.Contains(JoystickAction.Down)));
+        SetButton(0, actions.Contains(JoystickAction.Fire));
+        SetButton(1, actions.Contains(JoystickAction.Fire2));
+    }
+
+    private static byte AxisPosition(bool towardsMin, bool towardsMax)
+    {
+        if (towardsMin == towardsMax)
+            return PaddleCentre;   // neither held, or both.
+        return towardsMin ? PaddleMin : PaddleMax;
+    }
+
+    /// <summary>
+    /// Whether a paddle's timer is still running, i.e. what bit 7 of $C064+n reads. Position 0
+    /// expires immediately, so PREAD counts zero iterations and reports 0.
+    /// </summary>
+    public bool IsPaddleTimerRunning(int paddle)
+    {
+        ValidatePaddle(paddle);
+        if (_triggeredAtCycle is not { } triggeredAt)
+            return false;
+
+        var elapsed = _cpuCycleProvider() - triggeredAt;
+        return elapsed < (ulong)(_paddlePositions[paddle] * PreadLoopCycles);
+    }
+
+    /// <summary>
+    /// The byte the CPU reads from $C060-$C06F. Bit 7 carries the answer; the remaining bits are
+    /// whatever the data bus last held, which no software relies on, so zero is fine.
+    /// </summary>
+    public byte ReadGamePort(ushort address)
+    {
+        var offset = address & 0x0F;
+        if (offset is >= 1 and <= 3)
+            ButtonReadCounts[offset - 1]++;
+
+        return offset switch
+        {
+            >= 1 and <= 3 => IsButtonPressed(offset - 1) ? (byte)0x80 : (byte)0x00,
+            >= 4 and <= 7 => IsPaddleTimerRunning(offset - 4) ? (byte)0x80 : (byte)0x00,
+            _ => 0x00,   // $C060 cassette input, and the unassigned addresses above $C067.
+        };
+    }
+
+    private static void ValidatePaddle(int paddle)
+    {
+        if (paddle < 0 || paddle >= PaddleCount)
+            throw new ArgumentOutOfRangeException(nameof(paddle), paddle, $"Paddle must be 0-{PaddleCount - 1}.");
+    }
+
+    private static void ValidateButton(int button)
+    {
+        if (button < 0 || button >= ButtonCount)
+            throw new ArgumentOutOfRangeException(nameof(button), button, $"Button must be 0-{ButtonCount - 1}.");
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2SoftSwitches.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2SoftSwitches.cs
@@ -47,11 +47,23 @@ public class Apple2SoftSwitches
 
     private readonly Apple2Keyboard _keyboard;
     private readonly Disk2Controller? _diskController;
+    private readonly Apple2GamePort? _gamePort;
 
-    public Apple2SoftSwitches(Apple2Keyboard keyboard, Disk2Controller? diskController = null)
+    public Apple2SoftSwitches(Apple2Keyboard keyboard, Disk2Controller? diskController = null, Apple2GamePort? gamePort = null)
     {
         _keyboard = keyboard;
         _diskController = diskController;
+        _gamePort = gamePort;
+    }
+
+    /// <summary>
+    /// $C070 (PTRIG) restarts every paddle's one-shot. Reads and writes both strobe it, which the
+    /// generic write-forwards-to-read path below already gives us.
+    /// </summary>
+    private byte TriggerPaddles()
+    {
+        _gamePort?.Trigger();
+        return 0x00;
     }
 
     /// <summary>Text mode ($C051) vs. graphics mode ($C050).</summary>
@@ -118,7 +130,8 @@ public class Apple2SoftSwitches
             0x10 => _keyboard.ReadAndClearStrobe(),          // $C010-$C01F  clear strobe
             0x30 => ToggleSpeaker(),                         // $C030-$C03F  speaker
             0x50 => ApplyDisplaySwitch(address),             // $C050-$C05F  display mode
-            0x60 => 0x00,                                    // $C060-$C06F  cassette in, buttons, paddles: idle
+            0x60 => _gamePort?.ReadGamePort(address) ?? 0x00, // $C060-$C06F  cassette in, buttons, paddles
+            0x70 => TriggerPaddles(),                        // $C070-$C07F  PTRIG: restart paddle timers
             0xE0 => ReadDiskController(address),             // $C0E0-$C0EF  Disk II controller (slot 6)
             _ => UnconnectedReadValue,
         };

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64InputInjector.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64InputInjector.cs
@@ -1,3 +1,4 @@
+using Highbyte.DotNet6502.Systems.Input;
 using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
 using Highbyte.DotNet6502.Systems;
 
@@ -9,15 +10,15 @@ public class C64InputInjector : IInputInjector
 
     private readonly HashSet<C64Key> _frameInjectedKeys = new();
     private readonly HashSet<C64Key> _heldKeys = new();
-    private readonly Dictionary<int, HashSet<C64JoystickAction>> _heldJoystickActions = new()
+    private readonly Dictionary<int, HashSet<JoystickAction>> _heldJoystickActions = new()
     {
-        { 1, new HashSet<C64JoystickAction>() },
-        { 2, new HashSet<C64JoystickAction>() }
+        { 1, new HashSet<JoystickAction>() },
+        { 2, new HashSet<JoystickAction>() }
     };
-    private readonly Dictionary<int, HashSet<C64JoystickAction>> _frameInjectedJoystickActions = new()
+    private readonly Dictionary<int, HashSet<JoystickAction>> _frameInjectedJoystickActions = new()
     {
-        { 1, new HashSet<C64JoystickAction>() },
-        { 2, new HashSet<C64JoystickAction>() }
+        { 1, new HashSet<JoystickAction>() },
+        { 2, new HashSet<JoystickAction>() }
     };
 
     private static readonly Dictionary<string, C64Key> StringToC64Key = new(StringComparer.OrdinalIgnoreCase)
@@ -88,13 +89,13 @@ public class C64InputInjector : IInputInjector
         ["f7"]       = C64Key.F7,
     };
 
-    private static readonly Dictionary<string, C64JoystickAction> StringToC64JoystickAction = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly Dictionary<string, JoystickAction> StringToJoystickAction = new(StringComparer.OrdinalIgnoreCase)
     {
-        ["up"]    = C64JoystickAction.Up,
-        ["down"]  = C64JoystickAction.Down,
-        ["left"]  = C64JoystickAction.Left,
-        ["right"] = C64JoystickAction.Right,
-        ["fire"]  = C64JoystickAction.Fire,
+        ["up"]    = JoystickAction.Up,
+        ["down"]  = JoystickAction.Down,
+        ["left"]  = JoystickAction.Left,
+        ["right"] = JoystickAction.Right,
+        ["fire"]  = JoystickAction.Fire,
     };
 
     public C64InputInjector(C64 c64)
@@ -237,10 +238,10 @@ public class C64InputInjector : IInputInjector
         }
     }
 
-    private static bool TryGetJoystickAction(int port, string actionName, out C64JoystickAction action)
+    private static bool TryGetJoystickAction(int port, string actionName, out JoystickAction action)
     {
         action = default;
         if (port < 1 || port > 2) return false;
-        return StringToC64JoystickAction.TryGetValue(actionName, out action);
+        return StringToJoystickAction.TryGetValue(actionName, out action);
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64KeyboardJoystickMap.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Config/C64KeyboardJoystickMap.cs
@@ -1,28 +1,29 @@
+using Highbyte.DotNet6502.Systems.Input;
 using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
 
 namespace Highbyte.DotNet6502.Systems.Commodore64.Config;
 
 public class C64KeyboardJoystickMap
 {
-    private Dictionary<C64Key, C64JoystickAction> KeyToJoystick1Map = new()
+    private Dictionary<C64Key, JoystickAction> KeyToJoystick1Map = new()
     {
-            {C64Key.Space, C64JoystickAction.Fire},
-            {C64Key.W, C64JoystickAction.Up},
-            {C64Key.S, C64JoystickAction.Down},
-            {C64Key.A, C64JoystickAction.Left},
-            {C64Key.D, C64JoystickAction.Right}
+            {C64Key.Space, JoystickAction.Fire},
+            {C64Key.W, JoystickAction.Up},
+            {C64Key.S, JoystickAction.Down},
+            {C64Key.A, JoystickAction.Left},
+            {C64Key.D, JoystickAction.Right}
     };
 
-    private Dictionary<C64Key, C64JoystickAction> KeyToJoystick2Map = new()
+    private Dictionary<C64Key, JoystickAction> KeyToJoystick2Map = new()
     {
-            {C64Key.Space, C64JoystickAction.Fire},
-            {C64Key.W, C64JoystickAction.Up},
-            {C64Key.S, C64JoystickAction.Down},
-            {C64Key.A, C64JoystickAction.Left},
-            {C64Key.D, C64JoystickAction.Right}
+            {C64Key.Space, JoystickAction.Fire},
+            {C64Key.W, JoystickAction.Up},
+            {C64Key.S, JoystickAction.Down},
+            {C64Key.A, JoystickAction.Left},
+            {C64Key.D, JoystickAction.Right}
     };
 
-    public Dictionary<C64Key, C64JoystickAction> GetMap(int joystick)
+    public Dictionary<C64Key, JoystickAction> GetMap(int joystick)
     {
         if (joystick != 1 && joystick != 2)
             throw new ArgumentException($"Invalid joystick number: {joystick}");

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Input/C64InputConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Input/C64InputConfig.cs
@@ -43,28 +43,28 @@ public class C64InputConfig : ICloneable
     /// Per C64 joystick port: which host keyboard key maps to which C64 joystick action, for
     /// using the host keyboard as a joystick. Keyed by the neutral <see cref="HostKey"/> abstraction.
     /// </summary>
-    public Dictionary<int, Dictionary<HostKey, C64JoystickAction>> KeyboardToC64JoystickMap = new()
+    public Dictionary<int, Dictionary<HostKey, JoystickAction>> KeyboardToC64JoystickMap = new()
     {
         {
             1,
-            new Dictionary<HostKey, C64JoystickAction>
+            new Dictionary<HostKey, JoystickAction>
             {
-                { HostKey.Space, C64JoystickAction.Fire },
-                { HostKey.ArrowUp, C64JoystickAction.Up },
-                { HostKey.ArrowDown, C64JoystickAction.Down },
-                { HostKey.ArrowLeft, C64JoystickAction.Left },
-                { HostKey.ArrowRight, C64JoystickAction.Right },
+                { HostKey.Space, JoystickAction.Fire },
+                { HostKey.ArrowUp, JoystickAction.Up },
+                { HostKey.ArrowDown, JoystickAction.Down },
+                { HostKey.ArrowLeft, JoystickAction.Left },
+                { HostKey.ArrowRight, JoystickAction.Right },
             }
         },
         {
             2,
-            new Dictionary<HostKey, C64JoystickAction>
+            new Dictionary<HostKey, JoystickAction>
             {
-                { HostKey.ControlLeft, C64JoystickAction.Fire },
-                { HostKey.KeyW, C64JoystickAction.Up },
-                { HostKey.KeyS, C64JoystickAction.Down },
-                { HostKey.KeyA, C64JoystickAction.Left },
-                { HostKey.KeyD, C64JoystickAction.Right },
+                { HostKey.ControlLeft, JoystickAction.Fire },
+                { HostKey.KeyW, JoystickAction.Up },
+                { HostKey.KeyS, JoystickAction.Down },
+                { HostKey.KeyA, JoystickAction.Left },
+                { HostKey.KeyD, JoystickAction.Right },
             }
         }
     };
@@ -72,28 +72,28 @@ public class C64InputConfig : ICloneable
     /// <summary>
     /// Per C64 joystick port: which gamepad-button combination triggers which C64 joystick action.
     /// </summary>
-    public Dictionary<int, Dictionary<GamepadButton[], C64JoystickAction[]>> GamePadToC64JoystickMap = new()
+    public Dictionary<int, Dictionary<GamepadButton[], JoystickAction[]>> GamePadToC64JoystickMap = new()
     {
         {
             1,
-            new Dictionary<GamepadButton[], C64JoystickAction[]>
+            new Dictionary<GamepadButton[], JoystickAction[]>
             {
-                { new[] { GamepadButton.A }, new[] { C64JoystickAction.Fire } },
-                { new[] { GamepadButton.DPadUp }, new[] { C64JoystickAction.Up } },
-                { new[] { GamepadButton.DPadDown }, new[] { C64JoystickAction.Down } },
-                { new[] { GamepadButton.DPadLeft }, new[] { C64JoystickAction.Left } },
-                { new[] { GamepadButton.DPadRight }, new[] { C64JoystickAction.Right } },
+                { new[] { GamepadButton.A }, new[] { JoystickAction.Fire } },
+                { new[] { GamepadButton.DPadUp }, new[] { JoystickAction.Up } },
+                { new[] { GamepadButton.DPadDown }, new[] { JoystickAction.Down } },
+                { new[] { GamepadButton.DPadLeft }, new[] { JoystickAction.Left } },
+                { new[] { GamepadButton.DPadRight }, new[] { JoystickAction.Right } },
             }
         },
         {
             2,
-            new Dictionary<GamepadButton[], C64JoystickAction[]>
+            new Dictionary<GamepadButton[], JoystickAction[]>
             {
-                { new[] { GamepadButton.A }, new[] { C64JoystickAction.Fire } },
-                { new[] { GamepadButton.DPadUp }, new[] { C64JoystickAction.Up } },
-                { new[] { GamepadButton.DPadDown }, new[] { C64JoystickAction.Down } },
-                { new[] { GamepadButton.DPadLeft }, new[] { C64JoystickAction.Left } },
-                { new[] { GamepadButton.DPadRight }, new[] { C64JoystickAction.Right } },
+                { new[] { GamepadButton.A }, new[] { JoystickAction.Fire } },
+                { new[] { GamepadButton.DPadUp }, new[] { JoystickAction.Up } },
+                { new[] { GamepadButton.DPadDown }, new[] { JoystickAction.Down } },
+                { new[] { GamepadButton.DPadLeft }, new[] { JoystickAction.Left } },
+                { new[] { GamepadButton.DPadRight }, new[] { JoystickAction.Right } },
             }
         }
     };

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Input/C64InputHandler.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Input/C64InputHandler.cs
@@ -30,7 +30,7 @@ public class C64InputHandler : IInputConsumer
     private C64HostKeyboard _c64HostKeyboard = default!;
     private readonly List<C64Key> _c64KeysDownBuffer = new();
     private readonly List<HostKey[]> _foundHostKeyMappingsBuffer = new();
-    private readonly HashSet<C64JoystickAction> _c64JoystickActionsBuffer = new();
+    private readonly HashSet<JoystickAction> _c64JoystickActionsBuffer = new();
     private readonly List<GamepadButton[]> _foundGamepadMappingsBuffer = new();
     private readonly HashSet<HostKey> _swappedHostKeysBuffer = new();
     private readonly HashSet<HostKey> _lastSwappedSourceKeysBuffer = new();
@@ -288,13 +288,13 @@ public class C64InputHandler : IInputConsumer
 
     private void CaptureJoystick()
     {
-        var c64JoystickActions = GetC64JoystickActionsFromGamepad(_inputState.GamepadButtonsDown);
+        var c64JoystickActions = GetJoystickActionsFromGamepad(_inputState.GamepadButtonsDown);
         _c64.Cia1.Joystick.SetJoystickActions(_inputConfig.CurrentJoystick, c64JoystickActions, overwrite: false);
 
         _c64.InputInjector?.ApplyInjectedJoystickActionsTo(_c64.Cia1.Joystick);
     }
 
-    private HashSet<C64JoystickAction> GetC64JoystickActionsFromGamepad(IReadOnlySet<GamepadButton> gamepadButtonsDown)
+    private HashSet<JoystickAction> GetJoystickActionsFromGamepad(IReadOnlySet<GamepadButton> gamepadButtonsDown)
     {
         var c64JoystickActions = _c64JoystickActionsBuffer;
         c64JoystickActions.Clear();

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/C64Joystick.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/C64Joystick.cs
@@ -1,4 +1,5 @@
 using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Systems.Input;
 using Microsoft.Extensions.Logging;
 
 namespace Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
@@ -6,7 +7,7 @@ namespace Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
 public class C64Joystick
 {
     private readonly ILogger _logger;
-    public Dictionary<int, HashSet<C64JoystickAction>> CurrentJoystickActions { get; private set; } = new()
+    public Dictionary<int, HashSet<JoystickAction>> CurrentJoystickActions { get; private set; } = new()
     {
         {1, new() },
         {2, new() }
@@ -32,7 +33,7 @@ public class C64Joystick
         }
     }
 
-    public void SetJoystickActions(int joystick, HashSet<C64JoystickAction> joystickActions, bool overwrite = true)
+    public void SetJoystickActions(int joystick, HashSet<JoystickAction> joystickActions, bool overwrite = true)
     {
         if (joystick != 1 && joystick != 2)
             throw new ArgumentException($"Joystick number {joystick} is not supported. Valid values are 1 and 2.");
@@ -53,16 +54,21 @@ public class C64Joystick
             }
         }
     }
-}
-/// <summary>
-/// Possible joystick actions. More than one can be active at the same time.
-/// The integer value corresponds to the bit position in the joystick register (set = not active, clear = active).
-/// </summary>
-public enum C64JoystickAction
-{
-    Up = 0,
-    Down = 1,
-    Left = 2,
-    Right = 3,
-    Fire = 4
+
+    /// <summary>
+    /// The CIA 1 data-port bit a joystick action pulls low. Stated here rather than cast from the
+    /// enum's numeric value: <see cref="JoystickAction"/> is shared with other systems, and a
+    /// reorder or a new member added for one of them would otherwise silently change which bit
+    /// the C64 clears.
+    /// </summary>
+    public static int GetPortBit(JoystickAction action) => action switch
+    {
+        JoystickAction.Up => 0,
+        JoystickAction.Down => 1,
+        JoystickAction.Left => 2,
+        JoystickAction.Right => 3,
+        JoystickAction.Fire => 4,
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(action), action, "No C64 joystick port bit for this action."),
+    };
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/C64Keyboard.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/C64Keyboard.cs
@@ -1,3 +1,4 @@
+using Highbyte.DotNet6502.Systems.Input;
 using Highbyte.DotNet6502.Utils;
 using Microsoft.Extensions.Logging;
 
@@ -13,7 +14,7 @@ public class C64Keyboard
     private readonly List<C64Key> _pressedKeys = new List<C64Key>();
     private readonly C64 _c64;
     private readonly List<int> _selectedMatrixRowBitPositions = new();
-    private readonly HashSet<C64JoystickAction> _keyboardJoystickActionsBuffer = new();
+    private readonly HashSet<JoystickAction> _keyboardJoystickActionsBuffer = new();
     private bool _capsLockOn;
     private bool _restorePressedLastFrame;
     private bool _runStopPressedLastFrame;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/Cia1.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/Cia1.cs
@@ -95,7 +95,7 @@ public class Cia1 : CiaBase
         // low regardless of the DDR direction, so bits are cleared on the composed result rather
         // than on inputValue (which ComposePortReadValue ignores for output-configured bits).
         foreach (var action in Joystick.CurrentJoystickActions[2])
-            result.ClearBit((int)action);
+            result.ClearBit(C64Joystick.GetPortBit(action));
 
         return result;
     }
@@ -120,7 +120,7 @@ public class Cia1 : CiaBase
         // Joystick port 1 pins are shared with Port B. Same reasoning as DataALoad: joystick can
         // pull a pin low regardless of DDR direction, so bits are cleared on the composed result.
         foreach (var action in Joystick.CurrentJoystickActions[1])
-            result.ClearBit((int)action);
+            result.ClearBit(C64Joystick.GetPortBit(action));
 
         return result;
     }

--- a/src/libraries/Highbyte.DotNet6502.Systems/Input/JoystickAction.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Input/JoystickAction.cs
@@ -1,0 +1,31 @@
+namespace Highbyte.DotNet6502.Systems.Input;
+
+/// <summary>
+/// A direction or button press on a host joystick, independent of the machine it drives. More
+/// than one can be active at a time (diagonals, or a direction plus fire).
+///
+/// This is the seam between input acquisition and hardware: hosts and mapping tables deal in
+/// these, and each system decides what they mean electrically — the C64 pulls CIA port bits low,
+/// while the Apple II has no digital joystick at all and turns them into analog paddle positions.
+///
+/// Not every system has every action. An Apple II stick has two buttons and games do use both
+/// (Choplifter turns the helicopter with the second), whereas a C64 joystick has one — so a system
+/// asked for an action it has no wiring for should say so rather than guess.
+///
+/// The numeric values carry no meaning. A system that needs a particular bit order must map to it
+/// explicitly rather than casting, so reordering or extending this enum cannot silently change
+/// what a machine reads.
+/// </summary>
+public enum JoystickAction
+{
+    Up,
+    Down,
+    Left,
+    Right,
+    Fire,
+
+    /// <summary>
+    /// The second button, which the Apple II game port has and a C64 joystick does not.
+    /// </summary>
+    Fire2,
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2DownloadProgramInfoTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2DownloadProgramInfoTests.cs
@@ -1,0 +1,34 @@
+using Highbyte.DotNet6502.Systems.Apple2.DiskImage.Download;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
+
+/// <summary>
+/// Per-program emulator settings carried by the Download &amp; Run entries, mirroring the C64 list.
+/// </summary>
+public class Apple2DownloadProgramInfoTests
+{
+    [Fact]
+    public void A_Program_Does_Not_Enable_The_Keyboard_Joystick_Unless_Asked()
+    {
+        var info = new Apple2DownloadProgramInfo("Test", "https://example.invalid/test.dsk");
+
+        // Turning it on takes keys away from the Apple II keyboard, so it has to be opt-in per
+        // entry rather than something every program gets.
+        Assert.False(info.KeyboardJoystickEnabled);
+    }
+
+    [Fact]
+    public void A_Program_Can_Ask_For_The_Keyboard_Joystick()
+    {
+        var info = new Apple2DownloadProgramInfo(
+            "Test",
+            "https://example.invalid/test.zip",
+            zipEntryName: "test.dsk",
+            runMode: Apple2DownloadRunMode.BootDisk,
+            keyboardJoystickEnabled: true);
+
+        Assert.True(info.KeyboardJoystickEnabled);
+        Assert.Equal(Apple2DownloadRunMode.BootDisk, info.RunMode);
+        Assert.True(info.RequiresDisk2Rom);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2GamePortTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2GamePortTests.cs
@@ -1,0 +1,248 @@
+using Highbyte.DotNet6502.Systems.Apple2.Peripherals;
+using Highbyte.DotNet6502.Systems.Input;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
+
+/// <summary>
+/// The game port on its own, driven by a settable cycle clock so the 558 timing can be inspected
+/// without running a CPU. The end-to-end contract — that the real ROM's PREAD counts back the
+/// position that was set — is <see cref="Apple2RealRomPaddleReadTests"/>.
+/// </summary>
+public class Apple2GamePortTests
+{
+    private ulong _cycles;
+    private Apple2GamePort BuildPort() => new(() => _cycles);
+
+    private static IReadOnlySet<JoystickAction> Actions(params JoystickAction[] actions)
+        => new HashSet<JoystickAction>(actions);
+
+    [Fact]
+    public void An_Untriggered_Port_Reads_Every_Paddle_Timer_As_Idle()
+    {
+        var port = BuildPort();
+
+        // At power-on the cycle counter is 0 too, so "never triggered" must not look like
+        // "triggered at cycle 0" — otherwise an untouched port reads as though it were running.
+        for (var paddle = 0; paddle < Apple2GamePort.PaddleCount; paddle++)
+            Assert.False(port.IsPaddleTimerRunning(paddle));
+        Assert.Equal(0x00, port.ReadGamePort(Apple2GamePort.Paddle0Address));
+    }
+
+    [Fact]
+    public void A_Triggered_Paddle_Holds_Bit_7_For_Its_Position_And_Then_Drops()
+    {
+        var port = BuildPort();
+        port.SetPaddlePosition(0, 100);
+        port.Trigger();
+
+        var hold = (ulong)(100 * Apple2GamePort.PreadLoopCycles);
+
+        _cycles = hold - 1;
+        Assert.True(port.IsPaddleTimerRunning(0));
+        Assert.Equal(0x80, port.ReadGamePort(Apple2GamePort.Paddle0Address));
+
+        _cycles = hold;
+        Assert.False(port.IsPaddleTimerRunning(0));
+        Assert.Equal(0x00, port.ReadGamePort(Apple2GamePort.Paddle0Address));
+    }
+
+    [Fact]
+    public void Position_Zero_Expires_Immediately()
+    {
+        var port = BuildPort();
+        port.SetPaddlePosition(0, 0);
+        port.Trigger();
+
+        // PREAD counts zero iterations and reports 0, which is the bottom of the range.
+        Assert.False(port.IsPaddleTimerRunning(0));
+    }
+
+    [Fact]
+    public void Retriggering_Restarts_The_Timer()
+    {
+        var port = BuildPort();
+        port.SetPaddlePosition(0, 10);
+        port.Trigger();
+
+        _cycles = 10 * Apple2GamePort.PreadLoopCycles;
+        Assert.False(port.IsPaddleTimerRunning(0));
+
+        port.Trigger();
+        Assert.True(port.IsPaddleTimerRunning(0));
+    }
+
+    [Fact]
+    public void One_Trigger_Starts_Every_Paddle()
+    {
+        var port = BuildPort();
+        port.SetPaddlePosition(0, 50);
+        port.SetPaddlePosition(1, 200);
+        port.Trigger();
+
+        _cycles = 100 * Apple2GamePort.PreadLoopCycles;   // past paddle 0, still inside paddle 1
+        Assert.False(port.IsPaddleTimerRunning(0));
+        Assert.True(port.IsPaddleTimerRunning(1));
+    }
+
+    [Theory]
+    [InlineData(0xC061, 0)]
+    [InlineData(0xC062, 1)]
+    [InlineData(0xC063, 2)]
+    public void Buttons_Report_In_Bit_7(ushort address, int button)
+    {
+        var port = BuildPort();
+
+        Assert.Equal(0x00, port.ReadGamePort(address));
+        port.SetButton(button, true);
+        Assert.Equal(0x80, port.ReadGamePort(address));
+    }
+
+    [Fact]
+    public void The_Cassette_Input_Address_Is_Not_A_Button()
+    {
+        var port = BuildPort();
+        port.SetButton(0, true);
+
+        // $C060 is cassette in; button 0 is $C061. An off-by-one here would make every game
+        // think fire was held.
+        Assert.Equal(0x00, port.ReadGamePort(0xC060));
+    }
+
+    [Fact]
+    public void A_Held_Direction_Drives_Its_Axis_To_The_End_Of_Travel()
+    {
+        var port = BuildPort();
+
+        port.ApplyJoystickActions(Actions(JoystickAction.Left));
+        Assert.Equal(Apple2GamePort.PaddleMin, port.GetPaddlePosition(0));
+
+        port.ApplyJoystickActions(Actions(JoystickAction.Right));
+        Assert.Equal(Apple2GamePort.PaddleMax, port.GetPaddlePosition(0));
+
+        port.ApplyJoystickActions(Actions(JoystickAction.Up));
+        Assert.Equal(Apple2GamePort.PaddleMin, port.GetPaddlePosition(1));
+
+        port.ApplyJoystickActions(Actions(JoystickAction.Down));
+        Assert.Equal(Apple2GamePort.PaddleMax, port.GetPaddlePosition(1));
+    }
+
+    [Fact]
+    public void Releasing_Returns_The_Stick_To_Centre()
+    {
+        var port = BuildPort();
+
+        port.ApplyJoystickActions(Actions(JoystickAction.Left, JoystickAction.Up));
+        port.ApplyJoystickActions(Actions());
+
+        Assert.Equal(Apple2GamePort.PaddleCentre, port.GetPaddlePosition(0));
+        Assert.Equal(Apple2GamePort.PaddleCentre, port.GetPaddlePosition(1));
+    }
+
+    [Fact]
+    public void Opposite_Directions_Cancel_To_Centre()
+    {
+        var port = BuildPort();
+
+        port.ApplyJoystickActions(Actions(JoystickAction.Left, JoystickAction.Right));
+
+        Assert.Equal(Apple2GamePort.PaddleCentre, port.GetPaddlePosition(0));
+    }
+
+    [Fact]
+    public void Diagonals_Move_Both_Axes()
+    {
+        var port = BuildPort();
+
+        port.ApplyJoystickActions(Actions(JoystickAction.Right, JoystickAction.Up));
+
+        Assert.Equal(Apple2GamePort.PaddleMax, port.GetPaddlePosition(0));
+        Assert.Equal(Apple2GamePort.PaddleMin, port.GetPaddlePosition(1));
+    }
+
+    [Fact]
+    public void Fire_Is_Button_0()
+    {
+        var port = BuildPort();
+
+        port.ApplyJoystickActions(Actions(JoystickAction.Fire));
+        Assert.True(port.IsButtonPressed(0));
+        Assert.False(port.IsButtonPressed(1));
+
+        port.ApplyJoystickActions(Actions());
+        Assert.False(port.IsButtonPressed(0));
+    }
+
+    [Fact]
+    public void Fire2_Is_Button_1()
+    {
+        var port = BuildPort();
+
+        // Choplifter turns the helicopter with button 1 while firing with button 0, so the two
+        // must be independent — mapping Fire2 onto button 0 would look like it worked until a
+        // game read $C062.
+        port.ApplyJoystickActions(Actions(JoystickAction.Fire2));
+        Assert.False(port.IsButtonPressed(0));
+        Assert.True(port.IsButtonPressed(1));
+        Assert.Equal(0x80, port.ReadGamePort(0xC062));
+
+        port.ApplyJoystickActions(Actions(JoystickAction.Fire, JoystickAction.Fire2));
+        Assert.True(port.IsButtonPressed(0));
+        Assert.True(port.IsButtonPressed(1));
+
+        port.ApplyJoystickActions(Actions());
+        Assert.False(port.IsButtonPressed(0));
+        Assert.False(port.IsButtonPressed(1));
+    }
+
+    [Fact]
+    public void Fire_And_A_Direction_Can_Be_Held_Together()
+    {
+        var port = BuildPort();
+
+        // Turning in Choplifter is fire-plus-direction, so the two must not be exclusive.
+        port.ApplyJoystickActions(Actions(JoystickAction.Fire2, JoystickAction.Left));
+
+        Assert.True(port.IsButtonPressed(1));
+        Assert.Equal(Apple2GamePort.PaddleMin, port.GetPaddlePosition(0));
+    }
+
+    /// <summary>
+    /// The counters are a diagnostic for "does this program use the stick at all?", which cannot
+    /// be answered by watching the screen — a game that polls the button but never strobes $C070
+    /// looks identical to one that does both.
+    /// </summary>
+    [Fact]
+    public void Reads_And_Triggers_Are_Counted_For_Diagnostics()
+    {
+        var port = BuildPort();
+        Assert.Equal(0UL, port.PaddleTriggerCount);
+        Assert.Equal(0UL, port.ButtonReadCount);
+
+        port.Trigger();
+        port.Trigger();
+        Assert.Equal(2UL, port.PaddleTriggerCount);
+
+        port.ReadGamePort(Apple2GamePort.Button0Address);
+        port.ReadGamePort(0xC062);
+        Assert.Equal(2UL, port.ButtonReadCount);
+
+        // Per button, because "which button does this game poll?" is the useful question.
+        Assert.Equal(1UL, port.ButtonReadCounts[0]);
+        Assert.Equal(1UL, port.ButtonReadCounts[1]);
+        Assert.Equal(0UL, port.ButtonReadCounts[2]);
+
+        // Reading a paddle is not a button read, and does not re-trigger the one-shot.
+        port.ReadGamePort(Apple2GamePort.Paddle0Address);
+        Assert.Equal(2UL, port.ButtonReadCount);
+        Assert.Equal(2UL, port.PaddleTriggerCount);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(Apple2GamePort.PaddleCount)]
+    public void An_Out_Of_Range_Paddle_Is_Rejected(int paddle)
+    {
+        var port = BuildPort();
+        Assert.Throws<ArgumentOutOfRangeException>(() => port.SetPaddlePosition(paddle, 0));
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2InputInjectorTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2InputInjectorTests.cs
@@ -1,3 +1,4 @@
+using Highbyte.DotNet6502.Systems.Apple2.Peripherals;
 using Highbyte.DotNet6502.Systems.Apple2.Config;
 using Highbyte.DotNet6502.Systems.Apple2.Input;
 using Highbyte.DotNet6502.Systems.Input;
@@ -40,13 +41,73 @@ public class Apple2InputInjectorTests
     }
 
     [Fact]
-    public void No_Joystick_Actions_Are_Exposed()
+    public void The_Single_Game_Port_Is_Exposed_With_Both_Its_Buttons()
     {
         var apple2 = new Apple2System(new Apple2Config(), NullLoggerFactory.Instance);
 
-        Assert.Empty(apple2.InputInjector.GetAvailableJoystickActions());
-        Assert.Equal(0, apple2.InputInjector.JoystickPortCount);
+        var actions = apple2.InputInjector.GetAvailableJoystickActions();
+        Assert.Equal(6, actions.Count);
+        // "fire2" is the second game-port button, which Apple II sticks have and C64 sticks do not.
+        foreach (var expected in new[] { "up", "down", "left", "right", "fire", "fire2" })
+            Assert.Contains(expected, actions);
+
+        // One game port, unlike the C64's two.
+        Assert.Equal(1, apple2.InputInjector.JoystickPortCount);
         Assert.False(apple2.InputInjector.IsJoystickActionDown(1, "fire"));
+    }
+
+    [Fact]
+    public void An_Injected_Direction_Moves_The_Paddle_It_Belongs_To()
+    {
+        var (apple2, handler) = Build();
+
+        apple2.InputInjector.HoldJoystickAction(1, "left");
+        handler.BeforeFrame();
+        Assert.Equal(Apple2GamePort.PaddleMin, apple2.GamePort.GetPaddlePosition(0));
+
+        apple2.InputInjector.ReleaseHeldJoystickAction(1, "left");
+        handler.BeforeFrame();
+        Assert.Equal(Apple2GamePort.PaddleCentre, apple2.GamePort.GetPaddlePosition(0));
+    }
+
+    [Fact]
+    public void An_Injected_Fire_Presses_Button_0()
+    {
+        var (apple2, handler) = Build();
+
+        apple2.InputInjector.HoldJoystickAction(1, "fire");
+        handler.BeforeFrame();
+        Assert.True(apple2.GamePort.IsButtonPressed(0));
+        Assert.Equal(0x80, apple2.Mem[Apple2GamePort.Button0Address]);
+
+        apple2.InputInjector.ReleaseAllHeldJoystickActions(1);
+        handler.BeforeFrame();
+        Assert.False(apple2.GamePort.IsButtonPressed(0));
+    }
+
+    [Fact]
+    public void An_Injected_Fire2_Presses_Button_1()
+    {
+        var (apple2, handler) = Build();
+
+        apple2.InputInjector.HoldJoystickAction(1, "fire2");
+        handler.BeforeFrame();
+
+        Assert.True(apple2.GamePort.IsButtonPressed(1));
+        Assert.False(apple2.GamePort.IsButtonPressed(0));
+        Assert.Equal(0x80, apple2.Mem[0xC062]);
+    }
+
+    [Fact]
+    public void An_Unknown_Joystick_Action_Is_Ignored_Rather_Than_Throwing()
+    {
+        var (apple2, handler) = Build();
+
+        apple2.InputInjector.HoldJoystickAction(1, "diagonal");
+        handler.BeforeFrame();
+
+        Assert.Equal(Apple2GamePort.PaddleCentre, apple2.GamePort.GetPaddlePosition(0));
+        Assert.Equal(Apple2GamePort.PaddleCentre, apple2.GamePort.GetPaddlePosition(1));
     }
 
     [Fact]

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2KeyboardJoystickTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2KeyboardJoystickTests.cs
@@ -1,0 +1,194 @@
+using Highbyte.DotNet6502.Systems.Apple2.Config;
+using Highbyte.DotNet6502.Systems.Apple2.Input;
+using Highbyte.DotNet6502.Systems.Apple2.Peripherals;
+using Highbyte.DotNet6502.Systems.Input;
+using Microsoft.Extensions.Logging.Abstractions;
+using Apple2System = Highbyte.DotNet6502.Systems.Apple2.Apple2;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
+
+/// <summary>
+/// Driving the game port from the host keyboard.
+///
+/// The interesting half is what the keyboard stops receiving: the mapped keys must reach the stick
+/// and <em>not</em> the ASCII latch, because a key cannot both steer and type. WASD is chosen so
+/// the Apple II's own arrow keys stay available, and Left Shift so Right Shift still types.
+/// </summary>
+public class Apple2KeyboardJoystickTests
+{
+    private static (Apple2System Apple2, Apple2InputHandler Handler, MutableHostInputState Input)
+        Build(bool keyboardJoystickEnabled)
+    {
+        var apple2 = new Apple2System(new Apple2Config(), NullLoggerFactory.Instance);
+        var config = new Apple2InputConfig { KeyboardJoystickEnabled = keyboardJoystickEnabled };
+        var handler = new Apple2InputHandler(apple2, NullLoggerFactory.Instance, config);
+        var input = new MutableHostInputState();
+        handler.Init(input);
+        return (apple2, handler, input);
+    }
+
+    private static void Press(MutableHostInputState input, Apple2InputHandler handler, params HostKey[] keys)
+    {
+        input.SetKeys(keys);
+        handler.BeforeFrame();
+    }
+
+    [Fact]
+    public void Off_By_Default_So_The_Mapped_Keys_Still_Belong_To_The_Machine()
+    {
+        Assert.False(new Apple2InputConfig().KeyboardJoystickEnabled);
+    }
+
+    [Fact]
+    public void Disabled_The_Arrow_Keys_Leave_The_Stick_Centred()
+    {
+        var (apple2, handler, input) = Build(keyboardJoystickEnabled: false);
+
+        Press(input, handler, HostKey.KeyA);
+
+        Assert.Equal(Apple2GamePort.PaddleCentre, apple2.GamePort.GetPaddlePosition(0));
+    }
+
+    [Theory]
+    [InlineData(HostKey.KeyA, 0, Apple2GamePort.PaddleMin)]
+    [InlineData(HostKey.KeyD, 0, Apple2GamePort.PaddleMax)]
+    [InlineData(HostKey.KeyW, 1, Apple2GamePort.PaddleMin)]
+    [InlineData(HostKey.KeyS, 1, Apple2GamePort.PaddleMax)]
+    public void Enabled_Each_Direction_Key_Drives_Its_Axis(HostKey key, int paddle, byte expected)
+    {
+        var (apple2, handler, input) = Build(keyboardJoystickEnabled: true);
+
+        Press(input, handler, key);
+
+        Assert.Equal(expected, apple2.GamePort.GetPaddlePosition(paddle));
+    }
+
+    [Fact]
+    public void Enabled_Space_Is_The_Button()
+    {
+        var (apple2, handler, input) = Build(keyboardJoystickEnabled: true);
+
+        Press(input, handler, HostKey.Space);
+        Assert.True(apple2.GamePort.IsButtonPressed(0));
+
+        Press(input, handler);
+        Assert.False(apple2.GamePort.IsButtonPressed(0));
+    }
+
+    [Fact]
+    public void Enabled_Left_Shift_Is_The_Second_Button()
+    {
+        var (apple2, handler, input) = Build(keyboardJoystickEnabled: true);
+
+        Press(input, handler, HostKey.ShiftLeft);
+        Assert.True(apple2.GamePort.IsButtonPressed(1));
+        Assert.False(apple2.GamePort.IsButtonPressed(0));
+    }
+
+    [Fact]
+    public void Enabled_The_Second_Button_Combines_With_A_Direction()
+    {
+        var (apple2, handler, input) = Build(keyboardJoystickEnabled: true);
+
+        Press(input, handler, HostKey.ShiftLeft, HostKey.KeyA);
+
+        Assert.True(apple2.GamePort.IsButtonPressed(1));
+        Assert.Equal(Apple2GamePort.PaddleMin, apple2.GamePort.GetPaddlePosition(0));
+    }
+
+    [Fact]
+    public void Enabled_A_Steering_Key_Does_Not_Also_Type()
+    {
+        var (apple2, handler, input) = Build(keyboardJoystickEnabled: true);
+        apple2.Keyboard.ReadAndClearStrobe();
+
+        Press(input, handler, HostKey.Space);
+
+        // Space would otherwise latch $A0. It steers instead, so nothing reaches the latch.
+        Assert.False(apple2.Keyboard.StrobeSet);
+        Assert.Equal(Apple2GamePort.PaddleCentre, apple2.GamePort.GetPaddlePosition(0));
+        Assert.True(apple2.GamePort.IsButtonPressed(0));
+    }
+
+    [Fact]
+    public void Disabled_The_Same_Key_Types_As_Normal()
+    {
+        var (apple2, handler, input) = Build(keyboardJoystickEnabled: false);
+        apple2.Keyboard.ReadAndClearStrobe();
+
+        Press(input, handler, HostKey.Space);
+
+        Assert.True(apple2.Keyboard.StrobeSet);
+        Assert.Equal(0xA0, apple2.Keyboard.Latch);
+    }
+
+    [Fact]
+    public void Enabled_An_Unmapped_Key_Still_Reaches_The_Keyboard()
+    {
+        var (apple2, handler, input) = Build(keyboardJoystickEnabled: true);
+        apple2.Keyboard.ReadAndClearStrobe();
+
+        Press(input, handler, HostKey.KeyB);
+
+        Assert.True(apple2.Keyboard.StrobeSet);
+        Assert.Equal(0xC2, apple2.Keyboard.Latch);   // 'B'
+    }
+
+    [Fact]
+    public void Enabled_Steering_And_Typing_Can_Happen_In_The_Same_Frame()
+    {
+        var (apple2, handler, input) = Build(keyboardJoystickEnabled: true);
+        apple2.Keyboard.ReadAndClearStrobe();
+
+        Press(input, handler, HostKey.KeyA, HostKey.KeyB);
+
+        Assert.Equal(Apple2GamePort.PaddleMin, apple2.GamePort.GetPaddlePosition(0));
+        Assert.True(apple2.Keyboard.StrobeSet);
+        Assert.Equal(0xC2, apple2.Keyboard.Latch);
+    }
+
+    /// <summary>
+    /// Left Shift steers, but Right Shift must still shift — otherwise turning the joystick on
+    /// would cost the ability to type shifted characters entirely.
+    /// </summary>
+    [Fact]
+    public void Enabled_Right_Shift_Still_Works_As_A_Modifier()
+    {
+        var (apple2, handler, input) = Build(keyboardJoystickEnabled: true);
+        apple2.Keyboard.ReadAndClearStrobe();
+
+        Press(input, handler, HostKey.ShiftRight, HostKey.Digit1);
+
+        Assert.False(apple2.GamePort.IsButtonPressed(1));
+        Assert.True(apple2.Keyboard.StrobeSet);
+        Assert.Equal(0xA1, apple2.Keyboard.Latch);   // '!' — shifted '1'
+    }
+
+    [Fact]
+    public void A_Gamepad_Works_Whether_Or_Not_The_Keyboard_Joystick_Is_On()
+    {
+        foreach (var keyboardJoystick in new[] { false, true })
+        {
+            var (apple2, handler, input) = Build(keyboardJoystick);
+            input.SetGamepadButtons(GamepadButton.DPadRight);
+            handler.BeforeFrame();
+
+            Assert.Equal(Apple2GamePort.PaddleMax, apple2.GamePort.GetPaddlePosition(0));
+        }
+    }
+
+    private sealed class MutableHostInputState : IHostInputState
+    {
+        private HashSet<HostKey> _keys = new();
+        private HashSet<GamepadButton> _buttons = new();
+
+        public IReadOnlySet<HostKey> KeysDown => _keys;
+        public IReadOnlySet<GamepadButton> GamepadButtonsDown => _buttons;
+        public bool CapsLockOn => false;
+
+        public void SetKeys(params HostKey[] keys) => _keys = new HashSet<HostKey>(keys);
+        public void SetGamepadButtons(params GamepadButton[] buttons) => _buttons = new HashSet<GamepadButton>(buttons);
+
+        public void UpdatePerFrame() { }
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RealRomPaddleReadTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RealRomPaddleReadTests.cs
@@ -1,0 +1,113 @@
+using Highbyte.DotNet6502.Systems.Apple2.Config;
+using Highbyte.DotNet6502.Systems.Apple2.Peripherals;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit.Abstractions;
+using Apple2System = Highbyte.DotNet6502.Systems.Apple2.Apple2;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
+
+/// <summary>
+/// Drives the genuine ROM's PREAD routine against the emulated game port.
+///
+/// This is the test that matters for paddles. The game port is not read as a value but as a
+/// duration, so a hold time that is merely close produces positions that are merely close — games
+/// would feel subtly wrong rather than fail, which is the hardest kind of bug to notice. Running
+/// the real ROM's counting loop and asserting it recovers the exact position that was set pins the
+/// contract end to end, rather than testing our own model against itself.
+/// </summary>
+[Trait("TestType", "Integration")]
+public class Apple2RealRomPaddleReadTests
+{
+    /// <summary>PREAD in the Apple II Plus monitor ROM: strobe $C070, count until bit 7 drops.</summary>
+    private const ushort PreadAddress = 0xFB1E;
+
+    /// <summary>Where PREAD's RTS returns to; arbitrary, just needs to be recognisable.</summary>
+    private const ushort ReturnSentinel = 0x9000;
+
+    private readonly ITestOutputHelper _output;
+
+    public Apple2RealRomPaddleReadTests(ITestOutputHelper output) => _output = output;
+
+    private Apple2System BootRealRom()
+    {
+        var romPath = Apple2TestRoms.ResolveSystemRomPath();
+        Assert.NotNull(romPath);
+
+        var romData = new Dictionary<string, byte[]>
+        {
+            { Apple2SystemConfig.SYSTEM_ROM_NAME, File.ReadAllBytes(romPath) },
+        };
+        var apple2 = new Apple2System(new Apple2Config(), NullLoggerFactory.Instance, romData);
+        for (var frame = 0; frame < 180; frame++)
+            apple2.ExecuteOneFrame();
+        return apple2;
+    }
+
+    /// <summary>
+    /// Calls PREAD for one paddle and returns what it counted, exactly as Applesoft's PDL() does.
+    /// </summary>
+    private static byte CallPread(Apple2System apple2, int paddle)
+    {
+        var cpu = apple2.CPU;
+        var mem = apple2.Mem;
+
+        // Push the sentinel as PREAD's return address (RTS pops address-1 and adds one).
+        var returnMinusOne = ReturnSentinel - 1;
+        mem[(ushort)(0x0100 + cpu.SP)] = (byte)(returnMinusOne >> 8);
+        cpu.SP--;
+        mem[(ushort)(0x0100 + cpu.SP)] = (byte)(returnMinusOne & 0xFF);
+        cpu.SP--;
+
+        cpu.X = (byte)paddle;
+        cpu.PC = PreadAddress;
+
+        // PREAD is bounded (it gives up at 255), so a generous instruction cap only guards
+        // against a hang if the timer model never lets the bit drop.
+        for (var step = 0; step < 20_000 && cpu.PC != ReturnSentinel; step++)
+            cpu.ExecuteOneInstruction(mem);
+
+        Assert.Equal(ReturnSentinel, cpu.PC);
+        return cpu.Y;
+    }
+
+    [RequiresApple2RomTheory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(64)]
+    [InlineData(127)]
+    [InlineData(200)]
+    public void Pread_Counts_Back_The_Paddle_Position_That_Was_Set(byte position)
+    {
+        var apple2 = BootRealRom();
+        apple2.GamePort.SetPaddlePosition(0, position);
+
+        var read = CallPread(apple2, paddle: 0);
+        _output.WriteLine($"set {position} -> PREAD returned {read}");
+
+        Assert.Equal(position, read);
+    }
+
+    [RequiresApple2RomFact]
+    public void Pread_Saturates_Rather_Than_Wrapping_At_The_Top_Of_The_Range()
+    {
+        var apple2 = BootRealRom();
+        apple2.GamePort.SetPaddlePosition(0, 255);
+
+        var read = CallPread(apple2, paddle: 0);
+        _output.WriteLine($"set 255 -> PREAD returned {read}");
+
+        // PREAD's counter is a byte; the top of the range must not roll back round to 0.
+        Assert.True(read >= 254, $"Expected the top of the range, got {read}.");
+    }
+
+    [RequiresApple2RomFact]
+    public void Each_Paddle_Is_Read_Independently()
+    {
+        var apple2 = BootRealRom();
+        apple2.GamePort.SetPaddlePosition(0, 30);
+        apple2.GamePort.SetPaddlePosition(1, 200);
+
+        Assert.Equal(30, CallPread(apple2, paddle: 0));
+        Assert.Equal(200, CallPread(apple2, paddle: 1));
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2TestRoms.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2TestRoms.cs
@@ -82,6 +82,19 @@ public sealed class RequiresApple2RomFactAttribute : FactAttribute
     }
 }
 
+/// <summary>The <see cref="TheoryAttribute"/> counterpart of <see cref="RequiresApple2RomFactAttribute"/>.</summary>
+public sealed class RequiresApple2RomTheoryAttribute : TheoryAttribute
+{
+    public RequiresApple2RomTheoryAttribute()
+    {
+        if (Apple2TestRoms.ResolveSystemRomPath() == null)
+            Skip = Apple2TestRoms.MissingFileReason(
+                "Apple II system ROM",
+                Apple2TestRoms.SystemRomPathEnvironmentVariable,
+                Apple2TestRoms.SystemRomFileNames);
+    }
+}
+
 /// <summary>A test needing the system ROM <em>and</em> the character generator ROM.</summary>
 public sealed class RequiresApple2RomAndCharacterRomFactAttribute : FactAttribute
 {

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64InputHandlerTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64InputHandlerTests.cs
@@ -32,9 +32,9 @@ public class C64InputHandlerTests
         Assert.True(c64.Cia1.Keyboard.IsKeyCurrentlyPressed(C64Key.Return));
         Assert.False(c64.Cia1.Keyboard.IsKeyCurrentlyPressed(C64Key.W));
         Assert.False(c64.Cia1.Keyboard.IsKeyCurrentlyPressed(C64Key.Space));
-        Assert.Contains(C64JoystickAction.Up, c64.Cia1.Joystick.CurrentJoystickActions[2]);
-        Assert.Contains(C64JoystickAction.Fire, c64.Cia1.Joystick.CurrentJoystickActions[2]);
-        Assert.Contains(C64JoystickAction.Left, c64.Cia1.Joystick.CurrentJoystickActions[2]);
+        Assert.Contains(JoystickAction.Up, c64.Cia1.Joystick.CurrentJoystickActions[2]);
+        Assert.Contains(JoystickAction.Fire, c64.Cia1.Joystick.CurrentJoystickActions[2]);
+        Assert.Contains(JoystickAction.Left, c64.Cia1.Joystick.CurrentJoystickActions[2]);
     }
 
     [Fact]


### PR DESCRIPTION
`$C060`–`$C06F` returned `0x00` for every address. That is worse than unimplemented: the ROM's `PREAD` counts how long bit 7 of `$C064` stays high, so a permanently-low bit made every paddle read as position 0. A joystick game did not merely lack input — it saw the stick **jammed into a corner**, and `PDL(n)` always returned 0.

## Not the C64 job in a different costume

The Apple II has no digital joystick. A stick is two 150 kΩ potentiometers read by *timing* a 558 one-shot, so there is no register of direction bits to set. What the existing C64 work did give was everything above the hardware — gamepad acquisition, mapping tables, the remote commands.

- **`Apple2GamePort`** — pushbuttons at `$C061`–`$C063`, paddle one-shot at `$C064`–`$C067` restarted by the `$C070` strobe.
- **Hold time is modelled on `PREAD`'s loop cost** (11 cycles/iteration), so `PREAD` counts back exactly the position set and `PDL(n)` round-trips. Modelling the loop rather than the RC curve keeps it exact and testable; an approximate model's errors would surface as games feeling subtly wrong rather than failing.
- **Both buttons are wired.** Choplifter fires with button 0 and *turns the helicopter* with button 1; mapping only the first leaves it half-playable in a way that reads as a broken joystick.
- **Resting position is 128, not 127.** The midpoint of 0–255 has to round somewhere, and Choplifter splits the range at 128 with no dead zone — at 127 it reads a centred stick as held left and drifts.
- **Neutral `JoystickAction`** in `Systems/Input`, with C64 migrated onto it. `Cia1` used to do `result.ClearBit((int)action)` — the enum's numeric values *were* the CIA bit positions. `C64Joystick.GetPortBit` now states that mapping, so extending the shared enum (as `Fire2` does) cannot silently change which bit the C64 pulls low.
- **Keyboard joystick** on `W`/`A`/`S`/`D`, Space and Left Shift; opt-in, with those keys withheld from the machine while on. Chosen so enabling it costs little: the Apple II's own arrow keys keep working and Right Shift still types.
- **Enable setting follows the C64's structure** — persisted on the system config and shown in the configuration dialog, the only place it is saved, with a sidebar checkbox and an `Apple II → Toggle Joystick KB` menu item (`⌘⌥K`, same key as C64 and VIC-20) as non-saving views of it.
- **Download & Run entries carry it per program**, as the C64 list does, applied while the emulator is stopped. Set for Lode Runner and Choplifter.
- **Remote**: `fire2` added to the protocol, dispatcher and client. The dispatcher was already system-agnostic, but the wire had no field for a second button, so `--fire2` was silently dropped while the client still reported `ok`.

## Which games actually use it — measured, not guessed

New `PaddleTriggerCount` / `ButtonReadCounts` diagnostics (mirroring `Disk2Controller.DataReadCount`) answer a question no amount of watching the screen can:

| game | paddle triggers | button 0 | button 1 | uses the stick |
|---|---|---|---|---|
| Lode Runner | 15,150 | 219,050 | — | yes |
| Choplifter | 4,497 | 9,058 | **4,338** | yes, both buttons |
| Apple Panic | 0 | 0 | 0 | no — keyboard only |
| Bolo | 0 | 0 | 0 | no — keyboard only |

DOS 3.3 as a control reads 0 and 0 while its disk reads climb, so the counters only move on genuine game-port access.

## Verification

`Apple2RealRomPaddleReadTests` drives the genuine ROM's `PREAD` and asserts it counts back **0, 1, 64, 127, 200 and 255 exactly** — testing our model against the real ROM rather than against itself. Plus 16 game-port tests, 15 keyboard-joystick tests, and the C64 suite unchanged.

Live in the app: `PDL(0)`/`PDL(1)` round-trip, holding a mapped key steers and does not type, releasing recentres, and the second button registers at `$C062` alongside a direction.

**1,676 tests pass** across the solution.

## Notes for review

- **An existing test earned its keep.** `Buttons_And_Paddles_Read_As_Idle` asserted the old stub's `0x00` and could reasonably have been deleted with the stub. It failed instead — on a freshly constructed machine the CPU cycle counter is 0 and so was the "never triggered" timestamp, so every paddle one-shot read as running before anything strobed `$C070`.
- **The C64 sidebar still writes its system config**, so a toggle there can ride into the next dialog OK. Apple II deliberately does not. Noted, not changed — C64 is shipped and working, and that is its own decision.
- Testing the keyboard joystick with `apple2.type` does not work: that goes through the text-paste service, which writes ASCII straight to the keyboard latch and never becomes a `HostKey`. Use `keyboard.press --key w` and read `PDL(1)`. Documented in `automation.md`, having briefly fooled me into hunting a bug that wasn't there.