### PR TITLE
Add Apple II language card, so ProDOS software runs

### DIFF
--- a/docs/host-apps/avalonia/automation.md
+++ b/docs/host-apps/avalonia/automation.md
@@ -113,6 +113,9 @@ A non-exhaustive list of the most useful AutomationIds, grouped by view. All of 
   `RomFileTextBox.disk2` (optional Disk II boot ROM)
 - **ROM actions**: `RomStatusSummaryText`, `RomDirectoryTextBox`, `LoadRomsButton`,
   `DownloadRomsToFilesButton`, `DownloadRomsToMemoryButton`, `ClearRomsButton`
+- **Memory**: `LanguageCardEnableCheckBox` — fits the 16 KB language card (64 KB total). On by
+  default; unchecking it gives a stock 48 KB machine, which cannot run ProDOS software. Read at
+  build time, so it takes effect on the next start rather than live.
 - **Display**: `MonitorColorComboBox`, `RenderProviderComboBox`, `RenderTargetComboBox`
 - **Audio**: `AudioEnableCheckBox`, `AudioProviderComboBox`, `AudioTargetComboBox`. Audio needs
   *both* a provider and a target selected; a provider alone leaves the host building no audio

--- a/docs/systems/apple2/disk2.md
+++ b/docs/systems/apple2/disk2.md
@@ -83,20 +83,25 @@ swept (20/5, 16/16, 12/12, 10/10, 9/9) with no effect, confirming the cause is t
 rather than the track layout. Removing the wait needs a cycle-accurate read path — the natural
 companion to sequencer-PROM (LSS) emulation, if copy-protected media is ever supported.
 
+## Sector order
+
+Both **DOS 3.3-ordered** and **ProDOS-ordered** 140 KB images are supported, and the order is
+detected from the image's contents rather than its file name — a ProDOS volume directory header
+where a ProDOS-ordered file would keep it. File names cannot be trusted: the archive.org copy of
+"Dangerous Dave in the Deserted Pirate's Hideout" is named `.dsk` and is ProDOS-ordered. Nibblizing
+with the wrong order yields plausible garbage rather than an error, which presents as a drive fault
+instead of a misread image.
+
+ProDOS *software* runs too, now that the machine has the 64 KB ProDOS 8 requires — see
+[Language card](overview.md#language-card).
+
 ## Not supported
 
 - Writing. The drive reports write-protected, so saving, formatting and copying will fail.
 - A second drive; only drive 1 exists.
-- ProDOS-ordered `.po` images, and nibble/flux `.nib`/`.woz` images.
+- Nibble/flux `.nib`/`.woz` images.
 - Copy protection that depends on bit-level sequencer behaviour or exact rotational timing. Use a
   cracked release of such titles.
-- ProDOS *software*, whatever the image's sector order — but for a reason outside the drive.
-  ProDOS 8 needs 64 KB and the emulated machine is a 48 KB II Plus with no language card, so a
-  ProDOS disk boots only as far as ProDOS's own `RELOCATION / CONFIGURATION ERROR`. This is a
-  limit of the emulated machine, not of the II Plus: ProDOS 8 1.x supports the II and II Plus, on
-  a 64 KB one. Supporting these titles means emulating the language card (`$C080`–`$C08F`), not
-  changing anything here.
-
 ## Verified
 
 The sidebar's **Download & Run programs** list also uses the drive: entries marked as
@@ -120,10 +125,14 @@ Live-verified in the Avalonia desktop host:
   booted rather than injected because VisiCalc's `/S` and `/L` file commands call DOS, so DOS has
   to be resident.
 
-Verified *not* to work, and why it is worth recording: **Dangerous Dave** (Softdisk) is a ProDOS
-title, so it stops at the 64 KB requirement above — the 1988 disk carries `PRODOS 8 V1.4` and the
-1991 one `PRODOS 8 V1.9`. The 1988 disk is also ProDOS *block*-ordered, so it does not even get
-that far; it hangs at track 0 with the motor running.
+- **Dangerous Dave in the Deserted Pirate's Hideout** (Softdisk, 1988) boots through ProDOS 8 and
+  plays. It exercises the whole ProDOS path: the language card's 64 KB, and ProDOS sector order (its
+  archive.org copy is named `.dsk` but is ProDOS-ordered).
+
+Verified *not* to work, and why it is worth recording: the **1991 re-release** of Dangerous Dave is
+built for a **65C02**. It executes `$9C` (`STZ abs`), which this NMOS 6502 does not implement, so the
+instruction stream desynchronises and the CPU eventually lands on `$B2` — JAM on an NMOS part. Same
+game, different build, different CPU requirement; only the 1988 original targets a II Plus.
 
 Automated coverage lives in `Disk2NibbleCodecTests`, `Disk2TrackNibblizerTests` and
 `Disk2ControllerTests`, plus opt-in integration tests (`Apple2RealRomDisk2BootTests`) that boot a

--- a/docs/systems/apple2/overview.md
+++ b/docs/systems/apple2/overview.md
@@ -17,9 +17,9 @@ there is no CIA/VIA equivalent to emulate and no keyboard matrix to scan.
 ## Current capabilities
 
 - Boot to the Applesoft BASIC `]` prompt from a user-supplied Apple II Plus ROM.
-- 48 KB flat RAM at `$0000`–`$BFFF`, plus a **16 KB language card** overlaying the ROM space —
-  64 KB in total, which is the standard Apple II Plus configuration from about 1982 and what
-  ProDOS 8 requires. See [Language card](#language-card).
+- 48 KB flat RAM at `$0000`–`$BFFF`, plus an optional **16 KB language card** overlaying the ROM
+  space — 64 KB in total, which is what ProDOS 8 requires. Fitted by default, and switchable off in
+  the configuration dialog to emulate a plain 48 KB machine. See [Language card](#language-card).
 - 12 KB system ROM (Applesoft BASIC + Autostart Monitor) at `$D000`–`$FFFF`.
     - Accepts both a trimmed 12 KB image and the 20 KB `$B000`–`$FFFF` layout that older
       emulator distributions use (the loadable part is the last 12 KB).
@@ -145,9 +145,16 @@ there is no CIA/VIA equivalent to emulate and no keyboard matrix to scan.
 ## Language card
 
 16 KB of RAM overlaying the ROM space at `$D000`–`$FFFF`, switched by the soft switches at
-`$C080`–`$C08F`. It is always fitted, and at power-on it is invisible: reads come from ROM and
-writes are protected, so software that never touches `$C08x` sees exactly the 48 KB machine it did
-before.
+`$C080`–`$C08F`. At power-on it is invisible: reads come from ROM and writes are protected, so
+software that never touches `$C08x` sees exactly the 48 KB machine it would without one.
+
+On real hardware this was an **expansion card**, normally in slot 0 — not part of a stock Apple II
+Plus, whose motherboard held at most 48 KB. It arrived around 1980 with the Apple Pascal system and
+became a common upgrade because so much later software wanted 64 KB; the IIe folded the equivalent
+into the motherboard in 1983, using these same soft switches. Here it is **fitted by default** but
+can be switched off in the configuration dialog, which gives a genuine 48 KB machine — and that is a
+visible difference, not a cosmetic one: the DOS 3.3 System Master loads Integer BASIC into the card
+when it finds one, and skips that step when it does not.
 
 16 KB covers a 12 KB address range because `$D000`–`$DFFF` has **two** independently selected 4 KB
 banks, while `$E000`–`$FFFF` is a single 8 KB block.

--- a/docs/systems/apple2/overview.md
+++ b/docs/systems/apple2/overview.md
@@ -17,7 +17,9 @@ there is no CIA/VIA equivalent to emulate and no keyboard matrix to scan.
 ## Current capabilities
 
 - Boot to the Applesoft BASIC `]` prompt from a user-supplied Apple II Plus ROM.
-- 48 KB flat RAM at `$0000`–`$BFFF`, no bank switching.
+- 48 KB flat RAM at `$0000`–`$BFFF`, plus a **16 KB language card** overlaying the ROM space —
+  64 KB in total, which is the standard Apple II Plus configuration from about 1982 and what
+  ProDOS 8 requires. See [Language card](#language-card).
 - 12 KB system ROM (Applesoft BASIC + Autostart Monitor) at `$D000`–`$FFFF`.
     - Accepts both a trimmed 12 KB image and the 20 KB `$B000`–`$FFFF` layout that older
       emulator distributions use (the loadable part is the last 12 KB).
@@ -27,11 +29,13 @@ there is no CIA/VIA equivalent to emulate and no keyboard matrix to scan.
     - `$C050`–`$C057` display-mode switches (text/graphics, mixed, page 1/2, lo-res/hi-res),
       honored by the rasterizer render path.
     - `$C030` speaker toggle, driving the one-bit cone (see Speaker audio below).
+    - `$C080`–`$C08F` language card bank switching (see [Language card](#language-card)).
 - Empty peripheral slots at `$C100`–`$CFFF` read as `$FF`, which makes the Autostart ROM's disk
   scan fail cleanly so it falls through to BASIC. Slot 6 answers instead when the Disk II
   controller is active (see below).
-- Disk II controller card in slot 6, read-only: boots and runs standard 16-sector DOS 3.3
-  disk images (`.dsk`/`.do`). See [Disk II](disk2.md).
+- Disk II controller card in slot 6, read-only: boots and runs standard 16-sector disk images in
+  either DOS 3.3 or ProDOS sector order, detected from the image's contents. ProDOS software runs
+  too, given the language card's 64 KB. See [Disk II](disk2.md).
 - 40 &times; 24 text display in the hardware's 7&times;8 character cell (280&times;192 pixels),
   page 1 (`$0400`–`$07FF`) or page 2 (`$0800`–`$0BFF`).
     - Interleaved row addressing: `address = base + (row % 8) * $80 + (row / 8) * $28`.
@@ -138,6 +142,37 @@ there is no CIA/VIA equivalent to emulate and no keyboard matrix to scan.
 - Emulator state snapshots — save and restore the whole machine, disk included. See
   [Snapshots](#snapshots).
 
+## Language card
+
+16 KB of RAM overlaying the ROM space at `$D000`–`$FFFF`, switched by the soft switches at
+`$C080`–`$C08F`. It is always fitted, and at power-on it is invisible: reads come from ROM and
+writes are protected, so software that never touches `$C08x` sees exactly the 48 KB machine it did
+before.
+
+16 KB covers a 12 KB address range because `$D000`–`$DFFF` has **two** independently selected 4 KB
+banks, while `$E000`–`$FFFF` is a single 8 KB block.
+
+| Address | Reads from | Writes |
+|---|---|---|
+| `$C080` / `$C084` | card | protected |
+| `$C081` / `$C085` | ROM | to card, after two accesses |
+| `$C082` / `$C086` | ROM | protected |
+| `$C083` / `$C087` | card | to card, after two accesses |
+| `$C088`–`$C08F` | as above, but bank 1 instead of bank 2 | |
+
+Enabling writes takes **two consecutive accesses** to an odd address, and only a *read* arms the
+first of them — a hardware guard so that one stray access cannot silently unlock RAM under the ROM.
+The emulation models this, because software relies on it: reading the switch twice is the standard
+idiom for filling the card while still executing from ROM.
+
+**What it unlocks.** ProDOS 8 needs 64 KB. Without the card a ProDOS disk boots only as far as
+ProDOS's own memory check and stops with `RELOCATION/  CONFIGURATION ERROR`; with it, ProDOS
+relocates itself into the card and runs from there. DOS 3.3 notices the card too — the System Master
+loads Integer BASIC into it during boot, which it skips on a 48 KB machine.
+
+A reset returns the switches to their power-on state (ROM visible, writes protected, bank 2) so the
+CPU reads its reset vector from ROM, but leaves the card's contents alone, as the hardware does.
+
 ## Snapshots
 
 The Apple II supports the shared `.d6502snap` emulator-state snapshots, so the same save/load
@@ -149,6 +184,7 @@ Two machine modules make up an Apple II snapshot, alongside the shared `cpu-6502
 | Module | What it holds |
 |---|---|
 | `apple2-core` | The 48 KB RAM, the keyboard latch (strobe included), the four display soft switches, the speaker's cone position, and the game port's paddle positions, buttons and one-shot |
+| `apple2-languagecard` | The card's 16 KB and its switch state — without it a restored ProDOS session would come back with its operating system replaced by zeros |
 | `apple2-disk2` | Head half-track, motor, drive select, the Q6/Q7 latches, the read head's position in the current track — plus the inserted `.dsk` image, embedded in the package |
 
 One module rather than one per chip, because the machine has no chips to divide along: the
@@ -191,11 +227,10 @@ For general monitor commands, see [Monitor library](../../libraries/core/dotnet6
 - NTSC-accurate hi-res colour. The six artifact colours are modelled, but the underlying
   half-dot shift is not: bit 7 selects a colour rather than moving the dots half a pixel, so
   colour fringing at black/white boundaries does not appear.
-- Disk II writing (the drive is always write-protected), a second drive, ProDOS-ordered `.po`
-  images, and nibble/flux (`.nib`/`.woz`) media. See [Disk II](disk2.md) for what is supported.
+- Disk II writing (the drive is always write-protected), a second drive, and nibble/flux
+  (`.nib`/`.woz`) media. See [Disk II](disk2.md) for what is supported.
 - Sound cards (Mockingboard and friends). The built-in speaker is emulated; expansion audio is not.
 - Peripheral slots other than slot 6, cassette, the second paddle pair (2 and 3), light pen.
-- The language card / 16 KB RAM expansion.
 - The original, non-Autostart Apple II with Integer BASIC. That is a different ROM set rather
   than different hardware, so it is a plausible later configuration variant.
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/ViewModels/Apple2ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/ViewModels/Apple2ConfigDialogViewModel.cs
@@ -323,6 +323,22 @@ public class Apple2ConfigDialogViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// Whether the 16 KB language card is fitted, taking the machine to 64 KB. Off gives a stock
+    /// 48 KB Apple II Plus, which cannot run ProDOS software.
+    /// </summary>
+    public bool LanguageCardEnabled
+    {
+        get => _workingConfig.SystemConfig.LanguageCardEnabled;
+        set
+        {
+            if (_workingConfig.SystemConfig.LanguageCardEnabled == value)
+                return;
+            _workingConfig.SystemConfig.LanguageCardEnabled = value;
+            this.RaisePropertyChanged();
+        }
+    }
+
     public string SelectedRenderTargetHelpText => SelectedRenderTarget?.HelpText ?? string.Empty;
 
     public CpuCompatibilityProfileOption? SelectedCpuCompatibilityProfile
@@ -569,6 +585,7 @@ public class Apple2ConfigDialogViewModel : ViewModelBase
             _originalConfig.SystemConfig.KeyboardJoystickEnabled = _workingConfig.SystemConfig.KeyboardJoystickEnabled;
             _originalConfig.InputConfig.KeyboardLayout = _workingConfig.InputConfig.KeyboardLayout;
             _originalConfig.SystemConfig.AudioEnabled = _workingConfig.SystemConfig.AudioEnabled;
+            _originalConfig.SystemConfig.LanguageCardEnabled = _workingConfig.SystemConfig.LanguageCardEnabled;
             _originalConfig.SystemConfig.SetAudioProviderType(_workingConfig.SystemConfig.AudioProviderType);
             _originalConfig.SystemConfig.SetAudioTargetType(_workingConfig.SystemConfig.AudioTargetType);
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/ViewModels/Apple2MenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/ViewModels/Apple2MenuViewModel.cs
@@ -95,6 +95,15 @@ public class Apple2MenuViewModel : ViewModelBase, ISystemMenuContributor
             zipEntryName: "Bolo (4am crack)/Bolo (4am crack).dsk",
             runMode: Apple2DownloadRunMode.BootDisk) },
 
+        // The first ProDOS title in the list: it boots ProDOS 8 into the language card, and its
+        // image is ProDOS-ordered despite the .dsk name (the drive detects the order from the
+        // contents). Keyboard joystick stays off — the game reads the keyboard directly and never
+        // touches the game port, so switching it on would only steal keys from it.
+        { "dangerousdave", new Apple2DownloadProgramInfo(
+            "Dangerous Dave",
+            "https://archive.org/download/a2_asimov_dangerous_dave/dangerous_dave.dsk",
+            runMode: Apple2DownloadRunMode.BootDisk) },
+
         // The one non-game, and the only entry not on the asimov mirror — that mirror has no
         // VisiCalc image. Booted rather than injected: the binary is a plain catalog file, but
         // VisiCalc's /S and /L commands call DOS, so DOS has to be resident. Booting lands on the

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/Views/Apple2ConfigDialogView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/Views/Apple2ConfigDialogView.axaml
@@ -163,6 +163,26 @@
             </Border>
         </StackPanel>
 
+        <!-- Memory Section -->
+        <StackPanel Width="368" Classes="wrap-item">
+            <Border Classes="content-section">
+                <StackPanel Classes="spacing-tight">
+                <TextBlock Text="Memory"
+                            Classes=""/>
+
+                <CheckBox AutomationProperties.AutomationId="LanguageCardEnableCheckBox"
+                        AutomationProperties.Name="Fit the 16 KB language card"
+                        Content="Language card (64 KB)"
+                        IsChecked="{Binding LanguageCardEnabled}"/>
+
+                <TextBlock Text="Adds 16 KB over the machine's 48 KB, which is what ProDOS 8 needs — without it ProDOS software stops at its own memory check. On real hardware this was an expansion card rather than part of a stock II Plus, so switching it off gives a genuine 48 KB machine."
+                           Classes="small secondary-text"
+                           TextWrapping="Wrap"/>
+
+                </StackPanel>
+            </Border>
+        </StackPanel>
+
         <!-- Render Section -->
         <StackPanel Width="368" Classes="wrap-item">
             <Border Classes="content-section">

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Apple2.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Apple2.cs
@@ -84,6 +84,13 @@ public class Apple2 : ISystem, ITextMode, IScreen, ISystemState, ISystemMonitor,
     public const ushort SystemRomStartAddress = 0xD000;
     public const int SystemRomSize = 0x3000;
 
+    /// <summary>
+    /// Start of the part of the ROM space the language card covers with a single 8 KB block
+    /// ($E000-$FFFF). Below it, $D000-$DFFF is served by whichever of the card's two 4 KB banks is
+    /// selected — see <see cref="Apple2LanguageCard"/>.
+    /// </summary>
+    public const ushort UpperMemoryStartAddress = 0xE000;
+
     private readonly byte[] _ram = new byte[RamSize];
 
     /// <summary>
@@ -105,6 +112,12 @@ public class Apple2 : ISystem, ITextMode, IScreen, ISystemState, ISystemMonitor,
 
     /// <summary>The one-bit speaker. See <see cref="Apple2Speaker"/>.</summary>
     public Apple2Speaker Speaker { get; }
+
+    /// <summary>
+    /// The 16 KB language card, which takes the machine to the 64 KB ProDOS needs. See
+    /// <see cref="Apple2LanguageCard"/>.
+    /// </summary>
+    public Apple2LanguageCard LanguageCard { get; }
 
     /// <summary>Types text into the machine by feeding the keyboard latch, one char per frame.</summary>
     public Apple2TextPaste TextPaste { get; }
@@ -152,15 +165,23 @@ public class Apple2 : ISystem, ITextMode, IScreen, ISystemState, ISystemMonitor,
         DiskController = new Disk2Controller(() => CPU.ExecState.CyclesConsumed);
         GamePort = new Apple2GamePort(() => CPU.ExecState.CyclesConsumed);
         Speaker = new Apple2Speaker(() => CPU.ExecState.CyclesConsumed);
-        SoftSwitches = new Apple2SoftSwitches(Keyboard, DiskController, GamePort, Speaker);
+        LanguageCard = new Apple2LanguageCard();
+        SoftSwitches = new Apple2SoftSwitches(Keyboard, DiskController, GamePort, Speaker, LanguageCard);
         TextPaste = new Apple2TextPaste(this, loggerFactory);
         BasicTokenParser = new Apple2BasicTokenParser(this, loggerFactory);
         InputInjector = new Apple2InputInjector(this);
 
-        Mem = CreateMemory();
+        // ROM images are extracted before the memory map is built, because the map's ROM-reading
+        // configurations need the image in hand — unlike the pre-language-card layout, where a
+        // single ROM mapping could be applied afterwards.
+        var systemRom = LoadRoms(romData);
+        _hasSystemRom = systemRom != null;
+
+        Mem = CreateMemory(systemRom);
         DefaultExecOptions = new ExecOptions();
 
-        _hasSystemRom = romData != null && MapROMs(romData);
+        // A switch access swaps the whole memory map in one assignment.
+        LanguageCard.MemoryConfigurationChanged += Mem.SetMemoryConfiguration;
 
         // Only reset through the ROM's reset vector when a ROM is actually present; without one
         // $FFFC/$FFFD read as the unconnected value and the CPU would start executing garbage.
@@ -216,37 +237,111 @@ public class Apple2 : ISystem, ITextMode, IScreen, ISystemState, ISystemMonitor,
 
     public void SetCurrentRenderProviderType(Type? renderProviderType) => SetCurrentRenderProvider(renderProviderType);
 
-    private Memory CreateMemory()
+    /// <summary>
+    /// Builds the address space, once per language-card memory configuration.
+    ///
+    /// <para>
+    /// $0000-$BFFF and the I/O page are identical in every configuration; only $D000-$FFFF differs,
+    /// by where reads come from (ROM or one of the card's banks) and whether writes land in the
+    /// card. Pre-building all eight means a bank switch is a configuration swap rather than a
+    /// re-map of 12 KB of handlers — which matters because software toggles banks in tight loops.
+    /// </para>
+    /// </summary>
+    private Memory CreateMemory(byte[]? systemRom)
     {
-        var mem = new Memory(mapToDefaultRAM: false);
+        var mem = new Memory(
+            numberOfConfigurations: Apple2LanguageCard.MemoryConfigurationCount,
+            mapToDefaultRAM: false);
 
-        // $0000-$BFFF: 48 KB RAM.
-        mem.MapRAM(RamStartAddress, _ram);
+        for (var configuration = 0; configuration < Apple2LanguageCard.MemoryConfigurationCount; configuration++)
+        {
+            mem.SetMemoryConfiguration(configuration);
 
-        // $C000-$C0FF soft switches, $C100-$CFFF empty peripheral slots.
-        SoftSwitches.MapIOLocations(mem);
+            // $0000-$BFFF: 48 KB RAM, the same array in every configuration.
+            mem.MapRAM(RamStartAddress, _ram);
 
-        // $D000-$FFFF: ROM socket. Default to "no device" so a ROM-less instance (unit tests,
-        // the no-op system in a host's system list) still has a fully mapped address space;
-        // MapROMs() replaces the readers when an image is supplied.
-        MapUnconnectedRange(mem, SystemRomStartAddress, SystemRomSize);
+            // $C000-$C0FF soft switches, $C100-$CFFF empty peripheral slots.
+            SoftSwitches.MapIOLocations(mem);
 
+            MapHighMemory(mem, configuration, systemRom);
+        }
+
+        mem.SetMemoryConfiguration(LanguageCard.MemoryConfiguration);
         return mem;
     }
 
-    private static void MapUnconnectedRange(Memory mem, ushort startAddress, int length)
+    /// <summary>
+    /// Maps $D000-$FFFF for one language-card configuration: reads from the card or from ROM, and
+    /// writes either into the card or nowhere.
+    /// </summary>
+    private void MapHighMemory(Memory mem, int configuration, byte[]? systemRom)
     {
-        for (var offset = 0; offset < length; offset++)
+        var readRam = (configuration & 4) != 0;
+        var bank1Selected = (configuration & 2) != 0;
+        var writeEnabled = (configuration & 1) != 0;
+
+        var cardRam = LanguageCard.Ram;
+        var bankOffset = bank1Selected ? Apple2LanguageCard.Bank1Offset : Apple2LanguageCard.Bank2Offset;
+
+        if (readRam)
         {
-            var address = (ushort)(startAddress + offset);
-            mem.MapReader(address, static _ => Apple2SoftSwitches.UnconnectedReadValue);
-            mem.MapWriter(address, static (_, _) => { });
+            // The banked 4 KB at $D000, then the shared 8 KB at $E000.
+            MapCardReaders(mem, SystemRomStartAddress, Apple2LanguageCard.BankSize, cardRam, bankOffset);
+            MapCardReaders(mem, UpperMemoryStartAddress, Apple2LanguageCard.UpperSize, cardRam, Apple2LanguageCard.UpperOffset);
+        }
+        else if (systemRom != null)
+        {
+            mem.MapROM(SystemRomStartAddress, systemRom);
+        }
+        else
+        {
+            // No ROM image: a ROM-less instance (unit tests, the placeholder system in a host's
+            // system list) still needs a fully mapped address space.
+            for (var offset = 0; offset < SystemRomSize; offset++)
+                mem.MapReader((ushort)(SystemRomStartAddress + offset), static _ => Apple2SoftSwitches.UnconnectedReadValue);
+        }
+
+        if (writeEnabled)
+        {
+            MapCardWriters(mem, SystemRomStartAddress, Apple2LanguageCard.BankSize, cardRam, bankOffset);
+            MapCardWriters(mem, UpperMemoryStartAddress, Apple2LanguageCard.UpperSize, cardRam, Apple2LanguageCard.UpperOffset);
+        }
+        else
+        {
+            // Write-protected: writes are swallowed, as they are on a machine with no card.
+            for (var offset = 0; offset < SystemRomSize; offset++)
+                mem.MapWriter((ushort)(SystemRomStartAddress + offset), static (_, _) => { });
         }
     }
 
-    /// <summary>Loads the supplied ROM images. Returns whether a system ROM was mapped.</summary>
-    private bool MapROMs(Dictionary<string, byte[]> romData)
+    private static void MapCardReaders(Memory mem, ushort baseAddress, int length, byte[] cardRam, int cardOffset)
     {
+        for (var offset = 0; offset < length; offset++)
+        {
+            var index = cardOffset + offset;
+            mem.MapReader((ushort)(baseAddress + offset), _ => cardRam[index]);
+        }
+    }
+
+    private static void MapCardWriters(Memory mem, ushort baseAddress, int length, byte[] cardRam, int cardOffset)
+    {
+        for (var offset = 0; offset < length; offset++)
+        {
+            var index = cardOffset + offset;
+            mem.MapWriter((ushort)(baseAddress + offset), (_, value) => cardRam[index] = value);
+        }
+    }
+
+    /// <summary>
+    /// Takes the supplied ROM images: hands the character generator to the rasterizer and the boot
+    /// ROM to the disk controller, and returns the normalized system ROM image for the memory map
+    /// (null when none was supplied).
+    /// </summary>
+    private byte[]? LoadRoms(Dictionary<string, byte[]>? romData)
+    {
+        if (romData == null)
+            return null;
+
         // The character generator is not mapped into the CPU address space — it feeds the video
         // circuitry only, so the rasterizer reads it directly from CharacterRom.
         if (romData.TryGetValue(Apple2SystemConfig.CHARGEN_ROM_NAME, out var characterRom))
@@ -255,11 +350,9 @@ public class Apple2 : ISystem, ITextMode, IScreen, ISystemState, ISystemMonitor,
         if (romData.TryGetValue(Apple2SystemConfig.DISK2_ROM_NAME, out var disk2Rom))
             DiskController.SetBootRom(disk2Rom);
 
-        if (!romData.TryGetValue(Apple2SystemConfig.SYSTEM_ROM_NAME, out var systemRom))
-            return false;
-
-        Mem.MapROM(SystemRomStartAddress, ExtractSystemRomImage(systemRom));
-        return true;
+        return romData.TryGetValue(Apple2SystemConfig.SYSTEM_ROM_NAME, out var systemRom)
+            ? ExtractSystemRomImage(systemRom)
+            : null;
     }
 
     /// <summary>
@@ -390,6 +483,11 @@ public class Apple2 : ISystem, ITextMode, IScreen, ISystemState, ISystemMonitor,
         SoftSwitches.Reset();
         DiskController.Reset();
 
+        // Put ROM back in the address space before the CPU reads its reset vector: with the card
+        // still switched in, $FFFC/$FFFD would come from card RAM and the machine would jump into
+        // whatever happened to be there. The card's contents survive, as they do on the hardware.
+        LanguageCard.Reset();
+
         if (cpuStartPos == null)
             CPU.Reset(Mem);
         else
@@ -486,12 +584,16 @@ public class Apple2 : ISystem, ITextMode, IScreen, ISystemState, ISystemMonitor,
     /// has no model or timing variants to check beyond that — so
     /// <see cref="ValidateSnapshot"/> adds nothing.
     /// </summary>
-    public const int SnapshotVersion = 1;
+    /// <summary>Bumped to 2 when the language card was added, which changed the module set.</summary>
+    public const int SnapshotVersion = 2;
 
     private readonly IReadOnlyList<ISnapshotModule> _snapshotModules = new ISnapshotModule[]
     {
         new Cpu6502SnapshotModule(),
         new Apple2CoreSnapshotModule(),
+        // apple2-languagecard restores after apple2-core and sets the memory configuration, so the
+        // address space ends up matching the switch state it restored.
+        new Apple2LanguageCardSnapshotModule(),
         // apple2-disk2 restores after apple2-core because re-inserting the disk rebuilds the
         // nibble tracks the restored head position indexes into.
         new Apple2Disk2SnapshotModule(),

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Apple2.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Apple2.cs
@@ -115,9 +115,13 @@ public class Apple2 : ISystem, ITextMode, IScreen, ISystemState, ISystemMonitor,
 
     /// <summary>
     /// The 16 KB language card, which takes the machine to the 64 KB ProDOS needs. See
-    /// <see cref="Apple2LanguageCard"/>.
+    /// <see cref="Apple2LanguageCard"/>. Only reachable by the machine when
+    /// <see cref="LanguageCardEnabled"/>; the object exists either way so nothing has to null-check it.
     /// </summary>
     public Apple2LanguageCard LanguageCard { get; }
+
+    /// <summary>Whether the language card is fitted. False makes this a plain 48 KB Apple II Plus.</summary>
+    public bool LanguageCardEnabled => _apple2Config.LanguageCardEnabled;
 
     /// <summary>Types text into the machine by feeding the keyboard latch, one char per frame.</summary>
     public Apple2TextPaste TextPaste { get; }
@@ -166,7 +170,11 @@ public class Apple2 : ISystem, ITextMode, IScreen, ISystemState, ISystemMonitor,
         GamePort = new Apple2GamePort(() => CPU.ExecState.CyclesConsumed);
         Speaker = new Apple2Speaker(() => CPU.ExecState.CyclesConsumed);
         LanguageCard = new Apple2LanguageCard();
-        SoftSwitches = new Apple2SoftSwitches(Keyboard, DiskController, GamePort, Speaker, LanguageCard);
+        // Passing the card only when it is fitted is what makes $C080-$C08F read as unconnected on a
+        // 48 KB machine, exactly as it would with no card in slot 0.
+        SoftSwitches = new Apple2SoftSwitches(
+            Keyboard, DiskController, GamePort, Speaker,
+            config.LanguageCardEnabled ? LanguageCard : null);
         TextPaste = new Apple2TextPaste(this, loggerFactory);
         BasicTokenParser = new Apple2BasicTokenParser(this, loggerFactory);
         InputInjector = new Apple2InputInjector(this);
@@ -180,8 +188,10 @@ public class Apple2 : ISystem, ITextMode, IScreen, ISystemState, ISystemMonitor,
         Mem = CreateMemory(systemRom);
         DefaultExecOptions = new ExecOptions();
 
-        // A switch access swaps the whole memory map in one assignment.
-        LanguageCard.MemoryConfigurationChanged += Mem.SetMemoryConfiguration;
+        // A switch access swaps the whole memory map in one assignment. Not subscribed on a 48 KB
+        // machine, which has only the one configuration to be in.
+        if (LanguageCardEnabled)
+            LanguageCard.MemoryConfigurationChanged += Mem.SetMemoryConfiguration;
 
         // Only reset through the ROM's reset vector when a ROM is actually present; without one
         // $FFFC/$FFFD read as the unconnected value and the CPU would start executing garbage.
@@ -249,11 +259,15 @@ public class Apple2 : ISystem, ITextMode, IScreen, ISystemState, ISystemMonitor,
     /// </summary>
     private Memory CreateMemory(byte[]? systemRom)
     {
+        // A 48 KB machine can only ever be in the power-on map, so it gets one configuration rather
+        // than eight — the other seven describe states its address space cannot reach.
+        var configurationCount = LanguageCardEnabled ? Apple2LanguageCard.MemoryConfigurationCount : 1;
+
         var mem = new Memory(
-            numberOfConfigurations: Apple2LanguageCard.MemoryConfigurationCount,
+            numberOfConfigurations: configurationCount,
             mapToDefaultRAM: false);
 
-        for (var configuration = 0; configuration < Apple2LanguageCard.MemoryConfigurationCount; configuration++)
+        for (var configuration = 0; configuration < configurationCount; configuration++)
         {
             mem.SetMemoryConfiguration(configuration);
 
@@ -486,7 +500,8 @@ public class Apple2 : ISystem, ITextMode, IScreen, ISystemState, ISystemMonitor,
         // Put ROM back in the address space before the CPU reads its reset vector: with the card
         // still switched in, $FFFC/$FFFD would come from card RAM and the machine would jump into
         // whatever happened to be there. The card's contents survive, as they do on the hardware.
-        LanguageCard.Reset();
+        if (LanguageCardEnabled)
+            LanguageCard.Reset();
 
         if (cpuStartPos == null)
             CPU.Reset(Mem);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Apple2SystemConfigurerCore.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Apple2SystemConfigurerCore.cs
@@ -103,6 +103,7 @@ public class Apple2SystemConfigurerCore : ISystemConfigurer
         apple2Config.CpuCompatibilityProfile = apple2SystemConfig.CpuCompatibilityProfile;
         apple2Config.MonitorColor = apple2SystemConfig.MonitorColor;
         apple2Config.AudioEnabled = apple2SystemConfig.AudioEnabled;
+        apple2Config.LanguageCardEnabled = apple2SystemConfig.LanguageCardEnabled;
         apple2Config.AudioProviderType = apple2SystemConfig.AudioProviderType;
 
         Dictionary<string, byte[]>? romData = null;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2Config.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2Config.cs
@@ -53,6 +53,12 @@ public class Apple2Config
     /// </summary>
     public bool AudioEnabled { get; set; }
 
+    /// <summary>
+    /// Whether the 16 KB language card is fitted. On real hardware it was an expansion card rather
+    /// than part of a stock II Plus, so switching it off gives a genuine 48 KB machine.
+    /// </summary>
+    public bool LanguageCardEnabled { get; set; } = true;
+
     /// <summary>Which audio provider to select; defaults to the only one when unset.</summary>
     public Type? AudioProviderType { get; set; }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2SystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2SystemConfig.cs
@@ -124,6 +124,23 @@ public partial class Apple2SystemConfig : ISystemConfig, ISnapshotableConfig
     /// </summary>
     public bool AudioEnabled { get; set; } = true;
 
+    private bool _languageCardEnabled = true;
+
+    /// <summary>
+    /// Whether the 16 KB language card is fitted, taking the machine to the 64 KB ProDOS 8 requires.
+    ///
+    /// <para>On by default, because without it none of the ProDOS-era software catalogue runs and a
+    /// stock 48 KB machine is the narrower experience. It is a setting rather than a given because
+    /// the card was an <em>expansion card</em> on real hardware — not part of a stock Apple II Plus,
+    /// whose motherboard held at most 48 KB — and software can tell the difference: the DOS 3.3
+    /// System Master loads Integer BASIC into the card when it finds one.</para>
+    /// </summary>
+    public bool LanguageCardEnabled
+    {
+        get => _languageCardEnabled;
+        set { _languageCardEnabled = value; _isDirty = true; }
+    }
+
     private Apple2MonitorColor _monitorColor = Apple2MonitorColor.Color;
     public Apple2MonitorColor MonitorColor
     {

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2SystemConfigSnapshot.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Config/Apple2SystemConfigSnapshot.cs
@@ -13,8 +13,9 @@ namespace Highbyte.DotNet6502.Systems.Apple2.Config;
 /// these particular settings worth carrying: all three are read at build or init time rather than
 /// polled as live toggles. The audio provider is only constructed if <c>AudioEnabled</c> is set when
 /// the machine is built, the game port is only driven by host keys if
-/// <c>KeyboardJoystickEnabled</c> is set, and the monitor colour is baked into the rasterizer's
-/// palette per frame. Add a portable setting = add a field to
+/// <c>KeyboardJoystickEnabled</c> is set, the monitor colour is baked into the rasterizer's palette
+/// per frame, and <c>LanguageCardEnabled</c> decides how many memory configurations the address
+/// space is even built with. Add a portable setting = add a field to
 /// <see cref="Apple2SystemSnapshotSettings"/> and map it below; the snapshot framework is
 /// untouched.</para>
 /// </summary>
@@ -27,6 +28,7 @@ public partial class Apple2SystemConfig
             AudioEnabled = AudioEnabled,
             KeyboardJoystickEnabled = KeyboardJoystickEnabled,
             MonitorColor = MonitorColor,
+            LanguageCardEnabled = LanguageCardEnabled,
         };
         return JsonSerializer.Serialize(settings, Apple2SystemSnapshotSettingsJsonContext.Default.Apple2SystemSnapshotSettings);
     }
@@ -40,6 +42,7 @@ public partial class Apple2SystemConfig
         AudioEnabled = settings.AudioEnabled;
         KeyboardJoystickEnabled = settings.KeyboardJoystickEnabled;
         MonitorColor = settings.MonitorColor;
+        LanguageCardEnabled = settings.LanguageCardEnabled;
     }
 }
 
@@ -53,6 +56,13 @@ internal sealed class Apple2SystemSnapshotSettings
     public bool KeyboardJoystickEnabled { get; set; }
 
     public Apple2MonitorColor MonitorColor { get; set; } = Apple2MonitorColor.Color;
+
+    /// <summary>
+    /// Whether the machine that was captured had a language card. Carried because it decides the
+    /// <em>shape</em> of the rebuilt machine, not just a preference — a snapshot of a ProDOS session
+    /// restored into a 48 KB machine would have nowhere to put its operating system.
+    /// </summary>
+    public bool LanguageCardEnabled { get; set; } = true;
 }
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Disk2/Disk2Controller.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Disk2/Disk2Controller.cs
@@ -160,7 +160,14 @@ public class Disk2Controller
     /// <exception cref="InvalidDataException">The image is not a 140 KB DOS-ordered image.</exception>
     public void InsertDiskImage(byte[] diskImageData)
     {
-        _nibbleTracks = Disk2TrackNibblizer.BuildNibbleTracks(diskImageData);
+        // Detected from the image's own contents rather than its file name: extensions are not
+        // reliable in the wild (archive.org's "Dangerous Dave in the Deserted Pirate's Hideout" is
+        // named .dsk and is ProDOS-ordered), and nibblizing with the wrong order produces a track
+        // of plausible garbage rather than an error — which presents as a drive fault, not a
+        // misread image.
+        SectorOrder = DiskSectorOrderDetector.Detect(diskImageData);
+        _nibbleTracks = Disk2TrackNibblizer.BuildNibbleTracks(
+            diskImageData, Disk2TrackNibblizer.DefaultVolume, SectorOrder);
         _rawDiskImageData = diskImageData;
     }
 
@@ -168,7 +175,14 @@ public class Disk2Controller
     {
         _nibbleTracks = null;
         _rawDiskImageData = null;
+        SectorOrder = DiskSectorOrder.Dos;
     }
+
+    /// <summary>
+    /// The sector order detected for the inserted image. Exposed because it is the first thing to
+    /// check when a disk boots on other emulators but not here.
+    /// </summary>
+    public DiskSectorOrder SectorOrder { get; private set; } = DiskSectorOrder.Dos;
 
     /// <summary>Value the CPU sees at a boot ROM address ($C600-$C6FF).</summary>
     public byte ReadBootRom(ushort address)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Disk2/Disk2TrackNibblizer.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Disk2/Disk2TrackNibblizer.cs
@@ -3,7 +3,7 @@ using Highbyte.DotNet6502.Systems.Apple2.DiskImage;
 namespace Highbyte.DotNet6502.Systems.Apple2.Disk2;
 
 /// <summary>
-/// Converts a DOS-ordered 16-sector disk image (<c>.dsk</c>/<c>.do</c>) into the per-track nibble
+/// Converts a 16-sector disk image (<c>.dsk</c>/<c>.do</c>, or a ProDOS-ordered one) into the per-track nibble
 /// streams the Disk II controller feeds to the CPU — the standard emulator approach: nibblize
 /// once on insert, then let RWTS (or a game's own loader) run unmodified against the stream.
 ///
@@ -53,27 +53,48 @@ public static class Disk2TrackNibblizer
         0, 7, 14, 6, 13, 5, 12, 4, 11, 3, 10, 2, 9, 1, 8, 15,
     };
 
+    /// <summary>
+    /// The same mapping for a ProDOS-ordered image. ProDOS numbers its logical sectors differently
+    /// from DOS 3.3, so the identical disk dumped in the two orders produces two different files —
+    /// which is why the order has to be known before nibblizing, and why guessing it wrong yields a
+    /// track of plausible-looking garbage rather than an obvious error.
+    /// </summary>
+    public static ReadOnlySpan<byte> PhysicalToProdosSector => new byte[16]
+    {
+        0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15,
+    };
+
+    private static ReadOnlySpan<byte> PhysicalToLogicalSector(DiskSectorOrder sectorOrder)
+        => sectorOrder == DiskSectorOrder.ProDos ? PhysicalToProdosSector : PhysicalToDosSector;
+
     private static ReadOnlySpan<byte> AddressProlog => new byte[] { 0xD5, 0xAA, 0x96 };
     private static ReadOnlySpan<byte> DataProlog => new byte[] { 0xD5, 0xAA, 0xAD };
     private static ReadOnlySpan<byte> FieldEpilog => new byte[] { 0xDE, 0xAA, 0xEB };
 
-    /// <summary>Nibblizes all 35 tracks of a DOS-ordered disk image.</summary>
-    /// <exception cref="InvalidDataException">The image is not a 140 KB DOS-ordered image.</exception>
-    public static byte[][] BuildNibbleTracks(byte[] diskImageData, byte volume = DefaultVolume)
+    /// <summary>Nibblizes all 35 tracks of a 140 KB disk image stored in the given sector order.</summary>
+    /// <exception cref="InvalidDataException">The image is not 140 KB.</exception>
+    public static byte[][] BuildNibbleTracks(
+        byte[] diskImageData,
+        byte volume = DefaultVolume,
+        DiskSectorOrder sectorOrder = DiskSectorOrder.Dos)
     {
         ArgumentNullException.ThrowIfNull(diskImageData);
         if (diskImageData.Length != DskParser.DiskImageSize)
             throw new InvalidDataException(
-                $"Not a 140 KB DOS-ordered disk image: {diskImageData.Length} bytes, expected {DskParser.DiskImageSize}.");
+                $"Not a 140 KB disk image: {diskImageData.Length} bytes, expected {DskParser.DiskImageSize}.");
 
         var tracks = new byte[DskParser.Tracks][];
         for (var track = 0; track < DskParser.Tracks; track++)
-            tracks[track] = BuildNibbleTrack(diskImageData, track, volume);
+            tracks[track] = BuildNibbleTrack(diskImageData, track, volume, sectorOrder);
         return tracks;
     }
 
     /// <summary>Nibblizes one track of a DOS-ordered disk image.</summary>
-    public static byte[] BuildNibbleTrack(byte[] diskImageData, int track, byte volume = DefaultVolume)
+    public static byte[] BuildNibbleTrack(
+        byte[] diskImageData,
+        int track,
+        byte volume = DefaultVolume,
+        DiskSectorOrder sectorOrder = DiskSectorOrder.Dos)
     {
         ArgumentNullException.ThrowIfNull(diskImageData);
         if (track is < 0 or >= DskParser.Tracks)
@@ -103,7 +124,7 @@ public static class Disk2TrackNibblizer
 
             pos += Gap2SyncBytes;
 
-            var logicalSector = PhysicalToDosSector[physicalSector];
+            var logicalSector = PhysicalToLogicalSector(sectorOrder)[physicalSector];
             var sectorOffset = DskParser.SectorOffset(track, logicalSector);
             Disk2NibbleCodec.EncodeSector(
                 diskImageData.AsSpan(sectorOffset, Disk2NibbleCodec.SectorSize), encoded);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/DiskImage/DiskSectorOrder.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/DiskImage/DiskSectorOrder.cs
@@ -1,0 +1,110 @@
+namespace Highbyte.DotNet6502.Systems.Apple2.DiskImage;
+
+/// <summary>
+/// The order in which a 140 KB disk image file stores the sectors of each track.
+///
+/// <para>
+/// The bytes on the disk are the same either way; what differs is which sector of the file holds
+/// each physical position around the track. DOS 3.3 and ProDOS number their logical sectors
+/// differently, and image files were dumped in whichever order the dumping system used.
+/// </para>
+/// </summary>
+public enum DiskSectorOrder
+{
+    /// <summary>DOS 3.3 order, conventionally <c>.dsk</c> / <c>.do</c>.</summary>
+    Dos = 0,
+
+    /// <summary>ProDOS block order, conventionally <c>.po</c>.</summary>
+    ProDos = 1,
+}
+
+/// <summary>
+/// Works out how a disk image stores its sectors.
+///
+/// <para>
+/// <b>Why by content and not by file extension.</b> Extensions are unreliable in practice: the
+/// archive.org copy of "Dangerous Dave in the Deserted Pirate's Hideout" is named <c>.dsk</c> and is
+/// ProDOS-ordered. Guessing from the name would mis-nibblize it into garbage, and the resulting
+/// failure — a drive that spins with the read counter frozen — looks like a drive bug rather than a
+/// misread image, which is an expensive thing to debug.
+/// </para>
+/// </summary>
+public static class DiskSectorOrderDetector
+{
+    /// <summary>ProDOS block 2 holds the volume directory header; in a ProDOS-ordered file that is here.</summary>
+    private const int ProdosVolumeDirectoryOffset = 0x400;
+
+    /// <summary>Storage type nibble marking a volume directory header.</summary>
+    private const byte VolumeDirectoryStorageType = 0x0F;
+
+    /// <summary>DOS 3.3 keeps its VTOC at track 17 sector 0, which in a DOS-ordered file is here.</summary>
+    private const int DosVtocOffset = 17 * DskParser.SectorsPerTrack * DskParser.BytesPerSector;
+
+    /// <summary>
+    /// Detects the sector order of a 140 KB image, falling back to <see cref="DiskSectorOrder.Dos"/>
+    /// when neither filesystem is recognised — the historically commoner order, and what the drive
+    /// assumed before this existed.
+    /// </summary>
+    public static DiskSectorOrder Detect(byte[] diskImageData)
+    {
+        ArgumentNullException.ThrowIfNull(diskImageData);
+
+        if (LooksLikeProdosVolumeDirectory(diskImageData))
+            return DiskSectorOrder.ProDos;
+
+        return DiskSectorOrder.Dos;
+    }
+
+    /// <summary>
+    /// True if a ProDOS volume directory header sits where a ProDOS-ordered image would keep it: a
+    /// storage type of $F, a name of 1-15 characters, and that name actually being characters.
+    /// Checking the name as well as the type matters — the type nibble alone is four bits and turns
+    /// up by chance in game data often enough to matter.
+    /// </summary>
+    private static bool LooksLikeProdosVolumeDirectory(byte[] diskImageData)
+    {
+        if (diskImageData.Length < ProdosVolumeDirectoryOffset + 0x30)
+            return false;
+
+        var header = diskImageData[ProdosVolumeDirectoryOffset + 0x04];
+        if ((byte)(header >> 4) != VolumeDirectoryStorageType)
+            return false;
+
+        var nameLength = header & 0x0F;
+        if (nameLength is 0 or > 15)
+            return false;
+
+        for (var i = 0; i < nameLength; i++)
+        {
+            var c = diskImageData[ProdosVolumeDirectoryOffset + 0x05 + i];
+            var isUpper = c is >= (byte)'A' and <= (byte)'Z';
+            var isDigit = c is >= (byte)'0' and <= (byte)'9';
+            if (!isUpper && !isDigit && c != (byte)'.')
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// True if a DOS 3.3 VTOC sits where a DOS-ordered image would keep it. Not used by
+    /// <see cref="Detect"/> (which defaults to DOS anyway) but useful to tests and diagnostics that
+    /// want a positive identification rather than a fallback.
+    /// </summary>
+    public static bool LooksLikeDosVtoc(byte[] diskImageData)
+    {
+        ArgumentNullException.ThrowIfNull(diskImageData);
+        if (diskImageData.Length < DosVtocOffset + 0x40)
+            return false;
+
+        var catalogTrack = diskImageData[DosVtocOffset + 0x01];
+        var sectorsPerTrack = diskImageData[DosVtocOffset + 0x35];
+        var bytesPerSectorLow = diskImageData[DosVtocOffset + 0x36];
+        var bytesPerSectorHigh = diskImageData[DosVtocOffset + 0x37];
+
+        return catalogTrack < DskParser.Tracks
+            && sectorsPerTrack == DskParser.SectorsPerTrack
+            && bytesPerSectorLow == 0x00
+            && bytesPerSectorHigh == 0x01;   // 256, little-endian
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2LanguageCard.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2LanguageCard.cs
@@ -1,0 +1,166 @@
+namespace Highbyte.DotNet6502.Systems.Apple2.Peripherals;
+
+/// <summary>
+/// The Apple Language Card: 16 KB of RAM that overlays the ROM space, switched by the soft switches
+/// at $C080-$C08F (slot 0).
+///
+/// <para>
+/// It brings the machine to the 64 KB that ProDOS 8 requires, which is the gate in front of most
+/// Apple II software from roughly 1984 onward. A 48 KB machine boots a ProDOS disk only as far as
+/// ProDOS's own memory check, which stops with <c>RELOCATION/ CONFIGURATION ERROR</c>.
+/// </para>
+///
+/// <para>
+/// <b>Why 16 KB covers a 12 KB address range.</b> $E000-$FFFF is a single 8 KB block, but
+/// $D000-$DFFF has <em>two</em> 4 KB banks that are selected independently. 4 + 4 + 8 = 16.
+/// </para>
+///
+/// <para>
+/// <b>The write-enable rule.</b> Enabling writes to the card takes <em>two consecutive accesses</em>
+/// to an odd switch address, and only a <em>read</em> arms the first one. This is a deliberate
+/// hardware guard: a single stray access — an indexed read that happens to land in $C08x, say —
+/// must not silently unlock RAM under the ROM. Modelled here with the same pre-write flip-flop the
+/// hardware uses, because software does rely on it: the idiom for "write to the card while still
+/// executing from ROM" is to read the switch twice in a row.
+/// </para>
+///
+/// <para>
+/// Not modelled: the IIe's $C011/$C012 status readback (a IIe feature; the II Plus this machine
+/// emulates has no way to read the card's state back), and the IIe's 128 KB auxiliary memory, which
+/// is a different machine rather than a bigger II Plus.
+/// </para>
+/// </summary>
+public class Apple2LanguageCard
+{
+    /// <summary>First soft switch: $C080-$C08F, slot 0.</summary>
+    public const ushort IoBaseAddress = 0xC080;
+
+    /// <summary>One 4 KB bank at $D000-$DFFF; there are two of them.</summary>
+    public const int BankSize = 0x1000;
+
+    /// <summary>The single 8 KB block at $E000-$FFFF.</summary>
+    public const int UpperSize = 0x2000;
+
+    /// <summary>4 KB + 4 KB + 8 KB.</summary>
+    public const int RamSize = BankSize * 2 + UpperSize;
+
+    /// <summary>Offset of bank 1's 4 KB within <see cref="Ram"/>.</summary>
+    public const int Bank1Offset = 0;
+
+    /// <summary>Offset of bank 2's 4 KB within <see cref="Ram"/>.</summary>
+    public const int Bank2Offset = BankSize;
+
+    /// <summary>Offset of the shared $E000-$FFFF block within <see cref="Ram"/>.</summary>
+    public const int UpperOffset = BankSize * 2;
+
+    /// <summary>Number of distinct memory maps the switch state can produce.</summary>
+    public const int MemoryConfigurationCount = 8;
+
+    private readonly byte[] _ram = new byte[RamSize];
+
+    /// <summary>The card's 16 KB, laid out as bank 1, bank 2, then the shared $E000-$FFFF block.</summary>
+    public byte[] Ram => _ram;
+
+    /// <summary>
+    /// Whether $D000-$FFFF reads come from the card rather than from ROM. Power-on state is ROM, so
+    /// a machine that never touches $C08x behaves exactly like one with no card fitted.
+    /// </summary>
+    public bool ReadRam { get; private set; }
+
+    /// <summary>Which 4 KB bank is visible at $D000-$DFFF. Power-on selects bank 2, as the hardware does.</summary>
+    public bool Bank1Selected { get; private set; }
+
+    /// <summary>Whether writes to $D000-$FFFF reach the card. Requires the two-access sequence described above.</summary>
+    public bool WriteEnabled { get; private set; }
+
+    /// <summary>
+    /// The pre-write flip-flop: set by a <em>read</em> of an odd switch address, and the reason a
+    /// second access is needed before writes are enabled.
+    /// </summary>
+    public bool PreWrite { get; private set; }
+
+    /// <summary>
+    /// Index of the memory map this switch state implies, for
+    /// <see cref="Memory.SetMemoryConfiguration"/>. Bank switching is a configuration swap rather
+    /// than a re-map of 12 KB of handlers, so a switch access costs the same as a pointer
+    /// assignment — which matters because some software toggles banks in tight loops.
+    /// </summary>
+    public int MemoryConfiguration =>
+        (ReadRam ? 4 : 0) | (Bank1Selected ? 2 : 0) | (WriteEnabled ? 1 : 0);
+
+    /// <summary>Raised when an access changed the memory map, with the new configuration index.</summary>
+    public event Action<int>? MemoryConfigurationChanged;
+
+    /// <summary>
+    /// Applies the side effect of an access to $C080-$C08F. Reads and writes select the same things,
+    /// but only a read arms the pre-write flip-flop.
+    /// </summary>
+    public void Access(ushort address, bool isRead)
+    {
+        var previousConfiguration = MemoryConfiguration;
+
+        // Bit 3 picks the bank, bits 1-0 pick the read source and whether writes are being asked
+        // for. Bit 2 is not decoded, which is why $C084-$C087 mirror $C080-$C083.
+        Bank1Selected = (address & 0x08) != 0;
+
+        var lowBits = address & 0x03;
+        ReadRam = lowBits == 0x00 || lowBits == 0x03;
+
+        var oddAddress = (address & 0x01) != 0;
+        if (!oddAddress)
+        {
+            // An even address write-protects the card immediately, and disarms any half-finished
+            // enable sequence with it.
+            WriteEnabled = false;
+        }
+        else if (PreWrite)
+        {
+            // Second consecutive access to an odd address: the sequence completes.
+            WriteEnabled = true;
+        }
+
+        // Only a read arms it. A write to the switch leaves the card protected however many times
+        // it is repeated.
+        PreWrite = oddAddress && isRead;
+
+        var configuration = MemoryConfiguration;
+        if (configuration != previousConfiguration)
+            MemoryConfigurationChanged?.Invoke(configuration);
+    }
+
+    /// <summary>
+    /// Returns the card to its power-on state: ROM visible, writes protected, bank 2 selected. The
+    /// card's contents are deliberately kept — a reset does not clear RAM, and software that parks
+    /// code in the card across a reset depends on that.
+    /// </summary>
+    public void Reset()
+    {
+        var previousConfiguration = MemoryConfiguration;
+
+        ReadRam = false;
+        Bank1Selected = false;
+        WriteEnabled = false;
+        PreWrite = false;
+
+        if (MemoryConfiguration != previousConfiguration)
+            MemoryConfigurationChanged?.Invoke(MemoryConfiguration);
+    }
+
+    // --- Snapshot support (consumed by the apple2-languagecard snapshot module) ---
+
+    internal (bool ReadRam, bool Bank1Selected, bool WriteEnabled, bool PreWrite) GetSnapshotState()
+        => (ReadRam, Bank1Selected, WriteEnabled, PreWrite);
+
+    /// <summary>
+    /// Restores the switch state. Does not raise <see cref="MemoryConfigurationChanged"/> — the
+    /// caller applies the configuration itself, so a restore cannot half-apply if the event has no
+    /// subscriber yet.
+    /// </summary>
+    internal void RestoreSnapshotState(bool readRam, bool bank1Selected, bool writeEnabled, bool preWrite)
+    {
+        ReadRam = readRam;
+        Bank1Selected = bank1Selected;
+        WriteEnabled = writeEnabled;
+        PreWrite = preWrite;
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2SoftSwitches.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2SoftSwitches.cs
@@ -45,21 +45,27 @@ public class Apple2SoftSwitches
     /// </summary>
     public const byte UnconnectedReadValue = 0xFF;
 
+    /// <summary>Language card bank switching ($C080-$C08F, slot 0).</summary>
+    public const ushort LanguageCardAddress = 0xC080;
+
     private readonly Apple2Keyboard _keyboard;
     private readonly Disk2Controller? _diskController;
     private readonly Apple2GamePort? _gamePort;
     private readonly Apple2Speaker? _speaker;
+    private readonly Apple2LanguageCard? _languageCard;
 
     public Apple2SoftSwitches(
         Apple2Keyboard keyboard,
         Disk2Controller? diskController = null,
         Apple2GamePort? gamePort = null,
-        Apple2Speaker? speaker = null)
+        Apple2Speaker? speaker = null,
+        Apple2LanguageCard? languageCard = null)
     {
         _keyboard = keyboard;
         _diskController = diskController;
         _gamePort = gamePort;
         _speaker = speaker;
+        _languageCard = languageCard;
     }
 
     /// <summary>
@@ -133,7 +139,16 @@ public class Apple2SoftSwitches
     }
 
     /// <summary>Applies the side effect of an access and returns the value the CPU reads.</summary>
-    public byte Read(ushort address)
+    public byte Read(ushort address) => Access(address, isRead: true);
+
+    /// <summary>
+    /// A write triggers the same side effects as a read and the value is ignored — with one
+    /// exception: the language card's write-enable sequence is armed only by reads, so the access
+    /// kind has to be carried through rather than folded into <see cref="Read"/>.
+    /// </summary>
+    public void Write(ushort address, byte value) => Access(address, isRead: false);
+
+    private byte Access(ushort address, bool isRead)
     {
         return (address & 0x00F0) switch
         {
@@ -143,13 +158,17 @@ public class Apple2SoftSwitches
             0x50 => ApplyDisplaySwitch(address),             // $C050-$C05F  display mode
             0x60 => _gamePort?.ReadGamePort(address) ?? 0x00, // $C060-$C06F  cassette in, buttons, paddles
             0x70 => TriggerPaddles(),                        // $C070-$C07F  PTRIG: restart paddle timers
+            0x80 => AccessLanguageCard(address, isRead),     // $C080-$C08F  language card bank switching
             0xE0 => ReadDiskController(address),             // $C0E0-$C0EF  Disk II controller (slot 6)
             _ => UnconnectedReadValue,
         };
     }
 
-    /// <summary>A write triggers the same side effect as a read; the value is ignored.</summary>
-    public void Write(ushort address, byte value) => Read(address);
+    private byte AccessLanguageCard(ushort address, bool isRead)
+    {
+        _languageCard?.Access(address, isRead);
+        return UnconnectedReadValue;
+    }
 
     private byte ReadDiskController(ushort address)
         => _diskController != null && _diskController.IsEnabled

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Snapshots/Apple2LanguageCardSnapshotModule.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Snapshots/Apple2LanguageCardSnapshotModule.cs
@@ -1,0 +1,68 @@
+using Highbyte.DotNet6502.Systems.Snapshots;
+
+namespace Highbyte.DotNet6502.Systems.Apple2.Snapshots;
+
+/// <summary>
+/// Snapshot module for the language card: its 16 KB of RAM and the switch state that decides what
+/// is visible at $D000-$FFFF.
+///
+/// <para>
+/// Both halves are load-bearing. The RAM is where ProDOS itself lives once booted, so a snapshot
+/// without it restores a machine whose operating system has been replaced by zeros. The switch
+/// state decides whether the CPU is executing from the card or from ROM at the instant the snapshot
+/// was taken — restore it wrong and the machine resumes running different code than it was.
+/// </para>
+///
+/// <para>
+/// Restores after <c>apple2-core</c>, and applies the memory configuration itself rather than
+/// leaving it to the card's change event: the event is for live switch accesses, and a restore has
+/// to end with the map in a known state whether or not the state it restored differs from the one
+/// the freshly built machine started in.
+/// </para>
+/// </summary>
+public sealed class Apple2LanguageCardSnapshotModule : ISnapshotModule
+{
+    public const string ModuleName = "apple2-languagecard";
+
+    public string Name => ModuleName;
+    public int Version => 1;
+    public bool Required => true;
+
+    public void Capture(SnapshotModuleWriter writer, SnapshotCaptureContext context)
+    {
+        var card = ((Apple2)context.System).LanguageCard;
+
+        writer.WriteBytes(card.Ram);
+
+        var (readRam, bank1Selected, writeEnabled, preWrite) = card.GetSnapshotState();
+        writer.WriteBool(readRam);
+        writer.WriteBool(bank1Selected);
+        writer.WriteBool(writeEnabled);
+        // The pre-write flip-flop is half of an in-flight unlock sequence. It costs one byte, and
+        // without it a snapshot taken between the two switch reads resumes with the second read
+        // silently failing to unlock the card.
+        writer.WriteBool(preWrite);
+    }
+
+    public void Restore(SnapshotModuleReader reader, SnapshotRestoreContext context)
+    {
+        var apple2 = (Apple2)context.System;
+        var card = apple2.LanguageCard;
+
+        var ram = reader.ReadBytes()
+            ?? throw new SnapshotException("apple2-languagecard: card RAM bytes were missing.");
+        if (ram.Length != card.Ram.Length)
+            throw new SnapshotException(
+                $"apple2-languagecard: snapshot card RAM size {ram.Length} does not match target {card.Ram.Length}.");
+        // Copied into the existing array, which every memory configuration's handlers close over.
+        Array.Copy(ram, card.Ram, ram.Length);
+
+        card.RestoreSnapshotState(
+            readRam: reader.ReadBool(),
+            bank1Selected: reader.ReadBool(),
+            writeEnabled: reader.ReadBool(),
+            preWrite: reader.ReadBool());
+
+        apple2.Mem.SetMemoryConfiguration(card.MemoryConfiguration);
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Snapshots/Apple2LanguageCardSnapshotModule.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Snapshots/Apple2LanguageCardSnapshotModule.cs
@@ -63,6 +63,18 @@ public sealed class Apple2LanguageCardSnapshotModule : ISnapshotModule
             writeEnabled: reader.ReadBool(),
             preWrite: reader.ReadBool());
 
-        apple2.Mem.SetMemoryConfiguration(card.MemoryConfiguration);
+        if (apple2.LanguageCardEnabled)
+        {
+            apple2.Mem.SetMemoryConfiguration(card.MemoryConfiguration);
+        }
+        else if (card.ReadRam || card.WriteEnabled)
+        {
+            // Restoring a 64 KB capture into a machine configured without a card. The bytes are kept
+            // (so re-enabling the card and reloading recovers them) but the address space has only
+            // the one configuration, and switching to another would throw.
+            context.AddWarning(
+                "apple2-languagecard: the snapshot was taken with a language card switched in, but this " +
+                "machine is configured without one — the card's mapping was not applied.");
+        }
     }
 }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2LanguageCardTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2LanguageCardTests.cs
@@ -16,7 +16,7 @@ public class Apple2LanguageCardTests
     private const byte RomFillD000 = 0xAA;
     private const byte RomFillE000 = 0xBB;
 
-    private static Apple2System BuildApple2WithRom()
+    private static Apple2System BuildApple2WithRom(bool languageCardEnabled = true)
     {
         var rom = new byte[Apple2System.SystemRomSize];
         for (var offset = 0; offset < rom.Length; offset++)
@@ -26,7 +26,10 @@ public class Apple2LanguageCardTests
         }
 
         var romData = new Dictionary<string, byte[]> { { Apple2SystemConfig.SYSTEM_ROM_NAME, rom } };
-        return new Apple2System(new Apple2Config(), NullLoggerFactory.Instance, romData);
+        return new Apple2System(
+            new Apple2Config { LanguageCardEnabled = languageCardEnabled },
+            NullLoggerFactory.Instance,
+            romData);
     }
 
     /// <summary>Reads the switch, which is how software drives the card (a write works too).</summary>
@@ -218,6 +221,40 @@ public class Apple2LanguageCardTests
         SwitchTwice(apple2, 0xC083);
         Assert.Equal((byte)0x77, apple2.Mem[0xD000]);
         Assert.Equal((byte)0x88, apple2.Mem[0xE000]);
+    }
+
+    [Fact]
+    public void Without_The_Card_The_Switches_Do_Nothing_And_Rom_Stays_Visible()
+    {
+        var apple2 = BuildApple2WithRom(languageCardEnabled: false);
+
+        Assert.False(apple2.LanguageCardEnabled);
+
+        // The same sequence that switches a fitted card in and unlocks writing.
+        SwitchTwice(apple2, 0xC083);
+
+        // $C080-$C08F reads as unconnected, exactly as an empty slot 0 would.
+        Assert.Equal(Apple2SoftSwitches.UnconnectedReadValue, apple2.Mem[0xC083]);
+
+        // ROM is still what the CPU sees, and writes still go nowhere.
+        Assert.Equal(RomFillD000, apple2.Mem[0xD000]);
+        Assert.Equal(RomFillE000, apple2.Mem[0xE000]);
+        apple2.Mem[0xD000] = 0x42;
+        Assert.Equal(RomFillD000, apple2.Mem[0xD000]);
+    }
+
+    [Fact]
+    public void Without_The_Card_The_Machine_Keeps_Running_Across_A_Reset()
+    {
+        // Reset has to leave a 48 KB machine alone rather than trying to switch a memory
+        // configuration that was never built.
+        var apple2 = BuildApple2WithRom(languageCardEnabled: false);
+
+        SwitchTwice(apple2, 0xC08B);
+        apple2.Reset();
+
+        Assert.Equal(RomFillD000, apple2.Mem[0xD000]);
+        Assert.False(apple2.LanguageCard.ReadRam);
     }
 
     [Fact]

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2LanguageCardTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2LanguageCardTests.cs
@@ -1,0 +1,234 @@
+using Highbyte.DotNet6502.Systems.Apple2.Config;
+using Highbyte.DotNet6502.Systems.Apple2.Peripherals;
+using Microsoft.Extensions.Logging.Abstractions;
+using Apple2System = Highbyte.DotNet6502.Systems.Apple2.Apple2;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
+
+/// <summary>
+/// The language card's $C080-$C08F semantics, exercised through the machine's address space rather
+/// than against the card object directly — the point is what the CPU sees at $D000-$FFFF, and that
+/// depends on the memory mapping as much as on the switch state.
+/// </summary>
+public class Apple2LanguageCardTests
+{
+    // A stand-in ROM whose bytes are recognisable and differ from anything written to the card.
+    private const byte RomFillD000 = 0xAA;
+    private const byte RomFillE000 = 0xBB;
+
+    private static Apple2System BuildApple2WithRom()
+    {
+        var rom = new byte[Apple2System.SystemRomSize];
+        for (var offset = 0; offset < rom.Length; offset++)
+        {
+            var address = Apple2System.SystemRomStartAddress + offset;
+            rom[offset] = address < Apple2System.UpperMemoryStartAddress ? RomFillD000 : RomFillE000;
+        }
+
+        var romData = new Dictionary<string, byte[]> { { Apple2SystemConfig.SYSTEM_ROM_NAME, rom } };
+        return new Apple2System(new Apple2Config(), NullLoggerFactory.Instance, romData);
+    }
+
+    /// <summary>Reads the switch, which is how software drives the card (a write works too).</summary>
+    private static void Switch(Apple2System apple2, ushort address) => _ = apple2.Mem[address];
+
+    /// <summary>Reads the switch twice, the sequence that unlocks writing to the card.</summary>
+    private static void SwitchTwice(Apple2System apple2, ushort address)
+    {
+        Switch(apple2, address);
+        Switch(apple2, address);
+    }
+
+    [Fact]
+    public void At_Power_On_The_Rom_Is_Visible_And_The_Card_Is_Write_Protected()
+    {
+        var apple2 = BuildApple2WithRom();
+
+        Assert.False(apple2.LanguageCard.ReadRam);
+        Assert.False(apple2.LanguageCard.WriteEnabled);
+        Assert.False(apple2.LanguageCard.Bank1Selected);   // bank 2 at power-on
+
+        // A machine that never touches $C08x behaves exactly like one with no card fitted.
+        Assert.Equal(RomFillD000, apple2.Mem[0xD000]);
+        Assert.Equal(RomFillE000, apple2.Mem[0xE000]);
+
+        apple2.Mem[0xD000] = 0x11;
+        Assert.Equal(RomFillD000, apple2.Mem[0xD000]);
+    }
+
+    [Theory]
+    // (addr & 3): 0 and 3 read the card, 1 and 2 read ROM. Bit 2 is not decoded, so $C084-$C087
+    // mirror $C080-$C083.
+    [InlineData(0xC080, true)]
+    [InlineData(0xC081, false)]
+    [InlineData(0xC082, false)]
+    [InlineData(0xC083, true)]
+    [InlineData(0xC084, true)]
+    [InlineData(0xC085, false)]
+    [InlineData(0xC086, false)]
+    [InlineData(0xC087, true)]
+    [InlineData(0xC088, true)]
+    [InlineData(0xC08B, true)]
+    [InlineData(0xC08A, false)]
+    public void The_Switch_Address_Selects_Whether_Reads_Come_From_The_Card(int address, bool expectedReadRam)
+    {
+        var apple2 = BuildApple2WithRom();
+
+        Switch(apple2, (ushort)address);
+
+        Assert.Equal(expectedReadRam, apple2.LanguageCard.ReadRam);
+    }
+
+    [Theory]
+    [InlineData(0xC080, false)]   // bit 3 clear: bank 2
+    [InlineData(0xC083, false)]
+    [InlineData(0xC088, true)]    // bit 3 set: bank 1
+    [InlineData(0xC08B, true)]
+    public void Bit_Three_Of_The_Switch_Address_Selects_The_Bank(int address, bool expectedBank1)
+    {
+        var apple2 = BuildApple2WithRom();
+
+        Switch(apple2, (ushort)address);
+
+        Assert.Equal(expectedBank1, apple2.LanguageCard.Bank1Selected);
+    }
+
+    [Fact]
+    public void Writing_Needs_Two_Consecutive_Reads_Of_The_Switch()
+    {
+        var apple2 = BuildApple2WithRom();
+
+        // One read arms the sequence but must not unlock the card: a single stray access — an
+        // indexed read landing in $C08x — must not silently expose RAM under the ROM.
+        Switch(apple2, 0xC083);
+        Assert.True(apple2.LanguageCard.PreWrite);
+        Assert.False(apple2.LanguageCard.WriteEnabled);
+
+        apple2.Mem[0xD000] = 0x42;
+        Assert.NotEqual((byte)0x42, apple2.Mem[0xD000]);
+
+        // The second read completes it.
+        Switch(apple2, 0xC083);
+        Assert.True(apple2.LanguageCard.WriteEnabled);
+
+        apple2.Mem[0xD000] = 0x42;
+        Assert.Equal((byte)0x42, apple2.Mem[0xD000]);
+    }
+
+    [Fact]
+    public void A_Write_To_The_Switch_Does_Not_Arm_The_Sequence()
+    {
+        var apple2 = BuildApple2WithRom();
+
+        // Only reads set the pre-write flip-flop, so any number of writes leaves it protected.
+        apple2.Mem[0xC083] = 0x00;
+        apple2.Mem[0xC083] = 0x00;
+        apple2.Mem[0xC083] = 0x00;
+
+        Assert.False(apple2.LanguageCard.WriteEnabled);
+
+        apple2.Mem[0xD000] = 0x42;
+        Assert.NotEqual((byte)0x42, apple2.Mem[0xD000]);
+    }
+
+    [Fact]
+    public void An_Even_Switch_Address_Write_Protects_The_Card_Again()
+    {
+        var apple2 = BuildApple2WithRom();
+        SwitchTwice(apple2, 0xC083);
+        Assert.True(apple2.LanguageCard.WriteEnabled);
+
+        Switch(apple2, 0xC082);
+
+        Assert.False(apple2.LanguageCard.WriteEnabled);
+        Assert.False(apple2.LanguageCard.PreWrite);
+    }
+
+    [Fact]
+    public void The_Two_D000_Banks_Hold_Different_Data()
+    {
+        var apple2 = BuildApple2WithRom();
+
+        // Bank 1: read and write the card.
+        SwitchTwice(apple2, 0xC08B);
+        apple2.Mem[0xD000] = 0x11;
+        Assert.Equal((byte)0x11, apple2.Mem[0xD000]);
+
+        // Bank 2 at the same address is a different 4 KB.
+        SwitchTwice(apple2, 0xC083);
+        Assert.NotEqual((byte)0x11, apple2.Mem[0xD000]);
+        apple2.Mem[0xD000] = 0x22;
+        Assert.Equal((byte)0x22, apple2.Mem[0xD000]);
+
+        // Switching back finds bank 1 as it was left.
+        SwitchTwice(apple2, 0xC08B);
+        Assert.Equal((byte)0x11, apple2.Mem[0xD000]);
+    }
+
+    [Fact]
+    public void The_E000_Block_Is_Shared_By_Both_Banks()
+    {
+        var apple2 = BuildApple2WithRom();
+
+        SwitchTwice(apple2, 0xC08B);   // bank 1, read+write card
+        apple2.Mem[0xE000] = 0x33;
+        Assert.Equal((byte)0x33, apple2.Mem[0xE000]);
+
+        // $E000-$FFFF is a single 8 KB block, so the bank selection does not apply to it.
+        SwitchTwice(apple2, 0xC083);   // bank 2
+        Assert.Equal((byte)0x33, apple2.Mem[0xE000]);
+    }
+
+    [Fact]
+    public void Reads_Can_Come_From_Rom_While_Writes_Go_To_The_Card()
+    {
+        var apple2 = BuildApple2WithRom();
+
+        // $C081 twice: read ROM, write the card — the idiom for filling the card while still
+        // executing from ROM.
+        SwitchTwice(apple2, 0xC081);
+        Assert.False(apple2.LanguageCard.ReadRam);
+        Assert.True(apple2.LanguageCard.WriteEnabled);
+
+        apple2.Mem[0xD000] = 0x55;
+        Assert.Equal(RomFillD000, apple2.Mem[0xD000]);   // still reading ROM
+
+        // Switch reads over to the card and the written byte is there.
+        Switch(apple2, 0xC080);
+        Assert.Equal((byte)0x55, apple2.Mem[0xD000]);
+    }
+
+    [Fact]
+    public void Reset_Puts_Rom_Back_But_Keeps_The_Cards_Contents()
+    {
+        var apple2 = BuildApple2WithRom();
+        SwitchTwice(apple2, 0xC083);
+        apple2.Mem[0xD000] = 0x77;
+        apple2.Mem[0xE000] = 0x88;
+
+        apple2.Reset();
+
+        // ROM has to be back before the CPU reads its reset vector.
+        Assert.False(apple2.LanguageCard.ReadRam);
+        Assert.False(apple2.LanguageCard.WriteEnabled);
+        Assert.False(apple2.LanguageCard.Bank1Selected);
+        Assert.Equal(RomFillD000, apple2.Mem[0xD000]);
+
+        // A reset does not clear RAM: software parks code in the card across resets.
+        SwitchTwice(apple2, 0xC083);
+        Assert.Equal((byte)0x77, apple2.Mem[0xD000]);
+        Assert.Equal((byte)0x88, apple2.Mem[0xE000]);
+    }
+
+    [Fact]
+    public void The_Card_Adds_Sixteen_Kilobytes_Over_The_Machines_Forty_Eight()
+    {
+        var apple2 = BuildApple2WithRom();
+
+        Assert.Equal(Apple2LanguageCard.RamSize, apple2.LanguageCard.Ram.Length);
+        Assert.Equal(16 * 1024, apple2.LanguageCard.Ram.Length);
+
+        // 48 KB of main RAM plus the card is the 64 KB ProDOS requires.
+        Assert.Equal(64 * 1024, Apple2System.RamSize + apple2.LanguageCard.Ram.Length);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RealRomDisk2BootTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RealRomDisk2BootTests.cs
@@ -32,11 +32,13 @@ namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
 public class Apple2RealRomDisk2BootTests
 {
     /// <summary>
-    /// Frames to allow for the whole boot. A System Master boot measures ~42 M cycles (~2475
-    /// frames), most of it DOS's own motor spin-up waits — see the timing-model limitation
-    /// documented on <c>Disk2Controller</c> — so this leaves generous headroom.
+    /// Upper bound on frames to allow for a boot, used only as a safety cap — the boot is waited
+    /// for by watching the drive rather than by running a fixed number of frames (see
+    /// <see cref="RunUntilBootSettles"/>). A fixed budget was the original approach and proved to be
+    /// the wrong shape: adding the language card made DOS 3.3 also load Integer BASIC into it, which
+    /// legitimately lengthened the boot and failed a test that was not about boot duration at all.
     /// </summary>
-    private const int BootFrames = 3600;
+    private const int MaxBootFrames = 12000;
 
     private readonly ITestOutputHelper _output;
 
@@ -76,8 +78,7 @@ public class Apple2RealRomDisk2BootTests
         apple2.InvalidatePowerUpByte();
         apple2.Reset();
 
-        for (var frame = 0; frame < BootFrames; frame++)
-            apple2.ExecuteOneFrame();
+        RunUntilBootSettles(apple2);
 
         var screenText = string.Join('\n', ReadScreen(apple2));
         _output.WriteLine(screenText);
@@ -162,10 +163,49 @@ public class Apple2RealRomDisk2BootTests
         // Reset after inserting so the Autostart slot scan sees the controller.
         apple2.Reset();
 
-        for (var frame = 0; frame < (runFrames ?? BootFrames); frame++)
+        if (runFrames.HasValue)
+        {
+            for (var frame = 0; frame < runFrames.Value; frame++)
+                apple2.ExecuteOneFrame();
+            return apple2;
+        }
+
+        RunUntilBootSettles(apple2);
+        return apple2;
+    }
+
+    /// <summary>
+    /// Runs the machine until the drive has spun up and then stayed idle for a while — the
+    /// observable end of a boot — rather than for a fixed number of frames. Returns early on the
+    /// safety cap so a boot that never completes still fails on the test's own assertions, with the
+    /// frame count reported either way.
+    /// </summary>
+    private void RunUntilBootSettles(Apple2System apple2)
+    {
+        // Long enough to span DOS's own pauses between loads (it stops the motor between the DOS
+        // image, the greeting program and, with a language card fitted, Integer BASIC).
+        const int IdleFramesRequired = 120;
+
+        var motorHasRun = false;
+        var idleFrames = 0;
+
+        for (var frame = 0; frame < MaxBootFrames; frame++)
+        {
             apple2.ExecuteOneFrame();
 
-        return apple2;
+            if (apple2.DiskController.IsMotorOn)
+            {
+                motorHasRun = true;
+                idleFrames = 0;
+            }
+            else if (motorHasRun && ++idleFrames >= IdleFramesRequired)
+            {
+                _output.WriteLine($"Boot settled after {frame + 1} frames.");
+                return;
+            }
+        }
+
+        _output.WriteLine($"Boot did not settle within the {MaxBootFrames}-frame cap.");
     }
 
 

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RealRomProdosBootTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2RealRomProdosBootTests.cs
@@ -1,0 +1,183 @@
+using System.Text;
+using Highbyte.DotNet6502.Systems.Apple2.Config;
+using Highbyte.DotNet6502.Systems.Apple2.Video;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit.Abstractions;
+using Apple2System = Highbyte.DotNet6502.Systems.Apple2.Apple2;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
+
+/// <summary>
+/// The reason the language card exists: ProDOS 8 needs 64 KB, and a 48 KB machine gets exactly as
+/// far as ProDOS's own memory check before stopping with <c>RELOCATION/  CONFIGURATION ERROR</c>.
+/// This is the gate — that ProDOS boots at all — not that any particular title runs.
+///
+/// <para>
+/// Opt-in, like the DOS 3.3 boot tests: it needs the genuine ROMs and a ProDOS disk image, none of
+/// which can be checked in. Point <c>DOTNET6502_APPLE2_PRODOS_DSK</c> at a DOS-sector-ordered
+/// ProDOS <c>.dsk</c>. Developed against the 1991 release of Dangerous Dave
+/// (<c>a2_Dangerous_Dave_1</c> on archive.org), whose sector order the drive already supports.
+/// </para>
+/// </summary>
+[Trait("TestType", "Integration")]
+public class Apple2RealRomProdosBootTests
+{
+    /// <summary>
+    /// Frames to allow ProDOS to reach its prompt. Generous — the prompt is watched for, so this
+    /// only bounds a boot that never arrives. Observed at ~600 frames.
+    /// </summary>
+    private const int MaxFramesToPrompt = 3000;
+
+    /// <summary>Frames to allow the booted disk's title to reach its own graphics.</summary>
+    private const int MaxFramesToTitle = 6000;
+
+    private readonly ITestOutputHelper _output;
+
+    public Apple2RealRomProdosBootTests(ITestOutputHelper output) => _output = output;
+
+    [RequiresApple2ProdosBootFact]
+    public void Prodos_Boots_Past_The_Memory_Check_And_Runs_From_The_Language_Card()
+    {
+        var apple2 = BuildMachineWithProdosDisk();
+        apple2.Reset();
+
+        // Run until BASIC.SYSTEM puts up its prompt, capturing the machine's state at that moment
+        // rather than at the end of the run: what happens after ProDOS hands over is the title's
+        // business, and this test is about ProDOS.
+        var promptFrame = -1;
+        var readRamAtPrompt = false;
+        var cardBytesAtPrompt = 0;
+
+        for (var frame = 0; frame < MaxFramesToPrompt; frame++)
+        {
+            apple2.ExecuteOneFrame();
+
+            if (ScreenContainsBasicPrompt(apple2))
+            {
+                promptFrame = frame + 1;
+                readRamAtPrompt = apple2.LanguageCard.ReadRam;
+                cardBytesAtPrompt = CountNonZero(apple2.LanguageCard.Ram);
+                break;
+            }
+        }
+
+        var screenText = string.Join('\n', ReadScreen(apple2));
+        _output.WriteLine(screenText);
+        _output.WriteLine($"Prompt at frame {promptFrame}; card readRam={readRamAtPrompt} nonZeroBytes={cardBytesAtPrompt}");
+        _output.WriteLine($"Disk reads={apple2.DiskController.DataReadCount}, track={apple2.DiskController.CurrentTrack}");
+
+        // The failure this whole feature exists to remove. A 48 KB machine stops here.
+        Assert.DoesNotContain("RELOCATION", screenText, StringComparison.Ordinal);
+
+        Assert.True(promptFrame > 0, $"ProDOS did not reach its prompt within {MaxFramesToPrompt} frames.");
+
+        // ProDOS relocates itself into the card and runs from there, so by the time its prompt is up
+        // the card holds several KB and is switched in. Both would be false without a card.
+        Assert.True(cardBytesAtPrompt > 4096, "Expected ProDOS to have loaded itself into the language card.");
+        Assert.True(readRamAtPrompt, "Expected ProDOS to be running with the card switched in.");
+    }
+
+    /// <summary>
+    /// The milestone: the disk's title actually runs. Developed against "Dangerous Dave in the
+    /// Deserted Pirate's Hideout", which was built for a 64 KB Apple II Plus — so unlike the 1991
+    /// re-release (which is 65C02 code) it is within this machine's reach.
+    ///
+    /// <para>Asserted through what the machine does rather than through pixels: it leaves text mode
+    /// for hi-res, keeps running without halting, and needs no opcode this CPU lacks.</para>
+    /// </summary>
+    [RequiresApple2ProdosBootFact]
+    public void The_Title_On_The_Disk_Starts_And_Keeps_Running()
+    {
+        var apple2 = BuildMachineWithProdosDisk();
+        apple2.Reset();
+
+        var reachedHiRes = false;
+        for (var frame = 0; frame < MaxFramesToTitle; frame++)
+        {
+            apple2.ExecuteOneFrame();
+
+            if (!apple2.SoftSwitches.TextMode && apple2.SoftSwitches.HiRes)
+            {
+                reachedHiRes = true;
+                break;
+            }
+        }
+
+        Assert.True(reachedHiRes, $"The title did not switch to hi-res within {MaxFramesToTitle} frames.");
+
+        // Then keep going: a title that draws one frame and jams is not running.
+        var hiResBefore = CountNonZero(ReadHiResPage(apple2));
+        for (var frame = 0; frame < 600; frame++)
+            apple2.ExecuteOneFrame();
+
+        _output.WriteLine(
+            $"pc={apple2.CPU.PC:X4} halted={apple2.CPU.IsHalted} hires={apple2.SoftSwitches.HiRes} " +
+            $"unknownOpcodes={apple2.CPU.ExecState.UnknownOpCodeCount} " +
+            $"hiResNonZero={hiResBefore} -> {CountNonZero(ReadHiResPage(apple2))}");
+
+        Assert.False(apple2.CPU.IsHalted, "The title halted the CPU (a JAM opcode) instead of running.");
+        Assert.False(apple2.SoftSwitches.TextMode, "The title dropped back to text mode.");
+        Assert.Equal(0UL, apple2.CPU.ExecState.UnknownOpCodeCount);
+    }
+
+    /// <summary>Copy of hi-res page 1, used to show the screen is being drawn rather than static.</summary>
+    private static byte[] ReadHiResPage(Apple2System apple2)
+    {
+        var page = new byte[0x2000];
+        for (var i = 0; i < page.Length; i++)
+            page[i] = apple2.Mem[(ushort)(0x2000 + i)];
+        return page;
+    }
+
+    private Apple2System BuildMachineWithProdosDisk()
+    {
+        var romPath = Apple2TestRoms.ResolveSystemRomPath()!;
+        var disk2RomPath = Apple2TestRoms.ResolveDisk2RomPath()!;
+        var dskPath = Apple2TestRoms.ResolveProdosDskPath()!;
+
+        _output.WriteLine($"System ROM: {romPath}");
+        _output.WriteLine($"Disk II boot ROM: {disk2RomPath}");
+        _output.WriteLine($"ProDOS disk: {dskPath}");
+
+        var romData = new Dictionary<string, byte[]>
+        {
+            { Apple2SystemConfig.SYSTEM_ROM_NAME, File.ReadAllBytes(romPath) },
+            { Apple2SystemConfig.DISK2_ROM_NAME, File.ReadAllBytes(disk2RomPath) },
+        };
+
+        var apple2 = new Apple2System(new Apple2Config(), NullLoggerFactory.Instance, romData);
+        apple2.DiskController.InsertDiskImage(File.ReadAllBytes(dskPath));
+        return apple2;
+    }
+
+    /// <summary>
+    /// True once a line starts with the Applesoft prompt, which under ProDOS means BASIC.SYSTEM has
+    /// loaded and handed over — that is, ProDOS booted.
+    /// </summary>
+    private static bool ScreenContainsBasicPrompt(Apple2System apple2)
+        => ReadScreen(apple2).Any(row => row.StartsWith(']'));
+
+    private static int CountNonZero(byte[] data)
+    {
+        var count = 0;
+        foreach (var value in data)
+        {
+            if (value != 0)
+                count++;
+        }
+        return count;
+    }
+
+    private static string[] ReadScreen(Apple2System apple2)
+    {
+        var rows = new string[Apple2TextScreen.Rows];
+        for (var row = 0; row < Apple2TextScreen.Rows; row++)
+        {
+            var sb = new StringBuilder(Apple2TextScreen.Columns);
+            for (var col = 0; col < Apple2TextScreen.Columns; col++)
+                sb.Append(Apple2CharSet.ScreenCodeToUnicode(apple2.Mem[Apple2TextScreen.GetAddress(row, col)]));
+            rows[row] = sb.ToString();
+        }
+        return rows;
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2TestRoms.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2TestRoms.cs
@@ -20,6 +20,12 @@ internal static class Apple2TestRoms
     public const string BootDskPathEnvironmentVariable = "DOTNET6502_APPLE2_BOOT_DSK";
 
     /// <summary>
+    /// A bootable, DOS-sector-ordered ProDOS disk image. Kept separate from the DOS 3.3 boot disk
+    /// because it tests a different thing: that the machine has the 64 KB ProDOS requires.
+    /// </summary>
+    public const string ProdosDskPathEnvironmentVariable = "DOTNET6502_APPLE2_PRODOS_DSK";
+
+    /// <summary>
     /// File names as published by the ROM archive — the same names the app's ROM download writes
     /// into the ROM directory. The system ROM is published both as the bare 12 KB image and in the
     /// 20 KB layout, and the loader accepts either.
@@ -46,8 +52,14 @@ internal static class Apple2TestRoms
     /// in a known directory.
     /// </summary>
     public static string? ResolveBootDskPath()
+        => ResolveDiskImagePath(BootDskPathEnvironmentVariable);
+
+    public static string? ResolveProdosDskPath()
+        => ResolveDiskImagePath(ProdosDskPathEnvironmentVariable);
+
+    private static string? ResolveDiskImagePath(string environmentVariable)
     {
-        var fromEnvironment = Environment.GetEnvironmentVariable(BootDskPathEnvironmentVariable);
+        var fromEnvironment = Environment.GetEnvironmentVariable(environmentVariable);
         return !string.IsNullOrWhiteSpace(fromEnvironment) && File.Exists(fromEnvironment)
             ? fromEnvironment
             : null;
@@ -134,5 +146,30 @@ public sealed class RequiresApple2Disk2BootFactAttribute : FactAttribute
         else if (Apple2TestRoms.ResolveBootDskPath() == null)
             Skip = $"No bootable DOS 3.3 disk image. Set {Apple2TestRoms.BootDskPathEnvironmentVariable} " +
                    "to a .dsk path (there is deliberately no default location for disk images).";
+    }
+}
+
+/// <summary>
+/// A test needing the genuine ROMs plus a bootable, DOS-ordered ProDOS disk image. Skips, visibly,
+/// when any of them is absent — ProDOS images are user content with no default location, exactly
+/// like the DOS 3.3 boot disk.
+/// </summary>
+public sealed class RequiresApple2ProdosBootFactAttribute : FactAttribute
+{
+    public RequiresApple2ProdosBootFactAttribute()
+    {
+        if (Apple2TestRoms.ResolveSystemRomPath() == null)
+            Skip = Apple2TestRoms.MissingFileReason(
+                "Apple II system ROM",
+                Apple2TestRoms.SystemRomPathEnvironmentVariable,
+                Apple2TestRoms.SystemRomFileNames);
+        else if (Apple2TestRoms.ResolveDisk2RomPath() == null)
+            Skip = Apple2TestRoms.MissingFileReason(
+                "Disk II boot ROM",
+                Apple2TestRoms.Disk2RomPathEnvironmentVariable,
+                Apple2TestRoms.Disk2RomFileNames);
+        else if (Apple2TestRoms.ResolveProdosDskPath() == null)
+            Skip = $"No bootable ProDOS disk image. Set {Apple2TestRoms.ProdosDskPathEnvironmentVariable} " +
+                   "to a DOS-sector-ordered .dsk path.";
     }
 }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/Apple2SnapshotRoundTripTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/Apple2SnapshotRoundTripTests.cs
@@ -47,8 +47,64 @@ public class Apple2SnapshotRoundTripTests
 
         var moduleNames = provider.GetSnapshotModules().Select(m => m.Name).ToArray();
         Assert.Equal(
-            new[] { Cpu6502SnapshotModule.ModuleName, Apple2CoreSnapshotModule.ModuleName, Apple2Disk2SnapshotModule.ModuleName },
+            new[]
+            {
+                Cpu6502SnapshotModule.ModuleName,
+                Apple2CoreSnapshotModule.ModuleName,
+                Apple2LanguageCardSnapshotModule.ModuleName,
+                Apple2Disk2SnapshotModule.ModuleName,
+            },
             moduleNames);
+    }
+
+    /// <summary>
+    /// The card holds ProDOS itself once a ProDOS disk has booted, so losing it on restore would
+    /// replace the machine's operating system with zeros. The switch state travels too: it decides
+    /// whether the CPU resumes executing from the card or from ROM.
+    /// </summary>
+    [Fact]
+    public void Round_trip_restores_language_card_contents_and_switch_state()
+    {
+        var source = BuildApple2();
+
+        // Read+write the card, bank 1, and leave recognisable bytes in both of its regions.
+        source.Mem.Read(0xC08B);
+        source.Mem.Read(0xC08B);
+        source.Mem.Write(0xD000, 0x11);
+        source.Mem.Write(0xE000, 0x22);
+
+        // Then switch to bank 2 and write something different at the same address.
+        source.Mem.Read(0xC083);
+        source.Mem.Read(0xC083);
+        source.Mem.Write(0xD000, 0x33);
+
+        Assert.True(source.LanguageCard.ReadRam);
+        Assert.True(source.LanguageCard.WriteEnabled);
+        Assert.False(source.LanguageCard.Bank1Selected);
+
+        using var snapshotStream = new MemoryStream();
+        new SnapshotService().Save(source, snapshotStream);
+
+        snapshotStream.Position = 0;
+        var restored = BuildApple2();
+        // A fresh machine powers up reading ROM with the card protected — the opposite of the
+        // captured state, so a module that skipped this would fail rather than pass by accident.
+        Assert.False(restored.LanguageCard.ReadRam);
+        new SnapshotService().Restore(restored, snapshotStream);
+
+        Assert.True(restored.LanguageCard.ReadRam);
+        Assert.True(restored.LanguageCard.WriteEnabled);
+        Assert.False(restored.LanguageCard.Bank1Selected);
+
+        // The restored machine must also be *reading* the card, not just recording that it should:
+        // the memory configuration has to have been applied.
+        Assert.Equal((byte)0x33, restored.Mem.Read(0xD000));
+        Assert.Equal((byte)0x22, restored.Mem.Read(0xE000));
+
+        // The bank that was not selected at capture time survives too.
+        restored.Mem.Read(0xC08B);
+        restored.Mem.Read(0xC08B);
+        Assert.Equal((byte)0x11, restored.Mem.Read(0xD000));
     }
 
     [Fact]

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/Apple2SystemConfigSnapshotTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/Apple2SystemConfigSnapshotTests.cs
@@ -18,6 +18,7 @@ public class Apple2SystemConfigSnapshotTests
             AudioEnabled = false,
             KeyboardJoystickEnabled = true,
             MonitorColor = Apple2MonitorColor.Green,
+            LanguageCardEnabled = false,
         };
 
         var json = ((ISnapshotableConfig)source).ExportSnapshotSettings();
@@ -27,12 +28,15 @@ public class Apple2SystemConfigSnapshotTests
         Assert.True(target.AudioEnabled);
         Assert.False(target.KeyboardJoystickEnabled);
         Assert.Equal(Apple2MonitorColor.Color, target.MonitorColor);
+        Assert.True(target.LanguageCardEnabled);
 
         ((ISnapshotableConfig)target).ApplySnapshotSettings(json!);
 
         Assert.False(target.AudioEnabled);
         Assert.True(target.KeyboardJoystickEnabled);
         Assert.Equal(Apple2MonitorColor.Green, target.MonitorColor);
+        // Decides the shape of the rebuilt machine, so it has to travel with the rest.
+        Assert.False(target.LanguageCardEnabled);
     }
 
     [Fact]
@@ -45,6 +49,7 @@ public class Apple2SystemConfigSnapshotTests
         ((ISnapshotableConfig)config).ApplySnapshotSettings("{\"somethingElse\":123}");
 
         Assert.True(config.AudioEnabled);
+        Assert.True(config.LanguageCardEnabled);
         Assert.Equal(Apple2MonitorColor.Color, config.MonitorColor);
     }
 }


### PR DESCRIPTION
ProDOS 8 needs 64 KB, and the emulated machine was a 48 KB II Plus with no bank switching at all — so a ProDOS disk booted only as far as ProDOS's own memory check and stopped with `RELOCATION/  CONFIGURATION ERROR`. **ProDOS is the gate in front of most Apple II software from roughly 1984 onward**, so the Download & Run list could only ever hold DOS 3.3-era titles.

Now it boots, and **Dangerous Dave in the Deserted Pirate's Hideout plays**.

## The card

16 KB overlaying `$D000`–`$FFFF`, switched by `$C080`–`$C08F`: two independently selected 4 KB banks at `$D000`, one shared 8 KB block at `$E000` (which is why 16 KB covers a 12 KB range).

**Always fitted, invisible until used.** At power-on it reads as ROM with writes protected, so software that never touches `$C08x` sees exactly the machine it saw before. 64 KB was the standard II Plus configuration from 1982.

**The write-enable rule is modelled properly.** Enabling writes takes two consecutive accesses to an odd switch address, and only a *read* arms the first — a hardware guard so a single stray access (an indexed read landing in `$C08x`) cannot silently unlock RAM under the ROM. Software depends on it: reading the switch twice is the standard idiom for filling the card while still executing from ROM. The pre-write flip-flop is captured in snapshots too — one byte, without which a snapshot taken between the two reads resumes with the second read silently failing.

**Mapping costs nothing per switch.** The design note for this feature worried that bank switching meant re-mapping 12 KB of handlers, with an indirection as the fallback. Neither was needed: `Memory` already supports multiple configurations with O(1) swaps — the same mechanism C64 banking uses. The card has exactly 8 distinct maps (read source × bank × write enable), built once at startup, so a switch access costs a pointer assignment. That matters because software toggles banks in tight loops.

## ProDOS sector order

Filed as a "separate and much smaller" companion item; it turned out to be on the critical path, because the target disk is ProDOS-ordered.

**Detected from the image's contents, not its file name.** Archive.org's copy of *Deserted Pirate's Hideout* is named `.dsk` and is ProDOS-ordered — and the archive's own metadata confirms `Archive Order: ProDOS`. Nibblizing with the wrong order yields plausible garbage rather than an error, and the symptom (a drive spinning with the read counter frozen) reads as a drive bug rather than a misread image.

## Snapshots

New `apple2-languagecard` module for the card's 16 KB and switch state. Without it a restored ProDOS session comes back with its operating system replaced by zeros. It restores after `apple2-core` and applies the memory configuration itself, so the address space always ends up matching the switch state it restored.

## Verification

- **ProDOS boots**: no `RELOCATION` error, ProDOS relocates into the card, the CPU is observed executing from `$D0xx` with the card switched in, and BASIC.SYSTEM reaches its `]` prompt at frame 453 with ~10.9 KB resident.
- **The game runs**: leaves text mode for hi-res, loops in its own code, redraws the screen, and executes zero opcodes this CPU lacks. Confirmed visually in the desktop app — score, level 1, three lives, 60 fps — and now covered by an opt-in integration test.
- **DOS 3.3 still boots**, and independently confirms the card is real: the System Master now also loads Integer BASIC into it, which it skips on a 48 KB machine.
- 24 unit tests for the `$C08x` semantics, plus snapshot round-trip coverage.

All 1,801 tests pass, none skipped; build clean across 73 projects.

Added to the Download & Run list. Keyboard joystick is left **off** — the game reads the keyboard directly and never touches the game port, so enabling it would only steal keys.

## Test rework worth flagging

The DOS 3.3 boot test failed the moment the card was added, and the failure was correct: the boot legitimately got longer. The fix was not a bigger number — the test now waits for the drive to spin up and settle, with the frame count as a safety cap. A fixed budget was the wrong shape for a test that is not about boot duration, and would have broken again the next time the machine gained hardware.

## Not included

65C02 support. The **1991 re-release** of Dangerous Dave is a 65C02 build — it executes `$9C` (`STZ abs`), which this NMOS 6502 lacks, so the instruction stream desynchronises and the CPU lands on `$B2` (JAM). Same game, different build, different CPU requirement; only the 1988 original targets a II Plus. Recorded rather than pursued.