### PR TITLE
Draw attention to an invalid Apple II configuration

### DIFF
--- a/docs/host-apps/avalonia/automation.md
+++ b/docs/host-apps/avalonia/automation.md
@@ -254,6 +254,15 @@ Sidebar sections behave as an accordion in both the C64 and Apple II menus (shar
 scripts must therefore expand a section (header button or shortcut) before its inner
 controls exist in the accessibility tree.
 
+One exception worth knowing when a script asserts on section state: if the selected system's
+configuration is invalid — normally a fresh install whose ROM files are missing — the menu
+expands its Configuration section by itself and pulses the config button (`C64Config` /
+`OpenApple2ConfigButton`) orange until the configuration becomes valid or the button is clicked.
+So a Configuration section found already expanded is a signal about the config, not a leftover from
+an earlier step. The pulse is a `Background` change driven from the view (shared
+`ButtonFlashController`) and is not exposed through the accessibility tree; a screenshot is the only
+way to observe it.
+
 The Apple II menu contributes the Download & Run section (curated downloadable programs),
 the Load/Save section (Applesoft Basic and DOS 3.3 binary files, loading files from .dsk
 images, plus example programs) and the Configuration section — which is the route to the

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ButtonFlashController.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ButtonFlashController.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Core;
+
+/// <summary>
+/// Pulses a button's background between its normal colour and an attention colour, to point the user
+/// at something they have to deal with before the emulator can run — in practice, a system whose
+/// configuration is invalid because its ROM files are missing.
+///
+/// <para>
+/// The smooth fade is not produced here. This only sets <see cref="Button.Background"/> to two
+/// values in a loop; the button itself must declare a <c>BrushTransition</c> on <c>Background</c> in
+/// XAML, and <see cref="FlashOnDuration"/> is matched to that transition's duration so the colour is
+/// never yanked mid-fade.
+/// </para>
+///
+/// <para>
+/// One controller instance per view, holding at most one running flash. The awkward parts —
+/// capturing the token source into a local before awaiting, and only clearing the field when it is
+/// still the one this call created — exist because a restart can race an in-flight loop; see
+/// <see cref="StartAsync"/>.
+/// </para>
+/// </summary>
+public sealed class ButtonFlashController
+{
+    /// <summary>How long the attention colour is held. Matches the button's BrushTransition duration
+    /// so the fade completes before the colour is set back.</summary>
+    public static readonly TimeSpan FlashOnDuration = TimeSpan.FromMilliseconds(700);
+
+    /// <summary>How long the normal colour is held between pulses.</summary>
+    public static readonly TimeSpan FlashOffDuration = TimeSpan.FromMilliseconds(2000);
+
+    private CancellationTokenSource? _cancellation;
+
+    /// <summary>True while a flash loop is running.</summary>
+    public bool IsFlashing => _cancellation != null;
+
+    /// <summary>
+    /// Starts (or restarts) the flash on <paramref name="button"/>. Fire-and-forget: the loop runs
+    /// until <see cref="Cancel"/>, or until the user clicks the button when
+    /// <paramref name="stopAfterClick"/> is set — clicking it means they have seen the hint.
+    /// </summary>
+    public void Start(Button button, Color flashColor, bool stopAfterClick)
+        => SafeAsyncHelper.Execute(() => StartAsync(button, flashColor, stopAfterClick));
+
+    /// <summary>
+    /// Cancels a running flash without starting a new one, restoring the button's normal colour.
+    /// Safe to call when nothing is running.
+    /// </summary>
+    public void Cancel()
+    {
+        var cancellation = _cancellation;
+        if (cancellation == null)
+            return;
+
+        _cancellation = null;
+        SafeAsyncHelper.Execute(async () =>
+        {
+            await cancellation.CancelAsync();
+            cancellation.Dispose(); // safe; the loop's finally may dispose it too
+        });
+    }
+
+    private async Task StartAsync(Button button, Color flashColor, bool stopAfterClick)
+    {
+        // Capture the field into a local before awaiting, so the finally block's null-clear in
+        // another concurrent call cannot turn this into a NullReferenceException on Dispose().
+        var existingCancellation = _cancellation;
+        if (existingCancellation != null)
+        {
+            _cancellation = null;
+            await existingCancellation.CancelAsync();
+            existingCancellation.Dispose();
+        }
+
+        var cancellation = new CancellationTokenSource();
+        _cancellation = cancellation;
+
+        // Captured after any previous flash has been cancelled and had its colour restored above.
+        // Capturing while the button is still mid-pulse would record the attention colour as the
+        // "normal" one, leaving both halves of the loop the same colour and the flash looking stuck.
+        var originalBrush = button.Background;
+        var flashBrush = new SolidColorBrush(flashColor);
+
+        EventHandler<RoutedEventArgs>? clickHandler = null;
+        clickHandler = (_, _) => SafeAsyncHelper.Execute(async () =>
+        {
+            await cancellation.CancelAsync();
+            button.Click -= clickHandler;
+        });
+        if (stopAfterClick)
+            button.Click += clickHandler;
+
+        try
+        {
+            while (!cancellation.Token.IsCancellationRequested)
+            {
+                button.Background = flashBrush;
+                await Task.Delay(FlashOnDuration, cancellation.Token);
+
+                button.Background = originalBrush;
+                await Task.Delay(FlashOffDuration, cancellation.Token);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            button.Background = originalBrush;
+        }
+        finally
+        {
+            button.Click -= clickHandler;
+            cancellation.Dispose();
+
+            // Only clear the field if it is still ours: a newer Start may already have replaced it.
+            if (ReferenceEquals(_cancellation, cancellation))
+                _cancellation = null;
+        }
+    }
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/ViewModels/Apple2MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/ViewModels/Apple2MenuViewModel.cs
@@ -280,6 +280,31 @@ public class Apple2MenuViewModel : ViewModelBase, ISystemMenuContributor
     public bool IsApple2ConfigEnabled => _hostApp.EmulatorState == EmulatorState.Uninitialized;
 
     /// <summary>
+    /// Whether the Apple II configuration is currently unusable — in practice, on a machine where
+    /// the ROM files have not been supplied yet, which is what a first run after installing looks
+    /// like. The View uses this to expand the Configuration section and draw attention to the
+    /// config button, so the one thing standing between the user and a working emulator is not
+    /// hidden behind a collapsed section.
+    /// </summary>
+    public bool HasConfigValidationErrors
+        => Apple2HostConfig != null && !Apple2HostConfig.IsValid(out _);
+
+    private Apple2HostConfig? Apple2HostConfig => _hostApp.CurrentHostSystemConfig as Apple2HostConfig;
+
+    /// <summary>
+    /// Called by the View when the configuration is invalid: expands Config (which collapses the
+    /// other sections, per the accordion).
+    /// </summary>
+    public void ExpandConfigSectionOnValidationError()
+        => _sections.SetExpanded(Apple2MenuSection.Config, true);
+
+    /// <summary>
+    /// Re-evaluates every binding on this view model. Used after the configuration dialog closes,
+    /// when settings the menu reflects may have changed wholesale.
+    /// </summary>
+    public void RefreshAllBindings() => this.RaisePropertyChanged(string.Empty);
+
+    /// <summary>
     /// The running machine's input handler, or null when nothing is running.
     /// </summary>
     private Apple2InputHandler? RunningInputHandler

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/Views/Apple2MenuView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/Views/Apple2MenuView.axaml
@@ -314,7 +314,16 @@
                         AutomationProperties.Name="Open Apple II configuration"
                         Classes="small"
                         IsEnabled="{Binding IsApple2ConfigEnabled}"
-                        Click="OpenApple2Config_Click"/>
+                        Click="OpenApple2Config_Click">
+                    <!-- Fades the attention pulse the view drives while the config is invalid
+                         (missing ROMs). Duration matches ButtonFlashController.FlashOnDuration, so
+                         the colour is never yanked back mid-fade. -->
+                    <Button.Transitions>
+                        <Transitions>
+                            <BrushTransition Property="Background" Duration="0:0:0.7"/>
+                        </Transitions>
+                    </Button.Transitions>
+                </Button>
 
                 <TextBlock Text="ROM files, monitor colour, render provider and CPU compatibility. Only editable while the emulator is stopped."
                            Classes="small secondary-text"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/Views/Apple2MenuView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/Views/Apple2MenuView.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
+using Avalonia.Media;
 using Avalonia.Platform.Storage;
 using Highbyte.DotNet6502.App.Avalonia.Core;
 using Highbyte.DotNet6502.App.Avalonia.Core.Services;
@@ -32,11 +33,66 @@ public partial class Apple2MenuView : UserControl
 
         // Keep clipboard-event subscriptions in sync with the current DataContext.
         this.DataContextChanged += (s, e) => UpdateViewModelSubscriptions(ViewModel);
-        this.AttachedToVisualTree += (s, e) => UpdateViewModelSubscriptions(ViewModel);
+
+        // NOTE: the config-attention check is deliberately NOT run from DataContextChanged.
+        // That fires before the view is in the visual tree, and AttachedToVisualTree always
+        // follows shortly after in the plugin architecture — so a second flash would capture the
+        // button's background while it is already orange, making both halves of the pulse the same
+        // colour and the animation look stuck. AttachedToVisualTree is the single reliable trigger.
+        this.AttachedToVisualTree += (s, e) =>
+        {
+            UpdateViewModelSubscriptions(ViewModel);
+            if (ViewModel != null)
+                UpdateSectionStatesIfNeeded();
+        };
+
+        // In the plugin architecture the ContentControl (not this view) carries the IsVisible
+        // binding, so this rarely fires; kept for the case where it does, since it is the same
+        // "the user is now looking at this menu" moment.
+        this.PropertyChanged += (s, e) =>
+        {
+            if (e.Property == IsVisibleProperty && this.IsVisible && ViewModel != null)
+                UpdateSectionStatesIfNeeded();
+        };
+
         this.DetachedFromVisualTree += (s, e) => UpdateViewModelSubscriptions(null);
     }
 
     private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    /// <summary>
+    /// Points the user at the configuration when it is unusable — the normal state of a fresh
+    /// install, where the ROM files have not been supplied yet. Expands the Configuration section
+    /// and pulses the config button until either the config becomes valid or the button is clicked.
+    /// </summary>
+    private void UpdateSectionStatesIfNeeded()
+    {
+        try
+        {
+            if (ViewModel == null)
+                return;
+
+            if (ViewModel.HasConfigValidationErrors)
+            {
+                ViewModel.ExpandConfigSectionOnValidationError();
+
+                var configButton = this.FindControl<Button>("OpenApple2ConfigButton");
+                if (configButton != null)
+                    _configButtonFlash.Start(configButton, Colors.DarkOrange, stopAfterClick: true);
+            }
+            else
+            {
+                // Valid (or just became valid) — stop any ongoing flash.
+                _configButtonFlash.Cancel();
+            }
+        }
+        catch (Exception ex)
+        {
+            // During Browser startup the host system config may not be resolved yet; the next
+            // trigger will catch it, so a failure here must not take the menu down with it.
+            Logger.LogDebug(ex, "Skipping Apple II config attention update; state not ready yet.");
+        }
+    }
 
     private void UpdateViewModelSubscriptions(Apple2MenuViewModel? newViewModel)
     {
@@ -279,7 +335,15 @@ public partial class Apple2MenuView : UserControl
         }
 
         if (result == true)
+        {
+            // Re-validate so HasConfigValidationErrors and the Config Status tab both reflect what
+            // was just saved, then refresh the menu and re-run the attention check — which stops the
+            // flash if the ROMs are now in place, or keeps it going (restarting from a clean
+            // original-brush capture) if they are still missing.
             await ViewModel!.HostApp.ValidateConfigAsync();
+            ViewModel.RefreshAllBindings();
+            UpdateSectionStatesIfNeeded();
+        }
     }
 
     private async Task Apple2ConfigUserControlOverlayAsync()
@@ -306,11 +370,19 @@ public partial class Apple2MenuView : UserControl
         try
         {
             if (await taskCompletionSource.Task)
+            {
                 await ViewModel!.HostApp.ValidateConfigAsync();
+                ViewModel.RefreshAllBindings();
+                UpdateSectionStatesIfNeeded();
+            }
         }
         finally
         {
             mainGrid.Children.Remove(overlayPanel);
         }
     }
+
+    // Pulses the config button while the Apple II configuration is invalid. Shared with the other
+    // system shells so the race handling around restarting a flash lives in one place.
+    private readonly ButtonFlashController _configButtonFlash = new();
 }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Commodore64/Views/C64MenuView.axaml.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -206,12 +205,12 @@ public partial class C64MenuView : UserControl
 
                 var c64ConfigButton = this.FindControl<Button>("C64Config");
                 if (c64ConfigButton != null)
-                    StartButtonFlash(c64ConfigButton, Colors.DarkOrange, stopAfterClick: true);
+                    _configButtonFlash.Start(c64ConfigButton, Colors.DarkOrange, stopAfterClick: true);
             }
             else
             {
                 // Config is valid (or has just become valid) — stop any ongoing flash.
-                CancelButtonFlash();
+                _configButtonFlash.Cancel();
             }
         }
         catch (Exception ex)
@@ -221,81 +220,6 @@ public partial class C64MenuView : UserControl
             System.Diagnostics.Debug.WriteLine($"UpdateSectionStatesIfNeeded: Skipping update due to uninitialized state - {ex.Message}");
         }
     }
-
-    /// <summary>
-    /// Cancels any ongoing button flash animation without starting a new one.
-    /// CancellationTokenSource.Dispose() is safe to call multiple times, so even if
-    /// StartButtonFlash's finally block also disposes it, there is no harm.
-    /// </summary>
-    private void CancelButtonFlash()
-    {
-        var cts = _buttonFlashCancellation;
-        if (cts == null) return;
-        _buttonFlashCancellation = null;
-        SafeAsyncHelper.Execute(async () =>
-        {
-            await cts.CancelAsync();
-            cts.Dispose(); // safe; StartButtonFlash's catch/finally may also dispose it
-        });
-    }
-
-    private void StartButtonFlash(Button button, Color flashColor, bool stopAfterClick)
-        => SafeAsyncHelper.Execute(async () =>
-        {
-            // Capture the field into a local before awaiting so the finally block's
-            // null-clear cannot cause a NullReferenceException on the Dispose() line
-            // if another concurrent call races through the finally while we're awaiting.
-            var existingCancellation = _buttonFlashCancellation;
-            if (existingCancellation != null)
-            {
-                _buttonFlashCancellation = null;
-                await existingCancellation.CancelAsync();
-                existingCancellation.Dispose();
-            }
-
-            var buttonFlashCancellation = new CancellationTokenSource();
-            _buttonFlashCancellation = buttonFlashCancellation;
-            var originalBrush = button.Background;
-            var flashBrush = new SolidColorBrush(flashColor);
-
-            EventHandler<RoutedEventArgs>? tempHandler = null;
-            tempHandler = (s, e) =>
-            {
-                SafeAsyncHelper.Execute(async () =>
-                {
-                    await buttonFlashCancellation.CancelAsync();
-                    button.Click -= tempHandler;
-                });
-            };
-            if (stopAfterClick)
-                button.Click += tempHandler;
-
-            try
-            {
-                while (!buttonFlashCancellation.Token.IsCancellationRequested)
-                {
-                    button.Background = flashBrush;
-                    await Task.Delay(700, buttonFlashCancellation.Token); // Match delay with flash duration to be at least as long as BrushTransition Duration (otherwise abrupt change may occur)
-
-                    button.Background = originalBrush;
-                    await Task.Delay(2000, buttonFlashCancellation.Token);
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                // Animation was cancelled, restore original background
-                button.Background = originalBrush;
-            }
-            finally
-            {
-                // Clean up the handler in case animation completed naturally
-                button.Click -= tempHandler;
-                buttonFlashCancellation.Dispose();
-
-                if (ReferenceEquals(_buttonFlashCancellation, buttonFlashCancellation))
-                    _buttonFlashCancellation = null;
-            }
-        });
 
     private void OpenC64Config_Click(object? sender, RoutedEventArgs e)
         => SafeAsyncHelper.Execute(async () =>
@@ -683,5 +607,7 @@ public partial class C64MenuView : UserControl
             }
         });
 
-    private CancellationTokenSource? _buttonFlashCancellation;
+    // Flashes the C64 Config button while the configuration is invalid. Shared with the other
+    // system shells so the race handling around restarting a flash lives in one place.
+    private readonly ButtonFlashController _configButtonFlash = new();
 }


### PR DESCRIPTION
On a machine where the Apple II ROM files have not been supplied yet — what a first run after installing looks like — the one thing standing between the user and a working emulator was hidden behind a collapsed sidebar section. The C64 menu already handled this; the Apple II menu did not.

The Apple II menu now behaves the same way: when the configuration is invalid it **expands its Configuration section** and **pulses the config button** dark orange, until the configuration becomes valid or the button is clicked.

## Changes

**Apple II**

- `Apple2MenuViewModel` gains `HasConfigValidationErrors`, `ExpandConfigSectionOnValidationError()` and `RefreshAllBindings()`, mirroring `C64MenuViewModel`.
- `Apple2MenuView` runs the check from `AttachedToVisualTree` — deliberately *not* `DataContextChanged`, which fires before the view is in the visual tree and would capture the button's background while it is already orange, making both halves of the pulse the same colour — and again after the config dialog closes, on both the desktop-window and browser-overlay paths.
- The config button gets a `BrushTransition`; without it the colour snaps instead of fading.

**Shared**

The flash loop moves out of `C64MenuView` into a new `ButtonFlashController` in `App.Avalonia.Core`, so the race handling around restarting a flash (capture the token source before awaiting; only clear the field if it is still the one this call created; capture the "normal" brush only after any previous flash has restored it) lives in one place instead of being copied per shell. `C64MenuView` now uses it and is otherwise unchanged. Future system shells get the behaviour by calling one method.

## Verification

Both ROM directories happened to be empty, so both systems could be checked in their genuinely-invalid state against the running desktop app. The pulse is a `Background` change and is not exposed through the accessibility tree, so it was measured by sampling the button's pixels across a series of screenshots:

- **Apple II** — Configuration section auto-expanded, Config status listing all three missing ROMs, button cycling between the normal `(48,58,75)` and orange, with intermediate values `85 → 96 → 107 → 112 → 120 → 129` showing the transition fading rather than snapping.
- **C64** — identical behaviour after the refactor: `(87,96,110)` ↔ `(241,159,70)` with the same fade steps. This is the regression check that matters, since the change touches working C64 code.
- **Click-to-stop** was confirmed manually by the repo owner; it is unchanged shared code that the C64 already shipped, and I could not drive a synthetic click (the app would not come frontmost under automation, and Avalonia's sidebar controls are absent from the macOS AX tree).

Build clean across 73 projects with no warnings; all 1,751 tests pass.

The automation doc gains a note that a Configuration section found already expanded is a signal about the config rather than leftover state from an earlier automation step, and that the pulse is only observable in a screenshot.