### PR TITLE
Add VisiCalc to the Apple II Download & Run list

### DIFF
--- a/docs/systems/apple2/disk2.md
+++ b/docs/systems/apple2/disk2.md
@@ -90,6 +90,12 @@ companion to sequencer-PROM (LSS) emulation, if copy-protected media is ever sup
 - ProDOS-ordered `.po` images, and nibble/flux `.nib`/`.woz` images.
 - Copy protection that depends on bit-level sequencer behaviour or exact rotational timing. Use a
   cracked release of such titles.
+- ProDOS *software*, whatever the image's sector order — but for a reason outside the drive.
+  ProDOS 8 needs 64 KB and the emulated machine is a 48 KB II Plus with no language card, so a
+  ProDOS disk boots only as far as ProDOS's own `RELOCATION / CONFIGURATION ERROR`. This is a
+  limit of the emulated machine, not of the II Plus: ProDOS 8 1.x supports the II and II Plus, on
+  a 64 KB one. Supporting these titles means emulating the language card (`$C080`–`$C08F`), not
+  changing anything here.
 
 ## Verified
 
@@ -109,6 +115,15 @@ Live-verified in the Avalonia desktop host:
   Download & Run list end to end: download → unzip → insert → boot → playing.
 - **Choplifter** (Brøderbund, 4am + san inc crack) and **Bolo** (Synergistic, 4am crack) boot to
   their title screens.
+- **VisiCalc** (1.27, 40-column) boots to the disk's own `HELLO` menu; picking `1` there BRUNs the
+  22 KB `VISICALC` binary and the sheet comes up — cursor on `A1`, columns A–D, rows 1–20. It is
+  booted rather than injected because VisiCalc's `/S` and `/L` file commands call DOS, so DOS has
+  to be resident.
+
+Verified *not* to work, and why it is worth recording: **Dangerous Dave** (Softdisk) is a ProDOS
+title, so it stops at the 64 KB requirement above — the 1988 disk carries `PRODOS 8 V1.4` and the
+1991 one `PRODOS 8 V1.9`. The 1988 disk is also ProDOS *block*-ordered, so it does not even get
+that far; it hangs at track 0 with the motor running.
 
 Automated coverage lives in `Disk2NibbleCodecTests`, `Disk2TrackNibblizerTests` and
 `Disk2ControllerTests`, plus opt-in integration tests (`Apple2RealRomDisk2BootTests`) that boot a

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/ViewModels/Apple2MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/ViewModels/Apple2MenuViewModel.cs
@@ -94,6 +94,15 @@ public class Apple2MenuViewModel : ViewModelBase, ISystemMenuContributor
             "https://mirrors.apple2.org.za/ftp.apple.asimov.net/images/games/action/Bolo%20%284am%20crack%29.zip",
             zipEntryName: "Bolo (4am crack)/Bolo (4am crack).dsk",
             runMode: Apple2DownloadRunMode.BootDisk) },
+
+        // The one non-game, and the only entry not on the asimov mirror — that mirror has no
+        // VisiCalc image. Booted rather than injected: the binary is a plain catalog file, but
+        // VisiCalc's /S and /L commands call DOS, so DOS has to be resident. Booting lands on the
+        // disk's own HELLO menu, where 1 starts VisiCalc.
+        { "visicalc", new Apple2DownloadProgramInfo(
+            "VisiCalc",
+            "https://archive.org/download/Visicalc_1.27/Visicalc_1.27.dsk",
+            runMode: Apple2DownloadRunMode.BootDisk) },
     };
 
     public AvaloniaHostApp HostApp => _hostApp;


### PR DESCRIPTION
Adds VisiCalc 1.27 — the 40-column original, and the Apple II's killer app — to the Apple II sidebar's **Download & Run programs** list. The list has been games only until now.

### How it runs

`BootDisk`, not `InjectFileIntoRam`. The catalog does hold a plain 22 KB `VISICALC` binary that could be injected, but VisiCalc's `/S` and `/L` file commands call DOS, so DOS has to be resident. Booting lands on the disk's own `HELLO` menu, where `1` starts VisiCalc — so it isn't quite the straight-to-app boot the game entries are.

The URL points at archive.org rather than the asimov mirror the other four entries use, because that mirror carries no VisiCalc image.

### Verification

Per the curation rule in `docs/systems/apple2/disk2.md`, verified against the running emulator (Avalonia desktop host, remote control server):

- The image is a 140 K DOS 3.3-ordered `.dsk`, 35/16, deprotected with a readable catalog.
- Inserted and booted through the same `InsertDiskImage` + `InvalidatePowerUpByte` + `Reset` sequence `Apple2DiskBoot.InsertAndBootAsync` performs. Reaches the `HELLO` menu; `1` loads VisiCalc and the sheet renders — cursor `A1`, columns A–D, rows 1–20, 25K free — confirmed by decoding text page 1 out of RAM, not just by eye.
- The URL serves exactly the bytes that were booted (sha256 `d00e0606…db8794`), and its 302 to the archive.org node resolves.

Not exercised: the combobox click itself. The download half is the same `RomDownloader.DownloadRomAsync` call the non-ZIP `applepanic` entry makes with a null ZIP entry, and the boot half is the same call the three `BootDisk` entries make, so this is a new pairing of two already-covered paths rather than new code.

Build clean, 1676 tests pass.

### Also: the ProDOS limit, documented

While looking for other candidates I tried Dangerous Dave, which does not run, and the reason is worth recording because it is the first thing any ProDOS title hits and it is *not* a drive problem:

ProDOS 8 needs 64 KB. The emulated machine is a 48 KB II Plus with no language card (`Apple2.cs` maps 48 KB at `$0000-$BFFF` with the ROM socket straight at `$D000`, no `$C08x` bank switching), so a ProDOS disk boots only as far as ProDOS's own `RELOCATION / CONFIGURATION ERROR`. That is a limit of the emulated machine, not of the II Plus — ProDOS 8 1.x supports the II and II Plus, on a 64 KB one.

Dangerous Dave is the worked example: its 1988 disk carries `PRODOS 8 V1.4` and its 1991 disk `PRODOS 8 V1.9` (extracted and read from the images), and both stop there. The 1988 disk is additionally ProDOS *block*-ordered and so hangs at track 0 before ProDOS even loads. Supporting these titles means emulating the language card — separate work, not attempted here.

No changelog entry: this repo has no root changelog and the change doesn't touch `tools/vscode-extension/`.