### PR TITLE
Add Apple II support to Terminal app

### DIFF
--- a/docs/host-apps/overview.md
+++ b/docs/host-apps/overview.md
@@ -11,7 +11,7 @@ one app with two runtimes.
 | [Blazor WebAssembly](blazor-wasm/overview.md) | Browser | [Blazor WebAssembly](https://dotnet.microsoft.com/en-us/apps/aspnet/web-apps/blazor) + `Highbyte.DotNet6502.Impl.Skia` (SkiaSharp on canvas) | `Highbyte.DotNet6502.Impl.AspNet` (WebAudio JS interop). C64 command-stream provider only. | SkiaSharp-rendered browser alternative. |
 | [SadConsole](sadconsole/overview.md) | Desktop | [SadConsole](https://github.com/Thraka/SadConsole) (terminal/ASCII engine) | NAudio + OpenAL. | Console-style retro UI. |
 | [SilkNetNative](silknet-native/overview.md) | Desktop | [Silk.NET](https://github.com/dotnet/Silk.NET) + ImGui + OpenGL/SkiaSharp | NAudio + OpenAL. | OpenGL/shader rendering paths, incl. a custom GPU-packet C64 renderer. |
-| [Terminal (TUI)](terminal/overview.md) | Desktop / CLI | [Terminal.Gui](https://github.com/gui-cs/Terminal.Gui) v2 — renders the emulated text-mode screen as colored Unicode cells in a real terminal (works over SSH, in tmux). | none | Interactive emulator inside a real terminal. C64 and VIC-20 (text mode); no audio. |
+| [Terminal (TUI)](terminal/overview.md) | Desktop / CLI | [Terminal.Gui](https://github.com/gui-cs/Terminal.Gui) v2 — renders the emulated text-mode screen as colored Unicode cells in a real terminal (works over SSH, in tmux). | none | Interactive emulator inside a real terminal. C64, VIC-20, and Apple II Plus (text mode); no audio. |
 | [Console Monitor](console-monitor/overview.md) | Desktop | Plain .NET console | none | Stand-alone 6502 machine code monitor; no system emulation UI. |
 | [Headless](headless/overview.md) | Desktop / CLI | none | none | Automation, scripting, CI workflows. Driven entirely by CLI args and Lua. |
 

--- a/docs/host-apps/terminal/overview.md
+++ b/docs/host-apps/terminal/overview.md
@@ -49,9 +49,12 @@ It works over SSH and inside `tmux`/`screen` as long as the outer terminal meets
   PETSCII graphics screen codes are mapped best-effort to Unicode box-drawing / block / shade glyphs
   for the built-in (uppercase/graphics) charset.
 - **VIC-20** (`Impl.Terminal.Vic20` + `App.Terminal.Shell.Vic20`) — character mode only.
+- **Apple II Plus** (`Impl.Terminal.Apple2` + `App.Terminal.Shell.Apple2`) — 40×24 text page
+  with normal, inverse, and flashing characters. Lo-res and hi-res graphics are not represented;
+  while the machine is in a graphics mode, the Terminal host continues to show its text page.
 
 The screen pane resizes automatically to fit the running system's frame (C64 ≈ 40 columns,
-VIC-20 ≈ 22 columns), and the status/logs column reflows around it. The emulated screen is drawn
+VIC-20 ≈ 22 columns, Apple II = 40 columns), and the status/logs column reflows around it. The emulated screen is drawn
 without an extra framing box — each system renders its own coloured screen border, which is wide and
 wasteful in a terminal, so the view crops it down to a thin, consistent border on every side. This
 keeps the C64 (29 cells tall including its border) within a default ~30-row terminal without the user
@@ -136,8 +139,12 @@ emulator is stopped, with live validation:
   interrupt mode, receive mode, transport, TCP host/port, connect-on-boot), and keyboard joystick
   (enable + port 1/2). Keyboard-joystick settings can also be toggled live from the C64 menu.
 - **VIC-20** — ROM directory/files (with auto-download).
+- **Apple II Plus** — required system/character ROMs, optional Disk II boot ROM (with
+  auto-download), monitor colour, and language-card selection. Its system menu also provides
+  Applesoft copy/paste, read-only `.dsk` insertion/booting, and a live WASD keyboard joystick.
 
 See [Systems / C64 / ROMs](../../systems/c64/roms.md), [Systems / VIC-20 / ROMs](../../systems/vic20/roms.md),
+[Systems / Apple II / ROMs](../../systems/apple2/roms.md),
 and [Systems / C64 / SwiftLink](../../systems/c64/swiftlink.md).
 
 The shipped `appsettings.json` contains packaged defaults. User changes are saved to the Terminal host's `appsettings.user.json` under the OS local application data directory, not beside the shipped executable. Empty ROM directory settings use the shared user content directories under `~/Documents/Highbyte/DotNet6502/roms` (or the Windows Documents equivalent).

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ See [Desktop apps installation](host-apps/installation.md) for download links an
 
 ## Terminal (TUI) app
 
-[Terminal (TUI) app](host-apps/terminal/overview.md) — runs the emulator interactively inside a real terminal, rendering the emulated text-mode screen as colored Unicode cells via [Terminal.Gui](https://github.com/gui-cs/Terminal.Gui). Works over SSH and in `tmux`/`screen`. Supports the C64 and VIC-20 in character mode (no audio, no bitmap/sprite graphics), and includes the built-in machine code monitor.
+[Terminal (TUI) app](host-apps/terminal/overview.md) — runs the emulator interactively inside a real terminal, rendering the emulated text-mode screen as colored Unicode cells via [Terminal.Gui](https://github.com/gui-cs/Terminal.Gui). Works over SSH and in `tmux`/`screen`. Supports the C64, VIC-20, and Apple II Plus in character mode (no audio or pixel graphics), and includes the built-in machine code monitor.
 
 <img src="assets/screenshots/Terminal_C64_Basic.png" title="Terminal (TUI) app, C64 Basic" width="50%" />
 

--- a/docs/libraries/implementation/terminal.md
+++ b/docs/libraries/implementation/terminal.md
@@ -10,8 +10,9 @@ Library: `Highbyte.DotNet6502.Impl.Terminal`
 
 !!! note "System-specific code lives in companion libraries"
     This library holds only **system-agnostic** terminal glue. Per-system code is in the
-    engine-plugin libraries `Highbyte.DotNet6502.Impl.Terminal.Commodore64` and
-    `Highbyte.DotNet6502.Impl.Terminal.Vic20` (host config + `ISystemEnginePlugin` registration).
+    engine-plugin libraries `Highbyte.DotNet6502.Impl.Terminal.Commodore64`,
+    `Highbyte.DotNet6502.Impl.Terminal.Vic20`, and `Highbyte.DotNet6502.Impl.Terminal.Apple2`
+    (host config + `ISystemEnginePlugin` registration).
     See [Systems / C64 / Libraries](../../systems/c64/libraries.md) and
     [Systems / VIC-20 / Libraries](../../systems/vic20/libraries.md).
 

--- a/docs/systems/apple2/overview.md
+++ b/docs/systems/apple2/overview.md
@@ -38,7 +38,7 @@ The currently supported system variant is `APPLE2PLUS`.
 - Remote-control commands for keyboard input, BASIC source, and Disk II operations. See the
   [TCP protocol](../../tools/remote-control/tcp-protocol.md).
 - Avalonia Desktop and Avalonia Browser (WASM) apps with configuration for ROMs, display,
-  audio, input, and CPU compatibility.
+  audio, input, and CPU compatibility, plus text-mode support in the Terminal (TUI) app.
 - Emulator state snapshots, including the language card and inserted disk. See
   [Snapshots](#snapshots).
 

--- a/dotnet-6502.slnx
+++ b/dotnet-6502.slnx
@@ -82,6 +82,7 @@
   </Folder>
   <Folder Name="/src/apps/Terminal/">
     <Project Path="src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Core/Highbyte.DotNet6502.App.Terminal.Core.csproj" />
+    <Project Path="src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Apple2/Highbyte.DotNet6502.App.Terminal.Shell.Apple2.csproj" />
     <Project Path="src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Commodore64/Highbyte.DotNet6502.App.Terminal.Shell.Commodore64.csproj" />
     <Project Path="src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Vic20/Highbyte.DotNet6502.App.Terminal.Shell.Vic20.csproj" />
     <Project Path="src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/Highbyte.DotNet6502.App.Terminal.csproj" />
@@ -89,6 +90,7 @@
   <Folder Name="/src/libraries/">
     <Project Path="src/libraries/Highbyte.DotNet6502.Impl.SadConsole.Commodore64/Highbyte.DotNet6502.Impl.SadConsole.Commodore64.csproj" />
     <Project Path="src/libraries/Highbyte.DotNet6502.Impl.SadConsole.Generic/Highbyte.DotNet6502.Impl.SadConsole.Generic.csproj" />
+    <Project Path="src/libraries/Highbyte.DotNet6502.Impl.Terminal.Apple2/Highbyte.DotNet6502.Impl.Terminal.Apple2.csproj" />
     <Project Path="src/libraries/Highbyte.DotNet6502.Impl.Terminal.Commodore64/Highbyte.DotNet6502.Impl.Terminal.Commodore64.csproj" />
     <Project Path="src/libraries/Highbyte.DotNet6502.Impl.Terminal.Vic20/Highbyte.DotNet6502.Impl.Terminal.Vic20.csproj" />
     <Project Path="src/libraries/Highbyte.DotNet6502.Impl.Terminal/Highbyte.DotNet6502.Impl.Terminal.csproj" />

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Apple2/Apple2ConfigDialog.cs
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Apple2/Apple2ConfigDialog.cs
@@ -1,0 +1,248 @@
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using Highbyte.DotNet6502.Impl.Terminal.Apple2;
+using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Apple2.Config;
+using Highbyte.DotNet6502.Systems.Apple2.Video;
+using Highbyte.DotNet6502.Systems.Caching;
+using Highbyte.DotNet6502.Systems.Configuration;
+using Highbyte.DotNet6502.Utils;
+using Microsoft.Extensions.Logging;
+using Terminal.Gui.App;
+using Terminal.Gui.Drivers;
+using Terminal.Gui.ViewBase;
+using Terminal.Gui.Views;
+
+#pragma warning disable CS0618
+
+namespace Highbyte.DotNet6502.App.Terminal.Shell.Apple2;
+
+/// <summary>Apple II ROM, display and memory configuration for the Terminal host.</summary>
+internal static class Apple2ConfigDialog
+{
+    public static void Show(TuiHostApp host, ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger(nameof(Apple2ConfigDialog));
+        if (host.EmulatorState != EmulatorState.Uninitialized)
+        {
+            logger.LogInformation("Stop the Apple II before changing its configuration.");
+            return;
+        }
+
+        var hostConfig = (Apple2TerminalHostConfig)host.CurrentHostSystemConfig.Clone();
+        var cfg = hostConfig.SystemConfig;
+
+        var dialog = new Dialog
+        {
+            Title = "Apple II Config  (Esc to cancel)",
+            Width = 88,
+            Height = 19,
+        };
+        host.ApplyUiScheme(dialog);
+
+        var autoDownloadButton = new Button { X = 1, Y = 0, Text = "Auto download ROMs", ShadowStyle = ShadowStyles.None };
+        var manualDownloadButton = new Button { X = Pos.Right(autoDownloadButton) + 1, Y = 0, Text = "ROM archive", ShadowStyle = ShadowStyles.None };
+        var downloadStatusLabel = new Label { X = 1, Y = 1, Width = Dim.Fill(2), Text = "" };
+        dialog.Add(autoDownloadButton, manualDownloadButton, downloadStatusLabel);
+
+        dialog.Add(new Label { X = 1, Y = 2, Text = "ROM files:" });
+        var dirField = AddRow(host, dialog, 3, "ROM dir:", cfg.ROMDirectory, true, cfg);
+        var systemField = AddRow(host, dialog, 4, "System:", RomFile(cfg, Apple2SystemConfig.SYSTEM_ROM_NAME), false, cfg);
+        var chargenField = AddRow(host, dialog, 5, "Chargen:", RomFile(cfg, Apple2SystemConfig.CHARGEN_ROM_NAME), false, cfg);
+        var disk2Field = AddRow(host, dialog, 6, "Disk II:", RomFile(cfg, Apple2SystemConfig.DISK2_ROM_NAME), false, cfg);
+        var effectiveRomDirectoryLabel = new Label { X = 1, Y = 7, Width = Dim.Fill(2), Text = "" };
+        dialog.Add(effectiveRomDirectoryLabel);
+
+        var monitorValues = Enum.GetNames<Apple2MonitorColor>();
+        dialog.Add(new Label { X = 1, Y = 9, Text = "Monitor:" });
+        var monitorDropDown = new DropDownList
+        {
+            X = 11,
+            Y = 9,
+            Width = 18,
+            Source = new ListWrapper<string>(new ObservableCollection<string>(monitorValues)),
+            ReadOnly = true,
+            Text = cfg.MonitorColor.ToString(),
+        };
+        var languageCardCheck = new CheckBox
+        {
+            X = 34,
+            Y = 9,
+            Text = "64 KB language card",
+            Value = cfg.LanguageCardEnabled ? CheckState.Checked : CheckState.UnChecked,
+        };
+        dialog.Add(monitorDropDown, languageCardCheck);
+
+        var validationLabel = new Label { X = 1, Y = 11, Text = "Validation errors:" };
+        var validationList = new ListView { X = 1, Y = 12, Width = Dim.Fill(2), Height = 3 };
+        validationList.VerticalScrollBar.VisibilityMode = ScrollBarVisibilityMode.Auto;
+        dialog.Add(validationLabel, validationList);
+
+        var okButton = new Button { Text = "OK", IsDefault = true, ShadowStyle = ShadowStyles.None };
+        var cancelButton = new Button { Text = "Cancel", ShadowStyle = ShadowStyles.None };
+
+        void Sync()
+        {
+            cfg.ROMDirectory = dirField.Text;
+            cfg.SetROM(Apple2SystemConfig.SYSTEM_ROM_NAME, EmptyToNull(systemField.Text));
+            cfg.SetROM(Apple2SystemConfig.CHARGEN_ROM_NAME, EmptyToNull(chargenField.Text));
+            if (string.IsNullOrWhiteSpace(disk2Field.Text))
+                cfg.ROMs.RemoveAll(rom => rom.Name == Apple2SystemConfig.DISK2_ROM_NAME);
+            else
+                cfg.SetROM(Apple2SystemConfig.DISK2_ROM_NAME, disk2Field.Text);
+
+            if (Enum.TryParse<Apple2MonitorColor>(monitorDropDown.Text.ToString(), out var monitorColor))
+                cfg.MonitorColor = monitorColor;
+            cfg.LanguageCardEnabled = languageCardCheck.Value == CheckState.Checked;
+            cfg.AudioEnabled = false;
+            effectiveRomDirectoryLabel.Text =
+                $"Effective: {PathHelper.ExpandOSEnvironmentVariables(cfg.EffectiveROMDirectory)}";
+        }
+
+        void Validate()
+        {
+            Sync();
+            var isValid = hostConfig.IsValid(out var errors);
+            validationList.SetSource(new ObservableCollection<string>(
+                isValid ? new List<string> { "(none)" } : errors));
+            validationLabel.Visible = !isValid;
+            validationList.Visible = !isValid;
+            okButton.Enabled = isValid;
+            dialog.SetNeedsDraw();
+        }
+
+        dirField.TextChanged += (_, _) => Validate();
+        systemField.TextChanged += (_, _) => Validate();
+        chargenField.TextChanged += (_, _) => Validate();
+        disk2Field.TextChanged += (_, _) => Validate();
+        languageCardCheck.ValueChanged += (_, _) => Validate();
+
+        autoDownloadButton.Accepting += async (_, e) =>
+        {
+            e.Handled = true;
+            Sync();
+            downloadStatusLabel.Text = "Downloading ROMs…";
+            dialog.SetNeedsDraw();
+
+            string status;
+            try
+            {
+                var cache = new FileDownloadCache(AppStoragePaths.GetDownloadCacheDirectory(), loggerFactory);
+                using var httpClient = new HttpClient();
+                var downloader = new RomDownloader(loggerFactory, httpClient, downloadCache: cache);
+                var files = await downloader.DownloadRomsToFilesAsync(
+                    cfg.ROMDownloadSources,
+                    cfg.EffectiveROMDirectory);
+                foreach (var (romName, fileName) in files)
+                    cfg.SetROM(romName, fileName);
+                status = "ROMs downloaded OK";
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Apple II ROM download failed.");
+                status = ex.Message;
+            }
+
+            Application.Invoke(() =>
+            {
+                systemField.Text = RomFile(cfg, Apple2SystemConfig.SYSTEM_ROM_NAME);
+                chargenField.Text = RomFile(cfg, Apple2SystemConfig.CHARGEN_ROM_NAME);
+                disk2Field.Text = RomFile(cfg, Apple2SystemConfig.DISK2_ROM_NAME);
+                downloadStatusLabel.Text = status;
+                Validate();
+            });
+        };
+
+        manualDownloadButton.Accepting += (_, e) =>
+        {
+            e.Handled = true;
+            try
+            {
+                Process.Start(new ProcessStartInfo(Apple2SystemConfig.ROM_SOURCE_INFO_URL) { UseShellExecute = true });
+                downloadStatusLabel.Text = "Opened the Apple II ROM archive.";
+            }
+            catch (Exception ex)
+            {
+                downloadStatusLabel.Text = $"Could not open browser: {ex.Message}";
+            }
+        };
+
+        okButton.Accepting += (_, e) =>
+        {
+            e.Handled = true;
+            Sync();
+            if (!hostConfig.IsValid(out List<string> _))
+            {
+                Validate();
+                return;
+            }
+            host.UpdateHostSystemConfig(hostConfig);
+            logger.LogInformation("Apple II configuration updated.");
+            Application.RequestStop(dialog);
+        };
+        cancelButton.Accepting += (_, e) => { e.Handled = true; Application.RequestStop(dialog); };
+
+        dialog.KeyDown += (_, key) =>
+        {
+            if ((key.KeyCode & ~(KeyCode.ShiftMask | KeyCode.CtrlMask | KeyCode.AltMask)) != KeyCode.Esc)
+                return;
+            key.Handled = true;
+            Application.RequestStop(dialog);
+        };
+
+        dialog.AddButton(cancelButton);
+        dialog.AddButton(okButton);
+        Validate();
+
+        try { Application.Run(dialog); }
+        finally { dialog.Dispose(); }
+    }
+
+    private static string RomFile(Apple2SystemConfig cfg, string romName)
+        => cfg.HasROM(romName) ? cfg.GetROM(romName).File ?? string.Empty : string.Empty;
+
+    private static string? EmptyToNull(string value) => string.IsNullOrWhiteSpace(value) ? null : value;
+
+    private static TextField AddRow(
+        TuiHostApp host,
+        Dialog dialog,
+        int y,
+        string label,
+        string value,
+        bool isDirectory,
+        Apple2SystemConfig cfg)
+    {
+        dialog.Add(new Label { X = 1, Y = y, Text = label });
+        var field = new TextField { X = 11, Y = y, Width = Dim.Fill(10), Text = value };
+        var pickButton = new Button { X = Pos.AnchorEnd(8), Y = y, Text = "...", ShadowStyle = ShadowStyles.None };
+        pickButton.Accepting += (_, e) =>
+        {
+            e.Handled = true;
+            var picked = PickPath(host, cfg, isDirectory);
+            if (picked != null)
+                field.Text = isDirectory ? picked : Path.GetFileName(picked);
+        };
+        dialog.Add(field, pickButton);
+        return field;
+    }
+
+    private static string? PickPath(TuiHostApp host, Apple2SystemConfig cfg, bool isDirectory)
+    {
+        var startDir = PathHelper.ExpandOSEnvironmentVariables(cfg.EffectiveROMDirectory);
+        using var picker = new OpenDialog
+        {
+            Title = isDirectory ? "Select ROM directory" : "Select ROM file",
+            OpenMode = isDirectory ? OpenMode.Directory : OpenMode.File,
+            AllowsMultipleSelection = false,
+        };
+        host.ApplyUiScheme(picker);
+        if (Directory.Exists(startDir))
+        {
+            picker.Path = startDir.EndsWith(Path.DirectorySeparatorChar)
+                ? startDir
+                : startDir + Path.DirectorySeparatorChar;
+        }
+        Application.Run(picker);
+        return picker.Canceled || picker.FilePaths.Count == 0 ? null : picker.FilePaths[0];
+    }
+}

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Apple2/Apple2TerminalInfoView.cs
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Apple2/Apple2TerminalInfoView.cs
@@ -1,0 +1,43 @@
+using System.Collections.ObjectModel;
+using Terminal.Gui.ViewBase;
+using Terminal.Gui.Views;
+
+namespace Highbyte.DotNet6502.App.Terminal.Shell.Apple2;
+
+/// <summary>Apple II keyboard mapping and Terminal-host limitations.</summary>
+public sealed class Apple2TerminalInfoView : View, ITerminalInfoContribution
+{
+    private static readonly string[] s_lines =
+    {
+        "Apple II Plus",
+        "40 x 24 text, uppercase",
+        "",
+        "Keyboard mapping",
+        "Enter       Return",
+        "Esc         Esc",
+        "Backspace   Left arrow",
+        "Left/Right  Apple arrows",
+        "Up/Down     Line up/down",
+        "Ctrl+key    Control code",
+        "",
+        "Joystick (when enabled)",
+        "WASD        Direction",
+        "Space       Button 1",
+        "Shift       Button 2",
+        "",
+        "Terminal renders the text",
+        "page in graphics modes; hi-res",
+        "and lo-res pixels are unavailable.",
+    };
+
+    public View View => this;
+
+    public Apple2TerminalInfoView()
+    {
+        var list = new ListView { X = 0, Y = 0, Width = Dim.Fill(), Height = Dim.Fill() };
+        list.VerticalScrollBar.VisibilityMode = ScrollBarVisibilityMode.Auto;
+        list.HorizontalScrollBar.VisibilityMode = ScrollBarVisibilityMode.Auto;
+        list.SetSource(new ObservableCollection<string>(s_lines));
+        Add(list);
+    }
+}

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Apple2/Apple2TerminalMenuView.cs
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Apple2/Apple2TerminalMenuView.cs
@@ -1,0 +1,201 @@
+using Highbyte.DotNet6502.Impl.Terminal.Apple2;
+using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Apple2.Disk2;
+using Microsoft.Extensions.Logging;
+using Terminal.Gui.App;
+using Terminal.Gui.ViewBase;
+using Terminal.Gui.Views;
+using TextCopy;
+using Apple2System = Highbyte.DotNet6502.Systems.Apple2.Apple2;
+
+#pragma warning disable CS0618
+
+namespace Highbyte.DotNet6502.App.Terminal.Shell.Apple2;
+
+/// <summary>Apple II copy/paste, Disk II, joystick and configuration controls.</summary>
+public sealed class Apple2TerminalMenuView : View, ITerminalMenuContribution
+{
+    private readonly TuiHostApp _host;
+    private readonly ILogger _logger;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly Button _copyButton;
+    private readonly Button _pasteButton;
+    private readonly Button _diskButton;
+    private readonly Button _bootButton;
+    private readonly CheckBox _joystickCheck;
+    private readonly Button _configButton;
+
+    public string MenuTitle => "Apple II";
+
+    public int MenuRowCount => 4;
+
+    public View View => this;
+
+    public Apple2TerminalMenuView(TuiHostApp host, ILoggerFactory loggerFactory)
+    {
+        _host = host;
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory.CreateLogger(nameof(Apple2TerminalMenuView));
+
+        _copyButton = new Button { X = 0, Y = 0, Text = "Copy", ShadowStyle = ShadowStyles.None };
+        _copyButton.Accepting += (_, e) => { e.Handled = true; CopyBasicSource(); };
+
+        _pasteButton = new Button { X = 12, Y = 0, Text = "Paste", ShadowStyle = ShadowStyles.None };
+        _pasteButton.Accepting += (_, e) => { e.Handled = true; PasteText(); };
+
+        _diskButton = new Button { X = 0, Y = 1, Text = "Insert .dsk", ShadowStyle = ShadowStyles.None };
+        _diskButton.Accepting += async (_, e) => { e.Handled = true; await ToggleDisk(); };
+
+        _bootButton = new Button { X = 15, Y = 1, Text = "Boot", ShadowStyle = ShadowStyles.None };
+        _bootButton.Accepting += async (_, e) => { e.Handled = true; await BootDisk(); };
+
+        _joystickCheck = new CheckBox
+        {
+            X = 0,
+            Y = 2,
+            Text = "WASD joystick",
+            Value = CurrentConfig?.KeyboardJoystickEnabled == true
+                ? CheckState.Checked
+                : CheckState.UnChecked,
+        };
+        _joystickCheck.ValueChanged += (_, e) => SetKeyboardJoystick(e.NewValue == CheckState.Checked);
+
+        _configButton = new Button { X = 0, Y = 3, Text = "Config…", ShadowStyle = ShadowStyles.None };
+        _configButton.Accepting += (_, e) =>
+        {
+            e.Handled = true;
+            Apple2ConfigDialog.Show(_host, _loggerFactory);
+            SyncControls();
+        };
+
+        Add(_copyButton, _pasteButton, _diskButton, _bootButton, _joystickCheck, _configButton);
+        SyncControls();
+    }
+
+    public void RefreshControlStates()
+    {
+        var initialized = _host.EmulatorState != EmulatorState.Uninitialized;
+        _copyButton.Enabled = _host.EmulatorState == EmulatorState.Running;
+        _pasteButton.Enabled = _host.EmulatorState == EmulatorState.Running;
+        _diskButton.Enabled = initialized;
+        _bootButton.Enabled = initialized
+            && _host.CurrentRunningSystem is Apple2System apple2
+            && apple2.DiskController.IsDiskInserted;
+        _configButton.Enabled = !initialized;
+        SyncControls();
+    }
+
+    private global::Highbyte.DotNet6502.Systems.Apple2.Config.Apple2SystemConfig? CurrentConfig =>
+        (_host.CurrentHostSystemConfig as Apple2TerminalHostConfig)?.SystemConfig;
+
+    private void CopyBasicSource()
+    {
+        if (_host.CurrentRunningSystem is not Apple2System apple2)
+            return;
+        try
+        {
+            ClipboardService.SetText(apple2.BasicTokenParser.GetBasicText());
+            _logger.LogInformation("Copied Applesoft BASIC source to clipboard.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Could not copy Applesoft BASIC source.");
+        }
+    }
+
+    private void PasteText()
+    {
+        if (_host.CurrentRunningSystem is not Apple2System apple2)
+            return;
+        try
+        {
+            var text = ClipboardService.GetText();
+            if (!string.IsNullOrEmpty(text))
+                apple2.TextPaste.Paste(text);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Could not paste text into the Apple II.");
+        }
+    }
+
+    private async Task ToggleDisk()
+    {
+        if (_host.CurrentRunningSystem is not Apple2System apple2)
+            return;
+
+        if (apple2.DiskController.IsDiskInserted)
+        {
+            Apple2DiskBoot.Eject(_host, _logger);
+            SyncControls();
+            return;
+        }
+
+        try
+        {
+            using var dialog = new OpenDialog
+            {
+                Title = "Insert Apple II .dsk image",
+                OpenMode = OpenMode.File,
+                AllowsMultipleSelection = false,
+            };
+            _host.ApplyUiScheme(dialog);
+            Application.Run(dialog);
+            if (dialog.Canceled || dialog.FilePaths.Count == 0)
+                return;
+
+            var path = dialog.FilePaths[0];
+            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+                return;
+
+            await Apple2DiskBoot.InsertAsync(_host, await File.ReadAllBytesAsync(path), _logger);
+            _logger.LogInformation("Inserted {Disk}; disk is write-protected.", Path.GetFileName(path));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Could not insert Apple II disk image.");
+        }
+        SyncControls();
+    }
+
+    private async Task BootDisk()
+    {
+        try
+        {
+            await Apple2DiskBoot.BootAsync(_host, _logger);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Could not boot the Apple II disk image.");
+        }
+        SyncControls();
+    }
+
+    private void SetKeyboardJoystick(bool enabled)
+    {
+        if (_host.CurrentHostSystemConfig is not Apple2TerminalHostConfig hostConfig)
+            return;
+
+        hostConfig.SystemConfig.KeyboardJoystickEnabled = enabled;
+        if (_host.CurrentRunningSystem?.InputConsumer is global::Highbyte.DotNet6502.Systems.Apple2.Input.Apple2InputHandler input)
+            input.InputConfig.KeyboardJoystickEnabled = enabled;
+        else
+            _host.UpdateHostSystemConfig(hostConfig);
+
+        _logger.LogInformation("Apple II keyboard joystick {State}.", enabled ? "enabled" : "disabled");
+    }
+
+    private void SyncControls()
+    {
+        var hasDisk = _host.CurrentRunningSystem is Apple2System apple2
+            && apple2.DiskController.IsDiskInserted;
+        _diskButton.Text = hasDisk ? "Eject disk" : "Insert .dsk";
+        _bootButton.Enabled = hasDisk;
+        if (CurrentConfig is { } config)
+        {
+            _joystickCheck.Value = config.KeyboardJoystickEnabled
+                ? CheckState.Checked
+                : CheckState.UnChecked;
+        }
+    }
+}

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Apple2/Apple2TerminalShellPlugin.cs
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Apple2/Apple2TerminalShellPlugin.cs
@@ -1,0 +1,28 @@
+using Highbyte.DotNet6502.Systems.Plugins;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Apple2System = Highbyte.DotNet6502.Systems.Apple2.Apple2;
+
+[assembly: SystemPlugin(typeof(Highbyte.DotNet6502.App.Terminal.Shell.Apple2.Apple2TerminalShellPlugin))]
+
+namespace Highbyte.DotNet6502.App.Terminal.Shell.Apple2;
+
+/// <summary>Contributes Apple II controls and keyboard information to the Terminal host.</summary>
+public sealed class Apple2TerminalShellPlugin : ISystemShellPlugin
+{
+    public string SystemName => Apple2System.SystemName;
+
+    public void RegisterShellServices(IServiceCollection services)
+    {
+        services.AddSingleton<Apple2TerminalMenuView>(sp => new Apple2TerminalMenuView(
+            sp.GetRequiredService<TuiHostApp>(),
+            sp.GetRequiredService<ILoggerFactory>()));
+        services.AddSingleton<Apple2TerminalInfoView>();
+    }
+
+    public object? CreateMenuContribution(IServiceProvider sp) => sp.GetService<Apple2TerminalMenuView>();
+
+    public object? CreateInfoContribution(IServiceProvider sp) => sp.GetService<Apple2TerminalInfoView>();
+
+    public object? CreateConfigDialogContribution(IServiceProvider sp) => null;
+}

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Apple2/Highbyte.DotNet6502.App.Terminal.Shell.Apple2.csproj
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal.Shell.Apple2/Highbyte.DotNet6502.App.Terminal.Shell.Apple2.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Terminal.Gui" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="TextCopy" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Highbyte.DotNet6502.App.Terminal.Core\Highbyte.DotNet6502.App.Terminal.Core.csproj" />
+    <ProjectReference Include="..\..\..\libraries\Highbyte.DotNet6502\Highbyte.DotNet6502.csproj" />
+    <ProjectReference Include="..\..\..\libraries\Highbyte.DotNet6502.Systems\Highbyte.DotNet6502.Systems.csproj" />
+    <ProjectReference Include="..\..\..\libraries\Highbyte.DotNet6502.Systems.Apple2\Highbyte.DotNet6502.Systems.Apple2.csproj" />
+    <ProjectReference Include="..\..\..\libraries\Highbyte.DotNet6502.Systems.Plugins\Highbyte.DotNet6502.Systems.Plugins.csproj" />
+    <ProjectReference Include="..\..\..\libraries\Highbyte.DotNet6502.Impl.Terminal.Apple2\Highbyte.DotNet6502.Impl.Terminal.Apple2.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/appsettings.json
+++ b/src/apps/Terminal/Highbyte.DotNet6502.App.Terminal/appsettings.json
@@ -3,7 +3,7 @@
   // (Also disabled by the CI env var or DOTNET6502_NO_UPDATE_CHECK; only applies to brew/scoop installs.)
   "UpdateCheckEnabled": true,
 
-  "EnabledSystems": [ "C64", "VIC-20" ],
+  "EnabledSystems": [ "C64", "VIC-20", "Apple2" ],
 
   "Highbyte.DotNet6502.TerminalConfig": {
     "DefaultEmulator": "C64",
@@ -61,6 +61,18 @@
         { "Name": "kernal", "File": "kernal.901486-07.bin" },
         { "Name": "chargen", "File": "characters.901460-03.bin" }
       ]
+    }
+  },
+
+  "Highbyte.DotNet6502.Apple2.Terminal": {
+    "SystemConfig": {
+      // The Disk II ROM is optional for BASIC, but required to boot .dsk images.
+      "ROMs": [
+        { "Name": "apple2",  "File": "apple.rom" },
+        { "Name": "chargen", "File": "3410036.BIN" },
+        { "Name": "disk2",   "File": "Apple Disk II 16 Sector Interface Card ROM P5 - 341-0027.bin-with-D4-D7 data bits swapped.bin" }
+      ],
+      "AudioEnabled": false
     }
   }
 }

--- a/src/libraries/Highbyte.DotNet6502.Impl.Terminal.Apple2/Apple2TerminalEnginePlugin.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Terminal.Apple2/Apple2TerminalEnginePlugin.cs
@@ -1,0 +1,25 @@
+using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Plugins;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+[assembly: SystemPlugin(typeof(Highbyte.DotNet6502.Impl.Terminal.Apple2.Apple2TerminalEnginePlugin))]
+
+namespace Highbyte.DotNet6502.Impl.Terminal.Apple2;
+
+/// <summary>Registers Apple II emulation services for the Terminal host.</summary>
+public sealed class Apple2TerminalEnginePlugin : ISystemEnginePlugin
+{
+    public string SystemName => global::Highbyte.DotNet6502.Systems.Apple2.Apple2.SystemName;
+
+    public string HostTechName => "Terminal";
+
+    public void Register(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddSingleton<ISystemConfigurer>(sp =>
+            new Apple2TerminalSetup(
+                sp.GetRequiredService<ILoggerFactory>(),
+                sp.GetRequiredService<IConfiguration>()));
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Impl.Terminal.Apple2/Apple2TerminalHostConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Terminal.Apple2/Apple2TerminalHostConfig.cs
@@ -1,0 +1,29 @@
+using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Apple2.Config;
+using Highbyte.DotNet6502.Systems.Apple2.Input;
+using Highbyte.DotNet6502.Systems.Apple2.Render;
+
+namespace Highbyte.DotNet6502.Impl.Terminal.Apple2;
+
+/// <summary>Apple II host config for the Terminal host: text commands, keyboard input, no audio.</summary>
+public class Apple2TerminalHostConfig : HostSystemConfigBase<Apple2SystemConfig>
+{
+    public const string ConfigSectionName = "Highbyte.DotNet6502.Apple2.Terminal";
+
+    public override bool AudioSupported => false;
+
+    public Apple2InputConfig InputConfig { get; set; } = new();
+
+    public Apple2TerminalHostConfig()
+    {
+        SystemConfig.AudioEnabled = false;
+        SystemConfig.SetRenderProviderType(typeof(Apple2VideoCommandStream));
+    }
+
+    public override object Clone()
+    {
+        var clone = (Apple2TerminalHostConfig)base.Clone();
+        clone.InputConfig = (Apple2InputConfig)InputConfig.Clone();
+        return clone;
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Impl.Terminal.Apple2/Apple2TerminalSetup.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Terminal.Apple2/Apple2TerminalSetup.cs
@@ -1,0 +1,30 @@
+using Highbyte.DotNet6502.Systems;
+using Highbyte.DotNet6502.Systems.Apple2;
+using Highbyte.DotNet6502.Systems.Apple2.Input;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Apple2System = Highbyte.DotNet6502.Systems.Apple2.Apple2;
+
+namespace Highbyte.DotNet6502.Impl.Terminal.Apple2;
+
+/// <summary>Apple II configurer for the Terminal host, including keyboard and joystick input.</summary>
+public class Apple2TerminalSetup : Apple2SystemConfigurerCore
+{
+    public Apple2TerminalSetup(ILoggerFactory loggerFactory, IConfiguration configuration)
+        : base(loggerFactory, configuration, () => new Apple2TerminalHostConfig(),
+            Apple2TerminalHostConfig.ConfigSectionName)
+    {
+    }
+
+    public override Task<SystemRunner> BuildSystemRunner(ISystem system, IHostSystemConfig hostSystemConfig)
+    {
+        var apple2 = (Apple2System)system;
+        var terminalConfig = (Apple2TerminalHostConfig)hostSystemConfig;
+
+        terminalConfig.InputConfig.KeyboardJoystickEnabled =
+            terminalConfig.SystemConfig.KeyboardJoystickEnabled;
+        apple2.InputConsumer = new Apple2InputHandler(apple2, LoggerFactory, terminalConfig.InputConfig);
+
+        return Task.FromResult(new SystemRunner(apple2));
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Impl.Terminal.Apple2/Highbyte.DotNet6502.Impl.Terminal.Apple2.csproj
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Terminal.Apple2/Highbyte.DotNet6502.Impl.Terminal.Apple2.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <PackageId>Highbyte.DotNet6502.Impl.Terminal.Apple2</PackageId>
+    <Authors>Highbyte</Authors>
+    <PackageDescription>Apple II engine plugin for the Highbyte.DotNet6502 Terminal (TUI) host. Registers the Apple II system configurer and text-mode input/rendering support.</PackageDescription>
+    <RepositoryUrl>https://github.com/highbyte/dotnet-6502</RepositoryUrl>
+    <Version>0.3.0-alpha</Version>
+
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Highbyte.DotNet6502\Highbyte.DotNet6502.csproj" />
+    <ProjectReference Include="..\Highbyte.DotNet6502.Systems\Highbyte.DotNet6502.Systems.csproj" />
+    <ProjectReference Include="..\Highbyte.DotNet6502.Systems.Apple2\Highbyte.DotNet6502.Systems.Apple2.csproj" />
+    <ProjectReference Include="..\Highbyte.DotNet6502.Systems.Plugins\Highbyte.DotNet6502.Systems.Plugins.csproj" />
+    <ProjectReference Include="..\Highbyte.DotNet6502.Impl.Terminal\Highbyte.DotNet6502.Impl.Terminal.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/libraries/Highbyte.DotNet6502.Impl.Terminal/TerminalRenderTarget.cs
+++ b/src/libraries/Highbyte.DotNet6502.Impl.Terminal/TerminalRenderTarget.cs
@@ -40,6 +40,7 @@ public sealed class TerminalRenderTarget : ICommandTarget
     private int _frameMaxY = -1;
 
     private Func<byte, string>? _glyphToUnicode;
+    private bool _reverseVideoHighBit;
 
     // Caches to avoid per-cell allocations on the hot path.
     private readonly Dictionary<byte, Rune> _glyphCache = new();
@@ -65,8 +66,9 @@ public sealed class TerminalRenderTarget : ICommandTarget
     {
         switch (cmd)
         {
-            case SetConfig(var glyphToUnicodeConverter):
-                _glyphToUnicode = glyphToUnicodeConverter;
+            case SetConfig config:
+                _glyphToUnicode = config.GlyphToUnicodeConverter;
+                _reverseVideoHighBit = config.ReverseVideoHighBit;
                 // The converter's output for a screen code can change at runtime (e.g. the C64
                 // switching between the uppercase/graphics and lowercase charsets), so drop the
                 // cached glyphs. SetConfig is emitted once per frame, so within a frame repeated
@@ -144,7 +146,7 @@ public sealed class TerminalRenderTarget : ICommandTarget
     private void SetGlyphCell(int x, int y, int glyphId, Color fg, Color bg)
     {
         var id = (byte)glyphId;
-        if (IsCommodoreReverseScreenCode(id))
+        if (_reverseVideoHighBit && IsCommodoreReverseScreenCode(id))
         {
             // The C64/VIC-20 command streams pass raw screen codes as glyph ids. Codes with the
             // high bit set are reverse-video variants. Desktop hosts can render those with a C64

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/VideoCommands/C64VideoCommandStream.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/VideoCommands/C64VideoCommandStream.cs
@@ -68,7 +68,10 @@ public class C64VideoCommandStream : IRenderProvider, IVideoCommandStream
     private void GenerateConfig(C64 c64)
     {
         var configCommand = new SetConfig(
-            GlyphToUnicodeConverter: FromC64ScreenCodeToUnicode);
+            GlyphToUnicodeConverter: FromC64ScreenCodeToUnicode)
+        {
+            ReverseVideoHighBit = true,
+        };
 
         _commands.Enqueue(configCommand);
     }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Render/Vic20VideoCommandStream.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Vic20/Render/Vic20VideoCommandStream.cs
@@ -49,7 +49,11 @@ public class Vic20VideoCommandStream : IRenderProvider, IVideoCommandStream
 
     private void GenerateCommands()
     {
-        _commands.Enqueue(new SetConfig(GlyphToUnicodeConverter: Vic20ScreenCode.ScreenCodeToUnicode));
+        _commands.Enqueue(new SetConfig(
+            GlyphToUnicodeConverter: Vic20ScreenCode.ScreenCodeToUnicode)
+        {
+            ReverseVideoHighBit = true,
+        });
         RenderBorder();
         RenderMainScreen();
     }

--- a/src/libraries/Highbyte.DotNet6502.Systems/Rendering/VideoCommands/IVideoCommandStream.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Rendering/VideoCommands/IVideoCommandStream.cs
@@ -11,7 +11,14 @@ public interface IVideoCommandStream : IRenderSource
 
 public interface IVideoCommand { }
 
-public sealed record SetConfig(Func<byte, string> GlyphToUnicodeConverter) : IVideoCommand;
+public sealed record SetConfig(Func<byte, string> GlyphToUnicodeConverter) : IVideoCommand
+{
+    /// <summary>
+    /// Whether glyph IDs with bit 7 set represent Commodore-style reverse video. Most systems
+    /// encode display attributes elsewhere or have no such convention, so this is opt-in.
+    /// </summary>
+    public bool ReverseVideoHighBit { get; init; }
+}
 public sealed record FillRect(int X, int Y, int W, int H, uint ColorArgb) : IVideoCommand;
 public sealed record DrawGlyphArgb(int X, int Y, int GlyphId, uint ForeColorArgb, uint BackColorArgb) : IVideoCommand;
 

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2TerminalSupportTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2TerminalSupportTests.cs
@@ -1,0 +1,103 @@
+using Highbyte.DotNet6502.Impl.Terminal;
+using Highbyte.DotNet6502.Impl.Terminal.Apple2;
+using Highbyte.DotNet6502.Systems.Apple2.Config;
+using Highbyte.DotNet6502.Systems.Apple2.Input;
+using Highbyte.DotNet6502.Systems.Apple2.Render;
+using Highbyte.DotNet6502.Systems.Apple2.Video;
+using Highbyte.DotNet6502.Systems.Rendering.VideoCommands;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Apple2System = Highbyte.DotNet6502.Systems.Apple2.Apple2;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Apple2;
+
+public class Apple2TerminalSupportTests
+{
+    [Fact]
+    public void Terminal_Config_Selects_Text_Rendering_And_Disables_Audio()
+    {
+        var config = new Apple2TerminalHostConfig();
+
+        Assert.False(config.AudioSupported);
+        Assert.False(config.SystemConfig.AudioEnabled);
+        Assert.Equal(typeof(Apple2VideoCommandStream), config.SystemConfig.RenderProviderType);
+    }
+
+    [Fact]
+    public async Task Terminal_Setup_Wires_Apple2_Keyboard_And_Joystick_Input()
+    {
+        var setup = new Apple2TerminalSetup(
+            NullLoggerFactory.Instance,
+            new ConfigurationBuilder().Build());
+        var hostConfig = new Apple2TerminalHostConfig();
+        hostConfig.SystemConfig.KeyboardJoystickEnabled = true;
+        var apple2 = new Apple2System(new Apple2Config(), NullLoggerFactory.Instance);
+
+        _ = await setup.BuildSystemRunner(apple2, hostConfig);
+
+        var input = Assert.IsType<Apple2InputHandler>(apple2.InputConsumer);
+        Assert.True(input.InputConfig.KeyboardJoystickEnabled);
+    }
+
+    [Fact]
+    public void Apple2_Normal_And_Inverse_Attributes_Reach_The_Terminal_Unchanged()
+    {
+        var apple2 = new Apple2System(
+            new Apple2Config { MonitorColor = Apple2MonitorColor.Green },
+            NullLoggerFactory.Instance);
+        apple2.SetCurrentRenderProviderType(typeof(Apple2VideoCommandStream));
+        var stream = Assert.IsType<Apple2VideoCommandStream>(apple2.RenderProvider);
+        var target = new TerminalRenderTarget();
+
+        apple2.Mem[Apple2TextScreen.GetAddress(0, 0)] =
+            Apple2CharSet.FromAscii((byte)'A', Apple2TextAttribute.Normal);
+        var normal = RenderCell(stream, target);
+
+        apple2.Mem[Apple2TextScreen.GetAddress(0, 0)] =
+            Apple2CharSet.FromAscii((byte)'A', Apple2TextAttribute.Inverse);
+        var inverse = RenderCell(stream, target);
+
+        Assert.Equal('A', normal.Rune.Value);
+        Assert.Equal('A', inverse.Rune.Value);
+        Assert.Equal(normal.Foreground, inverse.Background);
+        Assert.Equal(normal.Background, inverse.Foreground);
+    }
+
+    [Fact]
+    public void Commodore_High_Bit_Reverse_Video_Remains_Opt_In()
+    {
+        var target = new TerminalRenderTarget();
+        var foreground = System.Drawing.Color.Red;
+        var background = System.Drawing.Color.Blue;
+
+        target.BeginFrame();
+        target.Execute(new SetConfig(code => ((char)code).ToString()) { ReverseVideoHighBit = true });
+        target.Execute(new DrawGlyph(0, 0, 0xC1, foreground, background));
+        target.EndFrame();
+
+        var buffer = new TerminalRenderTarget.ScreenCell[1, 1];
+        _ = target.Snapshot(ref buffer);
+        Assert.Equal('A', buffer[0, 0].Rune.Value);
+        Assert.Equal(0, buffer[0, 0].Foreground.R);
+        Assert.Equal(0, buffer[0, 0].Foreground.G);
+        Assert.Equal(255, buffer[0, 0].Foreground.B);
+        Assert.Equal(255, buffer[0, 0].Background.R);
+        Assert.Equal(0, buffer[0, 0].Background.G);
+        Assert.Equal(0, buffer[0, 0].Background.B);
+    }
+
+    private static TerminalRenderTarget.ScreenCell RenderCell(
+        Apple2VideoCommandStream stream,
+        TerminalRenderTarget target)
+    {
+        stream.OnEndFrame();
+        target.BeginFrame();
+        foreach (var command in stream.DequeueAll())
+            target.Execute(command);
+        target.EndFrame();
+
+        var buffer = new TerminalRenderTarget.ScreenCell[1, 1];
+        _ = target.Snapshot(ref buffer);
+        return buffer[0, 0];
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Highbyte.DotNet6502.Systems.Tests.csproj
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Highbyte.DotNet6502.Systems.Tests.csproj
@@ -26,6 +26,8 @@
     <ProjectReference Include="..\..\src\libraries\Highbyte.DotNet6502.Systems\Highbyte.DotNet6502.Systems.csproj" />
     <ProjectReference Include="..\..\src\libraries\Highbyte.DotNet6502.Impl.Avalonia\Highbyte.DotNet6502.Impl.Avalonia.csproj" />
     <ProjectReference Include="..\..\src\libraries\Highbyte.DotNet6502.Impl.Avalonia.Commodore64\Highbyte.DotNet6502.Impl.Avalonia.Commodore64.csproj" />
+    <ProjectReference Include="..\..\src\libraries\Highbyte.DotNet6502.Impl.Terminal\Highbyte.DotNet6502.Impl.Terminal.csproj" />
+    <ProjectReference Include="..\..\src\libraries\Highbyte.DotNet6502.Impl.Terminal.Apple2\Highbyte.DotNet6502.Impl.Terminal.Apple2.csproj" />
     <ProjectReference Include="..\..\src\libraries\Highbyte.DotNet6502.Systems.Apple2\Highbyte.DotNet6502.Systems.Apple2.csproj" />
     <ProjectReference Include="..\..\src\libraries\Highbyte.DotNet6502.Systems.Commodore64\Highbyte.DotNet6502.Systems.Commodore64.csproj" />
     <ProjectReference Include="..\..\src\libraries\Highbyte.DotNet6502.Systems.Generic\Highbyte.DotNet6502.Systems.Generic.csproj" />


### PR DESCRIPTION
## Summary

- add Apple II Plus engine and shell plugins to the Terminal host
- render the Apple II 40×24 text page with normal, inverse, and flashing attributes
- add keyboard input, optional WASD joystick controls, Applesoft copy/paste, and read-only Disk II insertion/booting
- add Apple II ROM, monitor-colour, and language-card configuration
- document the Terminal host’s Apple II support and text-only graphics limitation

## Impact

Apple II Plus is now selectable in the Terminal app and can boot to Applesoft BASIC or a configured Disk II image. Terminal users get the existing 40×24 text command stream; lo-res and hi-res pixel graphics remain unavailable in a text terminal.

## Validation

- `dotnet build dotnet-6502.slnx --no-restore` — 75 projects, 0 errors, 0 warnings
- `dotnet test tests/Highbyte.DotNet6502.Systems.Tests/Highbyte.DotNet6502.Systems.Tests.csproj --no-build --no-restore` — 969 passed
- Terminal self-test: `--selftest --frames 120 --system Apple2` — rendered the Apple II ROM banner and BASIC prompt as 40×24 cells
- changed-project and changed-file `dotnet format --verify-no-changes` checks passed
