### PR TITLE
Pace Disk II reads by the clock, cutting DOS 3.3 boot from 95s to 12s

### DIFF
--- a/docs/systems/apple2/disk2.md
+++ b/docs/systems/apple2/disk2.md
@@ -72,16 +72,27 @@ polling paces the data and a reader can never miss a byte regardless of how slow
 them. That robustness is deliberate: the machine has no cycle-accurate bus for a rotational model
 to key off.
 
-**Known limitation:** booting the DOS 3.3 System Master takes about 35 emulated seconds, most of
-it DOS's *own* one-second motor spin-up wait, entered 31 times. RWTS decides whether
-the drive is spinning by comparing successive reads of the data register, and that decision
-depends on real read timing this model does not reproduce. Everything loads correctly, just slower
-than a real machine (~7 s). Two alternatives were implemented and measured, and both are worse: a
-true rotational model (position from elapsed CPU cycles) never completed DOS's sector reads, and a
-latch that holds a byte for N cycles never reached the DOS banner at all. Sync-gap sizes were also
-swept (20/5, 16/16, 12/12, 10/10, 9/9) with no effect, confirming the cause is the timing model
-rather than the track layout. Removing the wait needs a cycle-accurate read path — the natural
-companion to sequencer-PROM (LSS) emulation, if copy-protected media is ever supported.
+**Known limitation:** booting the DOS 3.3 System Master is several times slower than the ~7 s a
+real machine takes. Measured on the emulated machine:
+
+| Configuration | DOS banner | Drive settles |
+|---|---|---|
+| 64 KB, language card fitted (the default) | 35 s | **95 s** |
+| 48 KB, no language card | 35 s | 49 s |
+
+The banner arrives at the same point either way; the card changes what happens *after* it, because
+the System Master goes on to load Integer BASIC into the card once it finds one. That second phase
+is the larger half of the wait in the default configuration.
+
+Most of the time is DOS's *own* one-second motor spin-up wait, entered repeatedly. RWTS decides
+whether the drive is spinning by comparing successive reads of the data register, and that decision
+depends on real read timing this model does not reproduce. Everything loads correctly, just slowly.
+Two alternatives were implemented and measured, and both are worse: a true rotational model
+(position from elapsed CPU cycles) never completed DOS's sector reads, and a latch that holds a
+byte for N cycles never reached the DOS banner at all. Sync-gap sizes were also swept (20/5, 16/16,
+12/12, 10/10, 9/9) with no effect, confirming the cause is the timing model rather than the track
+layout. Removing the wait needs a cycle-accurate read path — the natural companion to
+sequencer-PROM (LSS) emulation, if copy-protected media is ever supported.
 
 ## Sector order
 

--- a/docs/systems/apple2/disk2.md
+++ b/docs/systems/apple2/disk2.md
@@ -65,34 +65,38 @@ the power-up byte at `$03F4` first — what power-cycling a real Apple does.
 The `disk2` ROM is **optional** — without it the machine is simply a diskless Apple II Plus, and
 only disk booting is unavailable. Add it in the Apple II configuration dialog like the other ROMs.
 
-## Timing model and its known limitation
+## Timing model
 
-Each read of the data register delivers the next nibble of the track stream, so the consumer's own
-polling paces the data and a reader can never miss a byte regardless of how slowly it collects
-them. That robustness is deliberate: the machine has no cycle-accurate bus for a rotational model
-to key off.
+The disk turns at its own rate rather than at the speed the CPU polls: one byte passes under the
+head every **32 CPU cycles** (250 kbit/s at 1.023 MHz), and a read arriving before the next byte is
+due reports "not ready" with bit 7 clear, so DOS's `LDA $C08C / BPL` poll loops pace themselves
+against the drive. Bytes the CPU is too slow to collect spin past unread, as on the hardware.
 
-**Known limitation:** booting the DOS 3.3 System Master is several times slower than the ~7 s a
-real machine takes. Measured on the emulated machine:
+That fidelity is load-bearing rather than decorative, because **DOS measures the byte rate**. RWTS
+decides whether the drive is turning by reading the data register twice about 18 cycles apart, up
+to 8 times, and concluding "stopped" if the value never changes — a timing-ratio test against the
+32-cycle byte rate.
 
-| Configuration | DOS banner | Drive settles |
+An earlier model delivered the next byte on every read, with no notion of time at all. That reduced
+RWTS's test to "are these 16 consecutive track bytes identical?" — and inside a 20-byte sync gap
+they are. DOS read a spinning drive as stopped and took its full one-second motor spin-up wait on
+every call: 87 of them in a System Master boot, which loaded everything perfectly correctly and
+took 95 seconds doing it. Booting now:
+
+| Configuration | Before | Now |
 |---|---|---|
-| 64 KB, language card fitted (the default) | 35 s | **95 s** |
-| 48 KB, no language card | 35 s | 49 s |
+| 64 KB, language card fitted (the default) | 95 s | **12 s** |
+| 48 KB, no language card | 49 s | **9 s** |
 
-The banner arrives at the same point either way; the card changes what happens *after* it, because
-the System Master goes on to load Integer BASIC into the card once it finds one. That second phase
-is the larger half of the wait in the default configuration.
+A real machine takes about 7 s. The remaining difference is not fully accounted for, and the
+approximations below push in both directions.
 
-Most of the time is DOS's *own* one-second motor spin-up wait, entered repeatedly. RWTS decides
-whether the drive is spinning by comparing successive reads of the data register, and that decision
-depends on real read timing this model does not reproduce. Everything loads correctly, just slowly.
-Two alternatives were implemented and measured, and both are worse: a true rotational model
-(position from elapsed CPU cycles) never completed DOS's sector reads, and a latch that holds a
-byte for N cycles never reached the DOS banner at all. Sync-gap sizes were also swept (20/5, 16/16,
-12/12, 10/10, 9/9) with no effect, confirming the cause is the timing model rather than the track
-layout. Removing the wait needs a cycle-accurate read path — the natural companion to
-sequencer-PROM (LSS) emulation, if copy-protected media is ever supported.
+**Approximations that remain.** A read arriving before the next byte is due reports "not ready",
+where the hardware would still be holding the previous completed byte — so software gets one read
+per byte rather than a holding window. The motor reaches full speed the instant it is switched on,
+where a real drive takes about half a second. Head seeks are immediate, with no per-track settling
+time. None of these affect standard 16-sector software; bit-level sequencer (LSS) behaviour, which
+copy protection depends on, is still not modelled.
 
 ## Sector order
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Disk2/Disk2Controller.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Disk2/Disk2Controller.cs
@@ -11,28 +11,21 @@ namespace Highbyte.DotNet6502.Systems.Apple2.Disk2;
 /// through 16 soft switches at $C0E0-$C0EF. RWTS and custom game loaders run unmodified on the
 /// emulated CPU against the nibble streams produced by <see cref="Disk2TrackNibblizer"/>.
 ///
-/// Timing model: every read of the data register delivers the next nibble of the track stream.
-/// The consumer's own polling paces the data, so a reader can never miss a byte no matter how
-/// slowly it collects them — the property that makes this robust without a cycle-accurate bus,
-/// which this machine does not have. Two alternatives were implemented and measured against a
-/// real DOS 3.3 System Master boot, and both are worse:
-/// <list type="bullet">
-/// <item>Deriving the head position purely from elapsed CPU cycles (a true rotational model):
-/// the boot ROM stage ran and stepped the head, but DOS's sector reads never completed.</item>
-/// <item>Holding the latch for N cycles so that reads closer together than N return the same
-/// byte (any N from 12 to 17 tried): the boot never reached the DOS banner at all.</item>
-/// </list>
+/// <para><b>Timing model.</b> The disk turns at its own fixed rate rather than at the speed the
+/// CPU polls: one byte passes under the head every <see cref="CyclesPerNibble"/> CPU cycles, and a
+/// read arriving before the next byte is due gets <c>NoDataLatched</c> — bit 7 clear — so RWTS's
+/// <c>LDA $C08C / BPL</c> poll loops pace themselves against the drive. Bytes the CPU is too slow
+/// to collect spin past unread, as they would on the hardware.</para>
 ///
-/// <para><b>Known limitation.</b> Booting the System Master reaches the DOS banner in ~35 emulated
-/// seconds, and with a language card fitted (the default) the drive keeps loading Integer BASIC
-/// for another minute — ~95 s before it settles, against ~49 s on a 48 KB machine and ~7 s on real
-/// hardware. Most of it is DOS's own one-second motor spin-up wait, entered repeatedly: RWTS
-/// decides the drive is stopped by comparing successive reads of the data register, and that
-/// decision depends on real read timing this model does not reproduce. Everything loads correctly,
-/// just slowly. Nibblizer sync-gap sizes were swept (20/5, 16/16, 12/12, 10/10, 9/9) with no
-/// effect, so the cause is the timing model rather than the track layout. Removing the wait needs
-/// a cycle-accurate read path — the natural companion to sequencer-PROM emulation, if
-/// copy-protected media is ever supported.</para>
+/// <para>This matters far more than "a rotating disk ought to rotate" suggests, because DOS
+/// <em>measures</em> it. RWTS decides whether the drive is turning by reading the data register
+/// twice about 18 cycles apart, up to 8 times, and concluding "stopped" if the value never
+/// changes — a timing-ratio test against the 32-cycle byte rate. An earlier model here delivered
+/// the next byte on every read, with no notion of time at all, which reduced that test to "are
+/// these 16 consecutive track bytes identical?". Inside a run of sync bytes they are, so DOS read
+/// a spinning drive as stopped and took its full one-second motor spin-up wait every time: 87 of
+/// them in a System Master boot, which is why booting took ~95 s instead of ~12 s while loading
+/// everything perfectly correctly the whole way.</para>
 ///
 /// The motor's ~1 second spin-down is modeled: the card's one-shot keeps the disk turning after
 /// the motor-off switch, so an access shortly after a stop still finds data under the head
@@ -40,8 +33,12 @@ namespace Highbyte.DotNet6502.Systems.Apple2.Disk2;
 ///
 /// Simplifications (fine for standard 16-sector software, documented deviations from hardware):
 /// write mode is a no-op (the disk is always write-protected), drive 2 is not present, and the
-/// sequencer PROM's bit-level behavior and true rotational timing (needed only by
-/// copy-protection schemes) are not modeled.
+/// sequencer PROM's bit-level behavior (needed only by copy-protection schemes) is not modeled.
+/// Three timing details are also approximated: a read arriving before the next byte is due reports
+/// "not ready" where the hardware would still be holding the previous completed byte, so software
+/// gets one read per byte rather than a holding window; the motor reaches full speed the instant
+/// it is switched on, where a real drive takes about half a second; and head seeks are immediate,
+/// with no per-track settling time.
 /// </summary>
 public class Disk2Controller
 {
@@ -103,12 +100,16 @@ public class Disk2Controller
     private byte[]? _rawDiskImageData;
 
     /// <param name="cpuCycleProvider">
-    /// Source of the CPU's cumulative cycle count, used only to time the motor's spin-down.
-    /// Defaults to a stopped clock, which makes spin-down expire immediately.
+    /// Source of the CPU's cumulative cycle count. Required, and deliberately not defaulted: the
+    /// drive turns at a fixed rate, so both the motor's spin-down and the rate bytes arrive under
+    /// the head are measured in CPU cycles. A stopped clock would mean a disk that never turns —
+    /// no byte would ever be due and every read would report "not ready" — which is a silent
+    /// wrong answer rather than a loud one, so callers have to say what time it is.
     /// </param>
-    public Disk2Controller(Func<ulong>? cpuCycleProvider = null)
+    public Disk2Controller(Func<ulong> cpuCycleProvider)
     {
-        _cpuCycleProvider = cpuCycleProvider ?? (static () => 0);
+        ArgumentNullException.ThrowIfNull(cpuCycleProvider);
+        _cpuCycleProvider = cpuCycleProvider;
     }
 
     /// <summary>The P5 (341-0027) 16-sector boot ROM image, when configured.</summary>
@@ -171,6 +172,10 @@ public class Disk2Controller
         _nibbleTracks = Disk2TrackNibblizer.BuildNibbleTracks(
             diskImageData, Disk2TrackNibblizer.DefaultVolume, SectorOrder);
         _rawDiskImageData = diskImageData;
+
+        // Same reason as on snapshot restore: start the byte cadence now, so a disk inserted well
+        // into a session does not read as an enormous elapsed time on its first access.
+        _lastNibbleCycle = _cpuCycleProvider();
     }
 
     public void RemoveDiskImage()
@@ -265,16 +270,39 @@ public class Disk2Controller
             _halfTrack = Math.Max(_halfTrack - 1, 0);
     }
 
+    /// <summary>
+    /// How long one disk byte takes to pass under the head: 250 kbit/s is one bit per 4 µs, so
+    /// one byte per 32 µs, which at the 1.023 MHz CPU clock is 32 cycles.
+    /// </summary>
+    public const ulong CyclesPerNibble = 32;
+
+    /// <summary>Cycle at which the byte currently under the head became complete.</summary>
+    private ulong _lastNibbleCycle;
+
+    /// <summary>
+    /// PROTOTYPE: cycle-paced read. Bytes arrive on the disk's own cadence rather than one per
+    /// read access, so reading faster than the disk delivers returns "not ready" (high bit clear)
+    /// exactly as the hardware does, and RWTS's LDA/BPL poll loops pace themselves against it.
+    /// </summary>
     private byte ReadDataNibble()
     {
         if (_nibbleTracks == null || !IsSpinning || _selectedDrive != 1)
             return NoDataValue;
 
-        DataReadCount++;
+        var elapsed = _cpuCycleProvider() - _lastNibbleCycle;
+        if (elapsed < CyclesPerNibble)
+            return NoDataLatched;   // still shifting in — bit 7 clear, so a poll loop keeps waiting
+
+        // Bytes keep passing under the head whether or not the CPU collects them, so advance by
+        // however many are due. Carry the remainder rather than resetting to now, so the cadence
+        // does not drift a little later with every read.
         var trackData = _nibbleTracks[CurrentTrack];
-        var value = trackData[_nibblePosition % trackData.Length];
-        _nibblePosition = (_nibblePosition + 1) % trackData.Length;
-        return value;
+        var due = elapsed / CyclesPerNibble;
+        _lastNibbleCycle += due * CyclesPerNibble;
+        _nibblePosition = (int)((_nibblePosition + (long)(due % (ulong)trackData.Length)) % trackData.Length);
+
+        DataReadCount++;
+        return trackData[_nibblePosition];
     }
 
     public void Reset()
@@ -322,5 +350,13 @@ public class Disk2Controller
         // whose length depends on the nibblizer, so a snapshot written by a different build could
         // otherwise index out of range. ReadDataNibble wraps modulo the track length anyway.
         _nibblePosition = nibblePosition < 0 ? 0 : nibblePosition;
+
+        // Restart the byte cadence from now. This is not in the snapshot payload on purpose: what
+        // matters is *where* the head is, which is restored above, not the sub-byte phase of the
+        // next arrival — an error of at most 31 cycles, below the resolution of anything RWTS does.
+        // It does have to be stamped though. Left at its old value, the restored CPU cycle count
+        // would read as a huge elapsed time and the first read would advance the head by millions
+        // of bytes, throwing away the position this module just restored.
+        _lastNibbleCycle = _cpuCycleProvider();
     }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Disk2/Disk2Controller.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Disk2/Disk2Controller.cs
@@ -23,14 +23,16 @@ namespace Highbyte.DotNet6502.Systems.Apple2.Disk2;
 /// byte (any N from 12 to 17 tried): the boot never reached the DOS banner at all.</item>
 /// </list>
 ///
-/// <para><b>Known limitation.</b> Booting the System Master takes ~35 emulated seconds, most of it
-/// DOS's own one-second motor spin-up wait, entered 31 times: RWTS decides the drive
-/// is stopped by comparing successive reads of the data register, and that decision depends on
-/// real read timing this model does not reproduce. Everything loads correctly, just slower than
-/// a real machine (~7 s). Nibblizer sync-gap sizes were swept (20/5, 16/16, 12/12, 10/10, 9/9)
-/// with no effect on the count, so the cause is the timing model rather than the track layout.
-/// Removing the wait needs a cycle-accurate read path — the natural companion to sequencer-PROM
-/// emulation, if copy-protected media is ever supported.</para>
+/// <para><b>Known limitation.</b> Booting the System Master reaches the DOS banner in ~35 emulated
+/// seconds, and with a language card fitted (the default) the drive keeps loading Integer BASIC
+/// for another minute — ~95 s before it settles, against ~49 s on a 48 KB machine and ~7 s on real
+/// hardware. Most of it is DOS's own one-second motor spin-up wait, entered repeatedly: RWTS
+/// decides the drive is stopped by comparing successive reads of the data register, and that
+/// decision depends on real read timing this model does not reproduce. Everything loads correctly,
+/// just slowly. Nibblizer sync-gap sizes were swept (20/5, 16/16, 12/12, 10/10, 9/9) with no
+/// effect, so the cause is the timing model rather than the track layout. Removing the wait needs
+/// a cycle-accurate read path — the natural companion to sequencer-PROM emulation, if
+/// copy-protected media is ever supported.</para>
 ///
 /// The motor's ~1 second spin-down is modeled: the card's one-shot keeps the disk turning after
 /// the motor-off switch, so an access shortly after a stop still finds data under the head

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Disk2ControllerTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Disk2ControllerTests.cs
@@ -6,6 +6,13 @@ namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
 
 public class Disk2ControllerTests
 {
+    /// <summary>
+    /// The CPU clock the drive is timed against. The disk turns at a fixed rate, so a test that
+    /// wants the next byte has to let time pass for it — see
+    /// <see cref="A_Byte_Takes_A_Byte_Time_To_Pass_Under_The_Head"/>.
+    /// </summary>
+    private ulong _cycles;
+
     private static byte[] BuildDiskImage()
     {
         var image = new byte[DskParser.DiskImageSize];
@@ -25,25 +32,28 @@ public class Disk2ControllerTests
         return rom;
     }
 
-    private static Disk2Controller CreateEnabledController()
+    private Disk2Controller CreateEnabledController()
     {
-        var controller = new Disk2Controller();
+        var controller = new Disk2Controller(() => _cycles);
         controller.SetBootRom(BuildBootRom());
         controller.InsertDiskImage(BuildDiskImage());
         controller.BusAccess(0xC0E9);   // motor on
         controller.BusAccess(0xC0EE);   // Q7 off: read mode
-        controller.BusAccess(0xC0EC);   // Q6 off
+        _cycles += Disk2Controller.CyclesPerNibble;   // let the first byte come round
+        controller.BusAccess(0xC0EC);   // Q6 off — consumes the byte now under the head
         return controller;
     }
 
     /// <summary>Reads the next delivered nibble, skipping non-data values.</summary>
-    private static byte ReadNibble(Disk2Controller controller)
+    private byte ReadNibble(Disk2Controller controller)
     {
         for (var attempt = 0; attempt < 4; attempt++)
         {
             var value = controller.BusAccess(0xC0EC);
             if ((value & 0x80) != 0)
                 return value;
+            // Not ready: wait a byte time for the next one, which is what a poll loop does.
+            _cycles += Disk2Controller.CyclesPerNibble;
         }
         Assert.Fail("No nibble delivered within 4 reads.");
         return 0;
@@ -96,7 +106,7 @@ public class Disk2ControllerTests
     [Fact]
     public void Controller_Is_Enabled_Only_With_Both_Boot_Rom_And_Disk()
     {
-        var controller = new Disk2Controller();
+        var controller = new Disk2Controller(() => _cycles);
         Assert.False(controller.IsEnabled);
 
         controller.SetBootRom(BuildBootRom());
@@ -112,13 +122,13 @@ public class Disk2ControllerTests
     [Fact]
     public void SetBootRom_Rejects_Wrong_Size()
     {
-        Assert.Throws<DotNet6502Exception>(() => new Disk2Controller().SetBootRom(new byte[512]));
+        Assert.Throws<DotNet6502Exception>(() => new Disk2Controller(() => _cycles).SetBootRom(new byte[512]));
     }
 
     [Fact]
     public void ReadBootRom_Returns_Rom_Bytes_When_Enabled_And_Unconnected_When_Not()
     {
-        var controller = new Disk2Controller();
+        var controller = new Disk2Controller(() => _cycles);
         controller.SetBootRom(BuildBootRom());
 
         // No disk: the slot looks empty so the Autostart scan falls through to BASIC.
@@ -133,7 +143,7 @@ public class Disk2ControllerTests
     [Fact]
     public void Motor_And_Drive_Select_Soft_Switches_Update_State()
     {
-        var controller = new Disk2Controller();
+        var controller = new Disk2Controller(() => _cycles);
         Assert.False(controller.IsMotorOn);
 
         controller.BusAccess(0xC0E9);
@@ -153,7 +163,8 @@ public class Disk2ControllerTests
     {
         var controller = CreateEnabledController();
 
-        controller.BusAccess(0xC0E8);   // motor off
+        controller.BusAccess(0xC0E8);                 // motor off
+        _cycles += Disk2Controller.SpinDownCycles;    // and the one-shot expires: the disk stops
         Assert.Equal(0xFF, controller.BusAccess(0xC0EC));
 
         controller.BusAccess(0xC0E9);   // motor on
@@ -162,19 +173,56 @@ public class Disk2ControllerTests
     }
 
     [Fact]
-    public void Each_Data_Read_Delivers_The_Next_Nibble_Of_The_Track_And_Wraps()
+    public void Successive_Reads_A_Byte_Time_Apart_Deliver_The_Track_In_Order_And_Wrap()
     {
         var image = BuildDiskImage();
+        var track = Disk2TrackNibblizer.BuildNibbleTracks(image)[0];
+
+        var controller = new Disk2Controller(() => _cycles);
+        controller.SetBootRom(BuildBootRom());
+        controller.InsertDiskImage(image);   // the head sits at position 0 when the disk goes in
+        controller.BusAccess(0xC0E9);        // motor on
+        controller.BusAccess(0xC0EE);        // Q7 off: read mode
+
+        // The byte at index i passes under the head i byte times later, and the last one is
+        // followed by index 0 again — the next revolution.
+        for (var i = 1; i <= track.Length; i++)
+        {
+            _cycles += Disk2Controller.CyclesPerNibble;
+            Assert.Equal(track[i % track.Length], controller.BusAccess(0xC0EC));
+        }
+    }
+
+    /// <summary>
+    /// The timing contract the rest of the drive rests on: a byte takes 32 CPU cycles to pass
+    /// under the head, so a read that arrives early gets "not ready" (bit 7 clear) and a poll loop
+    /// waits for it.
+    ///
+    /// <para>This is worth a test of its own because getting it wrong does not fail loudly.
+    /// Delivering a byte on every read instead — which an earlier model did — still boots every
+    /// disk. What it breaks is DOS's drive-spinning check in RWTS, which reads the data register
+    /// twice ~18 cycles apart and concludes the drive is stopped if the value never changes. With
+    /// no time in the model that test degenerates into "are these 16 consecutive track bytes
+    /// identical?", the window lands inside a run of sync bytes, and DOS takes its full one-second
+    /// motor spin-up wait on every call: 87 of them in a System Master boot, 95 seconds instead of
+    /// 12, with everything loading correctly the whole time.</para>
+    /// </summary>
+    [Fact]
+    public void A_Byte_Takes_A_Byte_Time_To_Pass_Under_The_Head()
+    {
         var controller = CreateEnabledController();
-        var expectedTrack = Disk2TrackNibblizer.BuildNibbleTracks(image)[0];
 
-        // CreateEnabledController consumed position 0 with its Q6-off access.
-        for (var i = 1; i < expectedTrack.Length; i++)
-            Assert.Equal(expectedTrack[i], controller.BusAccess(0xC0EC));
+        _cycles += Disk2Controller.CyclesPerNibble;
+        var first = controller.BusAccess(0xC0EC);
+        Assert.True((first & 0x80) != 0, "A byte was due, so one must be delivered.");
 
-        // Past the end of the track buffer the stream wraps to the start — a new revolution.
-        Assert.Equal(expectedTrack[0], controller.BusAccess(0xC0EC));
-        Assert.Equal(expectedTrack[1], controller.BusAccess(0xC0EC));
+        // Too soon — still shifting in.
+        _cycles += Disk2Controller.CyclesPerNibble / 2;
+        Assert.Equal(0x00, controller.BusAccess(0xC0EC));
+
+        // A full byte time after the last delivery, the next one is there.
+        _cycles += Disk2Controller.CyclesPerNibble;
+        Assert.True((controller.BusAccess(0xC0EC) & 0x80) != 0);
     }
 
     [Fact]
@@ -257,8 +305,10 @@ public class Disk2ControllerTests
         controller.BusAccess(0xC0E5);
         Assert.Equal(1, controller.CurrentTrack);
 
-        // Position 0 was consumed on track 0 already; the head position carries over.
-        Assert.Equal(track1[1], controller.BusAccess(0xC0EC));
+        // The head keeps its angular position across a seek, so the next byte time brings the
+        // same point of the new track under it.
+        _cycles += Disk2Controller.CyclesPerNibble;
+        Assert.Equal(track1[2], controller.BusAccess(0xC0EC));
     }
 
     [Fact]

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/Apple2DiskSnapshotTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/Apple2DiskSnapshotTests.cs
@@ -32,6 +32,28 @@ public class Apple2DiskSnapshotTests
         return rom;
     }
 
+    /// <summary>
+    /// Moves the emulated clock on by running a NOP sled. The drive turns at a fixed rate, so a
+    /// test that pokes the card's soft switches without letting any time pass is asking a stopped
+    /// disk for data and will read "not ready" forever.
+    /// </summary>
+    private static void AdvanceCycles(Apple2System machine, ulong cycles)
+    {
+        const ushort SledStart = 0x0300;
+        const ushort SledEnd = 0x0400;
+        for (var addr = SledStart; addr < SledEnd; addr++)
+            machine.Mem[addr] = 0xEA;   // NOP
+
+        machine.CPU.PC = SledStart;
+        var target = machine.CPU.ExecState.CyclesConsumed + cycles;
+        while (machine.CPU.ExecState.CyclesConsumed < target)
+        {
+            machine.ExecuteOneInstruction(out _);
+            if (machine.CPU.PC >= SledEnd)
+                machine.CPU.PC = SledStart;
+        }
+    }
+
     [Fact]
     public void Saved_package_embeds_the_inserted_disk_image_bytes()
     {
@@ -64,8 +86,10 @@ public class Apple2DiskSnapshotTests
         // Drive the card the way the boot ROM does: motor on, read mode, step the head off track 0.
         source.Mem.Read(0xC0E9);                    // motor on
         source.Mem.Read(0xC0EE);                    // Q7 off (read mode)
+        AdvanceCycles(source, Disk2Controller.CyclesPerNibble);
         source.Mem.Read(0xC0EC);                    // Q6 off
         StepHeadUpOneTrack(source);
+        AdvanceCycles(source, Disk2Controller.CyclesPerNibble);
         source.Mem.Read(0xC0EC);                    // read a nibble, advancing the stream position
 
         var sourceTrack = source.DiskController.CurrentTrack;
@@ -87,8 +111,13 @@ public class Apple2DiskSnapshotTests
         Assert.Equal(sourceTrack, restored.DiskController.CurrentTrack);
         Assert.True(restored.DiskController.IsMotorOn);
 
-        // The read head resumes where it was: the next nibble matches the source machine's.
-        Assert.Equal(source.Mem.Read(0xC0EC), restored.Mem.Read(0xC0EC));
+        // The read head resumes where it was: given the same byte time on each machine, the next
+        // nibble matches the source's.
+        AdvanceCycles(source, Disk2Controller.CyclesPerNibble);
+        AdvanceCycles(restored, Disk2Controller.CyclesPerNibble);
+        var sourceNibble = source.Mem.Read(0xC0EC);
+        Assert.True((sourceNibble & 0x80) != 0, "A byte was due on the source machine.");
+        Assert.Equal(sourceNibble, restored.Mem.Read(0xC0EC));
     }
 
     [Fact]


### PR DESCRIPTION
The Disk II drive turned at whatever speed the CPU polled it — every read of the data register handed back the next byte of the track. Time played no part. That looked like harmless robustness (a reader could never miss a byte) and was in fact why booting a DOS 3.3 disk took a minute and a half.

## Why it was slow

DOS *measures* the byte rate. RWTS decides whether the drive is turning by reading the data register twice ~18 cycles apart, up to 8 times, and concluding "stopped" if the value never changes — a timing-ratio test against the 32-cycle byte rate.

With no time in the model, that test degenerates into "are these 16 consecutive track bytes identical?". A sync gap is 20 bytes of `$FF`, so the whole window sat inside one. DOS read a spinning drive as stopped and took its full one-second motor spin-up wait every time — 42 of them on a 48 KB boot, 87 with a language card.

Profiling a real System Master boot: **336 of 337 comparisons came out equal, and every read returned `$FF`**. Shortening the sync gap below the 16-byte window as an experiment collapsed the boot from 49 s to 8 s, confirming the mechanism before any fix was written.

## The change

Bytes arrive on the disk's own cadence: one per 32 CPU cycles (250 kbit/s at 1.023 MHz). A read arriving early reports "not ready" with bit 7 clear, so RWTS's `LDA/BPL` poll loops pace themselves against the drive, and bytes the CPU is too slow to collect spin past unread. The cycle remainder is carried, so the cadence does not drift.

| Configuration | Before | After |
|---|---|---|
| 64 KB, language card (default) | 95 s | **12 s** |
| 48 KB | 49 s | **9 s** |

A real machine takes about 7 s. The residual is not fully accounted for, and the remaining approximations push in both directions.

## Verification

Every title on the drive's verified list: DOS 3.3 System Master, Lode Runner, Choplifter, Bolo, VisiCalc, Dangerous Dave — across three loaders (DOS 3.3 RWTS, ProDOS, and the 4am cracks' own). Lode Runner's hi-res page comes back byte-identical to the previous model.

**Dangerous Dave loads slower**, 17 s → 24 s. That is the model getting more honest, not a regression: the old path delivered a byte on every access, faster than a drive can physically produce them. This is the one figure I could not check against real hardware.

## Notes for review

- **The cycle provider is now required** rather than defaulting to a stopped clock. One production call site, already passing the real clock. The default only armed a trap — a stopped clock now means a disk that never turns.
- **Snapshots need no format change.** The byte-cadence phase is re-stamped on restore rather than persisted; the head position is what matters and was already captured. It does have to be stamped, or the restored cycle count reads as an enormous elapsed time and the first read discards the restored position.
- **Two existing tests were asserting the wrong thing** and are corrected, not retimed. `Data_Read_Requires_Motor_On_And_Drive_1` asserted `$FF` for "motor off" without letting the spin-down one-shot expire — it passed only because the head sat on a sync byte, which is also `$FF`. Another encoded the old one-byte-per-read model in its name.
- **New:** `A_Byte_Takes_A_Byte_Time_To_Pass_Under_The_Head` covers the contract directly, with a comment noting that getting it wrong does not fail loudly.

Class comment and `disk2.md` rewritten — both described the old model — including the approximations that remain: no holding window for an early read, instant motor spin-up, instant head seeks.

All 1802 tests pass; 73 projects build with no warnings.