### PR TITLE
Add Apple II host keyboard layout detection, with US and Swedish

### DIFF
--- a/docs/host-apps/avalonia/automation.md
+++ b/docs/host-apps/avalonia/automation.md
@@ -117,6 +117,9 @@ A non-exhaustive list of the most useful AutomationIds, grouped by view. All of 
 - **Audio**: `AudioEnableCheckBox`, `AudioProviderComboBox`, `AudioTargetComboBox`. Audio needs
   *both* a provider and a target selected; a provider alone leaves the host building no audio
   coordinator, and the machine is then silent with nothing logged to say why.
+- **Input &amp; Joystick**: `KeyboardLayoutComboBox` — host keyboard layout (`Auto` plus each
+  explicit layout; `Auto` means auto-detect). Same id as the C64 dialog's equivalent, so a check
+  that walks both dialogs uses one name.
 - **Input &amp; Joystick**: `KeyboardJoystickEnableCheckBox` — the persisted setting. Its live
   counterpart is `KeyboardJoystickCheckBox` in the sidebar, needed because this dialog only opens
   while the emulator is stopped. Both show the same setting and stay in step; the difference is

--- a/docs/systems/apple2/overview.md
+++ b/docs/systems/apple2/overview.md
@@ -89,6 +89,21 @@ there is no CIA/VIA equivalent to emulate and no keyboard matrix to scan.
   rasterizer for a faithful picture and for graphics modes.
 - Host-agnostic input handling — host key to ASCII with Shift and Control, plus typematic
   auto-repeat.
+- **Host keyboard layout detection**, so punctuation matches the keys the user is actually
+  pressing. **US English** and **Swedish** are supported, and anything else falls back to US.
+  The layout is resolved once when the input handler starts, in this order: the explicit
+  *Keyboard layout* setting in the Apple II configuration dialog → the host's active keyboard
+  layout, read from the OS → the OS culture → US. Leaving the setting on **Auto** (the default)
+  runs the whole chain; every step is logged, so the Log tab shows which layout was chosen and
+  why. Notes on the Swedish map:
+    - Å, Ä and Ö have no 7-bit ASCII form, so those three keys are bound to `[`, `]` and `\`
+      (shifted: `{`, `}`, `|`) — characters a Swedish keyboard can otherwise only reach through
+      Alt/Option chords that differ between macOS and Windows.
+    - `Alt`/`Option` + `2`, `4`, `8`, `9` give `@`, `$`, `[`, `]`. Only these four are bound,
+      because they are the chords macOS and Windows agree on.
+    - `^` (Applesoft's exponent operator) is on shifted `¨`.
+    - On macOS the two ISO keys `§` and `<` arrive with their hardware codes swapped relative to
+      the W3C convention; this is corrected automatically for non-US layouts.
 - CTRL-RESET (warm reset through the reset vector, like the RESET key on the real keyboard)
   on **Ctrl + F12**, the same combo the Virtual ][ emulator uses.
 - Program loading without disk emulation, via the Avalonia sidebar's Load/Save section and

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/ViewModels/Apple2ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/ViewModels/Apple2ConfigDialogViewModel.cs
@@ -13,6 +13,7 @@ using Highbyte.DotNet6502.Impl.Avalonia.Apple2;
 using Highbyte.DotNet6502.Systems;
 using Highbyte.DotNet6502.Systems.Apple2.Config;
 using Highbyte.DotNet6502.Systems.Apple2.Video;
+using Highbyte.DotNet6502.Systems.Input;
 using Highbyte.DotNet6502.Systems.Utils;
 using Highbyte.DotNet6502.Utils;
 using ReactiveUI;
@@ -27,6 +28,9 @@ public class Apple2ConfigDialogViewModel : ViewModelBase
 {
     /// <summary>The largest Apple II ROM is the 20 KB $B000-$FFFF system image layout.</summary>
     private const long MaxRomFileSizeBytes = 32 * 1024;
+
+    // Keyboard layout dropdown entry meaning "no explicit setting" -> null config -> auto-detect.
+    private const string AutoKeyboardLayoutLabel = "Auto";
 
     private readonly AvaloniaHostApp _hostApp;
     private readonly Apple2HostConfig _originalConfig;
@@ -46,6 +50,7 @@ public class Apple2ConfigDialogViewModel : ViewModelBase
     private bool _suppressRenderTargetUpdate;
     private CpuCompatibilityProfileOption? _selectedCpuCompatibilityProfile;
     private MonitorColorOption? _selectedMonitorColor;
+    private string _selectedKeyboardLayout = AutoKeyboardLayoutLabel;
 
     public ReactiveCommand<Unit, Unit> DownloadRomsToByteArrayCommand { get; }
     public ReactiveCommand<Unit, Unit> DownloadRomsToFilesCommand { get; }
@@ -118,6 +123,9 @@ public class Apple2ConfigDialogViewModel : ViewModelBase
     public ObservableCollection<CpuCompatibilityProfileOption> CpuCompatibilityProfiles { get; } =
         new(CpuCompatibilityProfileOption.All);
     public ObservableCollection<MonitorColorOption> MonitorColors { get; } = new(MonitorColorOption.All);
+    // "Auto" (auto-detect) plus each explicit HostKeyboardLayout, as strings for the dropdown.
+    public ObservableCollection<string> AvailableKeyboardLayouts { get; } =
+        new(new[] { AutoKeyboardLayoutLabel }.Concat(Enum.GetNames<HostKeyboardLayout>()));
 
     public bool IsRunningInWebAssembly { get; } = PlatformDetection.IsRunningInWebAssembly();
 
@@ -356,6 +364,28 @@ public class Apple2ConfigDialogViewModel : ViewModelBase
     public string SelectedMonitorColorHelpText => SelectedMonitorColor?.HelpText ?? string.Empty;
 
     /// <summary>
+    /// The host keyboard layout the Apple II keyboard mapping assumes, as a dropdown string.
+    /// <see cref="AutoKeyboardLayoutLabel"/> means "no explicit setting" — a null config value,
+    /// which makes the input handler auto-detect.
+    /// </summary>
+    public string SelectedKeyboardLayout
+    {
+        get => _selectedKeyboardLayout;
+        set
+        {
+            if (_selectedKeyboardLayout == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _selectedKeyboardLayout, value);
+
+            _workingConfig.InputConfig.KeyboardLayout =
+                string.IsNullOrEmpty(value) || value == AutoKeyboardLayoutLabel
+                    ? null
+                    : Enum.Parse<HostKeyboardLayout>(value);
+        }
+    }
+
+    /// <summary>
     /// Whether host keys drive the game port. Edits the working copy like every other setting in
     /// this dialog, so Cancel discards it; the sidebar checkbox is the live counterpart for
     /// toggling it while a game is running.
@@ -537,6 +567,7 @@ public class Apple2ConfigDialogViewModel : ViewModelBase
             _originalConfig.SystemConfig.CpuCompatibilityProfile = _workingConfig.SystemConfig.CpuCompatibilityProfile;
             _originalConfig.SystemConfig.MonitorColor = _workingConfig.SystemConfig.MonitorColor;
             _originalConfig.SystemConfig.KeyboardJoystickEnabled = _workingConfig.SystemConfig.KeyboardJoystickEnabled;
+            _originalConfig.InputConfig.KeyboardLayout = _workingConfig.InputConfig.KeyboardLayout;
             _originalConfig.SystemConfig.AudioEnabled = _workingConfig.SystemConfig.AudioEnabled;
             _originalConfig.SystemConfig.SetAudioProviderType(_workingConfig.SystemConfig.AudioProviderType);
             _originalConfig.SystemConfig.SetAudioTargetType(_workingConfig.SystemConfig.AudioTargetType);
@@ -573,6 +604,7 @@ public class Apple2ConfigDialogViewModel : ViewModelBase
         RomDirectory = _workingConfig.SystemConfig.ROMDirectory;
         SelectedCpuCompatibilityProfile = CpuCompatibilityProfileOption.FromProfile(_workingConfig.SystemConfig.CpuCompatibilityProfile);
         SelectedMonitorColor = MonitorColorOption.FromMonitorColor(_workingConfig.SystemConfig.MonitorColor);
+        SelectedKeyboardLayout = _workingConfig.InputConfig.KeyboardLayout?.ToString() ?? AutoKeyboardLayoutLabel;
 
         InitializeRenderOptions();
         InitializeAudioOptions();

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/Views/Apple2ConfigDialogView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/Views/Apple2ConfigDialogView.axaml
@@ -266,6 +266,24 @@
                 <TextBlock Text="Input &amp; Joystick"
                             Classes=""/>
 
+                <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto" Classes="spacing-wide">
+                    <TextBlock Grid.Row="0" Grid.Column="0"
+                                Text="Keyboard layout:"
+                                Classes="secondary-text" />
+                    <ComboBox Grid.Row="0" Grid.Column="1"
+                            AutomationProperties.AutomationId="KeyboardLayoutComboBox"
+                            AutomationProperties.Name="Keyboard layout"
+                            ItemsSource="{Binding AvailableKeyboardLayouts}"
+                            SelectedItem="{Binding SelectedKeyboardLayout}"
+                            Classes="small"
+                            MinWidth="100"
+                            MaxDropDownHeight="100" />
+                </Grid>
+
+                <TextBlock Text="Which punctuation the host keys produce. Auto detects the layout from the operating system, and falls back to US English when it cannot tell."
+                            Classes="small secondary-text"
+                            TextWrapping="Wrap"/>
+
                 <CheckBox AutomationProperties.AutomationId="KeyboardJoystickEnableCheckBox"
                         AutomationProperties.Name="Enable keyboard joystick controls"
                         Content="Enable keyboard joystick controls"

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Input/Apple2HostKeyboard.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Input/Apple2HostKeyboard.cs
@@ -6,17 +6,45 @@ namespace Highbyte.DotNet6502.Systems.Apple2.Input;
 /// Maps host keys to the 7-bit ASCII codes the Apple II keyboard encoder produces.
 ///
 /// Far simpler than a matrix machine: the encoder emits one character code per key press, so
-/// there is no chord resolution to do — only the US-QWERTY shifted/unshifted pairs plus the
-/// Control modifier. The Apple II and II Plus have no lowercase, so letters always produce
-/// uppercase codes regardless of Shift or Caps Lock.
+/// there is no chord resolution to do — only the shifted/unshifted pairs plus the Control
+/// modifier. The Apple II and II Plus have no lowercase, so letters always produce uppercase
+/// codes regardless of Shift or Caps Lock.
+///
+/// Letters, digits and the control keys sit in the same place on every supported layout, so they
+/// form a shared base map; punctuation and the shifted digits are layout-specific and merged in
+/// by the constructor — the same split <c>C64HostKeyboard</c> uses.
 /// </summary>
 public class Apple2HostKeyboard
 {
-    /// <summary>Host key → (unshifted, shifted) ASCII code.</summary>
-    public static readonly IReadOnlyDictionary<HostKey, (byte Plain, byte Shifted)> HostKeyToAsciiMap =
+    /// <summary>The host keyboard layout this map was built for.</summary>
+    public HostKeyboardLayout Layout { get; }
+
+    /// <summary>
+    /// The complete host key → (unshifted, shifted) ASCII map for <see cref="Layout"/>: the
+    /// layout-independent base entries plus the layout-specific ones merged over them.
+    /// </summary>
+    public IReadOnlyDictionary<HostKey, (byte Plain, byte Shifted)> HostKeyToAsciiMap { get; }
+
+    /// <summary>Builds the keyboard map for the given host keyboard layout.</summary>
+    public Apple2HostKeyboard(HostKeyboardLayout layout)
+    {
+        Layout = layout;
+
+        var map = new Dictionary<HostKey, (byte, byte)>(LayoutIndependentMap);
+        var layoutSpecific = layout == HostKeyboardLayout.Swedish ? SwedishMap : USMap;
+        foreach (var entry in layoutSpecific)
+            map[entry.Key] = entry.Value;
+
+        HostKeyToAsciiMap = map;
+    }
+
+    /// <summary>
+    /// Keys that produce the same code on every supported layout: the letters (uppercase-only —
+    /// there is no lowercase character generator), the unshifted digits, and the control keys.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<HostKey, (byte Plain, byte Shifted)> LayoutIndependentMap =
         new Dictionary<HostKey, (byte, byte)>
         {
-            // Letters — uppercase in both states (no lowercase character generator).
             { HostKey.KeyA, ((byte)'A', (byte)'A') },
             { HostKey.KeyB, ((byte)'B', (byte)'B') },
             { HostKey.KeyC, ((byte)'C', (byte)'C') },
@@ -44,30 +72,18 @@ public class Apple2HostKeyboard
             { HostKey.KeyY, ((byte)'Y', (byte)'Y') },
             { HostKey.KeyZ, ((byte)'Z', (byte)'Z') },
 
-            // Digit row — US-QWERTY shifted symbols.
-            { HostKey.Digit1, ((byte)'1', (byte)'!') },
-            { HostKey.Digit2, ((byte)'2', (byte)'@') },
-            { HostKey.Digit3, ((byte)'3', (byte)'#') },
-            { HostKey.Digit4, ((byte)'4', (byte)'$') },
-            { HostKey.Digit5, ((byte)'5', (byte)'%') },
-            { HostKey.Digit6, ((byte)'6', (byte)'^') },
-            { HostKey.Digit7, ((byte)'7', (byte)'&') },
-            { HostKey.Digit8, ((byte)'8', (byte)'*') },
-            { HostKey.Digit9, ((byte)'9', (byte)'(') },
-            { HostKey.Digit0, ((byte)'0', (byte)')') },
-
-            // Punctuation.
-            { HostKey.Minus, ((byte)'-', (byte)'_') },
-            { HostKey.Equal, ((byte)'=', (byte)'+') },
-            { HostKey.BracketLeft, ((byte)'[', (byte)'{') },
-            { HostKey.BracketRight, ((byte)']', (byte)'}') },
-            { HostKey.Backslash, ((byte)'\\', (byte)'|') },
-            { HostKey.Semicolon, ((byte)';', (byte)':') },
-            { HostKey.Quote, ((byte)'\'', (byte)'"') },
-            { HostKey.Comma, ((byte)',', (byte)'<') },
-            { HostKey.Period, ((byte)'.', (byte)'>') },
-            { HostKey.Slash, ((byte)'/', (byte)'?') },
-            { HostKey.Backquote, ((byte)'`', (byte)'~') },
+            // Unshifted digits are the same everywhere; the shifted symbols are not, so every
+            // digit is re-stated in each layout map below.
+            { HostKey.Digit1, ((byte)'1', (byte)'1') },
+            { HostKey.Digit2, ((byte)'2', (byte)'2') },
+            { HostKey.Digit3, ((byte)'3', (byte)'3') },
+            { HostKey.Digit4, ((byte)'4', (byte)'4') },
+            { HostKey.Digit5, ((byte)'5', (byte)'5') },
+            { HostKey.Digit6, ((byte)'6', (byte)'6') },
+            { HostKey.Digit7, ((byte)'7', (byte)'7') },
+            { HostKey.Digit8, ((byte)'8', (byte)'8') },
+            { HostKey.Digit9, ((byte)'9', (byte)'9') },
+            { HostKey.Digit0, ((byte)'0', (byte)'0') },
 
             // Control keys.
             { HostKey.Space, (0x20, 0x20) },
@@ -83,6 +99,109 @@ public class Apple2HostKeyboard
             { HostKey.ArrowDown, (0x0A, 0x0A) },
         };
 
+    /// <summary>US (ANSI) punctuation and shifted digits — what the map used to hard-code.</summary>
+    private static readonly IReadOnlyDictionary<HostKey, (byte Plain, byte Shifted)> USMap =
+        new Dictionary<HostKey, (byte, byte)>
+        {
+            { HostKey.Digit1, ((byte)'1', (byte)'!') },
+            { HostKey.Digit2, ((byte)'2', (byte)'@') },
+            { HostKey.Digit3, ((byte)'3', (byte)'#') },
+            { HostKey.Digit4, ((byte)'4', (byte)'$') },
+            { HostKey.Digit5, ((byte)'5', (byte)'%') },
+            { HostKey.Digit6, ((byte)'6', (byte)'^') },
+            { HostKey.Digit7, ((byte)'7', (byte)'&') },
+            { HostKey.Digit8, ((byte)'8', (byte)'*') },
+            { HostKey.Digit9, ((byte)'9', (byte)'(') },
+            { HostKey.Digit0, ((byte)'0', (byte)')') },
+
+            { HostKey.Minus, ((byte)'-', (byte)'_') },
+            { HostKey.Equal, ((byte)'=', (byte)'+') },
+            { HostKey.BracketLeft, ((byte)'[', (byte)'{') },
+            { HostKey.BracketRight, ((byte)']', (byte)'}') },
+            { HostKey.Backslash, ((byte)'\\', (byte)'|') },
+            { HostKey.Semicolon, ((byte)';', (byte)':') },
+            { HostKey.Quote, ((byte)'\'', (byte)'"') },
+            { HostKey.Comma, ((byte)',', (byte)'<') },
+            { HostKey.Period, ((byte)'.', (byte)'>') },
+            { HostKey.Slash, ((byte)'/', (byte)'?') },
+            { HostKey.Backquote, ((byte)'`', (byte)'~') },
+        };
+
+    /// <summary>
+    /// Swedish (ISO) punctuation and shifted digits.
+    ///
+    /// Two kinds of entry, and the distinction matters when changing this map:
+    ///
+    /// <para><b>1. What the Swedish layout genuinely produces</b> — the shifted digits, and the
+    /// keys right of L and right of M. A user gets the character printed on the keycap.</para>
+    ///
+    /// <para><b>2. Convenience bindings for the Å/Ä/Ö keys.</b> Those three letters have no 7-bit
+    /// ASCII form, so the Apple II cannot receive them and the keys would otherwise be dead. They
+    /// are bound to <c>[ ] \</c> (and shifted, <c>{ } |</c>) — characters a Swedish keyboard can
+    /// otherwise only reach through Alt/Option chords that differ between macOS and Windows.
+    /// <c>C64HostKeyboard</c> takes the same approach with its Ä/Å bindings.</para>
+    ///
+    /// <para>Alt chords are bound only where macOS and Windows agree (<c>@ $ [ ]</c>). Others
+    /// diverge — Alt+7 is <c>{</c> on Windows but <c>|</c> on macOS — so binding them would be
+    /// wrong on one platform or the other, and the Å/Ä/Ö bindings above already cover the gap.
+    /// </para>
+    /// </summary>
+    private static readonly IReadOnlyDictionary<HostKey, (byte Plain, byte Shifted)> SwedishMap =
+        new Dictionary<HostKey, (byte, byte)>
+        {
+            // Digit row. Shift+4 is ¤ on Windows and $ on macOS; ¤ has no ASCII form, so $ is
+            // used for both — correct on macOS, and a usable $ rather than nothing on Windows.
+            { HostKey.Digit1, ((byte)'1', (byte)'!') },
+            { HostKey.Digit2, ((byte)'2', (byte)'"') },
+            { HostKey.Digit3, ((byte)'3', (byte)'#') },
+            { HostKey.Digit4, ((byte)'4', (byte)'$') },
+            { HostKey.Digit5, ((byte)'5', (byte)'%') },
+            { HostKey.Digit6, ((byte)'6', (byte)'&') },
+            { HostKey.Digit7, ((byte)'7', (byte)'/') },
+            { HostKey.Digit8, ((byte)'8', (byte)'(') },
+            { HostKey.Digit9, ((byte)'9', (byte)')') },
+            { HostKey.Digit0, ((byte)'0', (byte)'=') },
+
+            // Right of 0: the +/? key, then the ´/` dead key. A dead key produces no character
+            // on its own, so only the ^ on the ¨ key (below) is worth binding.
+            { HostKey.Minus, ((byte)'+', (byte)'?') },
+
+            // Right of P: Å, then the ¨/^ dead key. ^ is Applesoft's exponent operator, so the
+            // shifted position is bound even though the unshifted ¨ is not.
+            { HostKey.BracketLeft, ((byte)'[', (byte)'{') },   // Å — convenience, see remarks
+            { HostKey.BracketRight, (0x00, (byte)'^') },
+
+            // Right of L: Ö, Ä, then the '/* key.
+            { HostKey.Semicolon, ((byte)'\\', (byte)'|') },    // Ö — convenience, see remarks
+            { HostKey.Quote, ((byte)']', (byte)'}') },         // Ä — convenience, see remarks
+            { HostKey.Backslash, ((byte)'\'', (byte)'*') },
+
+            // Left of Z: the <> key.
+            { HostKey.IntlBackslash, ((byte)'<', (byte)'>') },
+
+            // Right of M: comma, period, then the -/_ key.
+            { HostKey.Comma, ((byte)',', (byte)';') },
+            { HostKey.Period, ((byte)'.', (byte)':') },
+            { HostKey.Slash, ((byte)'-', (byte)'_') },
+
+            // Left of 1 is §/½ on a Swedish keyboard — no ASCII form, so unbound. (On macOS it
+            // arrives as IntlBackslash; Apple2InputHandler corrects that before lookup.)
+        };
+
+    /// <summary>
+    /// Alt/Option + digit chords that produce a character on a Swedish keyboard, limited to the
+    /// ones macOS and Windows agree on. Checked before the plain map so the chord wins over the
+    /// digit it is built from.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<HostKey, byte> SwedishAltChords =
+        new Dictionary<HostKey, byte>
+        {
+            { HostKey.Digit2, (byte)'@' },
+            { HostKey.Digit4, (byte)'$' },
+            { HostKey.Digit8, (byte)'[' },
+            { HostKey.Digit9, (byte)']' },
+        };
+
     /// <summary>Host keys that only act as modifiers and never produce a character themselves.</summary>
     public static readonly IReadOnlySet<HostKey> ModifierKeys = new HashSet<HostKey>
     {
@@ -93,18 +212,35 @@ public class Apple2HostKeyboard
         HostKey.CapsLock,
     };
 
+    /// <summary>Whether the key produces a character on this layout (so is worth latching).</summary>
+    public bool ProducesCharacter(HostKey key) =>
+        HostKeyToAsciiMap.ContainsKey(key)
+        || (Layout == HostKeyboardLayout.Swedish && SwedishAltChords.ContainsKey(key));
+
     /// <summary>
     /// Resolves a host key press to an Apple II ASCII code.
     /// Control turns a letter (and @ / [ / \ / ] / ^ / _) into its $00-$1F control code, which is
     /// how Applesoft receives CTRL-C, CTRL-G and friends.
     /// </summary>
-    public static bool TryGetAscii(HostKey key, bool shift, bool control, out byte ascii)
+    public bool TryGetAscii(HostKey key, bool shift, bool control, out byte ascii, bool alt = false)
     {
         ascii = 0;
-        if (!HostKeyToAsciiMap.TryGetValue(key, out var codes))
-            return false;
 
-        ascii = shift ? codes.Shifted : codes.Plain;
+        if (alt && Layout == HostKeyboardLayout.Swedish && SwedishAltChords.TryGetValue(key, out var altAscii))
+        {
+            ascii = altAscii;
+        }
+        else
+        {
+            if (!HostKeyToAsciiMap.TryGetValue(key, out var codes))
+                return false;
+
+            ascii = shift ? codes.Shifted : codes.Plain;
+
+            // A dead key's unshifted half has no character (e.g. Swedish ¨), marked as 0x00.
+            if (ascii == 0x00)
+                return false;
+        }
 
         if (control && ascii >= 0x40 && ascii <= 0x5F)
             ascii = (byte)(ascii - 0x40);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Input/Apple2InputConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Input/Apple2InputConfig.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Highbyte.DotNet6502.Systems.Input;
 
 namespace Highbyte.DotNet6502.Systems.Apple2.Input;
@@ -11,6 +12,23 @@ namespace Highbyte.DotNet6502.Systems.Apple2.Input;
 /// </summary>
 public class Apple2InputConfig : ICloneable
 {
+    /// <summary>
+    /// The host physical keyboard layout the Apple II keyboard mapping assumes. Selects which
+    /// punctuation and shifted-digit map <see cref="Apple2HostKeyboard"/> merges in.
+    /// <para>
+    /// <c>null</c> — the default, and what an absent or empty <c>appsettings.json</c> value binds
+    /// to — means <em>auto-detect</em>: the input handler resolves the layout from the host's
+    /// detected keyboard layout, then the OS culture, then falls back to
+    /// <see cref="HostKeyboardLayout.US"/>. A non-null value forces that layout.
+    /// </para>
+    /// <para>
+    /// A property (not a field) so it binds from <c>appsettings.json</c>; the string-enum
+    /// converter keeps the persisted JSON readable (e.g. <c>"Swedish"</c> rather than a number).
+    /// </para>
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter<HostKeyboardLayout>))]
+    public HostKeyboardLayout? KeyboardLayout { get; set; }
+
     /// <summary>
     /// Whether host keys drive the joystick. Off by default, and deliberately opt-in: the mapped
     /// keys are taken away from the keyboard while it is on.

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Input/Apple2InputHandler.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Input/Apple2InputHandler.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Highbyte.DotNet6502.Systems.Input;
 using Highbyte.DotNet6502.Systems.Instrumentation;
 using Microsoft.Extensions.Logging;
@@ -31,6 +32,11 @@ public class Apple2InputHandler : IInputConsumer
 
     private IHostInputState _inputState = default!;
 
+    private Apple2HostKeyboard _hostKeyboard = new(HostKeyboardLayout.US);
+    private bool _swapBackquoteAndIntlBackslash;
+    // Reused so the macOS ISO swap does not allocate a set every frame.
+    private readonly HashSet<HostKey> _swappedHostKeysBuffer = new();
+
     private readonly HashSet<HostKey> _previousKeysDown = new();
     private HostKey _repeatingKey = HostKey.None;
     private int _framesHeld;
@@ -48,9 +54,94 @@ public class Apple2InputHandler : IInputConsumer
     /// <summary>The gamepad and keyboard-joystick mapping in force.</summary>
     public Apple2InputConfig InputConfig => _inputConfig;
 
+    /// <summary>The keyboard map in force, built for the resolved host keyboard layout.</summary>
+    public Apple2HostKeyboard HostKeyboard => _hostKeyboard;
+
     public void Init(IHostInputState inputState)
     {
         _inputState = inputState;
+
+        _hostKeyboard = new Apple2HostKeyboard(ResolveKeyboardLayout());
+
+        // macOS reports the two ISO-keyboard keys §/< (the keys left of '1' and left of 'Z') with
+        // hardware keycodes that are swapped relative to the W3C `code` convention that HostKey
+        // follows: the § key arrives as IntlBackslash and the < key as Backquote. The swap only
+        // makes sense on an ISO keyboard, which a non-US layout selection implies. Same correction
+        // C64InputHandler applies.
+        _swapBackquoteAndIntlBackslash =
+            _inputState.IsRunningOnMacOS && _hostKeyboard.Layout != HostKeyboardLayout.US;
+        if (_swapBackquoteAndIntlBackslash)
+            _logger.LogInformation("Applying macOS ISO-keyboard Backquote/IntlBackslash key swap.");
+    }
+
+    /// <summary>
+    /// Resolves the host keyboard layout the Apple II keyboard map is built for. Priority:
+    /// <list type="number">
+    /// <item>The explicit config setting <see cref="Apple2InputConfig.KeyboardLayout"/> — when set
+    ///   (non-null), it forces that layout.</item>
+    /// <item>Auto-detect: the host's native keyboard layout, via
+    ///   <see cref="IHostInputState.DetectNativeKeyboardLayoutId"/> / <see cref="HostKeyboardLayoutResolver"/>.</item>
+    /// <item>The OS/UI culture — inaccurate (it is not the physical keyboard) but better than
+    ///   nothing.</item>
+    /// <item>Default: <see cref="HostKeyboardLayout.US"/>.</item>
+    /// </list>
+    /// </summary>
+    private HostKeyboardLayout ResolveKeyboardLayout()
+    {
+        if (_inputConfig.KeyboardLayout.HasValue)
+        {
+            _logger.LogInformation(
+                $"Apple II keyboard layout: {_inputConfig.KeyboardLayout.Value} (explicit config setting).");
+            return _inputConfig.KeyboardLayout.Value;
+        }
+
+        var nativeLayoutId = _inputState.DetectNativeKeyboardLayoutId();
+        var detected = HostKeyboardLayoutResolver.FromNativeLayoutId(nativeLayoutId);
+        if (detected.HasValue)
+        {
+            _logger.LogInformation(
+                $"Apple II keyboard layout: {detected.Value} (auto-detected from host keyboard layout '{nativeLayoutId}').");
+            return detected.Value;
+        }
+
+        var hostLayoutDesc = nativeLayoutId is null ? "not detectable" : $"'{nativeLayoutId}' unmapped";
+        var culture = CultureInfo.CurrentCulture;
+        var fromCulture = HostKeyboardLayoutResolver.FromCulture(culture);
+        if (fromCulture.HasValue)
+        {
+            _logger.LogInformation(
+                $"Apple II keyboard layout: {fromCulture.Value} (from OS culture '{culture.Name}'; " +
+                $"host keyboard layout {hostLayoutDesc}).");
+            return fromCulture.Value;
+        }
+
+        _logger.LogInformation(
+            $"Apple II keyboard layout: {HostKeyboardLayout.US} (default; no config setting, " +
+            $"host keyboard layout {hostLayoutDesc}, OS culture '{culture.Name}' unmapped).");
+        return HostKeyboardLayout.US;
+    }
+
+    // Returns a copy of the held host keys with HostKey.Backquote and HostKey.IntlBackslash
+    // exchanged — the macOS ISO-keyboard correction (see Init). Returns the input unchanged when
+    // neither key is held, to avoid allocating on every frame.
+    private IReadOnlySet<HostKey> SwapBackquoteAndIntlBackslash(IReadOnlySet<HostKey> hostKeysDown)
+    {
+        var hasBackquote = hostKeysDown.Contains(HostKey.Backquote);
+        var hasIntlBackslash = hostKeysDown.Contains(HostKey.IntlBackslash);
+        if (!hasBackquote && !hasIntlBackslash)
+            return hostKeysDown;
+
+        _swappedHostKeysBuffer.Clear();
+        foreach (var key in hostKeysDown)
+        {
+            if (key == HostKey.Backquote)
+                _swappedHostKeysBuffer.Add(HostKey.IntlBackslash);
+            else if (key == HostKey.IntlBackslash)
+                _swappedHostKeysBuffer.Add(HostKey.Backquote);
+            else
+                _swappedHostKeysBuffer.Add(key);
+        }
+        return _swappedHostKeysBuffer;
     }
 
     public void BeforeFrame()
@@ -67,10 +158,14 @@ public class Apple2InputHandler : IInputConsumer
             keysDown = merged;
         }
 
+        if (_swapBackquoteAndIntlBackslash)
+            keysDown = SwapBackquoteAndIntlBackslash(keysDown);
+
         keysDown = ApplyJoystick(keysDown);
 
         var shift = keysDown.Contains(HostKey.ShiftLeft) || keysDown.Contains(HostKey.ShiftRight);
         var control = keysDown.Contains(HostKey.ControlLeft) || keysDown.Contains(HostKey.ControlRight);
+        var alt = keysDown.Contains(HostKey.AltLeft) || keysDown.Contains(HostKey.AltRight);
 
         // CTRL-RESET. The RESET key is wired to the 6502 /RES line (not the keyboard encoder),
         // with CTRL required on later II Plus keyboards. Mapped to Ctrl+F12, the same host combo
@@ -82,7 +177,7 @@ public class Apple2InputHandler : IInputConsumer
         }
 
         var key = ResolveKeyToLatch(keysDown);
-        if (key != HostKey.None && Apple2HostKeyboard.TryGetAscii(key, shift, control, out var ascii))
+        if (key != HostKey.None && _hostKeyboard.TryGetAscii(key, shift, control, out var ascii, alt))
         {
             _apple2.Keyboard.KeyPressed(ascii);
             _logger.LogTrace("Apple II input: host={HostKey} ascii=${Ascii:X2}", key, ascii);
@@ -155,7 +250,7 @@ public class Apple2InputHandler : IInputConsumer
         {
             if (Apple2HostKeyboard.ModifierKeys.Contains(key))
                 continue;
-            if (!Apple2HostKeyboard.HostKeyToAsciiMap.ContainsKey(key))
+            if (!_hostKeyboard.ProducesCharacter(key))
                 continue;
             if (_previousKeysDown.Contains(key))
                 continue;

--- a/src/libraries/Highbyte.DotNet6502.Systems/Input/HostKeyboardLayout.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Input/HostKeyboardLayout.cs
@@ -1,0 +1,29 @@
+namespace Highbyte.DotNet6502.Systems.Input;
+
+/// <summary>
+/// The host's physical keyboard layout, as far as an emulated system's keyboard mapping needs to
+/// care about it.
+///
+/// System-neutral on purpose: which punctuation a host key produces is a property of the host
+/// keyboard, not of the emulated machine, so several systems can share both this enum and
+/// <see cref="HostKeyboardLayoutResolver"/> rather than each carrying a private copy of the same
+/// platform-identifier switch.
+///
+/// Only layouts that at least one system has a specific punctuation map for belong here — an
+/// unrecognised host layout resolves to <c>null</c> and the caller falls back to
+/// <see cref="US"/>.
+///
+/// <para>
+/// The C64 predates this and keeps its own <c>C64KeyboardLayout</c>. That is deliberate: its
+/// value is persisted in user settings as a string ("Swedish"/"US"), so migrating it would risk
+/// breaking saved configs for no user-visible gain.
+/// </para>
+/// </summary>
+public enum HostKeyboardLayout
+{
+    /// <summary>US (ANSI) physical keyboard layout.</summary>
+    US,
+
+    /// <summary>Swedish (ISO) physical keyboard layout.</summary>
+    Swedish,
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems/Input/HostKeyboardLayoutResolver.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Input/HostKeyboardLayoutResolver.cs
@@ -1,0 +1,72 @@
+using System.Globalization;
+
+namespace Highbyte.DotNet6502.Systems.Input;
+
+/// <summary>
+/// Resolves a raw native keyboard-layout identifier (from <see cref="KeyboardLayoutDetector"/>, or
+/// fingerprinted by a browser host) — or an OS culture — to a <see cref="HostKeyboardLayout"/>.
+///
+/// The identifier formats are a property of the host platform, not of any emulated system, so this
+/// lives beside the detector and is shared. Anything unrecognised resolves to <c>null</c> so the
+/// caller can fall through to the next option in its own resolution chain.
+/// </summary>
+public static class HostKeyboardLayoutResolver
+{
+    private const string MacInputSourcePrefix = "com.apple.keylayout.";
+
+    /// <summary>
+    /// Maps a raw native layout id to a <see cref="HostKeyboardLayout"/>, or <c>null</c> when the
+    /// id is empty or names a layout with no specific map. Recognises Windows KLIDs, macOS
+    /// input-source ids, and a plain layout name (used by the browser host).
+    /// </summary>
+    public static HostKeyboardLayout? FromNativeLayoutId(string? nativeLayoutId)
+    {
+        if (string.IsNullOrWhiteSpace(nativeLayoutId))
+            return null;
+        nativeLayoutId = nativeLayoutId.Trim();
+
+        // Windows: KLID is 8 hex digits; the low 4 are the language id (0409 = US, 041D = Swedish).
+        if (nativeLayoutId.Length == 8 && nativeLayoutId.All(Uri.IsHexDigit))
+        {
+            return int.Parse(nativeLayoutId.Substring(4), NumberStyles.HexNumber) switch
+            {
+                0x041D => HostKeyboardLayout.Swedish,
+                0x0409 => HostKeyboardLayout.US,
+                _ => null,
+            };
+        }
+
+        // macOS: input-source id "com.apple.keylayout.<Name>".
+        if (nativeLayoutId.StartsWith(MacInputSourcePrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            var name = nativeLayoutId.Substring(MacInputSourcePrefix.Length);
+            if (name.Contains("Swedish", StringComparison.OrdinalIgnoreCase))
+                return HostKeyboardLayout.Swedish;
+            if (name.StartsWith("US", StringComparison.OrdinalIgnoreCase)
+                || name.StartsWith("ABC", StringComparison.OrdinalIgnoreCase))
+                return HostKeyboardLayout.US;
+            return null;
+        }
+
+        // Browser fingerprint / diagnostic token: a plain HostKeyboardLayout name.
+        if (Enum.TryParse<HostKeyboardLayout>(nativeLayoutId, ignoreCase: true, out var layout))
+            return layout;
+
+        return null;
+    }
+
+    /// <summary>
+    /// Maps an OS culture to a <see cref="HostKeyboardLayout"/> as a last-resort fallback when the
+    /// physical layout cannot be detected. Inaccurate by nature (culture is the UI/region language,
+    /// not the keyboard) — returns <c>null</c> for unmapped cultures.
+    /// </summary>
+    public static HostKeyboardLayout? FromCulture(CultureInfo culture)
+    {
+        return culture.TwoLetterISOLanguageName.ToLowerInvariant() switch
+        {
+            "sv" => HostKeyboardLayout.Swedish,
+            "en" => HostKeyboardLayout.US,
+            _ => null,
+        };
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2InputHandlerTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2InputHandlerTests.cs
@@ -8,11 +8,18 @@ namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
 
 public class Apple2InputHandlerTests
 {
-    private static (Apple2System Apple2, Apple2InputHandler Handler, TestHostInputState InputState) Build()
+    /// <summary>
+    /// Builds a handler with the keyboard layout pinned, so these assertions never depend on the
+    /// developer's own keyboard layout or OS culture. US unless a test asks for something else —
+    /// auto-detection is covered by its own tests below.
+    /// </summary>
+    private static (Apple2System Apple2, Apple2InputHandler Handler, TestHostInputState InputState) Build(
+        HostKeyboardLayout layout = HostKeyboardLayout.US)
     {
         var apple2 = new Apple2System(new Apple2Config(), NullLoggerFactory.Instance);
         var inputState = new TestHostInputState();
-        var handler = new Apple2InputHandler(apple2, NullLoggerFactory.Instance);
+        var inputConfig = new Apple2InputConfig { KeyboardLayout = layout };
+        var handler = new Apple2InputHandler(apple2, NullLoggerFactory.Instance, inputConfig);
         handler.Init(inputState);
         return (apple2, handler, inputState);
     }
@@ -183,11 +190,22 @@ public class Apple2InputHandlerTests
         Assert.Equal((byte)0xC1, apple2.Keyboard.Latch);
     }
 
-    private sealed class TestHostInputState : IHostInputState
+    internal sealed class TestHostInputState : IHostInputState
     {
         public IReadOnlySet<HostKey> KeysDown { get; private set; } = new HashSet<HostKey>();
         public IReadOnlySet<GamepadButton> GamepadButtonsDown { get; } = new HashSet<GamepadButton>();
         public bool CapsLockOn => false;
+        public bool IsRunningOnMacOS { get; set; }
+
+        /// <summary>
+        /// The layout id auto-detection sees. Null by default so tests never reach the real OS —
+        /// <see cref="IHostInputState.DetectNativeKeyboardLayoutId"/>'s default implementation
+        /// queries the host, which would make every keyboard assertion depend on the layout the
+        /// developer happens to be running.
+        /// </summary>
+        public string? NativeKeyboardLayoutId { get; set; }
+
+        public string? DetectNativeKeyboardLayoutId() => NativeKeyboardLayoutId;
 
         public void SetKeysDown(params HostKey[] keys) => KeysDown = new HashSet<HostKey>(keys);
         public void SetKeysDown(IReadOnlySet<HostKey> keys) => KeysDown = keys;

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2InputInjectorTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2InputInjectorTests.cs
@@ -12,7 +12,10 @@ public class Apple2InputInjectorTests
     private static (Apple2System Apple2, Apple2InputHandler Handler) Build()
     {
         var apple2 = new Apple2System(new Apple2Config(), NullLoggerFactory.Instance);
-        var handler = new Apple2InputHandler(apple2, NullLoggerFactory.Instance);
+        // Layout pinned so the shifted-digit assertions do not depend on the developer's own
+        // keyboard layout, which auto-detection would otherwise pick up.
+        var handler = new Apple2InputHandler(
+            apple2, NullLoggerFactory.Instance, new Apple2InputConfig { KeyboardLayout = HostKeyboardLayout.US });
         handler.Init(new TestHostInputState());
         return (apple2, handler);
     }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2KeyboardLayoutTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2KeyboardLayoutTests.cs
@@ -1,0 +1,231 @@
+using Highbyte.DotNet6502.Systems.Apple2.Config;
+using Highbyte.DotNet6502.Systems.Apple2.Input;
+using Highbyte.DotNet6502.Systems.Input;
+using Microsoft.Extensions.Logging.Abstractions;
+using Apple2System = Highbyte.DotNet6502.Systems.Apple2.Apple2;
+using TestHostInputState = Highbyte.DotNet6502.Systems.Tests.Apple2.Apple2InputHandlerTests.TestHostInputState;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
+
+/// <summary>
+/// The Apple II keyboard map per host layout, and how the layout is resolved.
+///
+/// ASCII values here are the bare 7-bit codes the map produces; the latch adds the high bit, which
+/// is why <see cref="Apple2InputHandlerTests"/> asserts 0xC1 where this file asserts 'A'.
+/// </summary>
+public class Apple2KeyboardLayoutTests
+{
+    // ------------------------------------------------------------------ the maps
+
+    [Theory]
+    // Shifted digits.
+    [InlineData(HostKey.Digit2, true, '@')]
+    [InlineData(HostKey.Digit6, true, '^')]
+    [InlineData(HostKey.Digit7, true, '&')]
+    [InlineData(HostKey.Digit8, true, '*')]
+    // Punctuation.
+    [InlineData(HostKey.Minus, false, '-')]
+    [InlineData(HostKey.Minus, true, '_')]
+    [InlineData(HostKey.Equal, false, '=')]
+    [InlineData(HostKey.Equal, true, '+')]
+    [InlineData(HostKey.Semicolon, false, ';')]
+    [InlineData(HostKey.Semicolon, true, ':')]
+    [InlineData(HostKey.Slash, false, '/')]
+    [InlineData(HostKey.Slash, true, '?')]
+    [InlineData(HostKey.BracketLeft, false, '[')]
+    [InlineData(HostKey.Backslash, false, '\\')]
+    [InlineData(HostKey.Quote, false, '\'')]
+    // The map emits the true code even where the II Plus has no glyph for it: '|' is $7C, and the
+    // Autostart ROM's input routine folds $E0-$FF down a bit-5 step on echo, so this one reaches
+    // Applesoft as '|' but shows on screen as '\'. Verified against the running machine by reading
+    // the keyboard latch at $C000 directly.
+    [InlineData(HostKey.Backslash, true, '|')]
+    [InlineData(HostKey.BracketLeft, true, '{')]
+    public void US_Layout_Produces_The_Expected_Character(HostKey key, bool shift, char expected)
+    {
+        var keyboard = new Apple2HostKeyboard(HostKeyboardLayout.US);
+
+        Assert.True(keyboard.TryGetAscii(key, shift, control: false, out var ascii));
+        Assert.Equal((byte)expected, ascii);
+    }
+
+    [Theory]
+    // Shifted digits differ from US almost everywhere.
+    [InlineData(HostKey.Digit2, true, '"')]
+    [InlineData(HostKey.Digit6, true, '&')]
+    [InlineData(HostKey.Digit7, true, '/')]
+    [InlineData(HostKey.Digit8, true, '(')]
+    [InlineData(HostKey.Digit9, true, ')')]
+    [InlineData(HostKey.Digit0, true, '=')]
+    // Right of 0 is +/? on a Swedish keyboard, not -/_.
+    [InlineData(HostKey.Minus, false, '+')]
+    [InlineData(HostKey.Minus, true, '?')]
+    // -/_ moves to where US has /?.
+    [InlineData(HostKey.Slash, false, '-')]
+    [InlineData(HostKey.Slash, true, '_')]
+    // ;/: move onto the comma and period keys.
+    [InlineData(HostKey.Comma, true, ';')]
+    [InlineData(HostKey.Period, true, ':')]
+    // The '/* key right of Ä.
+    [InlineData(HostKey.Backslash, false, '\'')]
+    [InlineData(HostKey.Backslash, true, '*')]
+    // The <> key left of Z, which US keyboards do not have.
+    [InlineData(HostKey.IntlBackslash, false, '<')]
+    [InlineData(HostKey.IntlBackslash, true, '>')]
+    // ^ is Applesoft's exponent operator; it lives on shifted ¨.
+    [InlineData(HostKey.BracketRight, true, '^')]
+    // Å/Ä/Ö convenience bindings — no ASCII form of their own.
+    [InlineData(HostKey.BracketLeft, false, '[')]
+    [InlineData(HostKey.Quote, false, ']')]
+    [InlineData(HostKey.Semicolon, false, '\\')]
+    public void Swedish_Layout_Produces_The_Expected_Character(HostKey key, bool shift, char expected)
+    {
+        var keyboard = new Apple2HostKeyboard(HostKeyboardLayout.Swedish);
+
+        Assert.True(keyboard.TryGetAscii(key, shift, control: false, out var ascii));
+        Assert.Equal((byte)expected, ascii);
+    }
+
+    [Theory]
+    [InlineData(HostKey.Digit2, '@')]
+    [InlineData(HostKey.Digit4, '$')]
+    [InlineData(HostKey.Digit8, '[')]
+    [InlineData(HostKey.Digit9, ']')]
+    public void Swedish_Alt_Chords_Beat_The_Digit_They_Are_Built_From(HostKey key, char expected)
+    {
+        var keyboard = new Apple2HostKeyboard(HostKeyboardLayout.Swedish);
+
+        Assert.True(keyboard.TryGetAscii(key, shift: false, control: false, out var ascii, alt: true));
+        Assert.Equal((byte)expected, ascii);
+
+        // Without Alt the same key is still the plain digit.
+        Assert.True(keyboard.TryGetAscii(key, shift: false, control: false, out var plain));
+        Assert.Equal((byte)('0' + (key - HostKey.Digit0)), plain);
+    }
+
+    [Fact]
+    public void Alt_Chords_Do_Not_Apply_On_The_US_Layout()
+    {
+        var keyboard = new Apple2HostKeyboard(HostKeyboardLayout.US);
+
+        Assert.True(keyboard.TryGetAscii(HostKey.Digit8, shift: false, control: false, out var ascii, alt: true));
+        Assert.Equal((byte)'8', ascii);
+    }
+
+    [Fact]
+    public void A_Swedish_Dead_Key_Produces_No_Character_Unshifted()
+    {
+        var keyboard = new Apple2HostKeyboard(HostKeyboardLayout.Swedish);
+
+        // The ¨ key: nothing on its own, ^ when shifted.
+        Assert.False(keyboard.TryGetAscii(HostKey.BracketRight, shift: false, control: false, out _));
+        Assert.True(keyboard.TryGetAscii(HostKey.BracketRight, shift: true, control: false, out var shifted));
+        Assert.Equal((byte)'^', shifted);
+
+        // A key with no character in either state is not latchable at all.
+        Assert.False(keyboard.ProducesCharacter(HostKey.Backquote));
+    }
+
+    [Theory]
+    [InlineData(HostKeyboardLayout.US)]
+    [InlineData(HostKeyboardLayout.Swedish)]
+    public void Letters_Digits_And_Control_Keys_Are_The_Same_On_Every_Layout(HostKeyboardLayout layout)
+    {
+        var keyboard = new Apple2HostKeyboard(layout);
+
+        Assert.True(keyboard.TryGetAscii(HostKey.KeyA, shift: true, control: false, out var a));
+        Assert.Equal((byte)'A', a);   // uppercase in both states — no lowercase generator
+
+        Assert.True(keyboard.TryGetAscii(HostKey.Digit5, shift: false, control: false, out var five));
+        Assert.Equal((byte)'5', five);
+
+        Assert.True(keyboard.TryGetAscii(HostKey.Enter, shift: false, control: false, out var ret));
+        Assert.Equal(0x0D, ret);
+
+        Assert.True(keyboard.TryGetAscii(HostKey.KeyC, shift: false, control: true, out var ctrlC));
+        Assert.Equal(0x03, ctrlC);
+    }
+
+    // ------------------------------------------------------------- layout resolution
+
+    [Fact]
+    public void An_Explicit_Config_Setting_Wins_Over_Detection()
+    {
+        var inputState = new TestHostInputState { NativeKeyboardLayoutId = "com.apple.keylayout.US" };
+        var handler = BuildHandler(new Apple2InputConfig { KeyboardLayout = HostKeyboardLayout.Swedish }, inputState);
+
+        Assert.Equal(HostKeyboardLayout.Swedish, handler.HostKeyboard.Layout);
+    }
+
+    [Theory]
+    [InlineData("com.apple.keylayout.Swedish", HostKeyboardLayout.Swedish)]
+    [InlineData("com.apple.keylayout.US", HostKeyboardLayout.US)]
+    [InlineData("0000041D", HostKeyboardLayout.Swedish)]
+    [InlineData("00000409", HostKeyboardLayout.US)]
+    public void An_Unpinned_Layout_Is_Auto_Detected_From_The_Host(string nativeLayoutId, HostKeyboardLayout expected)
+    {
+        var inputState = new TestHostInputState { NativeKeyboardLayoutId = nativeLayoutId };
+        var handler = BuildHandler(new Apple2InputConfig(), inputState);
+
+        Assert.Equal(expected, handler.HostKeyboard.Layout);
+    }
+
+    [Fact]
+    public void An_Undetectable_Unmapped_Host_Falls_Back_To_US()
+    {
+        // Neither detectable nor a culture this build maps — the end of the chain.
+        var inputState = new TestHostInputState { NativeKeyboardLayoutId = "com.apple.keylayout.Georgian" };
+        var handler = BuildHandler(new Apple2InputConfig(), inputState);
+
+        // Culture is whatever the test machine runs, so only assert the fallback is a valid
+        // layout and that an unmapped id did not throw or leave the map unbuilt.
+        Assert.True(handler.HostKeyboard.Layout is HostKeyboardLayout.US or HostKeyboardLayout.Swedish);
+        Assert.NotEmpty(handler.HostKeyboard.HostKeyToAsciiMap);
+    }
+
+    // --------------------------------------------------- macOS ISO keyboard correction
+
+    [Fact]
+    public void MacOS_Swaps_Backquote_And_IntlBackslash_On_A_Non_US_Layout()
+    {
+        var (apple2, handler, inputState) = BuildForMac(HostKeyboardLayout.Swedish);
+
+        // On a macOS ISO keyboard the physical <> key arrives as Backquote. After the correction
+        // it is looked up as IntlBackslash, which the Swedish map binds to '<'.
+        inputState.SetKeysDown(HostKey.Backquote);
+        handler.BeforeFrame();
+
+        Assert.Equal((byte)('<' | 0x80), apple2.Keyboard.Latch);
+    }
+
+    [Fact]
+    public void MacOS_Does_Not_Swap_On_The_US_Layout()
+    {
+        var (apple2, handler, inputState) = BuildForMac(HostKeyboardLayout.US);
+
+        // A US keyboard is ANSI, so Backquote really is the ` key and must stay as it is.
+        inputState.SetKeysDown(HostKey.Backquote);
+        handler.BeforeFrame();
+
+        Assert.Equal((byte)('`' | 0x80), apple2.Keyboard.Latch);
+    }
+
+    private static Apple2InputHandler BuildHandler(Apple2InputConfig inputConfig, TestHostInputState inputState)
+    {
+        var apple2 = new Apple2System(new Apple2Config(), NullLoggerFactory.Instance);
+        var handler = new Apple2InputHandler(apple2, NullLoggerFactory.Instance, inputConfig);
+        handler.Init(inputState);
+        return handler;
+    }
+
+    private static (Apple2System Apple2, Apple2InputHandler Handler, TestHostInputState InputState) BuildForMac(
+        HostKeyboardLayout layout)
+    {
+        var apple2 = new Apple2System(new Apple2Config(), NullLoggerFactory.Instance);
+        var inputState = new TestHostInputState { IsRunningOnMacOS = true };
+        var inputConfig = new Apple2InputConfig { KeyboardLayout = layout };
+        var handler = new Apple2InputHandler(apple2, NullLoggerFactory.Instance, inputConfig);
+        handler.Init(inputState);
+        return (apple2, handler, inputState);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RealRomBootTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RealRomBootTests.cs
@@ -79,7 +79,10 @@ public class Apple2RealRomBootTests
         apple2.InitBasicMemoryVariables(Apple2System.BASIC_LOAD_ADDRESS, s_tokenizedPrint3.Length);
 
         var inputState = new ScriptedHostInputState();
-        var inputHandler = new Apple2InputHandler(apple2, NullLoggerFactory.Instance);
+        // Layout pinned: these tests press US key positions (e.g. Shift+Equal for '+'), so they
+        // must not depend on the layout the developer's own machine reports.
+        var inputHandler = new Apple2InputHandler(
+            apple2, NullLoggerFactory.Instance, new Apple2InputConfig { KeyboardLayout = HostKeyboardLayout.US });
         inputHandler.Init(inputState);
 
         foreach (var key in new[] { HostKey.KeyR, HostKey.KeyU, HostKey.KeyN, HostKey.Enter })
@@ -119,7 +122,10 @@ public class Apple2RealRomBootTests
         var apple2 = BootRealRom();
 
         var inputState = new ScriptedHostInputState();
-        var inputHandler = new Apple2InputHandler(apple2, NullLoggerFactory.Instance);
+        // Layout pinned: these tests press US key positions (e.g. Shift+Equal for '+'), so they
+        // must not depend on the layout the developer's own machine reports.
+        var inputHandler = new Apple2InputHandler(
+            apple2, NullLoggerFactory.Instance, new Apple2InputConfig { KeyboardLayout = HostKeyboardLayout.US });
         inputHandler.Init(inputState);
 
         foreach (var key in new[]


### PR DESCRIPTION
The Apple II keyboard map was hard-coded US QWERTY (`Apple2HostKeyboard` was entirely static, with a `// Digit row — US-QWERTY shifted symbols` comment and no layout concept at all), so on a non-US keyboard the punctuation a key produced did not match its keycap. It now supports **US English** and **Swedish**, and auto-detects which to use, falling back to US.

Modelled on the C64 implementation throughout.

### How the layout is resolved

Once, when the input handler starts: explicit config setting → the host's active keyboard layout read from the OS → the OS culture → US. Every step is logged, so the Log tab shows which layout was chosen and why. `Apple2HostKeyboard` becomes instance-based with the same split `C64HostKeyboard` uses — letters, unshifted digits and control keys are layout-independent; punctuation and shifted digits come from a per-layout overlay.

### Where the shared pieces went, and why

The layout enum and the id resolver are new and live in `Systems/Input/` beside the existing `KeyboardLayoutDetector`, not in the Apple II assembly. The identifier formats (Windows KLIDs, macOS input-source ids) are a property of the host platform, not of any emulated machine — and keeping that logic inside one system's assembly is exactly what would have forced a second copy here. VIC-20 will want it next (see the design-log idea on its keyboard map gaps).

**C64 is deliberately left untouched.** Its `C64KeyboardLayout` value is persisted in user settings as a string, so migrating it to the neutral enum risks breaking saved configs for no user-visible gain. That leaves a temporary asymmetry, which seemed the better trade.

### Judgement calls in the Swedish map

- **Å, Ä, Ö** have no 7-bit ASCII form, so those keys would otherwise be dead. Bound to `[ ] \` (shifted `{ } |`) — characters a Swedish keyboard can only otherwise reach through Alt chords that differ between macOS and Windows. `C64HostKeyboard` takes the same approach with its Ä/Å bindings.
- **Alt chords**: only the four macOS and Windows agree on (`@ $ [ ]`). Alt+7 is `{` on Windows but `|` on macOS, so binding it would be wrong on one of them.
- **`^`** is Applesoft's exponent operator, so shifted `¨` is bound even though the unshifted dead key is not.
- **Shift+4** is `¤` on Windows and `$` on macOS; `¤` has no ASCII form, so `$` is used for both.
- The **macOS ISO Backquote/IntlBackslash swap** `C64InputHandler` applies is applied here too, for non-US layouts.

### Verification

Unit tests (53 new cases) plus live checks against the running emulator:

- **Auto-detection against the real OS**: a Swedish Mac reports `com.apple.keylayout.Swedish-Pro` → Swedish, with the ISO swap engaged.
- **All 12 Swedish punctuation cases** produce the right character in the running machine — injected as host keys over the remote-control protocol, read back off the text page: `+ - ; : [ ] \ * / = " &`.
- **Pinning US** in the persisted settings flips those same physical keys to their US characters, and the log confirms `US (explicit config setting)` with no ISO swap — so the JSON round-trip and the priority order both work end to end.
- One apparent mismatch was **authentic hardware, not a bug**: US `Shift+\` shows `\` on screen rather than `|`. Reading the keyboard latch at `$C000` directly gives `0x7C`, so the emulator delivers `|` correctly — the Autostart ROM folds `$E0-$FF` down a bit-5 step on echo because the II Plus has no `|` glyph. Captured as a test case with the explanation rather than "fixed".

Build clean (73 projects, 0 warnings), 1729 tests pass.

### Also: a latent test hazard, fixed

The existing Apple II tests built the input handler with no config, so they auto-detected and their assertions depended on whichever layout the developer's machine reports. On a Swedish host `Typed_Input_Reaches_Applesoft_And_Is_Evaluated` genuinely failed — US `Shift+Equal` for `+` is a dead key on Swedish, so the character was silently dropped (`]PRINT 23`). Those tests now pin the layout explicitly, and the test `IHostInputState` no longer falls through to the real OS detector.

No changelog entry: this repo has no root changelog and the change doesn't touch `tools/vscode-extension/`.