### PR TITLE
Add Apple II emulator state snapshots

### DIFF
--- a/docs/systems/apple2/overview.md
+++ b/docs/systems/apple2/overview.md
@@ -26,7 +26,7 @@ there is no CIA/VIA equivalent to emulate and no keyboard matrix to scan.
     - `$C010` clears the strobe.
     - `$C050`–`$C057` display-mode switches (text/graphics, mixed, page 1/2, lo-res/hi-res),
       honored by the rasterizer render path.
-    - `$C030` speaker toggle counted but silent.
+    - `$C030` speaker toggle, driving the one-bit cone (see Speaker audio below).
 - Empty peripheral slots at `$C100`–`$CFFF` read as `$FF`, which makes the Autostart ROM's disk
   scan fail cleanly so it falls through to BASIC. Slot 6 answers instead when the Disk II
   controller is active (see below).
@@ -135,6 +135,43 @@ there is no CIA/VIA equivalent to emulate and no keyboard matrix to scan.
 
 - Avalonia Desktop and Avalonia Browser (WASM) UI, with a configuration dialog for ROM files,
   ROM download, monitor colour, render provider and CPU compatibility profile.
+- Emulator state snapshots — save and restore the whole machine, disk included. See
+  [Snapshots](#snapshots).
+
+## Snapshots
+
+The Apple II supports the shared `.d6502snap` emulator-state snapshots, so the same save/load
+buttons, `emu.savesnapshot`/`emu.loadsnapshot` remote commands, Lua `emu.save_snapshot`, and
+`--load-snapshot` command line work here as on the other machines.
+
+Two machine modules make up an Apple II snapshot, alongside the shared `cpu-6502` one:
+
+| Module | What it holds |
+|---|---|
+| `apple2-core` | The 48 KB RAM, the keyboard latch (strobe included), the four display soft switches, the speaker's cone position, and the game port's paddle positions, buttons and one-shot |
+| `apple2-disk2` | Head half-track, motor, drive select, the Q6/Q7 latches, the read head's position in the current track — plus the inserted `.dsk` image, embedded in the package |
+
+One module rather than one per chip, because the machine has no chips to divide along: the
+display mode is four write-only flip-flops, the keyboard is one byte and the speaker is one bit,
+all decoded from the same page of addresses. The Disk II card is the other seam, because it has
+removable media.
+
+Notes on what a restored machine gets:
+
+- **The disk comes with it.** The image is embedded in the snapshot, so a snapshot of a booted
+  DOS 3.3 session restores complete — no need to have the original file still lying around. The
+  head position travels too, which matters more here than on a C64: this card has no processor of
+  its own, so a running RWTS resumes against a head that is exactly where it left it.
+- **Timing is continuous.** The disk motor's spin-down, the paddle one-shots and the speaker all
+  time themselves against the CPU's cumulative cycle count, which the shared `cpu-6502` module
+  restores. A paddle read caught in flight resumes and expires at the same point it would have.
+- **Settings travel optionally.** Audio enabled, keyboard joystick and monitor colour are carried
+  in the snapshot's portable settings block, applied before the machine is rebuilt (all three are
+  read at build time rather than polled), and only when the user opts into including config.
+- **ROMs are not captured**, by design — the system ROM, character generator and Disk II boot ROM
+  come from the configuration when the machine is rebuilt. Restoring a snapshot taken with a disk
+  inserted on a machine with no `disk2` ROM configured re-inserts the disk but warns that the
+  controller stays invisible.
 
 ## Monitor commands
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/Views/MainView.axaml.cs
@@ -1173,8 +1173,8 @@ public partial class MainView : UserControl
 
     // Emulator state snapshots (save/restore). Cross-system feature, so it lives in the common
     // MainView rather than a per-system menu. Only systems whose ISystem implements
-    // ISystemSnapshotProvider can be snapshotted (currently the Generic computer); for others the
-    // save is skipped with a log message.
+    // ISystemSnapshotProvider can be snapshotted; for others the save is skipped with a log
+    // message.
     private void SaveSnapshot_Click(object? sender, RoutedEventArgs e)
         => SafeAsyncHelper.Execute(async () =>
         {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Apple2.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Apple2.cs
@@ -13,6 +13,8 @@ using Highbyte.DotNet6502.Systems.Input;
 using Highbyte.DotNet6502.Systems.Instrumentation;
 using Highbyte.DotNet6502.Systems.Instrumentation.Stats;
 using Highbyte.DotNet6502.Systems.Rendering;
+using Highbyte.DotNet6502.Systems.Snapshots;
+using Highbyte.DotNet6502.Systems.Apple2.Snapshots;
 using Highbyte.DotNet6502.Utils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -27,7 +29,7 @@ namespace Highbyte.DotNet6502.Systems.Apple2;
 /// Autostart Monitor and Applesoft BASIC poll the keyboard latch directly — so a frame is just
 /// "run the CPU for a frame's worth of cycles, then render".
 /// </summary>
-public class Apple2 : ISystem, ITextMode, IScreen, ISystemState, ISystemMonitor
+public class Apple2 : ISystem, ITextMode, IScreen, ISystemState, ISystemMonitor, ISystemSnapshotProvider
 {
     public const string SystemName = "Apple2";
 
@@ -459,4 +461,36 @@ public class Apple2 : ISystem, ITextMode, IScreen, ISystemState, ISystemMonitor
     }
 
     bool ISystemState.IsSystemReady() => HasBasicStarted();
+
+    // --- Snapshot support ---
+
+    /// <summary>
+    /// The 48 KB RAM backing array. Mapped into <see cref="Mem"/> by reference, so the apple2-core
+    /// snapshot module copies bytes into it rather than replacing the instance — reassigning would
+    /// leave the memory map pointing at the old array.
+    /// </summary>
+    internal byte[] SnapshotRam => _ram;
+
+    /// <summary>
+    /// The machine-level snapshot version. The shared <c>SnapshotService</c> already enforces the
+    /// format version, machine name, unknown required modules and module versions, and this machine
+    /// has no model or timing variants to check beyond that — so
+    /// <see cref="ValidateSnapshot"/> adds nothing.
+    /// </summary>
+    public const int SnapshotVersion = 1;
+
+    private readonly IReadOnlyList<ISnapshotModule> _snapshotModules = new ISnapshotModule[]
+    {
+        new Cpu6502SnapshotModule(),
+        new Apple2CoreSnapshotModule(),
+        // apple2-disk2 restores after apple2-core because re-inserting the disk rebuilds the
+        // nibble tracks the restored head position indexes into.
+        new Apple2Disk2SnapshotModule(),
+    };
+
+    public SnapshotMachineId MachineId => new(SystemName, SnapshotVersion);
+
+    public IReadOnlyList<ISnapshotModule> GetSnapshotModules() => _snapshotModules;
+
+    public SnapshotCompatibility ValidateSnapshot(SnapshotManifest manifest) => SnapshotCompatibility.Compatible();
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2SystemConfig.cs
@@ -3,6 +3,7 @@ using Highbyte.DotNet6502.Systems.Apple2.Render;
 using Highbyte.DotNet6502.Systems.Apple2.Audio.Sample;
 using Highbyte.DotNet6502.Systems.Apple2.Video;
 using Highbyte.DotNet6502.Systems.Configuration;
+using Highbyte.DotNet6502.Systems.Snapshots;
 using Highbyte.DotNet6502.Utils;
 using Apple2System = Highbyte.DotNet6502.Systems.Apple2.Apple2;
 
@@ -11,7 +12,7 @@ namespace Highbyte.DotNet6502.Systems.Apple2.Config;
 /// <summary>
 /// User-facing Apple II configuration: ROM files and display preferences.
 /// </summary>
-public class Apple2SystemConfig : ISystemConfig
+public partial class Apple2SystemConfig : ISystemConfig, ISnapshotableConfig
 {
     /// <summary>
     /// The combined Applesoft BASIC + Autostart Monitor ROM mapped at $D000-$FFFF.

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2SystemConfigSnapshot.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2SystemConfigSnapshot.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Highbyte.DotNet6502.Systems.Apple2.Video;
+
+namespace Highbyte.DotNet6502.Systems.Apple2.Config;
+
+/// <summary>
+/// Snapshot config support for <see cref="Apple2SystemConfig"/>: the portable "system config" block of
+/// a snapshot. These settings live in the global <c>Apple2SystemConfig</c> (the same type on every
+/// host), so the block is portable across host apps.
+///
+/// <para>Applied to the config <i>before</i> the machine is rebuilt on restore, which is what makes
+/// these particular settings worth carrying: all three are read at build or init time rather than
+/// polled as live toggles. The audio provider is only constructed if <c>AudioEnabled</c> is set when
+/// the machine is built, the game port is only driven by host keys if
+/// <c>KeyboardJoystickEnabled</c> is set, and the monitor colour is baked into the rasterizer's
+/// palette per frame. Add a portable setting = add a field to
+/// <see cref="Apple2SystemSnapshotSettings"/> and map it below; the snapshot framework is
+/// untouched.</para>
+/// </summary>
+public partial class Apple2SystemConfig
+{
+    public string? ExportSnapshotSettings()
+    {
+        var settings = new Apple2SystemSnapshotSettings
+        {
+            AudioEnabled = AudioEnabled,
+            KeyboardJoystickEnabled = KeyboardJoystickEnabled,
+            MonitorColor = MonitorColor,
+        };
+        return JsonSerializer.Serialize(settings, Apple2SystemSnapshotSettingsJsonContext.Default.Apple2SystemSnapshotSettings);
+    }
+
+    public void ApplySnapshotSettings(string payload)
+    {
+        var settings = JsonSerializer.Deserialize(payload, Apple2SystemSnapshotSettingsJsonContext.Default.Apple2SystemSnapshotSettings);
+        if (settings == null)
+            return;
+
+        AudioEnabled = settings.AudioEnabled;
+        KeyboardJoystickEnabled = settings.KeyboardJoystickEnabled;
+        MonitorColor = settings.MonitorColor;
+    }
+}
+
+/// <summary>Serialization schema for <see cref="Apple2SystemConfig"/>'s portable snapshot settings.</summary>
+internal sealed class Apple2SystemSnapshotSettings
+{
+    /// <summary>Defaults mirror <see cref="Apple2SystemConfig"/>'s own, so a payload that omits a
+    /// field leaves the setting where a fresh config would put it.</summary>
+    public bool AudioEnabled { get; set; }
+
+    public bool KeyboardJoystickEnabled { get; set; }
+
+    public Apple2MonitorColor MonitorColor { get; set; } = Apple2MonitorColor.Color;
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(Apple2SystemSnapshotSettings))]
+internal partial class Apple2SystemSnapshotSettingsJsonContext : JsonSerializerContext
+{
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Disk2/Disk2Controller.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Disk2/Disk2Controller.cs
@@ -77,13 +77,28 @@ public class Disk2Controller
     private readonly bool[] _phaseOn = new bool[4];
     private int _halfTrack;
     private bool _motorSwitchedOn;
-    private ulong _motorSwitchedOffAtCycle;
+
+    /// <summary>
+    /// When the motor switch was last turned off, or null if the drive has not been switched off
+    /// since it was last stopped for good. Null rather than 0, for the same reason the game port's
+    /// trigger stamp is nullable: at power-on the CPU cycle counter is 0 too, so treating "never
+    /// switched off" as "switched off at cycle 0" puts the one-shot inside its own spin-down window
+    /// and a drive that has never run reports as spinning for its first million cycles.
+    /// </summary>
+    private ulong? _motorSwitchedOffAtCycle;
     private int _selectedDrive = 1;
     private bool _q6;
     private bool _q7;
     private int _nibblePosition;
 
     private byte[][]? _nibbleTracks;
+
+    /// <summary>
+    /// The inserted image exactly as supplied. Kept alongside the nibblized tracks because
+    /// nibblizing is one-way: a snapshot has to embed the original image to be able to re-insert
+    /// the same disk on restore.
+    /// </summary>
+    private byte[]? _rawDiskImageData;
 
     /// <param name="cpuCycleProvider">
     /// Source of the CPU's cumulative cycle count, used only to time the motor's spin-down.
@@ -110,7 +125,8 @@ public class Disk2Controller
     /// than <see cref="SpinDownCycles"/> ago and the one-shot still holds the motor.
     /// </summary>
     public bool IsSpinning => _motorSwitchedOn
-        || _cpuCycleProvider() - _motorSwitchedOffAtCycle < SpinDownCycles;
+        || (_motorSwitchedOffAtCycle is { } switchedOffAt
+            && _cpuCycleProvider() - switchedOffAt < SpinDownCycles);
 
     /// <summary>The whole track currently under the head.</summary>
     public int CurrentTrack => _halfTrack / 2;
@@ -145,9 +161,14 @@ public class Disk2Controller
     public void InsertDiskImage(byte[] diskImageData)
     {
         _nibbleTracks = Disk2TrackNibblizer.BuildNibbleTracks(diskImageData);
+        _rawDiskImageData = diskImageData;
     }
 
-    public void RemoveDiskImage() => _nibbleTracks = null;
+    public void RemoveDiskImage()
+    {
+        _nibbleTracks = null;
+        _rawDiskImageData = null;
+    }
 
     /// <summary>Value the CPU sees at a boot ROM address ($C600-$C6FF).</summary>
     public byte ReadBootRom(ushort address)
@@ -244,10 +265,46 @@ public class Disk2Controller
     {
         Array.Clear(_phaseOn);
         _motorSwitchedOn = false;
-        _motorSwitchedOffAtCycle = 0;
+        _motorSwitchedOffAtCycle = null;
         _selectedDrive = 1;
         _q6 = false;
         _q7 = false;
         // Head position is intentionally kept — a reset does not move a physical head.
+    }
+
+    // --- Snapshot support (consumed by the apple2-disk2 snapshot module in the same assembly) ---
+
+    /// <summary>
+    /// The inserted image as originally supplied, or null when the drive is empty. The snapshot
+    /// embeds these bytes so the same disk can be re-inserted on restore.
+    /// </summary>
+    internal byte[]? SnapshotRawDiskImageData => _rawDiskImageData;
+
+    /// <summary>
+    /// The mechanical and sequencer state that is not derivable from anything else: where the head
+    /// is, whether the motor is running (and if coasting, since when), which drive is selected, the
+    /// Q6/Q7 latches, and how far into the current track's nibble stream the read head sits.
+    ///
+    /// <para>The nibble position is the one that is easy to dismiss and should not be: a snapshot
+    /// taken during a sector read resumes mid-stream, and starting that stream over would hand the
+    /// running RWTS a field header where it expects data.</para>
+    /// </summary>
+    internal (int HalfTrack, bool MotorOn, ulong? MotorSwitchedOffAtCycle, int SelectedDrive, bool Q6, bool Q7, int NibblePosition)
+        GetSnapshotState()
+        => (_halfTrack, _motorSwitchedOn, _motorSwitchedOffAtCycle, _selectedDrive, _q6, _q7, _nibblePosition);
+
+    internal void RestoreSnapshotState(
+        int halfTrack, bool motorOn, ulong? motorSwitchedOffAtCycle, int selectedDrive, bool q6, bool q7, int nibblePosition)
+    {
+        _halfTrack = Math.Clamp(halfTrack, 0, MaxHalfTrack);
+        _motorSwitchedOn = motorOn;
+        _motorSwitchedOffAtCycle = motorSwitchedOffAtCycle;
+        _selectedDrive = selectedDrive;
+        _q6 = q6;
+        _q7 = q7;
+        // Guarded rather than trusted: the position indexes into the current track's nibble stream,
+        // whose length depends on the nibblizer, so a snapshot written by a different build could
+        // otherwise index out of range. ReadDataNibble wraps modulo the track length anyway.
+        _nibblePosition = nibblePosition < 0 ? 0 : nibblePosition;
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2GamePort.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2GamePort.cs
@@ -203,6 +203,25 @@ public class Apple2GamePort
         };
     }
 
+    // --- Snapshot support (consumed by the apple2-core snapshot module in the same assembly) ---
+
+    /// <summary>
+    /// When the one-shot was last fired, or null if it never has been. Absolute, and meaningful
+    /// after a restore because the CPU's cumulative cycle count is restored with it.
+    /// </summary>
+    internal ulong? SnapshotTriggeredAtCycle => _triggeredAtCycle;
+
+    /// <summary>
+    /// Restores the one-shot's firing stamp and the strobe count. Paddle positions and button
+    /// states go back through the ordinary public setters — they are plain values with no derived
+    /// state behind them.
+    /// </summary>
+    internal void RestoreSnapshotState(ulong? triggeredAtCycle, ulong paddleTriggerCount)
+    {
+        _triggeredAtCycle = triggeredAtCycle;
+        PaddleTriggerCount = paddleTriggerCount;
+    }
+
     private static void ValidatePaddle(int paddle)
     {
         if (paddle < 0 || paddle >= PaddleCount)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2Keyboard.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2Keyboard.cs
@@ -35,4 +35,13 @@ public class Apple2Keyboard
     public void ClearStrobe() => _latch &= 0x7F;
 
     public void Reset() => _latch = 0;
+
+    // --- Snapshot support (consumed by the apple2-core snapshot module in the same assembly) ---
+
+    /// <summary>
+    /// Restores the raw latch, strobe bit included. Set directly rather than through
+    /// <see cref="KeyPressed"/>, which would force the strobe on and turn a machine that had
+    /// already consumed its keypress into one with a key waiting.
+    /// </summary>
+    internal void RestoreSnapshotLatch(byte latch) => _latch = latch;
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2SoftSwitches.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2SoftSwitches.cs
@@ -192,4 +192,20 @@ public class Apple2SoftSwitches
         _speaker?.Reset();
         _speakerTogglesWithoutSpeaker = 0;
     }
+
+    // --- Snapshot support (consumed by the apple2-core snapshot module in the same assembly) ---
+
+    /// <summary>
+    /// Restores the four display switches. These are the whole of the machine's video state: unlike
+    /// the C64's VIC-II there are no registers to re-derive anything from, because the switches are
+    /// write-only flip-flops that live nowhere in the address space. Restoring them is what makes a
+    /// snapshot taken in hi-res come back in hi-res rather than at the text prompt.
+    /// </summary>
+    internal void RestoreSnapshotDisplaySwitches(bool textMode, bool mixedMode, bool page2, bool hiRes)
+    {
+        TextMode = textMode;
+        MixedMode = mixedMode;
+        Page2 = page2;
+        HiRes = hiRes;
+    }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2Speaker.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2Speaker.cs
@@ -62,4 +62,22 @@ public class Apple2Speaker
         ToggleCount = 0;
         LastToggleCycle = 0;
     }
+
+    // --- Snapshot support (consumed by the apple2-core snapshot module in the same assembly) ---
+
+    /// <summary>
+    /// Restores the cone position and toggle bookkeeping.
+    ///
+    /// <para>The level matters even though its absolute polarity does not: the audio path measures
+    /// the level across each output sample, so resuming with the cone on the wrong side inverts the
+    /// first sample window and puts a step through the DC blocker — an audible click on every load.
+    /// <see cref="LastToggleCycle"/> is an absolute stamp, which stays meaningful because the CPU's
+    /// cumulative cycle count is restored alongside it.</para>
+    /// </summary>
+    internal void RestoreSnapshotState(bool level, ulong toggleCount, ulong lastToggleCycle)
+    {
+        Level = level;
+        ToggleCount = toggleCount;
+        LastToggleCycle = lastToggleCycle;
+    }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Snapshots/Apple2CoreSnapshotModule.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Snapshots/Apple2CoreSnapshotModule.cs
@@ -1,0 +1,126 @@
+using Highbyte.DotNet6502.Systems.Apple2.Peripherals;
+using Highbyte.DotNet6502.Systems.Snapshots;
+
+namespace Highbyte.DotNet6502.Systems.Apple2.Snapshots;
+
+/// <summary>
+/// Snapshot module for the Apple II mainboard: the 48 KB RAM, and the handful of latches behind the
+/// soft-switch page — keyboard, display mode, speaker and game port. Paired with the shared
+/// <c>cpu-6502</c> module.
+///
+/// <para>
+/// This is one module rather than several because the machine has no chips to divide along. There
+/// is no video chip with registers to re-derive state from, no timer, and no interrupt source: the
+/// display mode is four write-only flip-flops, the keyboard is one byte, and the speaker is one
+/// bit. All of it is decoded from the same page of addresses, so the mainboard is the natural seam,
+/// and the Disk II card — which has removable media — is the other one.
+/// </para>
+///
+/// <para>
+/// Not captured: ROM (the system ROM, character generator and Disk II boot ROM all come from the
+/// config when the machine is rebuilt) and the video output itself (the rasterizer reads memory
+/// live, so restoring RAM and the display switches restores the picture).
+/// </para>
+/// </summary>
+public sealed class Apple2CoreSnapshotModule : ISnapshotModule
+{
+    public const string ModuleName = "apple2-core";
+
+    public string Name => ModuleName;
+    public int Version => 1;
+    public bool Required => true;
+
+    public void Capture(SnapshotModuleWriter writer, SnapshotCaptureContext context)
+    {
+        var apple2 = (Apple2)context.System;
+
+        writer.WriteBytes(apple2.SnapshotRam);
+
+        // Keyboard latch (ASCII in bits 6-0, strobe in bit 7).
+        writer.WriteByte(apple2.Keyboard.Latch);
+
+        // Display soft switches.
+        var switches = apple2.SoftSwitches;
+        writer.WriteBool(switches.TextMode);
+        writer.WriteBool(switches.MixedMode);
+        writer.WriteBool(switches.Page2);
+        writer.WriteBool(switches.HiRes);
+
+        CaptureSpeaker(writer, apple2.Speaker);
+        CaptureGamePort(writer, apple2.GamePort);
+    }
+
+    public void Restore(SnapshotModuleReader reader, SnapshotRestoreContext context)
+    {
+        var apple2 = (Apple2)context.System;
+
+        var ram = reader.ReadBytes() ?? throw new SnapshotException("apple2-core: RAM bytes were missing.");
+        if (ram.Length != apple2.SnapshotRam.Length)
+            throw new SnapshotException(
+                $"apple2-core: snapshot RAM size {ram.Length} does not match target {apple2.SnapshotRam.Length}.");
+        // Copied into the existing array so the memory map, which holds a reference to it, keeps working.
+        Array.Copy(ram, apple2.SnapshotRam, ram.Length);
+
+        apple2.Keyboard.RestoreSnapshotLatch(reader.ReadByte());
+
+        apple2.SoftSwitches.RestoreSnapshotDisplaySwitches(
+            textMode: reader.ReadBool(),
+            mixedMode: reader.ReadBool(),
+            page2: reader.ReadBool(),
+            hiRes: reader.ReadBool());
+
+        RestoreSpeaker(reader, apple2.Speaker);
+        RestoreGamePort(reader, apple2.GamePort);
+    }
+
+    private static void CaptureSpeaker(SnapshotModuleWriter writer, Apple2Speaker speaker)
+    {
+        writer.WriteBool(speaker.Level);
+        writer.WriteUInt64(speaker.ToggleCount);
+        writer.WriteUInt64(speaker.LastToggleCycle);
+    }
+
+    private static void RestoreSpeaker(SnapshotModuleReader reader, Apple2Speaker speaker)
+    {
+        var level = reader.ReadBool();
+        var toggleCount = reader.ReadUInt64();
+        var lastToggleCycle = reader.ReadUInt64();
+        speaker.RestoreSnapshotState(level, toggleCount, lastToggleCycle);
+    }
+
+    private static void CaptureGamePort(SnapshotModuleWriter writer, Apple2GamePort gamePort)
+    {
+        for (var paddle = 0; paddle < Apple2GamePort.PaddleCount; paddle++)
+            writer.WriteByte(gamePort.GetPaddlePosition(paddle));
+
+        for (var button = 0; button < Apple2GamePort.ButtonCount; button++)
+            writer.WriteBool(gamePort.IsButtonPressed(button));
+
+        var triggeredAtCycle = gamePort.SnapshotTriggeredAtCycle;
+        writer.WriteBool(triggeredAtCycle.HasValue);
+        writer.WriteUInt64(triggeredAtCycle ?? 0);
+
+        // Usage counters. Kept because they are how you tell whether a program touches the stick at
+        // all, and a snapshot that reset them would make a restored session look like it never had.
+        writer.WriteUInt64(gamePort.PaddleTriggerCount);
+        for (var button = 0; button < Apple2GamePort.ButtonCount; button++)
+            writer.WriteUInt64(gamePort.ButtonReadCounts[button]);
+    }
+
+    private static void RestoreGamePort(SnapshotModuleReader reader, Apple2GamePort gamePort)
+    {
+        for (var paddle = 0; paddle < Apple2GamePort.PaddleCount; paddle++)
+            gamePort.SetPaddlePosition(paddle, reader.ReadByte());
+
+        for (var button = 0; button < Apple2GamePort.ButtonCount; button++)
+            gamePort.SetButton(button, reader.ReadBool());
+
+        var hasTriggered = reader.ReadBool();
+        var triggeredAtCycle = reader.ReadUInt64();
+        var paddleTriggerCount = reader.ReadUInt64();
+        gamePort.RestoreSnapshotState(hasTriggered ? triggeredAtCycle : null, paddleTriggerCount);
+
+        for (var button = 0; button < Apple2GamePort.ButtonCount; button++)
+            gamePort.ButtonReadCounts[button] = reader.ReadUInt64();
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Snapshots/Apple2Disk2SnapshotModule.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Snapshots/Apple2Disk2SnapshotModule.cs
@@ -1,0 +1,109 @@
+using Highbyte.DotNet6502.Systems.Snapshots;
+
+namespace Highbyte.DotNet6502.Systems.Apple2.Snapshots;
+
+/// <summary>
+/// Snapshot module for the Disk II controller in slot 6. Embeds the inserted <c>.dsk</c> image in
+/// the package so the snapshot is self-contained, and restores the drive's mechanical and sequencer
+/// state: head position, motor, drive select, the Q6/Q7 latches and the read head's position in the
+/// current track's nibble stream.
+///
+/// <para>
+/// The head position matters more here than the equivalent does on a C64, because this card has no
+/// processor of its own. On a 1541 the drive runs its own DOS and a restored machine can simply ask
+/// it for a file again; here the Apple's own CPU is mid-way through stepping phase magnets and
+/// shifting bytes out of a latch, so where the head sits <em>is</em> the drive's state. Restoring
+/// the disk without it would resume a running RWTS against a head that had jumped elsewhere.
+/// </para>
+///
+/// <para>
+/// Not captured: the boot ROM (it comes from the config when the machine is rebuilt) and the
+/// nibblized track data (rebuilt from the embedded image on insert, which is why this module
+/// restores after <c>apple2-core</c>). Write state needs nothing — the emulated drive is read-only,
+/// so no inserted disk can have been modified.
+/// </para>
+/// </summary>
+public sealed class Apple2Disk2SnapshotModule : ISnapshotModule
+{
+    public const string ModuleName = "apple2-disk2";
+    public const string MediaId = "disk1";
+    public const string MediaKind = "dsk";
+
+    public string Name => ModuleName;
+    public int Version => 1;
+    public bool Required => true;
+
+    public void Capture(SnapshotModuleWriter writer, SnapshotCaptureContext context)
+    {
+        var controller = ((Apple2)context.System).DiskController;
+        var rawDiskImageData = controller.SnapshotRawDiskImageData;
+        var inserted = controller.IsDiskInserted && rawDiskImageData != null;
+
+        writer.WriteBool(inserted);
+
+        var (halfTrack, motorOn, motorSwitchedOffAtCycle, selectedDrive, q6, q7, nibblePosition) =
+            controller.GetSnapshotState();
+
+        writer.WriteInt32(halfTrack);
+        writer.WriteBool(motorOn);
+        writer.WriteBool(motorSwitchedOffAtCycle.HasValue);
+        writer.WriteUInt64(motorSwitchedOffAtCycle ?? 0);
+        writer.WriteInt32(selectedDrive);
+        writer.WriteBool(q6);
+        writer.WriteBool(q7);
+        writer.WriteInt32(nibblePosition);
+
+        if (inserted)
+            context.AddEmbeddedMedia(MediaId, MediaKind, sourceName: null, rawDiskImageData!);
+    }
+
+    public void Restore(SnapshotModuleReader reader, SnapshotRestoreContext context)
+    {
+        var controller = ((Apple2)context.System).DiskController;
+
+        var inserted = reader.ReadBool();
+
+        var halfTrack = reader.ReadInt32();
+        var motorOn = reader.ReadBool();
+        var hasMotorSwitchedOffAtCycle = reader.ReadBool();
+        var motorSwitchedOffAtCycle = reader.ReadUInt64();
+        var selectedDrive = reader.ReadInt32();
+        var q6 = reader.ReadBool();
+        var q7 = reader.ReadBool();
+        var nibblePosition = reader.ReadInt32();
+
+        // Insert first: nibblizing rebuilds the track data that the head position indexes into.
+        if (inserted)
+        {
+            if (context.TryGetEmbeddedMedia(MediaId, out var diskImageData))
+            {
+                controller.InsertDiskImage(diskImageData);
+            }
+            else
+            {
+                context.AddWarning(
+                    "apple2-disk2: snapshot marked a disk inserted but no embedded disk image was found.");
+                inserted = false;
+            }
+        }
+        else
+        {
+            controller.RemoveDiskImage();
+        }
+
+        controller.RestoreSnapshotState(
+            halfTrack,
+            motorOn,
+            hasMotorSwitchedOffAtCycle ? motorSwitchedOffAtCycle : null,
+            selectedDrive,
+            q6,
+            q7,
+            // With no disk there is no track to be positioned in.
+            inserted ? nibblePosition : 0);
+
+        if (inserted && controller.BootRom == null)
+            context.AddWarning(
+                "apple2-disk2: snapshot has a disk inserted but no Disk II boot ROM is configured, " +
+                "so the controller stays invisible to the machine.");
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Snapshots/C64Vic2SnapshotModule.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Snapshots/C64Vic2SnapshotModule.cs
@@ -19,9 +19,11 @@ namespace Highbyte.DotNet6502.Systems.Commodore64.Snapshots;
 /// </para>
 ///
 /// <para>
-/// The live raster position is captured for diagnostics/forward-compatibility but not forced back:
-/// it is re-derived as the restored machine runs, and the per-frame renderer state rebuilds itself
-/// once execution resumes.
+/// The live raster position is restored too, so a machine captured mid-frame resumes mid-frame:
+/// <see cref="C64.ExecuteOneFrame"/> runs only the remainder of the frame, keeping raster
+/// interrupts where the running program expects them. Only the cycle count is written back — the
+/// raster line is re-derived from it inside <see cref="Vic2"/> so the two cannot disagree. The
+/// per-frame renderer state rebuilds itself once execution resumes.
 /// </para>
 /// </summary>
 public sealed class C64Vic2SnapshotModule : ISnapshotModule
@@ -69,8 +71,8 @@ public sealed class C64Vic2SnapshotModule : ISnapshotModule
         var c64 = (C64)context.System;
         var vic2 = c64.Vic2;
 
-        _ = reader.ReadUInt16(); // CurrentRasterLine (re-derived during execution)
-        _ = reader.ReadUInt64(); // CyclesConsumedCurrentVblank (re-derived during execution)
+        _ = reader.ReadUInt16(); // CurrentRasterLine (re-derived from the cycle count below)
+        vic2.RestoreSnapshotRasterPosition(reader.ReadUInt64());
 
         var hasConfiguredRasterLine = reader.ReadBool();
         var configuredRasterLine = reader.ReadUInt16();

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2.cs
@@ -920,6 +920,29 @@ public class Vic2
         }
     }
 
+    // --- Snapshot support (consumed by the c64-vic2 snapshot module in the same assembly) ---
+
+    /// <summary>
+    /// Restores the live raster position saved in a snapshot: how far into the current frame the
+    /// machine was. Without it a restored machine resumes at the top of a frame regardless of where
+    /// it was interrupted, which moves every raster interrupt relative to the game's timing for the
+    /// first frame — visible as a split-screen effect tearing on the frame after a load.
+    ///
+    /// <para>Only the cycle count is stored; the raster line is re-derived from it using the same
+    /// expression <see cref="AdvanceRaster"/> uses, so the pair cannot be restored inconsistent with
+    /// each other. The per-line side effects (raster IRQ, CIA timer stepping) are deliberately not
+    /// replayed — they already ran on the machine that was captured.</para>
+    /// </summary>
+    internal void RestoreSnapshotRasterPosition(ulong cyclesConsumedCurrentVblank)
+    {
+        CyclesConsumedCurrentVblank = cyclesConsumedCurrentVblank < Vic2Model.CyclesPerFrame
+            ? cyclesConsumedCurrentVblank
+            : 0;
+
+        var line = (ushort)(CyclesConsumedCurrentVblank / Vic2Model.CyclesPerLine);
+        _currentRasterLineInternal = (ushort)Math.Clamp(line, 0, Vic2Model.TotalHeight - 1);
+    }
+
     private void RaiseRasterIRQ(CPU cpu)
     {
         // Check if a IRQ should be issued

--- a/src/libraries/Highbyte.DotNet6502.Systems/Snapshots/Cpu6502SnapshotModule.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Snapshots/Cpu6502SnapshotModule.cs
@@ -9,10 +9,19 @@ namespace Highbyte.DotNet6502.Systems.Snapshots;
 /// <para>
 /// Capture (v1): PC, SP, A, X, Y, processor-status byte, compatibility profile, halted flag,
 /// <see cref="ExecState"/> totals, and <see cref="CPUInterrupts"/> (pending-NMI flag plus
-/// active IRQ/NMI sources). Restore applies registers, flags and interrupt sources through the
-/// CPU's public API. The compatibility profile is validated against the rebuilt CPU; the
-/// halted flag and <see cref="ExecState"/> totals are captured for forward-compatibility and
-/// diagnostics but are re-derived as the system runs rather than forced back onto the CPU.
+/// active IRQ/NMI sources). Restore applies registers, flags, interrupt sources and the
+/// <see cref="ExecState"/> totals through the CPU's public API. The compatibility profile is
+/// validated against the rebuilt CPU; the halted flag is captured for diagnostics only.
+/// </para>
+///
+/// <para>
+/// The cumulative cycle count is restored rather than restarted at zero, because peripherals
+/// across machines time themselves against it with <em>absolute</em> stamps — the Apple II disk
+/// motor's spin-down, its paddle one-shots and its speaker toggles, and the C64's SwiftLink
+/// receive pacing. Restarting the counter would put every such stamp in the future, so timers
+/// that had long expired would read as though they were still running. Execution limits are
+/// unaffected: they are evaluated against the per-invocation <see cref="ExecState"/> that
+/// <c>CPU.Execute</c> accumulates, not against these totals.
 /// </para>
 /// </summary>
 public sealed class Cpu6502SnapshotModule : ISnapshotModule
@@ -76,11 +85,14 @@ public sealed class Cpu6502SnapshotModule : ISnapshotModule
 
         var capturedHalted = reader.ReadBool();
 
-        // ExecState totals are read to keep the stream aligned and for potential diagnostics;
-        // they are re-derived as the restored system runs and are not forced back onto the CPU.
-        _ = reader.ReadUInt64(); // CyclesConsumed
-        _ = reader.ReadUInt64(); // InstructionsExecutionCount
-        _ = reader.ReadUInt64(); // UnknownOpCodeCount
+        // ExecState totals are restored so the cumulative cycle count continues from the saved
+        // machine rather than restarting at zero. Peripherals that time themselves against it hold
+        // absolute cycle stamps, which are only meaningful against a continuous counter — see
+        // ExecState.RestoreTotals.
+        var cyclesConsumed = reader.ReadUInt64();
+        var instructionsExecutionCount = reader.ReadUInt64();
+        var unknownOpCodeCount = reader.ReadUInt64();
+        cpu.ExecState.RestoreTotals(cyclesConsumed, instructionsExecutionCount, unknownOpCodeCount);
 
         RestoreInterrupts(reader, cpu);
 

--- a/src/libraries/Highbyte.DotNet6502/ExecState.cs
+++ b/src/libraries/Highbyte.DotNet6502/ExecState.cs
@@ -39,6 +39,24 @@ public class ExecState
         };
     }
 
+    /// <summary>
+    /// Overwrites the running totals with values captured earlier. Intended for snapshot restore,
+    /// which has to make the cumulative cycle count continue from where the saved machine left off
+    /// rather than from zero: peripherals that time themselves against it (the Apple II disk motor,
+    /// paddle one-shots and speaker; the C64's SwiftLink receive pacing) hold <em>absolute</em>
+    /// cycle stamps, which are only meaningful against a continuous counter.
+    ///
+    /// <para>This does not affect execution limits. <c>ExecOptions.CyclesRequested</c> and
+    /// <c>MaxNumberOfInstructions</c> are evaluated against the per-invocation <see cref="ExecState"/>
+    /// that <see cref="CPU.Execute"/> accumulates, not against these cumulative totals.</para>
+    /// </summary>
+    public void RestoreTotals(ulong cyclesConsumed, ulong instructionsExecutionCount, ulong unknownOpCodeCount)
+    {
+        CyclesConsumed = cyclesConsumed;
+        InstructionsExecutionCount = instructionsExecutionCount;
+        UnknownOpCodeCount = unknownOpCodeCount;
+    }
+
     internal void UpdateTotal(ExecState newExecState)
     {
         CyclesConsumed += newExecState.CyclesConsumed;

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Disk2ControllerTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Disk2ControllerTests.cs
@@ -49,6 +49,50 @@ public class Disk2ControllerTests
         return 0;
     }
 
+    /// <summary>
+    /// A drive whose motor has never been switched on is not turning. The one-shot that keeps the
+    /// disk coasting after a motor-off is timed against the CPU's cumulative cycle count, which is
+    /// also 0 at power-on — so treating "never switched off" as "switched off at cycle 0" would put
+    /// a brand new drive inside its own spin-down window for its first million cycles.
+    /// </summary>
+    [Fact]
+    public void Drive_Is_Not_Spinning_Before_The_Motor_Has_Ever_Been_Switched_On()
+    {
+        ulong cycles = 0;
+        var controller = new Disk2Controller(() => cycles);
+        controller.SetBootRom(BuildBootRom());
+        controller.InsertDiskImage(BuildDiskImage());
+
+        Assert.False(controller.IsMotorOn);
+        Assert.False(controller.IsSpinning);
+
+        // Still not spinning a little way into the machine's life (inside the spin-down window).
+        cycles = Disk2Controller.SpinDownCycles / 2;
+        Assert.False(controller.IsSpinning);
+    }
+
+    [Fact]
+    public void Motor_Keeps_Spinning_Through_The_Spin_Down_Window_After_Being_Switched_Off()
+    {
+        ulong cycles = 1_000;
+        var controller = new Disk2Controller(() => cycles);
+        controller.SetBootRom(BuildBootRom());
+        controller.InsertDiskImage(BuildDiskImage());
+
+        controller.BusAccess(0xC0E9);   // motor on
+        Assert.True(controller.IsSpinning);
+
+        controller.BusAccess(0xC0E8);   // motor off: the one-shot starts here
+        Assert.False(controller.IsMotorOn);
+        Assert.True(controller.IsSpinning);
+
+        cycles += Disk2Controller.SpinDownCycles - 1;
+        Assert.True(controller.IsSpinning);
+
+        cycles += 1;
+        Assert.False(controller.IsSpinning);
+    }
+
     [Fact]
     public void Controller_Is_Enabled_Only_With_Both_Boot_Rom_And_Disk()
     {

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/Apple2DiskSnapshotTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/Apple2DiskSnapshotTests.cs
@@ -1,0 +1,153 @@
+using System.IO.Compression;
+using Highbyte.DotNet6502.Systems.Apple2.Config;
+using Highbyte.DotNet6502.Systems.Apple2.Disk2;
+using Highbyte.DotNet6502.Systems.Apple2.DiskImage;
+using Highbyte.DotNet6502.Systems.Apple2.Snapshots;
+using Highbyte.DotNet6502.Systems.Snapshots;
+using Microsoft.Extensions.Logging.Abstractions;
+using Apple2System = Highbyte.DotNet6502.Systems.Apple2.Apple2;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Snapshots;
+
+public class Apple2DiskSnapshotTests
+{
+    private static Apple2System BuildApple2()
+        => new Apple2System(new Apple2Config(), NullLoggerFactory.Instance);
+
+    private static byte[] BuildTestDiskImage()
+    {
+        var image = new byte[DskParser.DiskImageSize];
+        // Recognizable markers, to prove the bytes survive the embed/extract round trip.
+        image[0x1000] = 0xAB;
+        image[0x2000] = 0xCD;
+        image[^1] = 0xEF;
+        return image;
+    }
+
+    private static byte[] BuildBootRom()
+    {
+        var rom = new byte[Disk2Controller.BootRomSize];
+        rom[0] = 0xA2; rom[1] = 0x20; rom[2] = 0xA0; rom[3] = 0x00;
+        rom[4] = 0xA2; rom[5] = 0x03;
+        return rom;
+    }
+
+    [Fact]
+    public void Saved_package_embeds_the_inserted_disk_image_bytes()
+    {
+        var source = BuildApple2();
+        var image = BuildTestDiskImage();
+        source.DiskController.InsertDiskImage(image);
+
+        using var snapshotStream = new MemoryStream();
+        new SnapshotService().Save(source, snapshotStream);
+
+        snapshotStream.Position = 0;
+        using var archive = new ZipArchive(snapshotStream, ZipArchiveMode.Read);
+        var mediaEntry = archive.GetEntry(
+            $"{SnapshotService.MediaDirectory}/{Apple2Disk2SnapshotModule.MediaId}.{Apple2Disk2SnapshotModule.MediaKind}");
+        Assert.NotNull(mediaEntry);
+
+        using var entryStream = mediaEntry!.Open();
+        using var ms = new MemoryStream();
+        entryStream.CopyTo(ms);
+        Assert.Equal(image, ms.ToArray());
+    }
+
+    [Fact]
+    public void Round_trip_reinserts_the_disk_and_restores_drive_state()
+    {
+        var source = BuildApple2();
+        source.DiskController.SetBootRom(BuildBootRom());
+        source.DiskController.InsertDiskImage(BuildTestDiskImage());
+
+        // Drive the card the way the boot ROM does: motor on, read mode, step the head off track 0.
+        source.Mem.Read(0xC0E9);                    // motor on
+        source.Mem.Read(0xC0EE);                    // Q7 off (read mode)
+        source.Mem.Read(0xC0EC);                    // Q6 off
+        StepHeadUpOneTrack(source);
+        source.Mem.Read(0xC0EC);                    // read a nibble, advancing the stream position
+
+        var sourceTrack = source.DiskController.CurrentTrack;
+        Assert.True(sourceTrack > 0);
+        Assert.True(source.DiskController.IsMotorOn);
+        Assert.True(source.DiskController.DataReadCount > 0);
+
+        using var snapshotStream = new MemoryStream();
+        new SnapshotService().Save(source, snapshotStream);
+
+        snapshotStream.Position = 0;
+        var restored = BuildApple2();
+        restored.DiskController.SetBootRom(BuildBootRom());
+        var result = new SnapshotService().Restore(restored, snapshotStream);
+
+        Assert.Empty(result.Warnings);
+        Assert.True(restored.DiskController.IsDiskInserted);
+        Assert.True(restored.DiskController.IsEnabled);
+        Assert.Equal(sourceTrack, restored.DiskController.CurrentTrack);
+        Assert.True(restored.DiskController.IsMotorOn);
+
+        // The read head resumes where it was: the next nibble matches the source machine's.
+        Assert.Equal(source.Mem.Read(0xC0EC), restored.Mem.Read(0xC0EC));
+    }
+
+    [Fact]
+    public void Round_trip_with_an_empty_drive_embeds_no_media_and_stays_empty()
+    {
+        var source = BuildApple2();
+        Assert.False(source.DiskController.IsDiskInserted);
+
+        using var snapshotStream = new MemoryStream();
+        new SnapshotService().Save(source, snapshotStream);
+
+        snapshotStream.Position = 0;
+        using (var archive = new ZipArchive(snapshotStream, ZipArchiveMode.Read, leaveOpen: true))
+        {
+            Assert.Null(archive.GetEntry(
+                $"{SnapshotService.MediaDirectory}/{Apple2Disk2SnapshotModule.MediaId}.{Apple2Disk2SnapshotModule.MediaKind}"));
+        }
+
+        // A machine that had a disk must end up empty after restoring an empty-drive snapshot —
+        // the snapshot describes the whole machine, not just the parts that changed.
+        snapshotStream.Position = 0;
+        var restored = BuildApple2();
+        restored.DiskController.InsertDiskImage(BuildTestDiskImage());
+        new SnapshotService().Restore(restored, snapshotStream);
+
+        Assert.False(restored.DiskController.IsDiskInserted);
+    }
+
+    [Fact]
+    public void Restoring_an_inserted_disk_without_a_boot_rom_warns_rather_than_failing()
+    {
+        var source = BuildApple2();
+        source.DiskController.SetBootRom(BuildBootRom());
+        source.DiskController.InsertDiskImage(BuildTestDiskImage());
+
+        using var snapshotStream = new MemoryStream();
+        new SnapshotService().Save(source, snapshotStream);
+
+        // Target machine has no disk2 ROM configured, so the controller cannot appear on the bus.
+        snapshotStream.Position = 0;
+        var restored = BuildApple2();
+        var result = new SnapshotService().Restore(restored, snapshotStream);
+
+        Assert.True(restored.DiskController.IsDiskInserted);
+        Assert.False(restored.DiskController.IsEnabled);
+        Assert.Contains(result.Warnings, w => w.Contains("boot ROM", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Pulses the stepper phases to move the head from track 0 to track 1 (two half-track steps).
+    /// Phase alignment repeats every four half-tracks, so the pulses have to walk in order.
+    /// </summary>
+    private static void StepHeadUpOneTrack(Apple2System apple2)
+    {
+        for (var halfStep = 0; halfStep < 2; halfStep++)
+        {
+            var phase = (apple2.DiskController.CurrentTrack * 2 + halfStep + 1) & 0x03;
+            apple2.Mem.Read((ushort)(Disk2Controller.IoBaseAddress + phase * 2 + 1));   // phase on
+            apple2.Mem.Read((ushort)(Disk2Controller.IoBaseAddress + phase * 2));       // phase off
+        }
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/Apple2SnapshotRoundTripTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/Apple2SnapshotRoundTripTests.cs
@@ -1,0 +1,282 @@
+using Highbyte.DotNet6502.Systems.Apple2.Config;
+using Highbyte.DotNet6502.Systems.Apple2.Peripherals;
+using Highbyte.DotNet6502.Systems.Apple2.Snapshots;
+using Highbyte.DotNet6502.Systems.Generic;
+using Highbyte.DotNet6502.Systems.Snapshots;
+using Microsoft.Extensions.Logging.Abstractions;
+using Apple2System = Highbyte.DotNet6502.Systems.Apple2.Apple2;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Snapshots;
+
+public class Apple2SnapshotRoundTripTests
+{
+    // Program in RAM that writes a marker and advances X/Y in a loop, so continued execution after
+    // restore is observable:
+    //   0300: A9 5A      LDA #$5A
+    //   0302: 8D 00 04   STA $0400   (text page 1)
+    //   0305: E8         INX
+    //   0306: C8         INY
+    //   0307: 4C 05 03   JMP $0305
+    private const ushort ProgramStart = 0x0300;
+    private static readonly byte[] Program =
+    {
+        0xA9, 0x5A,
+        0x8D, 0x00, 0x04,
+        0xE8,
+        0xC8,
+        0x4C, 0x05, 0x03,
+    };
+
+    private static Apple2System BuildApple2()
+        => new Apple2System(new Apple2Config(), NullLoggerFactory.Instance);
+
+    private static void LoadProgram(Apple2System apple2)
+    {
+        for (var i = 0; i < Program.Length; i++)
+            apple2.Mem.Write((ushort)(ProgramStart + i), Program[i]);
+        apple2.CPU.PC = ProgramStart;
+    }
+
+    [Fact]
+    public void Apple2_implements_snapshot_provider_with_cpu_core_and_disk_modules()
+    {
+        var provider = (ISystemSnapshotProvider)BuildApple2();
+
+        Assert.Equal(Apple2System.SystemName, provider.MachineId.SystemName);
+        Assert.Equal(Apple2System.SnapshotVersion, provider.MachineId.SupportedSnapshotVersion);
+
+        var moduleNames = provider.GetSnapshotModules().Select(m => m.Name).ToArray();
+        Assert.Equal(
+            new[] { Cpu6502SnapshotModule.ModuleName, Apple2CoreSnapshotModule.ModuleName, Apple2Disk2SnapshotModule.ModuleName },
+            moduleNames);
+    }
+
+    [Fact]
+    public void Round_trip_restores_memory_registers_and_resumes_execution()
+    {
+        var source = BuildApple2();
+        LoadProgram(source);
+        for (var i = 0; i < 20; i++)
+            source.ExecuteOneInstruction(out _);
+
+        Assert.Equal((byte)0x5A, source.Mem.Read(0x0400));
+
+        using var snapshotStream = new MemoryStream();
+        var service = new SnapshotService();
+        service.Save(source, snapshotStream);
+
+        // Restore into a fresh machine that has been perturbed away from the captured state.
+        snapshotStream.Position = 0;
+        var restored = BuildApple2();
+        restored.CPU.PC = 0x0000;
+        restored.Mem.Write(0x0400, 0x00);
+        var result = service.Restore(restored, snapshotStream);
+
+        Assert.Empty(result.Warnings);
+        Assert.Equal((byte)0x5A, restored.Mem.Read(0x0400));
+        Assert.Equal(Program[0], restored.Mem.Read(ProgramStart));
+        Assert.Equal(source.CPU.PC, restored.CPU.PC);
+        Assert.Equal(source.CPU.X, restored.CPU.X);
+        Assert.Equal(source.CPU.Y, restored.CPU.Y);
+        Assert.Equal(source.CPU.A, restored.CPU.A);
+
+        // Continued execution mirrors the source machine.
+        for (var i = 0; i < 30; i++)
+        {
+            source.ExecuteOneInstruction(out _);
+            restored.ExecuteOneInstruction(out _);
+        }
+        Assert.Equal(source.CPU.PC, restored.CPU.PC);
+        Assert.Equal(source.CPU.X, restored.CPU.X);
+        Assert.Equal(source.CPU.Y, restored.CPU.Y);
+    }
+
+    [Fact]
+    public void Round_trip_restores_display_soft_switches()
+    {
+        var source = BuildApple2();
+        // Hi-res, mixed, page 2, graphics — every switch away from its power-on value.
+        source.Mem.Read(Apple2SoftSwitches.GraphicsModeAddress);
+        source.Mem.Read(Apple2SoftSwitches.MixedModeOnAddress);
+        source.Mem.Read(Apple2SoftSwitches.TextPage2Address);
+        source.Mem.Read(Apple2SoftSwitches.HiResModeAddress);
+
+        using var snapshotStream = new MemoryStream();
+        new SnapshotService().Save(source, snapshotStream);
+
+        snapshotStream.Position = 0;
+        var restored = BuildApple2();
+        // A fresh machine powers up in text mode, page 1 — the opposite of every value above, so a
+        // module that silently skipped these would leave the assertions below failing rather than
+        // accidentally passing.
+        Assert.True(restored.SoftSwitches.TextMode);
+        new SnapshotService().Restore(restored, snapshotStream);
+
+        Assert.False(restored.SoftSwitches.TextMode);
+        Assert.True(restored.SoftSwitches.MixedMode);
+        Assert.True(restored.SoftSwitches.Page2);
+        Assert.True(restored.SoftSwitches.HiRes);
+        Assert.Equal(source.SoftSwitches.ActiveHiResPageBaseAddress, restored.SoftSwitches.ActiveHiResPageBaseAddress);
+    }
+
+    [Fact]
+    public void Round_trip_restores_keyboard_latch_including_strobe_state()
+    {
+        var source = BuildApple2();
+        source.Keyboard.KeyPressed((byte)'Q');
+        Assert.True(source.Keyboard.StrobeSet);
+
+        using var pending = new MemoryStream();
+        new SnapshotService().Save(source, pending);
+
+        // ...and again after the machine has consumed the keypress, so the strobe bit is proven to
+        // travel rather than being implied by the ASCII code.
+        source.Keyboard.ClearStrobe();
+        using var consumed = new MemoryStream();
+        new SnapshotService().Save(source, consumed);
+
+        pending.Position = 0;
+        var restoredPending = BuildApple2();
+        new SnapshotService().Restore(restoredPending, pending);
+        Assert.True(restoredPending.Keyboard.StrobeSet);
+        Assert.Equal((byte)'Q', (byte)(restoredPending.Keyboard.Latch & 0x7F));
+
+        consumed.Position = 0;
+        var restoredConsumed = BuildApple2();
+        new SnapshotService().Restore(restoredConsumed, consumed);
+        Assert.False(restoredConsumed.Keyboard.StrobeSet);
+        Assert.Equal((byte)'Q', restoredConsumed.Keyboard.Latch);
+    }
+
+    [Fact]
+    public void Round_trip_restores_speaker_level_and_toggle_count()
+    {
+        var source = BuildApple2();
+        LoadProgram(source);
+        // An odd number of toggles, so the cone ends up away from its power-on position.
+        for (var i = 0; i < 5; i++)
+            source.Mem.Read(Apple2SoftSwitches.SpeakerToggleAddress);
+        Assert.True(source.Speaker.Level);
+
+        using var snapshotStream = new MemoryStream();
+        new SnapshotService().Save(source, snapshotStream);
+
+        snapshotStream.Position = 0;
+        var restored = BuildApple2();
+        new SnapshotService().Restore(restored, snapshotStream);
+
+        Assert.Equal(source.Speaker.Level, restored.Speaker.Level);
+        Assert.Equal(source.Speaker.ToggleCount, restored.Speaker.ToggleCount);
+        Assert.Equal(source.Speaker.LastToggleCycle, restored.Speaker.LastToggleCycle);
+    }
+
+    [Fact]
+    public void Round_trip_restores_paddle_positions_buttons_and_counters()
+    {
+        var source = BuildApple2();
+        source.GamePort.SetPaddlePosition(0, 200);
+        source.GamePort.SetPaddlePosition(1, 40);
+        source.GamePort.SetButton(0, true);
+        source.GamePort.SetButton(1, false);
+        source.Mem.Read(Apple2GamePort.Button0Address);      // bump a read counter
+        source.Mem.Read(Apple2SoftSwitches.SpeakerToggleAddress);
+        source.Mem.Read(0xC070);                             // strobe the one-shot
+
+        using var snapshotStream = new MemoryStream();
+        new SnapshotService().Save(source, snapshotStream);
+
+        snapshotStream.Position = 0;
+        var restored = BuildApple2();
+        new SnapshotService().Restore(restored, snapshotStream);
+
+        Assert.Equal((byte)200, restored.GamePort.GetPaddlePosition(0));
+        Assert.Equal((byte)40, restored.GamePort.GetPaddlePosition(1));
+        Assert.True(restored.GamePort.IsButtonPressed(0));
+        Assert.False(restored.GamePort.IsButtonPressed(1));
+        Assert.Equal(source.GamePort.PaddleTriggerCount, restored.GamePort.PaddleTriggerCount);
+        Assert.Equal(source.GamePort.ButtonReadCounts[0], restored.GamePort.ButtonReadCounts[0]);
+    }
+
+    /// <summary>
+    /// The cumulative CPU cycle count is restored (see <see cref="Cpu6502SnapshotModule"/>), which is
+    /// what makes the machine's absolute cycle stamps survive a round trip. Without it the restored
+    /// counter would restart near zero, putting every stamp in the future.
+    /// </summary>
+    [Fact]
+    public void Round_trip_restores_cumulative_cpu_cycle_count()
+    {
+        var source = BuildApple2();
+        LoadProgram(source);
+        for (var i = 0; i < 50; i++)
+            source.ExecuteOneInstruction(out _);
+
+        var sourceCycles = source.CPU.ExecState.CyclesConsumed;
+        Assert.True(sourceCycles > 0);
+
+        using var snapshotStream = new MemoryStream();
+        new SnapshotService().Save(source, snapshotStream);
+
+        snapshotStream.Position = 0;
+        var restored = BuildApple2();
+        new SnapshotService().Restore(restored, snapshotStream);
+
+        Assert.Equal(sourceCycles, restored.CPU.ExecState.CyclesConsumed);
+        Assert.Equal(
+            source.CPU.ExecState.InstructionsExecutionCount,
+            restored.CPU.ExecState.InstructionsExecutionCount);
+    }
+
+    /// <summary>
+    /// The payoff of restoring the cycle count: a paddle read caught mid-flight resumes with its
+    /// one-shot still running and expiring at the same point, instead of the timer reading as
+    /// already expired (or, worse, as freshly triggered) on the restored machine.
+    /// </summary>
+    [Fact]
+    public void Round_trip_resumes_an_in_flight_paddle_one_shot()
+    {
+        var source = BuildApple2();
+        LoadProgram(source);
+        // Burn cycles first, so the trigger stamp is a large absolute value rather than one a fresh
+        // machine could coincidentally match.
+        for (var i = 0; i < 200; i++)
+            source.ExecuteOneInstruction(out _);
+
+        source.GamePort.SetPaddlePosition(0, Apple2GamePort.PaddleMax);
+        source.Mem.Read(Apple2GamePort.TriggerAddress);
+        Assert.True(source.GamePort.IsPaddleTimerRunning(0));
+
+        using var snapshotStream = new MemoryStream();
+        new SnapshotService().Save(source, snapshotStream);
+
+        snapshotStream.Position = 0;
+        var restored = BuildApple2();
+        new SnapshotService().Restore(restored, snapshotStream);
+
+        // Still running at the moment of restore...
+        Assert.True(restored.GamePort.IsPaddleTimerRunning(0));
+
+        // ...and expires after the same amount of further execution as on the source machine. The
+        // loop runs long enough to outlast a full-scale one-shot (PaddleMax * PreadLoopCycles =
+        // 2,805 cycles, at roughly 2.6 cycles per instruction in this program).
+        for (var i = 0; i < 1500; i++)
+        {
+            source.ExecuteOneInstruction(out _);
+            restored.ExecuteOneInstruction(out _);
+            Assert.Equal(source.GamePort.IsPaddleTimerRunning(0), restored.GamePort.IsPaddleTimerRunning(0));
+        }
+        Assert.False(restored.GamePort.IsPaddleTimerRunning(0));
+    }
+
+    [Fact]
+    public void Restoring_a_snapshot_of_another_machine_is_rejected()
+    {
+        var source = BuildApple2();
+        using var snapshotStream = new MemoryStream();
+        new SnapshotService().Save(source, snapshotStream);
+
+        snapshotStream.Position = 0;
+        var genericComputer = new GenericComputer();
+        Assert.Throws<SnapshotIncompatibleException>(
+            () => new SnapshotService().Restore(genericComputer, snapshotStream));
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/Apple2SystemConfigSnapshotTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/Apple2SystemConfigSnapshotTests.cs
@@ -1,0 +1,46 @@
+using Highbyte.DotNet6502.Systems.Apple2.Config;
+using Highbyte.DotNet6502.Systems.Apple2.Video;
+using Highbyte.DotNet6502.Systems.Snapshots;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Snapshots;
+
+public class Apple2SystemConfigSnapshotTests
+{
+    [Fact]
+    public void Portable_settings_round_trip_through_export_and_apply()
+    {
+        var source = new Apple2SystemConfig
+        {
+            AudioEnabled = true,
+            KeyboardJoystickEnabled = true,
+            MonitorColor = Apple2MonitorColor.Green,
+        };
+
+        var json = ((ISnapshotableConfig)source).ExportSnapshotSettings();
+        Assert.False(string.IsNullOrEmpty(json));
+
+        var target = new Apple2SystemConfig();
+        // Start the target on the opposite of every captured value, so an ignored field fails.
+        Assert.False(target.AudioEnabled);
+        Assert.False(target.KeyboardJoystickEnabled);
+        Assert.Equal(Apple2MonitorColor.Color, target.MonitorColor);
+
+        ((ISnapshotableConfig)target).ApplySnapshotSettings(json!);
+
+        Assert.True(target.AudioEnabled);
+        Assert.True(target.KeyboardJoystickEnabled);
+        Assert.Equal(Apple2MonitorColor.Green, target.MonitorColor);
+    }
+
+    [Fact]
+    public void Applying_a_payload_with_unknown_fields_is_tolerated()
+    {
+        var config = new Apple2SystemConfig();
+
+        // A snapshot written by a newer build may carry settings this one has never heard of.
+        ((ISnapshotableConfig)config).ApplySnapshotSettings("{\"somethingElse\":123}");
+
+        Assert.False(config.AudioEnabled);
+        Assert.Equal(Apple2MonitorColor.Color, config.MonitorColor);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/C64CoreSnapshotRoundTripTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/C64CoreSnapshotRoundTripTests.cs
@@ -240,4 +240,45 @@ public class C64CoreSnapshotRoundTripTests
         Assert.Equal(sourceBank, restored.CurrentBank);
         Assert.Equal(source.Mem.Read(0x0001), restored.Mem.Read(0x0001));
     }
+
+    /// <summary>
+    /// A machine captured mid-frame resumes mid-frame. Without this the raster restarts at line 0
+    /// on load, so every raster interrupt lands in a different place than the running program
+    /// expects for the first frame — visible as a split-screen effect tearing after a restore.
+    /// </summary>
+    [Fact]
+    public void C64_round_trip_restores_the_raster_position_within_the_frame()
+    {
+        var source = BuildC64();
+        LoadProgram(source);
+        // Run part of a frame's worth of cycles, so the raster ends up well down the screen but
+        // short of the frame boundary. A fixed instruction count rather than a loop on
+        // CurrentRasterLine, which reads ushort.MaxValue as its "no line yet" sentinel until the
+        // first instruction advances it.
+        for (var i = 0; i < 2000; i++)
+            source.ExecuteOneInstruction(out _);
+
+        var sourceRasterLine = source.Vic2.CurrentRasterLine;
+        var sourceVblankCycles = source.Vic2.CyclesConsumedCurrentVblank;
+        Assert.True(sourceVblankCycles > 0);
+        Assert.InRange(sourceRasterLine, (ushort)1, (ushort)(source.Vic2.Vic2Model.TotalHeight - 1));
+
+        using var snapshotStream = new MemoryStream();
+        new SnapshotService().Save(source, snapshotStream);
+
+        snapshotStream.Position = 0;
+        var restored = BuildC64();
+        new SnapshotService().Restore(restored, snapshotStream);
+
+        Assert.Equal(sourceVblankCycles, restored.Vic2.CyclesConsumedCurrentVblank);
+        Assert.Equal(sourceRasterLine, restored.Vic2.CurrentRasterLine);
+
+        // The re-derived line stays consistent with the cycle count as execution continues.
+        for (var i = 0; i < 200; i++)
+        {
+            source.ExecuteOneInstruction(out _);
+            restored.ExecuteOneInstruction(out _);
+        }
+        Assert.Equal(source.Vic2.CurrentRasterLine, restored.Vic2.CurrentRasterLine);
+    }
 }


### PR DESCRIPTION
Adds `.d6502snap` emulator-state snapshot support for the Apple II, so the existing save/load buttons, `emu.savesnapshot`/`emu.loadsnapshot` remote commands, Lua `emu.save_snapshot` and `--load-snapshot` all work on this machine. The snapshot framework is fully generic, so no host or UI plumbing changed.

## Apple II modules

| Module | Contents |
|---|---|
| `apple2-core` | 48 KB RAM, keyboard latch (strobe included), the four display soft switches, speaker cone position, game port paddles/buttons/one-shot |
| `apple2-disk2` | Head half-track, motor, drive select, Q6/Q7, the read head's position in the current track, plus the inserted `.dsk` embedded in the package |

Two modules rather than one per chip, because this machine has no chips to divide along: the display mode is four write-only flip-flops, the keyboard is one byte and the speaker is one bit, all decoded from the same page. The Disk II card is the other seam, because it has removable media.

`Disk2Controller` now retains the raw image bytes — nibblizing is one-way, and the snapshot has to embed the original to re-insert the same disk. The head position matters more here than the C64 equivalent: the card has no processor of its own, so where the head sits *is* the drive's state, including the position within the track's nibble stream.

`Apple2SystemConfig` implements `ISnapshotableConfig`, carrying audio enabled, keyboard joystick and monitor colour — all three are read at build time rather than polled, so they are applied before the machine is rebuilt.

## Shared framework: restoring the cumulative cycle count

`cpu-6502` wrote the `ExecState` totals into the payload and then discarded them on restore, so a restored machine's counter restarted near zero. The Apple II is the first machine where that bites — the disk motor's spin-down, the paddle one-shots and the speaker all hold **absolute** cycle stamps.

The local workaround (capture deltas per machine and rebase on restore) was rejected because it cannot represent what it needs to: "triggered 2,000 cycles ago" is unrepresentable on a counter currently at 7, so it degrades to treating anything in flight as expired — a permanent fidelity loss every future machine with a cycle-stamped peripheral would reinvent.

Restoring the counter was checked against the thing that could have made it unsafe:

- **Execution limits are unaffected.** `ExecOptions.CyclesRequested` / `MaxNumberOfInstructions` are compared against `execState.CyclesConsumed` in `ExecEvaluator`, which reads as though a restored counter of millions would trip every cycle-limited run instantly. It doesn't: `CPU.Execute` passes `thisExecState`, a per-invocation accumulator starting at zero each call. The cumulative total is never consulted for limits.
- **Audio providers are safe.** Both `C64SidSampleProvider` and `Apple2SpeakerSampleProvider` compute `delta = nowCycles - _lastCycles`, but both guard the first instruction with `_firstInstructionSeen`, and a restore always builds a fresh system — so they seed from the already-restored value rather than emitting a burst.
- **No format change.** The value was already in the v1 payload, so no version bump, and existing snapshots already carry a correct value.

This generalises: the C64 already has an absolute-cycle consumer in `SwiftLinkDevice` (receive pacing). Cost is one public method, `ExecState.RestoreTotals`, because the setter was private.

## Shared framework: VIC-II raster position

`c64-vic2` discarded `CyclesConsumedCurrentVblank` for the same stated reason ("re-derived during execution"). It isn't re-derived, it restarts — so a C64 captured mid-frame resumed at the top of a frame, moving every raster interrupt relative to the running program's timing for the first frame after a load. Only the cycle count is written back; the raster line is re-derived from it inside `Vic2` using the same expression `AdvanceRaster` uses, so the pair cannot be restored inconsistent with each other.

## Bug fixed on the way

`Disk2Controller.IsSpinning` computed `cycles - _motorSwitchedOffAtCycle < SpinDownCycles` with a non-nullable stamp, so at power-on it evaluated `0 - 0 = 0` and **a drive that had never been switched on reported as spinning** for its first million cycles. Same shape as the bug the game port already fixed by making its trigger stamp nullable; found again because snapshots forced "not spinning" to be representable.

## Verification

All tests pass across the five test projects (1,718 tests, none skipped).

The five real-ROM Disk II boot tests are the only integration coverage for the spin-down change and skip by default, so they were run explicitly against a real DOS 3.3 System Master rather than assumed — all five pass.

Verified end-to-end through the desktop app and remote control server, not just at module level: typed a BASIC program, inserted the System Master, saved a snapshot, then `NEW`'d the program and ejected the disk. After loading, the machine came back paused as documented, the program returned verbatim and the disk was re-inserted — and booting it ran DOS 3.3 (head out to track 21, 97k nibbles read, motor off at the prompt), so the embedded bytes are a working disk rather than a flag that survived.

Also corrects one stale doc line: `$C030` was still described as "counted but silent", which the speaker audio PR made untrue.