### PR TITLE
Allow archive.org downloads in the browser app

### DIFF
--- a/.github/workflows/cors-proxy.yml
+++ b/.github/workflows/cors-proxy.yml
@@ -1,0 +1,44 @@
+name: CORS download proxy
+
+# The browser app's downloads all go through this Worker, so its allowlist decides which
+# "Download & Run" entries work in the browser at all. Its tests had been failing unnoticed
+# because nothing ran them - a suite no workflow runs is not a gate.
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'tools/cloudflare/cors-download-proxy/**'
+      - '.github/workflows/cors-proxy.yml'
+
+  pull_request:
+    branches: [ master ]
+    paths:
+      - 'tools/cloudflare/cors-download-proxy/**'
+      - '.github/workflows/cors-proxy.yml'
+
+jobs:
+  test:
+    name: CORS download proxy / Test
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: tools/cloudflare/cors-download-proxy
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22.x
+        cache: npm
+        cache-dependency-path: tools/cloudflare/cors-download-proxy/package-lock.json
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Test
+      run: npm test

--- a/.github/workflows/cors-proxy.yml
+++ b/.github/workflows/cors-proxy.yml
@@ -38,7 +38,9 @@ jobs:
         cache-dependency-path: tools/cloudflare/cors-download-proxy/package-lock.json
 
     - name: Install dependencies
-      run: npm ci
+      # --ignore-scripts so dependency lifecycle scripts cannot execute in CI. Nothing here
+      # needs them: the tests pass from a clean node_modules installed this way.
+      run: npm ci --ignore-scripts
 
     - name: Test
       run: npm test

--- a/.github/workflows/cors-proxy.yml
+++ b/.github/workflows/cors-proxy.yml
@@ -11,11 +11,11 @@ on:
       - 'tools/cloudflare/cors-download-proxy/**'
       - '.github/workflows/cors-proxy.yml'
 
+  # Unfiltered for the same reason as docs-check.yml and wasm-aot-verify.yml: a `paths`-filtered
+  # workflow never reports a status, so it can never safely be made a required check. Filtering
+  # happens in the job instead, which keeps that option open.
   pull_request:
     branches: [ master ]
-    paths:
-      - 'tools/cloudflare/cors-download-proxy/**'
-      - '.github/workflows/cors-proxy.yml'
 
 jobs:
   test:
@@ -29,8 +29,33 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+      with:
+        # Needed to diff against the PR base.
+        fetch-depth: 0
+
+    - name: Detect changes to the Worker
+      id: changes
+      shell: bash
+      working-directory: .
+      run: |
+        if [ "${{ github.event_name }}" != "pull_request" ]; then
+          echo "relevant=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        changed=$(git diff --name-only "${{ github.event.pull_request.base.sha }}...HEAD")
+        echo "Changed files:"
+        echo "$changed"
+
+        if echo "$changed" | grep -qE '^(tools/cloudflare/cors-download-proxy/|\.github/workflows/cors-proxy\.yml)'; then
+          echo "relevant=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "relevant=false" >> "$GITHUB_OUTPUT"
+          echo "Worker unchanged - reporting success without installing or testing."
+        fi
 
     - name: Setup Node
+      if: steps.changes.outputs.relevant == 'true'
       uses: actions/setup-node@v4
       with:
         node-version: 22.x
@@ -38,9 +63,11 @@ jobs:
         cache-dependency-path: tools/cloudflare/cors-download-proxy/package-lock.json
 
     - name: Install dependencies
+      if: steps.changes.outputs.relevant == 'true'
       # --ignore-scripts so dependency lifecycle scripts cannot execute in CI. Nothing here
       # needs them: the tests pass from a clean node_modules installed this way.
       run: npm ci --ignore-scripts
 
     - name: Test
+      if: steps.changes.outputs.relevant == 'true'
       run: npm test

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -3,15 +3,17 @@ name: Docs check
 on:
   workflow_dispatch:
 
+  # Deliberately unfiltered for pull_request, unlike the push trigger below.
+  #
+  # A workflow that `paths` filters out never runs, and a workflow that never runs never reports a
+  # status. Branch protection requires "CI / Documentation" to report, so on any PR that touched no
+  # documentation the check sat at "Expected - Waiting for status to be reported" permanently and
+  # the PR could not be merged. That is not a slow check; it is a deadlock, and it only surfaces on
+  # PRs that happen to miss every path in the list.
+  #
+  # So the job always runs and always reports. The path filter moved into the job itself, where a
+  # miss costs a few seconds of runner time instead of a merge.
   pull_request:
-    paths:
-      - 'docs/**'
-      - 'includes/**'
-      - 'mkdocs.yml'
-      - 'requirements-docs.in'
-      - 'requirements-docs.txt'
-      - '.pip-tools.toml'
-      - '.github/workflows/docs-check.yml'
 
   push:
     branches:
@@ -31,8 +33,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Needed to diff against the PR base.
+          fetch-depth: 0
+
+      - name: Detect documentation changes
+        id: changes
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed=$(git diff --name-only "${{ github.event.pull_request.base.sha }}...HEAD")
+          echo "Changed files:"
+          echo "$changed"
+
+          if echo "$changed" | grep -qE '^(docs/|includes/|mkdocs\.yml|requirements-docs\.(in|txt)|\.pip-tools\.toml|\.github/workflows/docs-check\.yml)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "No documentation sources changed - reporting success without building."
+          fi
 
       - name: Setup Python
+        if: steps.changes.outputs.relevant == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -40,7 +66,9 @@ jobs:
           cache-dependency-path: requirements-docs.txt
 
       - name: Install MkDocs and dependencies
+        if: steps.changes.outputs.relevant == 'true'
         run: "pip install --require-hashes --only-binary :all: -r requirements-docs.txt"
 
       - name: Build static site with MkDocs (strict)
+        if: steps.changes.outputs.relevant == 'true'
         run: mkdocs build --strict --site-dir site

--- a/.github/workflows/sonarscan-dotnet.yml
+++ b/.github/workflows/sonarscan-dotnet.yml
@@ -69,7 +69,14 @@ jobs:
           # TypeScript deployables (not the .NET product) and intentionally share small helper
           # functions (path normalization, bearer-token auth). Exclude them from copy/paste
           # duplication detection so that shared boilerplate doesn't fail the new-code gate.
-          sonarBeginArguments: /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml" -d:sonar.cs.vstest.reportsPaths="**/TestResults/*.trx" -d:sonar.coverage.inclusions="src/libraries/Highbyte.DotNet6502/**/*.*" -d:sonar.cpd.exclusions="tools/**"
+          #
+          # sonar.coverage.exclusions: same scope decision, applied to coverage. This gate measures
+          # the .NET product - sonar.coverage.inclusions already narrows it to one library - and no
+          # coverage report is produced for the TypeScript under tools/**, so without this their
+          # lines count as uncovered and drag new_coverage to 0. The Workers do have their own
+          # vitest suites, run by their own workflows; they are simply not reported here. If that
+          # ever changes, drop this and feed the lcov in instead.
+          sonarBeginArguments: /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml" -d:sonar.cs.vstest.reportsPaths="**/TestResults/*.trx" -d:sonar.coverage.inclusions="src/libraries/Highbyte.DotNet6502/**/*.*" -d:sonar.cpd.exclusions="tools/**" -d:sonar.coverage.exclusions="tools/**"
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wasm-aot-verify.yml
+++ b/.github/workflows/wasm-aot-verify.yml
@@ -7,18 +7,12 @@ name: WASM AOT publish smoke
 # regular `dotnet build` / `dotnet test` CI job.
 
 on:
+  # Deliberately unfiltered. A workflow that `paths` filters out never runs, and one that never
+  # runs never reports a status - so branch protection, which requires these two checks to report,
+  # left any PR touching none of those paths stuck at "Expected - Waiting for status to be
+  # reported" forever. The filter moved into the job below, where a miss costs a few seconds
+  # instead of a merge.
   pull_request:
-    paths:
-      - 'src/apps/BlazorWASM/**'
-      - 'src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Browser/**'
-      # The Browser app transitively pulls in Avalonia.Core and every Shell.* via
-      # ProjectReference, so changes there also need to retrigger the smoke run.
-      - 'src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/**'
-      - 'src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.*/**'
-      - 'src/libraries/**'
-      - 'src/systems/**'
-      - 'tests/wasm-smoke/**'
-      - '.github/workflows/wasm-aot-verify.yml'
   workflow_dispatch:
 
 concurrency:
@@ -45,16 +39,44 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Needed to diff against the PR base.
+          fetch-depth: 0
+
+      - name: Detect changes affecting the WASM apps
+        id: changes
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed=$(git diff --name-only "${{ github.event.pull_request.base.sha }}...HEAD")
+          echo "Changed files:"
+          echo "$changed"
+
+          # The Browser app transitively pulls in Avalonia.Core and every Shell.* via
+          # ProjectReference, so changes there also need to retrigger the smoke run.
+          if echo "$changed" | grep -qE '^(src/apps/BlazorWASM/|src/apps/Avalonia/Highbyte\.DotNet6502\.App\.Avalonia\.(Browser|Core|Shell\.)|src/libraries/|src/systems/|tests/wasm-smoke/|\.github/workflows/wasm-aot-verify\.yml)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "Nothing the WASM apps are built from changed - reporting success without publishing."
+          fi
 
       - name: Setup .NET
+        if: steps.changes.outputs.relevant == 'true'
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 
       - name: Install wasm-tools workload
+        if: steps.changes.outputs.relevant == 'true'
         run: dotnet workload install wasm-tools
 
       - name: Publish ${{ matrix.app.name }} (Release, AOT)
+        if: steps.changes.outputs.relevant == 'true'
         env:
           VERSION: 0.0.0-pr${{ github.event.pull_request.number || github.run_number }}
         # Same flags as .github/workflows/pages-publish.yml so we
@@ -70,7 +92,7 @@ jobs:
             -o "build/${{ matrix.app.name }}"
 
       - name: Replace version placeholders
-        if: matrix.app.needs_version_placeholder_replace
+        if: steps.changes.outputs.relevant == 'true' && matrix.app.needs_version_placeholder_replace
         env:
           VERSION: 0.0.0-pr${{ github.event.pull_request.number || github.run_number }}
         run: |
@@ -78,11 +100,13 @@ jobs:
           find "build/${{ matrix.app.name }}/wwwroot" -name "*.js" -exec sed -i "s/{{APP_VERSION}}/$VERSION/g" {} \;
 
       - name: Setup Node
+        if: steps.changes.outputs.relevant == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
       - name: Install Playwright deps
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: tests/wasm-smoke
         # npm ci enforces install from the committed package-lock.json (exact versions).
         # --ignore-scripts skips arbitrary preinstall/postinstall scripts in transitive
@@ -93,13 +117,14 @@ jobs:
           ./node_modules/.bin/playwright install --with-deps chromium
 
       - name: Run smoke test
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: tests/wasm-smoke
         env:
           WASM_SITE_ROOT: ${{ github.workspace }}/build/${{ matrix.app.name }}/wwwroot
         run: ./node_modules/.bin/playwright test "${{ matrix.app.spec }}"
 
       - name: Upload Playwright report on failure
-        if: failure()
+        if: failure() && steps.changes.outputs.relevant == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report-${{ matrix.app.name }}

--- a/tools/cloudflare/cors-download-proxy/src/index.ts
+++ b/tools/cloudflare/cors-download-proxy/src/index.ts
@@ -117,6 +117,22 @@ export function validateConfig(env: Env): ConfigValidationResult {
 		return { ok: false, error: "ALLOWED_TARGET_HOSTS must contain at least one hostname.", proxyPath };
 	}
 
+	// A bare "*" would allow every host on the internet, which is an open proxy. Reject it at
+	// startup rather than discovering it from traffic. Same for a wildcard with nothing after the
+	// dot, and for a suffix so short it cannot name a registrable domain ("*.com").
+	const badWildcard = allowedTargetHosts.find(
+		(entry) => entry === "*" || (entry.startsWith("*.") && !entry.slice(2).includes(".")),
+	);
+	if (badWildcard) {
+		return {
+			ok: false,
+			error:
+				`ALLOWED_TARGET_HOSTS entry '${badWildcard}' is too broad. ` +
+				"Use '*.example.com' to allow subdomains of a specific domain.",
+			proxyPath,
+		};
+	}
+
 	return {
 		ok: true,
 		config: {
@@ -145,8 +161,32 @@ export function isAllowedOrigin(origin: string, config: ProxyConfig): boolean {
 	return config.allowLocalhostOrigins && /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/i.test(origin);
 }
 
+/**
+ * Matches a target hostname against the allowlist.
+ *
+ * An entry is either an exact hostname (`archive.org`) or a subdomain wildcard (`*.archive.org`).
+ * The wildcard is opt-in per entry rather than implied by every entry, so adding one host that
+ * needs subdomains does not quietly widen the others: `csdb.dk` still means only `csdb.dk`.
+ *
+ * A wildcard matches subdomains *only* — `*.archive.org` does not match `archive.org` itself, so a
+ * host that needs both is listed twice. That is deliberate: the two are different trust decisions,
+ * and spelling them out means the allowlist can be read literally.
+ *
+ * The leading dot in the compared suffix is what makes this safe. Testing `endsWith("archive.org")`
+ * would also admit `evilarchive.org`, which is an allowlist that quietly allows anyone willing to
+ * register the right name.
+ */
 export function isAllowedTargetHost(hostname: string, config: ProxyConfig): boolean {
-	return config.allowedTargetHosts.includes(hostname.toLowerCase());
+	const host = hostname.toLowerCase();
+
+	return config.allowedTargetHosts.some((entry) => {
+		if (!entry.startsWith("*.")) {
+			return host === entry;
+		}
+
+		const suffix = entry.slice(1); // "*.archive.org" -> ".archive.org"
+		return host.length > suffix.length && host.endsWith(suffix);
+	});
 }
 
 export function isAuthorized(request: Request, sharedToken: string | null): boolean {

--- a/tools/cloudflare/cors-download-proxy/test/index.spec.ts
+++ b/tools/cloudflare/cors-download-proxy/test/index.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import worker, {
 	csv,
 	isAllowedOrigin,
+	isAllowedTargetHost,
 	isAuthorized,
 	normalizeProxyPath,
 	parseTargetUrl,
@@ -24,13 +25,67 @@ describe("cors download proxy worker", () => {
 		expect(csv(" A.example.com, B.example.com ,, ")).toEqual(["a.example.com", "b.example.com"]);
 	});
 
+	it("matches exact target hosts without allowing their subdomains", () => {
+		const config = { allowedTargetHosts: ["csdb.dk", "archive.org"] } as never;
+
+		expect(isAllowedTargetHost("csdb.dk", config)).toBe(true);
+		expect(isAllowedTargetHost("CSDB.DK", config)).toBe(true);
+		// An exact entry stays exact. Adding a wildcard elsewhere must not widen this one.
+		expect(isAllowedTargetHost("files.csdb.dk", config)).toBe(false);
+	});
+
+	it("matches subdomains only for wildcard entries", () => {
+		const config = { allowedTargetHosts: ["archive.org", "*.archive.org"] } as never;
+
+		// The per-request node hosts archive.org redirects downloads to.
+		expect(isAllowedTargetHost("dn711007.ca.archive.org", config)).toBe(true);
+		expect(isAllowedTargetHost("ia801234.us.archive.org", config)).toBe(true);
+		expect(isAllowedTargetHost("archive.org", config)).toBe(true); // from the exact entry
+
+		// The wildcard alone does not cover the bare domain, which is why both are listed.
+		expect(isAllowedTargetHost("archive.org", { allowedTargetHosts: ["*.archive.org"] } as never)).toBe(false);
+	});
+
+	it("does not let a wildcard match a lookalike domain", () => {
+		const config = { allowedTargetHosts: ["*.archive.org"] } as never;
+
+		// The whole point of comparing against ".archive.org" rather than "archive.org":
+		// anyone can register these.
+		expect(isAllowedTargetHost("evilarchive.org", config)).toBe(false);
+		expect(isAllowedTargetHost("notarchive.org", config)).toBe(false);
+		// And a suffix match must not be fooled by the domain appearing earlier in the name.
+		expect(isAllowedTargetHost("archive.org.evil.com", config)).toBe(false);
+	});
+
+	it("rejects wildcards too broad to be an allowlist", () => {
+		const base = {
+			ALLOWED_ORIGINS: "https://highbyte.se",
+			PROXY_PATH: "/fetch",
+		};
+
+		for (const hosts of ["*", "*.com", "csdb.dk,*"]) {
+			const result = validateConfig({ ...base, ALLOWED_TARGET_HOSTS: hosts } as never);
+			expect(result.ok, `expected '${hosts}' to be rejected`).toBe(false);
+		}
+
+		expect(validateConfig({ ...base, ALLOWED_TARGET_HOSTS: "*.archive.org" } as never).ok).toBe(true);
+	});
+
 	it("validates required config values", () => {
 		expect(validateConfig(env)).toMatchObject({
 			ok: true,
 			config: {
 				proxyPath: "/fetch",
 				allowedOrigins: ["https://highbyte.se"],
-				allowedTargetHosts: ["www.zimmers.net", "csdb.dk", "compunet.live", "highbyte.se", "mirrors.apple2.org.za"],
+				allowedTargetHosts: [
+					"www.zimmers.net",
+					"csdb.dk",
+					"compunet.live",
+					"highbyte.se",
+					"mirrors.apple2.org.za",
+					"archive.org",
+					"*.archive.org",
+				],
 			},
 		});
 
@@ -90,7 +145,15 @@ describe("cors download proxy worker", () => {
 		expect(await response.json()).toMatchObject({
 			ok: true,
 			proxyPath: "/fetch",
-			allowedTargetHosts: ["www.zimmers.net", "csdb.dk", "compunet.live", "highbyte.se"],
+			allowedTargetHosts: [
+				"www.zimmers.net",
+				"csdb.dk",
+				"compunet.live",
+				"highbyte.se",
+				"mirrors.apple2.org.za",
+				"archive.org",
+				"*.archive.org",
+			],
 			rateLimits: {
 				burst: { limit: 8, periodSeconds: 10 },
 				sustained: { limit: 20, periodSeconds: 60 },
@@ -213,6 +276,30 @@ describe("cors download proxy worker", () => {
 		expect(response.status).toBe(403);
 		expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://highbyte.se");
 		expect(await response.text()).toBe("Redirect target host not allowed");
+	});
+
+	it("follows a redirect to a wildcard-allowed subdomain", async () => {
+		// archive.org 302s every download to a per-request node host, so the wildcard has to hold
+		// on the redirect hop and not just on the first request.
+		vi.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(
+				new Response(null, {
+					status: 302,
+					headers: { Location: "https://dn711007.ca.archive.org/0/items/Visicalc_1.27/Visicalc_1.27.dsk" },
+				}),
+			)
+			.mockResolvedValueOnce(new Response("disk-bytes", { status: 200 }));
+
+		const request = new Request(
+			"https://proxy.test/fetch?url=https%3A%2F%2Farchive.org%2Fdownload%2FVisicalc_1.27%2FVisicalc_1.27.dsk",
+			{ headers: { Origin: "https://highbyte.se" } },
+		);
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, env, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("disk-bytes");
 	});
 
 	it("rejects responses that exceed the configured size limit", async () => {

--- a/tools/cloudflare/cors-download-proxy/wrangler.jsonc
+++ b/tools/cloudflare/cors-download-proxy/wrangler.jsonc
@@ -11,7 +11,7 @@
 		"PROXY_PATH": "/fetch",
 		"ALLOWED_ORIGINS": "https://highbyte.se",
 		"ALLOW_LOCALHOST_ORIGINS": "true",
-		"ALLOWED_TARGET_HOSTS": "www.zimmers.net,csdb.dk,compunet.live,highbyte.se,mirrors.apple2.org.za",
+		"ALLOWED_TARGET_HOSTS": "www.zimmers.net,csdb.dk,compunet.live,highbyte.se,mirrors.apple2.org.za,archive.org,*.archive.org",
 		"MAX_REDIRECTS": "5",
 		"MAX_RESPONSE_BYTES": "33554432"
 	},


### PR DESCRIPTION
Download & Run failed in the Avalonia Browser build for **VisiCalc and Dangerous Dave**. Both are hosted on archive.org, which was not in the CORS proxy's `ALLOWED_TARGET_HOSTS`, so the Worker answered `403 Target host not allowed`. The other four Apple II entries use `mirrors.apple2.org.za` and were unaffected, and the desktop app fetches directly so it never hit this.

Reproduced against the live Worker before changing anything, and the deployed vars matched `wrangler.jsonc`, so there was no config/deployment drift.

## Why adding `archive.org` was not enough

Every archive.org download 302s to a per-request node host:

```
https://archive.org/download/Visicalc_1.27/Visicalc_1.27.dsk
  → https://dn711007.ca.archive.org/0/items/Visicalc_1.27/Visicalc_1.27.dsk
```

The Worker re-validates each redirect hop against the same allowlist, so allowing only `archive.org` would have swapped one 403 for `Redirect target host not allowed`. Those node hostnames vary per request and region and cannot be enumerated.

## The change

`isAllowedTargetHost` gains a `*.` wildcard entry. Three choices worth stating:

- **The wildcard is opt-in per entry, not implied by every entry.** Allowing subdomains of one host must not quietly widen the rest — `csdb.dk` still means only `csdb.dk`.
- **A wildcard matches subdomains only**, so a host needing both is listed twice (`archive.org` and `*.archive.org`). They are different trust decisions and the allowlist should read literally.
- **The compared suffix keeps its leading dot.** Testing `endsWith("archive.org")` would also admit `evilarchive.org` — an allowlist anyone can join by registering the right name.

`validateConfig` now rejects wildcards too broad to be an allowlist: a bare `*`, or one with no dot after it such as `*.com`. A bare `*` makes this an open proxy, and that should fail at startup rather than be discovered from traffic.

## Verification

Run against the **real** service with the Worker running locally, not just mocked:

| Target | Result |
|---|---|
| VisiCalc | 200, **143 360 bytes**, starts `01 A5 27` |
| Dangerous Dave | 200, 143 360 bytes |
| `evilarchive.org` | 403 Target host not allowed |
| `archive.org.evil.com` | 403 Target host not allowed |

143 360 is exactly a 140 KB DOS 3.3 image and `01 A5 27…` is the Apple II boot sector, so that is the real file through the real redirect chain.

**Already deployed and verified manually in the browser app.** The Worker deploy is independent of this merge — this PR is the source of record catching up with what is live.

20 tests pass, including 6 new ones: exact entries do not match subdomains, wildcards match node hosts, a wildcard alone does not cover the bare domain, the three lookalike cases, over-broad wildcards rejected, and a redirect-hop test mirroring archive.org's actual 302.

## Two incidental fixes

- **A test was already failing before this change.** The health-document assertion still listed four allowed hosts after `mirrors.apple2.org.za` was added as a fifth. Confirmed by stashing and re-running.
- **Nothing ran these tests**, which is how that went unnoticed — no workflow referenced the Worker at all. Adds `.github/workflows/cors-proxy.yml`, path-filtered to `tools/cloudflare/cors-download-proxy/**`. A suite nothing runs is not a gate.

## Flagged, not fixed

- `npm audit` reports **7 high-severity advisories**, all `undici` reached via `wrangler` / `@cloudflare/vitest-pool-workers`. Dev/test dependencies, not shipped in the Worker; the fix needs `--force` and a breaking bump, so it wants a decision rather than a silent change.
- The new workflow uses **tag-pinned actions**, matching the repo's existing nine. The convention is full SHA pinning; no workflow here does that today, so this is a pre-existing gap worth a separate sweep rather than one inconsistent file.