### PR TITLE
Enable Apple II audio by default

### DIFF
--- a/docs/systems/apple2/overview.md
+++ b/docs/systems/apple2/overview.md
@@ -74,8 +74,8 @@ there is no CIA/VIA equivalent to emulate and no keyboard matrix to scan.
   Reproducing it is therefore resampling rather than synthesis: the cone's level is averaged over
   each output sample, which is what makes pulse-width modulation (how the Apple II fakes
   intermediate levels, and plays sampled audio at all) come out as sound rather than aliasing
-  noise. A DC blocker removes the offset of a cone left parked on one side. Off by default;
-  enable it in the configuration dialog.
+  noise. A DC blocker removes the offset of a cone left parked on one side. On by default, as on
+  the C64; turn it off in the configuration dialog.
 - Selectable monitor: a composite colour monitor (the default) or a green, white or amber
   phosphor monitor. The choice applies to every mode, not just hi-res: text is monochrome either
   way (a colour monitor renders it white), and lo-res is full colour on a colour monitor and

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2SystemConfig.cs
@@ -113,10 +113,16 @@ public partial class Apple2SystemConfig : ISystemConfig, ISnapshotableConfig
     }
 
     /// <summary>
-    /// Off by default. The speaker is faithful but shrill — it is a small cone driven by a square
-    /// wave — so it is the user's choice to switch on rather than something sprung on them.
+    /// On by default, as the C64's is (<c>C64SystemConfig</c> sets the same default in its
+    /// constructor). A machine that boots silently reads as a machine whose sound is not
+    /// implemented, and the speaker is part of how an Apple II sounds — the boot beep included.
+    /// Turn it off in the configuration dialog.
+    ///
+    /// <para>The default has to live here rather than in a host's <c>appsettings.json</c>, because
+    /// the Browser app builds its configuration from browser local storage alone and never reads
+    /// an appsettings file — so on a first visit only this default applies.</para>
     /// </summary>
-    public bool AudioEnabled { get; set; } = false;
+    public bool AudioEnabled { get; set; } = true;
 
     private Apple2MonitorColor _monitorColor = Apple2MonitorColor.Color;
     public Apple2MonitorColor MonitorColor

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2SystemConfigSnapshot.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2SystemConfigSnapshot.cs
@@ -48,7 +48,7 @@ internal sealed class Apple2SystemSnapshotSettings
 {
     /// <summary>Defaults mirror <see cref="Apple2SystemConfig"/>'s own, so a payload that omits a
     /// field leaves the setting where a fresh config would put it.</summary>
-    public bool AudioEnabled { get; set; }
+    public bool AudioEnabled { get; set; } = true;
 
     public bool KeyboardJoystickEnabled { get; set; }
 

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2SystemConfigTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2SystemConfigTests.cs
@@ -29,12 +29,13 @@ public class Apple2SystemConfigTests
     }
 
     [Fact]
-    public void Audio_Offers_Only_The_Speaker_Sample_Path_And_Is_Off_By_Default()
+    public void Audio_Offers_Only_The_Speaker_Sample_Path_And_Is_On_By_Default()
     {
         var config = new Apple2SystemConfig();
 
-        // Off by default: the speaker is faithful but shrill, so switching it on is the user's call.
-        Assert.False(config.AudioEnabled);
+        // On by default, matching the C64. This default is the only one the Browser app sees, since
+        // it builds its configuration from local storage and never reads an appsettings file.
+        Assert.True(config.AudioEnabled);
 
         // One provider only. There is no register set describing notes or voices for a
         // synth-command stream to work from — the machine's whole output is a one-bit cone

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/Apple2SystemConfigSnapshotTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/Apple2SystemConfigSnapshotTests.cs
@@ -9,9 +9,13 @@ public class Apple2SystemConfigSnapshotTests
     [Fact]
     public void Portable_settings_round_trip_through_export_and_apply()
     {
+        // Every value is the opposite of what a fresh config starts with, so a field the payload
+        // silently dropped would leave the target on its default and fail the assertions below.
+        // Note AudioEnabled is captured as false: it defaults to true, so capturing true here would
+        // pass whether or not the field actually travelled.
         var source = new Apple2SystemConfig
         {
-            AudioEnabled = true,
+            AudioEnabled = false,
             KeyboardJoystickEnabled = true,
             MonitorColor = Apple2MonitorColor.Green,
         };
@@ -20,14 +24,13 @@ public class Apple2SystemConfigSnapshotTests
         Assert.False(string.IsNullOrEmpty(json));
 
         var target = new Apple2SystemConfig();
-        // Start the target on the opposite of every captured value, so an ignored field fails.
-        Assert.False(target.AudioEnabled);
+        Assert.True(target.AudioEnabled);
         Assert.False(target.KeyboardJoystickEnabled);
         Assert.Equal(Apple2MonitorColor.Color, target.MonitorColor);
 
         ((ISnapshotableConfig)target).ApplySnapshotSettings(json!);
 
-        Assert.True(target.AudioEnabled);
+        Assert.False(target.AudioEnabled);
         Assert.True(target.KeyboardJoystickEnabled);
         Assert.Equal(Apple2MonitorColor.Green, target.MonitorColor);
     }
@@ -38,9 +41,10 @@ public class Apple2SystemConfigSnapshotTests
         var config = new Apple2SystemConfig();
 
         // A snapshot written by a newer build may carry settings this one has never heard of.
+        // Fields the payload omits fall back to the schema's defaults, which mirror a fresh config.
         ((ISnapshotableConfig)config).ApplySnapshotSettings("{\"somethingElse\":123}");
 
-        Assert.False(config.AudioEnabled);
+        Assert.True(config.AudioEnabled);
         Assert.Equal(Apple2MonitorColor.Color, config.MonitorColor);
     }
 }


### PR DESCRIPTION
A fresh installation had Apple II sound switched off, so the machine booted silent — which reads as sound not being implemented rather than as a setting waiting to be found. The C64 has had it on by default all along.

## The default belongs in code, not appsettings

`Apple2SystemConfig.AudioEnabled` now defaults to `true`, matching how `C64SystemConfig` sets `_audioEnabled = true` in its constructor.

It has to live there rather than in a host's `appsettings.json`, because the **Browser app builds its configuration from browser local storage alone** and never reads an appsettings file — so on a first visit only the code default applies. That is exactly why the C64 has sound in the browser today, verified by clearing local storage on a Browser build.

`Apple2SystemSnapshotSettings` gets the same default, keeping the promise stated in its own comment that the schema's defaults mirror a fresh config. That value is what applies when an older snapshot omits the field.

## The rest of the audio pipeline needs no configuration

Checked, because a bare flag was not sufficient once before — the speaker feature originally shipped completely silent:

- **Provider**: `Apple2.AddAudioProviders` falls back to `Apple2SpeakerSampleProvider` when `AudioProviderType` is null, covered by `Apple2AudioWiringTests.The_Only_Provider_Is_Selected_When_The_Config_Names_None`.
- **Target**: `AudioTargetProvider.CreateAudioTargetByAudioProviderType` picks the first compatible target when none is configured — the same path the C64 relies on.
- `Apple2HostConfig.AudioSupported` is already `true`.

## One test needed inverting, not flipping

`Portable_settings_round_trip_through_export_and_apply` captured `AudioEnabled = true` and asserted `true` after applying. With the new default that assertion would pass whether or not the field actually travelled — a test that cannot fail. It now captures `false`, so a dropped field leaves the target on its default and fails.

The other two affected assertions simply pinned the old default.

## Verification

Build clean across 73 projects with no warnings; all 1,771 tests pass with none skipped (run with the Apple II ROMs and a DOS 3.3 boot image present, so the opt-in integration tests actually executed).

Not verified live: that a genuinely fresh install now makes sound. Existing user settings on the dev machine already carry `AudioEnabled: true` with an explicit provider and target, so the app would show a ticked box regardless and prove nothing about the default. Clearing browser local storage on a Browser build is the one-step check.