### PR TITLE
Emulate per-model CPU bus access sequences (RMW, dummy reads, interrupt entry)

### DIFF
--- a/benchmarks/Highbyte.DotNet6502.Benchmarks/6502/HotPathBenchmarks.cs
+++ b/benchmarks/Highbyte.DotNet6502.Benchmarks/6502/HotPathBenchmarks.cs
@@ -33,8 +33,6 @@ internal class HotPathConfig : ManualConfig
 /// linearly. These benchmarks isolate the smallest units on that path so refactors can
 /// be validated empirically against a baseline before merge.
 ///
-/// See <c>documents/features/hot-path-benchmarking-and-improvements.md</c> in the
-/// design log for the design notes that drove these picks.
 /// </summary>
 [Config(typeof(HotPathConfig))]
 public class HotPathBenchmarks

--- a/benchmarks/Highbyte.DotNet6502.Benchmarks/RESULTS.md
+++ b/benchmarks/Highbyte.DotNet6502.Benchmarks/RESULTS.md
@@ -207,7 +207,7 @@ Observations:
 
 ## CPU-model refactor baseline — 2026-08-12 (master `8803350a`, Apple M1)
 
-M0 baseline for the CPU model architecture feature (design log: `cpu-models-65c02`).
+M0 baseline for the CPU model architecture feature .
 Every milestone of that feature re-runs these two suites on the same machine and
 compares against this section; >5% regression on an unaffected benchmark or a new
 allocation blocks the milestone. Recorded on a different machine than the 2026-06
@@ -256,6 +256,37 @@ the other scenarios are recorded for context.
 | `AudioOnly` | `MixedVisibleSprites` | 380.6 μs | - |
 | `RenderAndAudio` | `None` | 603.5 μs | - |
 | `RenderAndAudio` | `MixedVisibleSprites` | 606.8 μs | - |
+
+## Ordered-bus-accesses (M2) baseline — 2026-08-12 (master `75d9678d`, Apple M1)
+
+Baseline for the CPU-model feature's M2 milestone .
+recorded on the M1 merge commit. M2's benchmark policy is PER-CATEGORY: instructions
+that deliberately gain real bus accesses (RMW, indexed page-cross reads, indexed
+stores, interrupt entry) may regress in isolated microbenchmarks — that cost is
+quantified separately and accepted as semantic; instructions whose access sequence
+did not change must stay within noise of these numbers. Same machine/environment as
+the CPU-model refactor baseline above.
+
+### `HotPathBenchmarks` (DefaultJob)
+
+| Method                                         |          Mean | Allocated |
+|------------------------------------------------|--------------:|----------:|
+| `ExecEvaluator_Check_NotTriggered`             |     0.5724 ns |         - |
+| `ExecEvaluator_Check_OneConditionConfigured`   |     8.8737 ns |         - |
+| `ExecEvaluator_Check_AllConditionsConfigured`  |     9.8424 ns |         - |
+| `InstructionExecutor_OneStep`                  |    18.454 ns  |         - |
+| `CPU_Run_1000Instructions`                     | 13,649.27 ns  |         - |
+| `CPU_Execute_NoSubscribers_1000Instructions`   | 16,199.13 ns  |     136 B |
+| `CPU_Execute_WithSubscribers_1000Instructions` | 35,533.29 ns  |  136136 B |
+| `Memory_Read_TightLoop`                        |  1,661.14 ns  |         - |
+| `Memory_Write_TightLoop`                       |  1,605.10 ns  |         - |
+
+### `C64ExecuteFrameBenchmark` (ShortRun) — representative workload
+
+| Scenario | SpriteScenario | 1 frame |
+|----------|----------------|--------:|
+| `CoreOnly` | `None` | 209.7 μs |
+| `CoreOnly` | `MixedVisibleSprites` | 221.0 μs |
 
 ## Confirming `[AggressiveInlining]` folded the ExecEvaluator helpers
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2LanguageCard.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Apple2/Peripherals/Apple2LanguageCard.cs
@@ -113,9 +113,13 @@ public class Apple2LanguageCard
             // enable sequence with it.
             WriteEnabled = false;
         }
-        else if (PreWrite)
+        else if (PreWrite && isRead)
         {
-            // Second consecutive access to an odd address: the sequence completes.
+            // Second consecutive READ of an odd address: the sequence completes. Per Sather
+            // (Understanding the Apple IIe, 5-23) a WRITE never completes it — it only resets
+            // PRE-WRITE below. This is what makes the card CPU-model observable: a 65C02 RMW
+            // on an odd switch (read-read-write) unlocks the card, an NMOS RMW
+            // (read-write-write) does not.
             WriteEnabled = true;
         }
 

--- a/src/libraries/Highbyte.DotNet6502/CPU.cs
+++ b/src/libraries/Highbyte.DotNet6502/CPU.cs
@@ -425,6 +425,12 @@ public class CPU
     /// <param name="mem"></param>
     private void ProcessHardwareIRQ(Memory mem)
     {
+        // Real hardware entry: the first two cycles of the 7-cycle sequence read the
+        // next opcode byte (twice, discarded) while the interrupt takes over the
+        // instruction flow. Observable through mapped I/O at the PC address.
+        FetchByte(mem, PC);
+        FetchByte(mem, PC);
+
         // The return address pushed to stack is the current PC (the address of the next instruction at this point)
         ushort pcPushedToStack = PC;
         PushWordToStack(pcPushedToStack, mem);
@@ -450,6 +456,12 @@ public class CPU
     /// <param name="mem"></param>
     private void ProcessHardwareNMI(Memory mem)
     {
+        // Real hardware entry: the first two cycles of the 7-cycle sequence read the
+        // next opcode byte (twice, discarded) while the interrupt takes over the
+        // instruction flow. Observable through mapped I/O at the PC address.
+        FetchByte(mem, PC);
+        FetchByte(mem, PC);
+
         // The return address pushed to stack is the current PC (the address of the next instruction at this point)
         ushort pcPushedToStack = PC;
         PushWordToStack(pcPushedToStack, mem);

--- a/src/libraries/Highbyte.DotNet6502/CpuModels/CmosHandlers.cs
+++ b/src/libraries/Highbyte.DotNet6502/CpuModels/CmosHandlers.cs
@@ -128,6 +128,8 @@ internal static class CmosHandlers
 
     private static ulong TestAndSetBits(CPU cpu, Memory mem, ushort address, ulong cycles)
     {
+        cpu.FetchByte(mem, address);
+        // 65C02 RMW is read-read-write: a second read replaces the NMOS write-back cycle.
         var value = cpu.FetchByte(mem, address);
         cpu.ProcessorStatus.Zero = (cpu.A & value) == 0;
         cpu.StoreByte((byte)(value | cpu.A), mem, address);
@@ -136,10 +138,35 @@ internal static class CmosHandlers
 
     private static ulong TestAndResetBits(CPU cpu, Memory mem, ushort address, ulong cycles)
     {
+        cpu.FetchByte(mem, address);
+        // 65C02 RMW is read-read-write: a second read replaces the NMOS write-back cycle.
         var value = cpu.FetchByte(mem, address);
         cpu.ProcessorStatus.Zero = (cpu.A & value) == 0;
         cpu.StoreByte((byte)(value & ~cpu.A), mem, address);
         return cycles;
+    }
+
+    /// <summary>
+    /// One read-modify-write operation's compute step: takes the value read from memory,
+    /// returns the value to write back, updating processor flags. Matches the signature
+    /// of the shared BinaryArithmeticHelpers shift/rotate helpers.
+    /// </summary>
+    internal delegate byte RmwCore(byte value, ref ProcessorStatus status);
+
+    /// <summary>INC memory core (the shifts/rotates use their BinaryArithmeticHelpers directly).</summary>
+    public static byte IncCore(byte value, ref ProcessorStatus status)
+    {
+        value++;
+        BinaryArithmeticHelpers.SetFlagsAfterRegisterLoadIncDec(value, ref status);
+        return value;
+    }
+
+    /// <summary>DEC memory core.</summary>
+    public static byte DecCore(byte value, ref ProcessorStatus status)
+    {
+        value--;
+        BinaryArithmeticHelpers.SetFlagsAfterRegisterLoadIncDec(value, ref status);
+        return value;
     }
 
     /// <summary>

--- a/src/libraries/Highbyte.DotNet6502/CpuModels/CpuModelTraits.cs
+++ b/src/libraries/Highbyte.DotNet6502/CpuModels/CpuModelTraits.cs
@@ -14,6 +14,14 @@ namespace Highbyte.DotNet6502;
 /// must have 256 populated entries. NMOS: false — undefined bytes depend on the
 /// compatibility profile.
 /// </param>
+/// <param name="PerformsIndexedDummyReads">
+/// NMOS: true — indexed addressing performs a dummy read at the "un-carried" address
+/// (high byte not yet corrected) when a read crosses a page, and ALWAYS before indexed
+/// stores and indexed RMW instructions. 65C02: false — the CMOS part re-targeted those
+/// dummy cycles (different addresses); modelling them is deferred until something
+/// observable needs them. Consumed at table BUILD time, never per instruction.
+/// </param>
 internal readonly record struct CpuModelTraits(
     bool ClearsDecimalOnInterrupt,
-    bool AllBytesDefined);
+    bool AllBytesDefined,
+    bool PerformsIndexedDummyReads);

--- a/src/libraries/Highbyte.DotNet6502/CpuModels/IReadModifyWriteInstruction.cs
+++ b/src/libraries/Highbyte.DotNet6502/CpuModels/IReadModifyWriteInstruction.cs
@@ -1,0 +1,14 @@
+namespace Highbyte.DotNet6502;
+
+/// <summary>
+/// Marker for <see cref="IInstructionUsesByte"/> instructions that are read-modify-write
+/// (INC/DEC and the undocumented RMW combos): on NMOS models their indexed forms ALWAYS
+/// perform the dummy read at the un-carried address — unlike plain reads, which dummy-read
+/// only when the page crosses. Consulted at table BUILD time by the descriptor composer.
+/// (The shift/rotate RMW instructions are <see cref="IInstructionUsesAddress"/>, which the
+/// composer already treats as always-dummy-read on indexed modes; transitional until the
+/// handler migration retires the instruction classes.)
+/// </summary>
+internal interface IReadModifyWriteInstruction
+{
+}

--- a/src/libraries/Highbyte.DotNet6502/CpuModels/Ncr65c02Model.cs
+++ b/src/libraries/Highbyte.DotNet6502/CpuModels/Ncr65c02Model.cs
@@ -14,6 +14,15 @@ namespace Highbyte.DotNet6502;
 /// </summary>
 internal static class Ncr65c02Model
 {
+    // Single source of truth for the model's traits: referenced both by the definition
+    // and by the descriptor-table build below, so the two can never disagree.
+    private static readonly CpuModelTraits s_traits = new(
+        ClearsDecimalOnInterrupt: true,
+        AllBytesDefined: true,
+        // The 65C02 re-targeted the NMOS dummy-read cycles to different addresses;
+        // modelling its dummy reads is deferred until something observable needs them.
+        PerformsIndexedDummyReads: false);
+
     public static readonly CpuModelDefinition Definition = new()
     {
         ModelId = CpuModelIds.Ncr65c02,
@@ -24,9 +33,7 @@ internal static class Ncr65c02Model
         // Public façade view: the officially documented instruction set shared with the
         // NMOS 6502. Per-model tooling metadata comes from the descriptor table.
         CreateInstructionList = InstructionList.GetAllInstructions,
-        Traits = new CpuModelTraits(
-            ClearsDecimalOnInterrupt: true,
-            AllBytesDefined: true),
+        Traits = s_traits,
         CreateDescriptors = BuildDescriptors,
     };
 
@@ -34,7 +41,8 @@ internal static class Ncr65c02Model
     {
         // Start from the generic composition of the shared official instructions
         // (semantics identical on the 65C02 for these), then apply the CMOS delta.
-        var table = OpCodeDescriptorTableBuilder.Build(instructionList);
+        var table = OpCodeDescriptorTableBuilder.Build(instructionList,
+            indexedDummyReads: s_traits.PerformsIndexedDummyReads);
 
         // JMP (addr): pointer read is linear (NMOS wrap bug fixed), 6 cycles (was 5).
         table[(byte)OpCodeId.JMP_IND] = new OpCodeDescriptor

--- a/src/libraries/Highbyte.DotNet6502/CpuModels/Ncr65c02Model.cs
+++ b/src/libraries/Highbyte.DotNet6502/CpuModels/Ncr65c02Model.cs
@@ -68,12 +68,28 @@ internal static class Ncr65c02Model
         AddZpIndirectForm(table, GetInstruction(instructionList, (byte)OpCodeId.CMP_I), newCode: 0xD2);
         AddZpIndirectForm(table, cmosSbc, newCode: 0xF2);
 
-        // Shift/rotate abs,X: 6 cycles + 1 on page cross on the 65C02 (NMOS: always 7).
-        // INC/DEC abs,X deliberately stay at 7 cycles — the 65C02 only changed the shifts.
-        ReplaceShiftRmwAbsX(table, instructionList, (byte)OpCodeId.ASL_ABS_X);
-        ReplaceShiftRmwAbsX(table, instructionList, (byte)OpCodeId.ROL_ABS_X);
-        ReplaceShiftRmwAbsX(table, instructionList, (byte)OpCodeId.LSR_ABS_X);
-        ReplaceShiftRmwAbsX(table, instructionList, (byte)OpCodeId.ROR_ABS_X);
+        // Read-modify-write instructions: the 65C02 sequence is read-READ-write (the
+        // NMOS classes now perform the NMOS read-WRITE-write), so every RMW byte gets a
+        // CMOS-sequenced handler. Cycle differences also live here: shift/rotate abs,X
+        // is 6 + 1 on page cross (NMOS: always 7); INC/DEC abs,X deliberately stay at 7.
+        ReplaceCmosRmw(table, "ASL", BinaryArithmeticHelpers.PerformASLAndSetStatusRegisters,
+            zp: (byte)OpCodeId.ASL_ZP, zpX: (byte)OpCodeId.ASL_ZP_X, abs: (byte)OpCodeId.ASL_ABS,
+            absX: (byte)OpCodeId.ASL_ABS_X, absXAddsPageCrossCycle: true);
+        ReplaceCmosRmw(table, "ROL", BinaryArithmeticHelpers.PerformROLAndSetStatusRegisters,
+            zp: (byte)OpCodeId.ROL_ZP, zpX: (byte)OpCodeId.ROL_ZP_X, abs: (byte)OpCodeId.ROL_ABS,
+            absX: (byte)OpCodeId.ROL_ABS_X, absXAddsPageCrossCycle: true);
+        ReplaceCmosRmw(table, "LSR", BinaryArithmeticHelpers.PerformLSRAndSetStatusRegisters,
+            zp: (byte)OpCodeId.LSR_ZP, zpX: (byte)OpCodeId.LSR_ZP_X, abs: (byte)OpCodeId.LSR_ABS,
+            absX: (byte)OpCodeId.LSR_ABS_X, absXAddsPageCrossCycle: true);
+        ReplaceCmosRmw(table, "ROR", BinaryArithmeticHelpers.PerformRORAndSetStatusRegisters,
+            zp: (byte)OpCodeId.ROR_ZP, zpX: (byte)OpCodeId.ROR_ZP_X, abs: (byte)OpCodeId.ROR_ABS,
+            absX: (byte)OpCodeId.ROR_ABS_X, absXAddsPageCrossCycle: true);
+        ReplaceCmosRmw(table, "INC", CmosHandlers.IncCore,
+            zp: (byte)OpCodeId.INC_ZP, zpX: (byte)OpCodeId.INC_ZP_X, abs: (byte)OpCodeId.INC_ABS,
+            absX: (byte)OpCodeId.INC_ABS_X, absXAddsPageCrossCycle: false);
+        ReplaceCmosRmw(table, "DEC", CmosHandlers.DecCore,
+            zp: (byte)OpCodeId.DEC_ZP, zpX: (byte)OpCodeId.DEC_ZP_X, abs: (byte)OpCodeId.DEC_ABS,
+            absX: (byte)OpCodeId.DEC_ABS_X, absXAddsPageCrossCycle: false);
 
         // New 65C02 instructions, bound as static handlers.
         Add(table, 0x04, "TSB", AddrMode.ZP, size: 2, cycles: 5, CmosHandlers.Tsb_Zp);
@@ -159,32 +175,54 @@ internal static class Ncr65c02Model
     }
 
     /// <summary>
-    /// Rebinds a shift/rotate abs,X byte with the 65C02's cycle behavior: base 6 cycles
-    /// plus 1 on page cross (the NMOS takes an unconditional 7). The shift semantics are
-    /// the shared instruction object's.
+    /// Rebinds all four memory addressing modes of a read-modify-write operation with
+    /// the 65C02 bus sequence: read, read again (replacing the NMOS write-back cycle),
+    /// then write the result. The compute step is the shared per-operation core.
+    /// abs,X cycles: shifts/rotates take 6 + 1 on page cross; INC/DEC always 7.
     /// </summary>
-    private static void ReplaceShiftRmwAbsX(OpCodeDescriptor?[] table, InstructionList instructionList, byte code)
+    private static void ReplaceCmosRmw(OpCodeDescriptor?[] table, string mnemonic, CmosHandlers.RmwCore core,
+        byte zp, byte zpX, byte abs, byte absX, bool absXAddsPageCrossCycle)
     {
-        var opCode = instructionList.GetOpCode(code);
-        var instruction = (IInstructionUsesAddress)instructionList.GetInstruction(opCode);
-        var mnemonic = instructionList.GetInstruction(opCode).Name;
-        table[code] = new OpCodeDescriptor
+        table[zp] = CmosRmwDescriptor(zp, mnemonic, AddrMode.ZP, size: 2, baseCycles: 5, core,
+            static (cpu, mem) => ((ushort)cpu.FetchOperand(mem), false));
+        table[zpX] = CmosRmwDescriptor(zpX, mnemonic, AddrMode.ZP_X, size: 2, baseCycles: 6, core,
+            static (cpu, mem) => (cpu.CalcZeroPageAddressX(cpu.FetchOperand(mem), wrapZeroPage: true), false));
+        table[abs] = CmosRmwDescriptor(abs, mnemonic, AddrMode.ABS, size: 3, baseCycles: 6, core,
+            static (cpu, mem) => (cpu.FetchOperandWord(mem), false));
+        var absXBaseCycles = (byte)(absXAddsPageCrossCycle ? 6 : 7);
+        table[absX] = CmosRmwDescriptor(absX, mnemonic, AddrMode.ABS_X, size: 3, baseCycles: absXBaseCycles, core,
+            static (cpu, mem) =>
+            {
+                var address = cpu.CalcFullAddressX(cpu.FetchOperandWord(mem), out var crossedPageBoundary);
+                return (address, crossedPageBoundary);
+            },
+            addPageCrossCycle: absXAddsPageCrossCycle);
+    }
+
+    private delegate (ushort Address, bool CrossedPageBoundary) ResolveRmwAddress(CPU cpu, Memory mem);
+
+    private static OpCodeDescriptor CmosRmwDescriptor(byte code, string mnemonic, AddrMode addressing,
+        byte size, byte baseCycles, CmosHandlers.RmwCore core, ResolveRmwAddress resolveAddress,
+        bool addPageCrossCycle = false)
+        => new()
         {
             Code = code,
             Mnemonic = mnemonic,
-            Addressing = AddrMode.ABS_X,
-            Size = 3,
-            BaseCycles = 6,
+            Addressing = addressing,
+            Size = size,
+            BaseCycles = baseCycles,
             Documented = true,
             Execute = (cpu, mem) =>
             {
-                var address = cpu.CalcFullAddressX(cpu.FetchOperandWord(mem), out var crossedPageBoundary);
-                var calc = new AddrModeCalcResult { OpCode = opCode, InsAddress = address, AddressCalculationCrossedPageBoundary = crossedPageBoundary };
-                instruction.ExecuteWithWord(cpu, mem, address, calc);
-                return crossedPageBoundary ? 7ul : 6ul;
+                var (address, crossedPageBoundary) = resolveAddress(cpu, mem);
+                cpu.FetchByte(mem, address);
+                // 65C02 RMW is read-read-write; the value from the second (final) read
+                // feeds the modify step.
+                var value = cpu.FetchByte(mem, address);
+                cpu.StoreByte(core(value, ref cpu.ProcessorStatus), mem, address);
+                return baseCycles + (addPageCrossCycle && crossedPageBoundary ? 1ul : 0ul);
             },
         };
-    }
 
     private static void Add(OpCodeDescriptor?[] table, byte code, string mnemonic, AddrMode addressing, byte size, byte cycles, ExecuteHandler handler)
     {

--- a/src/libraries/Highbyte.DotNet6502/CpuModels/Ncr65c02Model.cs
+++ b/src/libraries/Highbyte.DotNet6502/CpuModels/Ncr65c02Model.cs
@@ -7,7 +7,7 @@ namespace Highbyte.DotNet6502;
 /// byte defined — bytes without an instruction are NOPs with specific sizes/cycles.
 /// No Rockwell (RMB/SMB/BBR/BBS) or WDC (WAI/STP) extensions; those bytes are NOPs.
 ///
-/// Built up in stages (design log: cpu-models-65c02 M1.4): this stage carries the shared
+/// Built up in stages : this stage carries the shared
 /// official instruction set, the CMOS JMP (addr), and the defined-NOP map. The new
 /// 65C02 instructions, CMOS decimal arithmetic, and shift/rotate abs,X cycle changes
 /// follow in the next stages before the model is wired into any system.

--- a/src/libraries/Highbyte.DotNet6502/CpuModels/Nmos6502Model.cs
+++ b/src/libraries/Highbyte.DotNet6502/CpuModels/Nmos6502Model.cs
@@ -7,6 +7,13 @@ namespace Highbyte.DotNet6502;
 /// </summary>
 internal static class Nmos6502Model
 {
+    // Single source of truth for the model's traits: referenced both by the definition
+    // and by the descriptor-table build below, so the two can never disagree.
+    private static readonly CpuModelTraits s_traits = new(
+        ClearsDecimalOnInterrupt: false,
+        AllBytesDefined: false,
+        PerformsIndexedDummyReads: true);
+
     public static readonly CpuModelDefinition Definition = new()
     {
         ModelId = CpuModelIds.Nmos6502,
@@ -19,15 +26,14 @@ internal static class Nmos6502Model
             CpuCompatibilityProfile.FullUnofficial,
         },
         CreateInstructionList = InstructionList.GetAllInstructions,
-        Traits = new CpuModelTraits(
-            ClearsDecimalOnInterrupt: false,
-            AllBytesDefined: false),
+        Traits = s_traits,
         CreateDescriptors = static instructionList => OpCodeDescriptorTableBuilder.Build(
             instructionList,
             handlerOverrides: new Dictionary<byte, ExecuteHandler>
             {
                 // NMOS indirect-JMP page-wrap bug (JMP ($xxFF) reads the high byte from $xx00).
                 [(byte)OpCodeId.JMP_IND] = NmosHandlers.Jmp_Indirect,
-            }),
+            },
+            indexedDummyReads: s_traits.PerformsIndexedDummyReads),
     };
 }

--- a/src/libraries/Highbyte.DotNet6502/CpuModels/OpCodeDescriptorTableBuilder.cs
+++ b/src/libraries/Highbyte.DotNet6502/CpuModels/OpCodeDescriptorTableBuilder.cs
@@ -1,3 +1,5 @@
+using Highbyte.DotNet6502.Utils;
+
 namespace Highbyte.DotNet6502;
 
 /// <summary>
@@ -24,7 +26,12 @@ internal static class OpCodeDescriptorTableBuilder
     /// Applied last; metadata stays from the instruction table. Overriding a byte the
     /// instruction table leaves undefined is a construction error.
     /// </param>
-    public static OpCodeDescriptor?[] Build(InstructionList instructionList, IReadOnlyDictionary<byte, ExecuteHandler>? handlerOverrides = null)
+    /// <param name="indexedDummyReads">
+    /// True for NMOS models (<see cref="CpuModelTraits.PerformsIndexedDummyReads"/>):
+    /// abs,X / abs,Y / (zp),Y compose with the NMOS dummy read at the un-carried address
+    /// — on page cross for plain reads; always for stores and read-modify-write.
+    /// </param>
+    public static OpCodeDescriptor?[] Build(InstructionList instructionList, IReadOnlyDictionary<byte, ExecuteHandler>? handlerOverrides = null, bool indexedDummyReads = false)
     {
         var table = new OpCodeDescriptor?[256];
         for (var code = 0; code <= 0xff; code++)
@@ -42,7 +49,7 @@ internal static class OpCodeDescriptorTableBuilder
                 Size = (byte)opCode.Size,
                 BaseCycles = opCode.MinimumCycles,
                 Documented = InstructionList.GetMinimumCompatibilityProfile(opCode.Code) == CpuCompatibilityProfile.OfficialOnly,
-                Execute = ComposeExecuteHandler(opCode, instruction),
+                Execute = ComposeExecuteHandler(opCode, instruction, indexedDummyReads),
             };
         }
 
@@ -79,7 +86,7 @@ internal static class OpCodeDescriptorTableBuilder
     /// Internal so model table builders can compose additional (instruction, mode)
     /// pairs that the NMOS opcode tables don't contain (e.g. 65C02 "(zp)" modes).
     /// </summary>
-    internal static ExecuteHandler ComposeExecuteHandler(OpCode opCode, Instruction instruction)
+    internal static ExecuteHandler ComposeExecuteHandler(OpCode opCode, Instruction instruction, bool indexedDummyReads = false)
     {
         var oc = opCode;
         var baseCycles = opCode.MinimumCycles;
@@ -129,52 +136,60 @@ internal static class OpCodeDescriptorTableBuilder
 
             case AddrMode.ZP:
                 return ComposeWithAddress(oc, baseCycles, instruction,
-                    static (cpu, mem) => ((ushort)cpu.FetchOperand(mem), false));
+                    static (cpu, mem) => { var address = (ushort)cpu.FetchOperand(mem); return (address, false, address); });
 
             case AddrMode.ZP_X:
                 return ComposeWithAddress(oc, baseCycles, instruction,
-                    static (cpu, mem) => (cpu.CalcZeroPageAddressX(cpu.FetchOperand(mem), wrapZeroPage: true), false));
+                    static (cpu, mem) => { var address = cpu.CalcZeroPageAddressX(cpu.FetchOperand(mem), wrapZeroPage: true); return (address, false, address); });
 
             case AddrMode.ZP_Y:
                 return ComposeWithAddress(oc, baseCycles, instruction,
-                    static (cpu, mem) => (cpu.CalcZeroPageAddressY(cpu.FetchOperand(mem), wrapZeroPage: true), false));
+                    static (cpu, mem) => { var address = cpu.CalcZeroPageAddressY(cpu.FetchOperand(mem), wrapZeroPage: true); return (address, false, address); });
 
             case AddrMode.ABS:
                 return ComposeWithAddress(oc, baseCycles, instruction,
-                    static (cpu, mem) => (cpu.FetchOperandWord(mem), false));
+                    static (cpu, mem) => { var address = cpu.FetchOperandWord(mem); return (address, false, address); });
 
             case AddrMode.ABS_X:
                 return ComposeWithAddress(oc, baseCycles, instruction,
                     static (cpu, mem) =>
                     {
-                        var address = cpu.CalcFullAddressX(cpu.FetchOperandWord(mem), out var didCrossPageBoundary);
-                        return (address, didCrossPageBoundary);
-                    });
+                        var baseAddress = cpu.FetchOperandWord(mem);
+                        var address = cpu.CalcFullAddressX(baseAddress, out var didCrossPageBoundary);
+                        return (address, didCrossPageBoundary, UncarriedAddress(baseAddress, cpu.X));
+                    },
+                    DummyReadsFor(instruction, indexedDummyReads));
 
             case AddrMode.ABS_Y:
                 return ComposeWithAddress(oc, baseCycles, instruction,
                     static (cpu, mem) =>
                     {
-                        var address = cpu.CalcFullAddressY(cpu.FetchOperandWord(mem), out var didCrossPageBoundary);
-                        return (address, didCrossPageBoundary);
-                    });
+                        var baseAddress = cpu.FetchOperandWord(mem);
+                        var address = cpu.CalcFullAddressY(baseAddress, out var didCrossPageBoundary);
+                        return (address, didCrossPageBoundary, UncarriedAddress(baseAddress, cpu.Y));
+                    },
+                    DummyReadsFor(instruction, indexedDummyReads));
 
             case AddrMode.IX_IND:
+                // "(zp,X)": the pointer lives in zero page and wraps within it ($FF -> $00).
                 return ComposeWithAddress(oc, baseCycles, instruction,
-                    static (cpu, mem) => (cpu.FetchWord(mem, cpu.CalcZeroPageAddressX(cpu.FetchOperand(mem))), false));
+                    static (cpu, mem) => { var address = ReadZeroPagePointer(cpu, mem, cpu.CalcZeroPageAddressX(cpu.FetchOperand(mem))); return (address, false, address); });
 
             case AddrMode.ZP_IND:
-                // 65C02 "(zp)": pointer in zero page, no index, no page-cross extra.
+                // 65C02 "(zp)": pointer in zero page (wrapping), no index, no page-cross extra.
                 return ComposeWithAddress(oc, baseCycles, instruction,
-                    static (cpu, mem) => (cpu.FetchWord(mem, cpu.FetchOperand(mem)), false));
+                    static (cpu, mem) => { var address = ReadZeroPagePointer(cpu, mem, cpu.FetchOperand(mem)); return (address, false, address); });
 
             case AddrMode.IND_IX:
+                // "(zp),Y": zero-page pointer (wrapping), then Y-indexed.
                 return ComposeWithAddress(oc, baseCycles, instruction,
                     static (cpu, mem) =>
                     {
-                        var address = cpu.CalcFullAddressY(cpu.FetchWord(mem, cpu.FetchOperand(mem)), out var didCrossPageBoundary);
-                        return (address, didCrossPageBoundary);
-                    });
+                        var baseAddress = ReadZeroPagePointer(cpu, mem, cpu.FetchOperand(mem));
+                        var address = cpu.CalcFullAddressY(baseAddress, out var didCrossPageBoundary);
+                        return (address, didCrossPageBoundary, UncarriedAddress(baseAddress, cpu.Y));
+                    },
+                    DummyReadsFor(instruction, indexedDummyReads));
 
             case AddrMode.Indirect:
                 // Default composition: linear pointer read. A model whose indirect JMP
@@ -182,7 +197,7 @@ internal static class OpCodeDescriptorTableBuilder
                 // linear read) binds its own handler for that byte instead of using this
                 // generic composition.
                 return ComposeWithAddress(oc, baseCycles, instruction,
-                    static (cpu, mem) => (cpu.FetchWord(mem, cpu.FetchOperandWord(mem)), false));
+                    static (cpu, mem) => { var address = cpu.FetchWord(mem, cpu.FetchOperandWord(mem)); return (address, false, address); });
 
             default:
                 throw BuildError(opCode, instruction);
@@ -190,40 +205,108 @@ internal static class OpCodeDescriptorTableBuilder
     }
 
     /// <summary>
-    /// Resolves the effective address for an address-producing mode; the bool reports a
-    /// page-boundary crossing (feeds extra-cycle calculation in the instruction logic).
+    /// The address the NMOS 6502 touches on the cycle before the index-carry into the high
+    /// byte is resolved: high byte from the base address, low byte already indexed.
     /// </summary>
-    private delegate (ushort Address, bool CrossedPageBoundary) ResolveAddress(CPU cpu, Memory mem);
+    private static ushort UncarriedAddress(ushort baseAddress, byte index)
+        => (ushort)((baseAddress & 0xFF00) | ((baseAddress + index) & 0x00FF));
 
-    private static ExecuteHandler ComposeWithAddress(OpCode oc, ulong baseCycles, Instruction instruction, ResolveAddress resolveAddress)
+    /// <summary>
+    /// Reads a 16-bit pointer from zero page, wrapping within the page: a pointer at $FF
+    /// takes its high byte from $00, on NMOS and CMOS alike.
+    /// </summary>
+    private static ushort ReadZeroPagePointer(CPU cpu, Memory mem, ushort zeroPageAddress)
+    {
+        var lowByte = cpu.FetchByte(mem, zeroPageAddress);
+        var highByte = cpu.FetchByte(mem, (ushort)((zeroPageAddress + 1) & 0x00FF));
+        return ByteHelpers.ToLittleEndianWord(lowByte, highByte);
+    }
+
+    /// <summary>
+    /// NMOS dummy-read policy for an indexed-mode instruction: plain reads touch the
+    /// un-carried address only when the page crosses; stores (IInstructionUsesAddress)
+    /// and read-modify-write instructions ALWAYS touch it first — the reason indexed
+    /// stores and RMW have no "+1 on page cross" and why e.g. STA $DC0D,X reads $DC0D
+    /// before writing it.
+    /// </summary>
+    private static DummyReadBehavior DummyReadsFor(Instruction instruction, bool indexedDummyReads)
+    {
+        if (!indexedDummyReads)
+            return DummyReadBehavior.None;
+        return instruction is IInstructionUsesAddress or IReadModifyWriteInstruction
+            ? DummyReadBehavior.Always
+            : DummyReadBehavior.OnPageCross;
+    }
+
+    private enum DummyReadBehavior { None, OnPageCross, Always }
+
+    /// <summary>
+    /// Resolves the effective address for an address-producing mode. CrossedPageBoundary
+    /// feeds extra-cycle calculation; UncarriedAddress is the dummy-read target for
+    /// indexed modes (equals Address for non-indexed modes and non-crossing accesses).
+    /// </summary>
+    private delegate (ushort Address, bool CrossedPageBoundary, ushort UncarriedAddress) ResolveAddress(CPU cpu, Memory mem);
+
+    private static ExecuteHandler ComposeWithAddress(OpCode oc, ulong baseCycles, Instruction instruction, ResolveAddress resolveAddress,
+        DummyReadBehavior dummyReads = DummyReadBehavior.None)
     {
         switch (instruction)
         {
             case IInstructionUsesByte usesByte:
-                return (cpu, mem) =>
+                return dummyReads switch
                 {
-                    var (address, crossedPageBoundary) = resolveAddress(cpu, mem);
-                    var calc = new AddrModeCalcResult { OpCode = oc, InsAddress = address, AddressCalculationCrossedPageBoundary = crossedPageBoundary };
-                    return baseCycles + usesByte.ExecuteWithByte(cpu, mem, cpu.FetchByte(mem, address), calc);
+                    DummyReadBehavior.Always => (cpu, mem) =>
+                    {
+                        var (address, crossedPageBoundary, uncarriedAddress) = resolveAddress(cpu, mem);
+                        cpu.FetchByte(mem, uncarriedAddress);
+                        var calc = new AddrModeCalcResult { OpCode = oc, InsAddress = address, AddressCalculationCrossedPageBoundary = crossedPageBoundary };
+                        return baseCycles + usesByte.ExecuteWithByte(cpu, mem, cpu.FetchByte(mem, address), calc);
+                    },
+                    DummyReadBehavior.OnPageCross => (cpu, mem) =>
+                    {
+                        var (address, crossedPageBoundary, uncarriedAddress) = resolveAddress(cpu, mem);
+                        if (crossedPageBoundary)
+                            cpu.FetchByte(mem, uncarriedAddress);
+                        var calc = new AddrModeCalcResult { OpCode = oc, InsAddress = address, AddressCalculationCrossedPageBoundary = crossedPageBoundary };
+                        return baseCycles + usesByte.ExecuteWithByte(cpu, mem, cpu.FetchByte(mem, address), calc);
+                    },
+                    _ => (cpu, mem) =>
+                    {
+                        var (address, crossedPageBoundary, _) = resolveAddress(cpu, mem);
+                        var calc = new AddrModeCalcResult { OpCode = oc, InsAddress = address, AddressCalculationCrossedPageBoundary = crossedPageBoundary };
+                        return baseCycles + usesByte.ExecuteWithByte(cpu, mem, cpu.FetchByte(mem, address), calc);
+                    },
                 };
             case IInstructionUsesAddress usesAddress:
-                return (cpu, mem) =>
+                return dummyReads switch
                 {
-                    var (address, crossedPageBoundary) = resolveAddress(cpu, mem);
-                    var calc = new AddrModeCalcResult { OpCode = oc, InsAddress = address, AddressCalculationCrossedPageBoundary = crossedPageBoundary };
-                    return baseCycles + usesAddress.ExecuteWithWord(cpu, mem, address, calc);
+                    // Stores and shift/rotate RMW: the dummy read always happens (its
+                    // address equals the effective address when no page is crossed).
+                    DummyReadBehavior.Always => (cpu, mem) =>
+                    {
+                        var (address, crossedPageBoundary, uncarriedAddress) = resolveAddress(cpu, mem);
+                        cpu.FetchByte(mem, uncarriedAddress);
+                        var calc = new AddrModeCalcResult { OpCode = oc, InsAddress = address, AddressCalculationCrossedPageBoundary = crossedPageBoundary };
+                        return baseCycles + usesAddress.ExecuteWithWord(cpu, mem, address, calc);
+                    },
+                    _ => (cpu, mem) =>
+                    {
+                        var (address, crossedPageBoundary, _) = resolveAddress(cpu, mem);
+                        var calc = new AddrModeCalcResult { OpCode = oc, InsAddress = address, AddressCalculationCrossedPageBoundary = crossedPageBoundary };
+                        return baseCycles + usesAddress.ExecuteWithWord(cpu, mem, address, calc);
+                    },
                 };
             case IInstructionUsesStack usesStack:
                 return (cpu, mem) =>
                 {
-                    var (address, crossedPageBoundary) = resolveAddress(cpu, mem);
+                    var (address, crossedPageBoundary, _) = resolveAddress(cpu, mem);
                     var calc = new AddrModeCalcResult { OpCode = oc, InsAddress = address, AddressCalculationCrossedPageBoundary = crossedPageBoundary };
                     return baseCycles + usesStack.ExecuteWithStack(cpu, mem, calc);
                 };
             case IInstructionUsesOnlyRegOrStatus usesRegOrStatus:
                 return (cpu, mem) =>
                 {
-                    var (address, crossedPageBoundary) = resolveAddress(cpu, mem);
+                    var (address, crossedPageBoundary, _) = resolveAddress(cpu, mem);
                     var calc = new AddrModeCalcResult { OpCode = oc, InsAddress = address, AddressCalculationCrossedPageBoundary = crossedPageBoundary };
                     return baseCycles + usesRegOrStatus.Execute(cpu, calc);
                 };

--- a/src/libraries/Highbyte.DotNet6502/Instructions/ASL.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/ASL.cs
@@ -14,6 +14,11 @@ public class ASL : Instruction, IInstructionUsesAddress, IInstructionUsesOnlyReg
     public ulong ExecuteWithWord(CPU cpu, Memory mem, ushort address, AddrModeCalcResult addrModeCalcResult)
     {
         var tempValue = cpu.FetchByte(mem, address);
+        // Real NMOS RMW is read-write-write: the modify cycle writes the unmodified
+        // value back before the result (observable through mapped I/O). The 65C02
+        // model binds its own read-read-write handlers for these opcodes, so this
+        // memory path serves NMOS models only.
+        cpu.StoreByte(tempValue, mem, address);
         tempValue = BinaryArithmeticHelpers.PerformASLAndSetStatusRegisters(tempValue, ref cpu.ProcessorStatus);
         cpu.StoreByte(tempValue, mem, address);
 

--- a/src/libraries/Highbyte.DotNet6502/Instructions/BRK.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/BRK.cs
@@ -13,11 +13,12 @@ public class BRK : Instruction, IInstructionUsesStack
 
     public ulong ExecuteWithStack(CPU cpu, Memory mem, AddrModeCalcResult addrModeCalcResult)
     {
-        // BRK is strange. The complete instruction is only one byte but the processor increases 
+        // BRK is strange. The complete instruction is only one byte but the processor increases
         // the return address pushed to stack is the *second* byte after the opcode!
         // It is advisable to use a NOP after it to avoid issues (when returning from BRK with RTI, the PC will point to the next-next instruction)
+        // The padding byte is fetched as a real bus access (cycle 2 of the sequence) and discarded.
+        cpu.FetchOperand(mem);
         ushort pcPushedToStack = cpu.PC;
-        pcPushedToStack++;
         cpu.PushWordToStack(pcPushedToStack, mem);
         // Set the Break flag on the copy of the ProcessorStatus that will be stored in stack.
         var processorStatusCopy = cpu.ProcessorStatus;

--- a/src/libraries/Highbyte.DotNet6502/Instructions/DCP.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/DCP.cs
@@ -12,6 +12,11 @@ public class DCP : Instruction, IInstructionUsesByte
 
     public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
     {
+        // Real NMOS RMW is read-write-write: the modify cycle writes the unmodified
+        // value back before the result (observable through mapped I/O). The 65C02
+        // model binds its own read-read-write handlers for these opcodes, so this
+        // memory path serves NMOS models only.
+        cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
         value--;
         cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
         BinaryArithmeticHelpers.SetFlagsAfterCompare(cpu.A, value, ref cpu.ProcessorStatus);

--- a/src/libraries/Highbyte.DotNet6502/Instructions/DCP.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/DCP.cs
@@ -5,7 +5,7 @@ namespace Highbyte.DotNet6502.Instructions;
 /// Decrements the value at the effective address by 1, then compares the result
 /// with the accumulator setting N, Z, and C flags as CMP does.
 /// </summary>
-public class DCP : Instruction, IInstructionUsesByte
+public class DCP : Instruction, IInstructionUsesByte, IReadModifyWriteInstruction
 {
     private readonly List<OpCode> _opCodes;
     public override List<OpCode> OpCodes => _opCodes;

--- a/src/libraries/Highbyte.DotNet6502/Instructions/DEC.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/DEC.cs
@@ -11,6 +11,11 @@ public class DEC : Instruction, IInstructionUsesByte
 
     public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
     {
+        // Real NMOS RMW is read-write-write: the modify cycle writes the unmodified
+        // value back before the result (observable through mapped I/O). The 65C02
+        // model binds its own read-read-write handlers for these opcodes, so this
+        // memory path serves NMOS models only.
+        cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
         value--;
         cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
         BinaryArithmeticHelpers.SetFlagsAfterRegisterLoadIncDec(value, ref cpu.ProcessorStatus);

--- a/src/libraries/Highbyte.DotNet6502/Instructions/DEC.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/DEC.cs
@@ -4,7 +4,7 @@ namespace Highbyte.DotNet6502.Instructions;
 /// Decrement Memory.
 /// Subtracts one from the value held at a specified memory location setting the zero and negative flags as appropriate.
 /// </summary>
-public class DEC : Instruction, IInstructionUsesByte
+public class DEC : Instruction, IInstructionUsesByte, IReadModifyWriteInstruction
 {
     private readonly List<OpCode> _opCodes;
     public override List<OpCode> OpCodes => _opCodes;

--- a/src/libraries/Highbyte.DotNet6502/Instructions/INC.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/INC.cs
@@ -4,7 +4,7 @@ namespace Highbyte.DotNet6502.Instructions;
 /// Increment Memory.
 /// Adds one to the value held at a specified memory location setting the zero and negative flags as appropriate.
 /// </summary>
-public class INC : Instruction, IInstructionUsesByte
+public class INC : Instruction, IInstructionUsesByte, IReadModifyWriteInstruction
 {
     private readonly List<OpCode> _opCodes;
     public override List<OpCode> OpCodes => _opCodes;

--- a/src/libraries/Highbyte.DotNet6502/Instructions/INC.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/INC.cs
@@ -11,6 +11,11 @@ public class INC : Instruction, IInstructionUsesByte
 
     public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
     {
+        // Real NMOS RMW is read-write-write: the modify cycle writes the unmodified
+        // value back before the result (observable through mapped I/O). The 65C02
+        // model binds its own read-read-write handlers for these opcodes, so this
+        // memory path serves NMOS models only.
+        cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
         value++;
         cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
         BinaryArithmeticHelpers.SetFlagsAfterRegisterLoadIncDec(value, ref cpu.ProcessorStatus);

--- a/src/libraries/Highbyte.DotNet6502/Instructions/ISC.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/ISC.cs
@@ -5,7 +5,7 @@ namespace Highbyte.DotNet6502.Instructions;
 /// Increments the value at the effective address by 1, then subtracts the
 /// result from A (with borrow), setting N, V, Z, and C flags as SBC does.
 /// </summary>
-public class ISC : Instruction, IInstructionUsesByte
+public class ISC : Instruction, IInstructionUsesByte, IReadModifyWriteInstruction
 {
     private readonly List<OpCode> _opCodes;
     public override List<OpCode> OpCodes => _opCodes;

--- a/src/libraries/Highbyte.DotNet6502/Instructions/ISC.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/ISC.cs
@@ -12,6 +12,11 @@ public class ISC : Instruction, IInstructionUsesByte
 
     public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
     {
+        // Real NMOS RMW is read-write-write: the modify cycle writes the unmodified
+        // value back before the result (observable through mapped I/O). The 65C02
+        // model binds its own read-read-write handlers for these opcodes, so this
+        // memory path serves NMOS models only.
+        cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
         value++;
         cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
         cpu.A = BinaryArithmeticHelpers.SubtractWithCarryAndOverflow(cpu.A, value, ref cpu.ProcessorStatus);

--- a/src/libraries/Highbyte.DotNet6502/Instructions/LSR.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/LSR.cs
@@ -11,6 +11,11 @@ public class LSR : Instruction, IInstructionUsesAddress, IInstructionUsesOnlyReg
     public ulong ExecuteWithWord(CPU cpu, Memory mem, ushort address, AddrModeCalcResult addrModeCalcResult)
     {
         var tempValue = cpu.FetchByte(mem, address);
+        // Real NMOS RMW is read-write-write: the modify cycle writes the unmodified
+        // value back before the result (observable through mapped I/O). The 65C02
+        // model binds its own read-read-write handlers for these opcodes, so this
+        // memory path serves NMOS models only.
+        cpu.StoreByte(tempValue, mem, address);
         tempValue = BinaryArithmeticHelpers.PerformLSRAndSetStatusRegisters(tempValue, ref cpu.ProcessorStatus);
         cpu.StoreByte(tempValue, mem, address);               
 

--- a/src/libraries/Highbyte.DotNet6502/Instructions/RLA.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/RLA.cs
@@ -12,6 +12,11 @@ public class RLA : Instruction, IInstructionUsesByte
 
     public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
     {
+        // Real NMOS RMW is read-write-write: the modify cycle writes the unmodified
+        // value back before the result (observable through mapped I/O). The 65C02
+        // model binds its own read-read-write handlers for these opcodes, so this
+        // memory path serves NMOS models only.
+        cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
         value = BinaryArithmeticHelpers.PerformROLAndSetStatusRegisters(value, ref cpu.ProcessorStatus);
         cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
         cpu.A &= value;

--- a/src/libraries/Highbyte.DotNet6502/Instructions/RLA.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/RLA.cs
@@ -5,7 +5,7 @@ namespace Highbyte.DotNet6502.Instructions;
 /// Rotates the value at the effective address one bit left through carry,
 /// then ANDs the rotated result into A, setting N, Z, and C flags.
 /// </summary>
-public class RLA : Instruction, IInstructionUsesByte
+public class RLA : Instruction, IInstructionUsesByte, IReadModifyWriteInstruction
 {
     private readonly List<OpCode> _opCodes;
     public override List<OpCode> OpCodes => _opCodes;

--- a/src/libraries/Highbyte.DotNet6502/Instructions/ROL.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/ROL.cs
@@ -14,6 +14,11 @@ public class ROL : Instruction, IInstructionUsesAddress, IInstructionUsesOnlyReg
     public ulong ExecuteWithWord(CPU cpu, Memory mem, ushort address, AddrModeCalcResult addrModeCalcResult)
     {
         var tempValue = cpu.FetchByte(mem, address);
+        // Real NMOS RMW is read-write-write: the modify cycle writes the unmodified
+        // value back before the result (observable through mapped I/O). The 65C02
+        // model binds its own read-read-write handlers for these opcodes, so this
+        // memory path serves NMOS models only.
+        cpu.StoreByte(tempValue, mem, address);
         tempValue = BinaryArithmeticHelpers.PerformROLAndSetStatusRegisters(tempValue, ref cpu.ProcessorStatus);
         cpu.StoreByte(tempValue, mem, address);
 

--- a/src/libraries/Highbyte.DotNet6502/Instructions/ROR.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/ROR.cs
@@ -13,6 +13,11 @@ public class ROR : Instruction, IInstructionUsesAddress, IInstructionUsesOnlyReg
     public ulong ExecuteWithWord(CPU cpu, Memory mem, ushort address, AddrModeCalcResult addrModeCalcResult)
     {
         var tempValue = cpu.FetchByte(mem, address);
+        // Real NMOS RMW is read-write-write: the modify cycle writes the unmodified
+        // value back before the result (observable through mapped I/O). The 65C02
+        // model binds its own read-read-write handlers for these opcodes, so this
+        // memory path serves NMOS models only.
+        cpu.StoreByte(tempValue, mem, address);
         tempValue = BinaryArithmeticHelpers.PerformRORAndSetStatusRegisters(tempValue, ref cpu.ProcessorStatus);
         cpu.StoreByte(tempValue, mem, address);
 

--- a/src/libraries/Highbyte.DotNet6502/Instructions/RRA.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/RRA.cs
@@ -5,7 +5,7 @@ namespace Highbyte.DotNet6502.Instructions;
 /// Rotates the value at the effective address one bit right through carry,
 /// then adds the rotated result to A with carry, setting N, V, Z, and C flags.
 /// </summary>
-public class RRA : Instruction, IInstructionUsesByte
+public class RRA : Instruction, IInstructionUsesByte, IReadModifyWriteInstruction
 {
     private readonly List<OpCode> _opCodes;
     public override List<OpCode> OpCodes => _opCodes;

--- a/src/libraries/Highbyte.DotNet6502/Instructions/RRA.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/RRA.cs
@@ -12,6 +12,11 @@ public class RRA : Instruction, IInstructionUsesByte
 
     public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
     {
+        // Real NMOS RMW is read-write-write: the modify cycle writes the unmodified
+        // value back before the result (observable through mapped I/O). The 65C02
+        // model binds its own read-read-write handlers for these opcodes, so this
+        // memory path serves NMOS models only.
+        cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
         value = BinaryArithmeticHelpers.PerformRORAndSetStatusRegisters(value, ref cpu.ProcessorStatus);
         cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
         cpu.A = BinaryArithmeticHelpers.AddWithCarryAndOverflow(cpu.A, value, ref cpu.ProcessorStatus);

--- a/src/libraries/Highbyte.DotNet6502/Instructions/SLO.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/SLO.cs
@@ -12,6 +12,11 @@ public class SLO : Instruction, IInstructionUsesByte
 
     public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
     {
+        // Real NMOS RMW is read-write-write: the modify cycle writes the unmodified
+        // value back before the result (observable through mapped I/O). The 65C02
+        // model binds its own read-read-write handlers for these opcodes, so this
+        // memory path serves NMOS models only.
+        cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
         value = BinaryArithmeticHelpers.PerformASLAndSetStatusRegisters(value, ref cpu.ProcessorStatus);
         cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
         cpu.A |= value;

--- a/src/libraries/Highbyte.DotNet6502/Instructions/SLO.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/SLO.cs
@@ -5,7 +5,7 @@ namespace Highbyte.DotNet6502.Instructions;
 /// Shifts the value at the effective address one bit left (bit 0 = 0, old bit 7 → C),
 /// then ORs the shifted result into A, setting N, Z, and C flags.
 /// </summary>
-public class SLO : Instruction, IInstructionUsesByte
+public class SLO : Instruction, IInstructionUsesByte, IReadModifyWriteInstruction
 {
     private readonly List<OpCode> _opCodes;
     public override List<OpCode> OpCodes => _opCodes;

--- a/src/libraries/Highbyte.DotNet6502/Instructions/SRE.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/SRE.cs
@@ -12,6 +12,11 @@ public class SRE : Instruction, IInstructionUsesByte
 
     public ulong ExecuteWithByte(CPU cpu, Memory mem, byte value, AddrModeCalcResult addrModeCalcResult)
     {
+        // Real NMOS RMW is read-write-write: the modify cycle writes the unmodified
+        // value back before the result (observable through mapped I/O). The 65C02
+        // model binds its own read-read-write handlers for these opcodes, so this
+        // memory path serves NMOS models only.
+        cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
         value = BinaryArithmeticHelpers.PerformLSRAndSetStatusRegisters(value, ref cpu.ProcessorStatus);
         cpu.StoreByte(value, mem, addrModeCalcResult.InsAddress!.Value);
         cpu.A ^= value;

--- a/src/libraries/Highbyte.DotNet6502/Instructions/SRE.cs
+++ b/src/libraries/Highbyte.DotNet6502/Instructions/SRE.cs
@@ -5,7 +5,7 @@ namespace Highbyte.DotNet6502.Instructions;
 /// Shifts the value at the effective address one bit right (bit 7 = 0, old bit 0 → C),
 /// then XORs the shifted result into A, setting N, Z, and C flags.
 /// </summary>
-public class SRE : Instruction, IInstructionUsesByte
+public class SRE : Instruction, IInstructionUsesByte, IReadModifyWriteInstruction
 {
     private readonly List<OpCode> _opCodes;
     public override List<OpCode> OpCodes => _opCodes;

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2LanguageCardTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2LanguageCardTests.cs
@@ -32,6 +32,26 @@ public class Apple2LanguageCardTests
             romData);
     }
 
+    private static Apple2System BuildApple2With65c02AndRom()
+    {
+        var rom = new byte[Apple2System.SystemRomSize];
+        for (var offset = 0; offset < rom.Length; offset++)
+        {
+            var address = Apple2System.SystemRomStartAddress + offset;
+            rom[offset] = address < Apple2System.UpperMemoryStartAddress ? RomFillD000 : RomFillE000;
+        }
+
+        var romData = new Dictionary<string, byte[]> { { Apple2SystemConfig.SYSTEM_ROM_NAME, rom } };
+        return new Apple2System(
+            new Apple2Config
+            {
+                CpuModelId = CpuModelIds.Ncr65c02,
+                CpuCompatibilityProfile = CpuCompatibilityProfile.OfficialOnly,
+            },
+            NullLoggerFactory.Instance,
+            romData);
+    }
+
     /// <summary>Reads the switch, which is how software drives the card (a write works too).</summary>
     private static void Switch(Apple2System apple2, ushort address) => _ = apple2.Mem[address];
 
@@ -119,24 +139,61 @@ public class Apple2LanguageCardTests
     }
 
     /// <summary>
-    /// Characterization of a KNOWN DEVIATION. Per Sather (UTAIIe:5-23, confirmed against
-    /// two independent emulator implementations): WRITE enable is set only by an odd
-    /// READ while PRE-WRITE is set — a WRITE resets PRE-WRITE without completing the
-    /// sequence. The current implementation lets the write complete it. This is the
-    /// substrate of the CPU-model bus-accuracy work:
-    /// with correct card semantics plus real per-model bus sequences, an NMOS RMW on
-    /// $C083 (read-write-write) must NOT unlock the card while a 65C02 RMW
-    /// (read-read-write) must. When the card is fixed, this test's expectation flips.
+    /// Per Sather (Understanding the Apple IIe, 5-23): WRITE enable is set only by an
+    /// odd READ while PRE-WRITE is set — a WRITE resets PRE-WRITE without completing
+    /// the sequence. (The emulator historically let the write complete it; fixed as part
+    /// of the CPU-model bus-accuracy work.)
     /// </summary>
     [Fact]
-    public void Read_Then_Write_Of_The_Switch_Currently_Completes_The_Sequence_Known_Deviation()
+    public void Read_Then_Write_Of_The_Switch_Does_Not_Complete_The_Sequence()
     {
         var apple2 = BuildApple2WithRom();
 
         Switch(apple2, 0xC083);         // read: arms PRE-WRITE
-        apple2.Mem[0xC083] = 0x00;      // write: real hardware resets PRE-WRITE, no unlock
+        apple2.Mem[0xC083] = 0x00;      // write: resets PRE-WRITE, no unlock
 
-        // Current behavior: the write completes the sequence (deviation).
+        Assert.False(apple2.LanguageCard.WriteEnabled);
+        Assert.False(apple2.LanguageCard.PreWrite);
+    }
+
+    /// <summary>
+    /// The CPU-model-observable payoff of ordered bus accesses: INC $C083 is a single
+    /// instruction whose effect on the language card depends on which CPU executes it.
+    /// NMOS RMW is read-write-write — the write resets PRE-WRITE, no unlock.
+    /// </summary>
+    [Fact]
+    public void INC_Of_An_Odd_Switch_On_Nmos_Cpu_Does_Not_Unlock_The_Card()
+    {
+        var apple2 = BuildApple2WithRom();
+
+        // INC $C083 executed by the machine's (NMOS) CPU.
+        apple2.Mem[0x0300] = (byte)OpCodeId.INC_ABS;
+        apple2.Mem[0x0301] = 0x83;
+        apple2.Mem[0x0302] = 0xC0;
+        apple2.CPU.PC = 0x0300;
+        apple2.CPU.ExecuteOneInstructionMinimal(apple2.Mem);
+
+        Assert.False(apple2.LanguageCard.WriteEnabled);
+        Assert.False(apple2.LanguageCard.PreWrite);
+    }
+
+    /// <summary>
+    /// 65C02 RMW is read-read-write — the two reads complete the unlock sequence, and
+    /// the trailing write only resets PRE-WRITE (an already-enabled write survives).
+    /// This is how a real enhanced IIe behaves, and why some 65C02-era software can
+    /// unlock the card with a single instruction.
+    /// </summary>
+    [Fact]
+    public void INC_Of_An_Odd_Switch_On_65c02_Cpu_Unlocks_The_Card()
+    {
+        var apple2 = BuildApple2With65c02AndRom();
+
+        apple2.Mem[0x0300] = (byte)OpCodeId.INC_ABS;
+        apple2.Mem[0x0301] = 0x83;
+        apple2.Mem[0x0302] = 0xC0;
+        apple2.CPU.PC = 0x0300;
+        apple2.CPU.ExecuteOneInstructionMinimal(apple2.Mem);
+
         Assert.True(apple2.LanguageCard.WriteEnabled);
         Assert.False(apple2.LanguageCard.PreWrite);
     }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2LanguageCardTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Apple2/Apple2LanguageCardTests.cs
@@ -118,6 +118,29 @@ public class Apple2LanguageCardTests
         Assert.Equal((byte)0x42, apple2.Mem[0xD000]);
     }
 
+    /// <summary>
+    /// Characterization of a KNOWN DEVIATION. Per Sather (UTAIIe:5-23, confirmed against
+    /// two independent emulator implementations): WRITE enable is set only by an odd
+    /// READ while PRE-WRITE is set — a WRITE resets PRE-WRITE without completing the
+    /// sequence. The current implementation lets the write complete it. This is the
+    /// substrate of the CPU-model bus-accuracy work:
+    /// with correct card semantics plus real per-model bus sequences, an NMOS RMW on
+    /// $C083 (read-write-write) must NOT unlock the card while a 65C02 RMW
+    /// (read-read-write) must. When the card is fixed, this test's expectation flips.
+    /// </summary>
+    [Fact]
+    public void Read_Then_Write_Of_The_Switch_Currently_Completes_The_Sequence_Known_Deviation()
+    {
+        var apple2 = BuildApple2WithRom();
+
+        Switch(apple2, 0xC083);         // read: arms PRE-WRITE
+        apple2.Mem[0xC083] = 0x00;      // write: real hardware resets PRE-WRITE, no unlock
+
+        // Current behavior: the write completes the sequence (deviation).
+        Assert.True(apple2.LanguageCard.WriteEnabled);
+        Assert.False(apple2.LanguageCard.PreWrite);
+    }
+
     [Fact]
     public void A_Write_To_The_Switch_Does_Not_Arm_The_Sequence()
     {

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64CiaDummyReadTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64CiaDummyReadTests.cs
@@ -1,0 +1,70 @@
+using Highbyte.DotNet6502;
+using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64;
+
+/// <summary>
+/// The C64 motivating case for NMOS indexed dummy reads: the CIA interrupt control
+/// register ($DC0D) clears its pending flags on ANY read — including the dummy read an
+/// indexed store performs before writing. `STA $DC0D,X` with X=0 therefore silently
+/// acknowledges pending CIA interrupts on real hardware, a classic C64 gotcha that only
+/// exists when the emulator performs real bus access sequences.
+/// </summary>
+public class C64CiaDummyReadTests
+{
+    [Fact]
+    public void Indexed_Store_To_ICR_Clears_Pending_Flags_Via_Its_Dummy_Read()
+    {
+        var c64 = BuildC64();
+        RaiseTimerAInterruptFlag(c64);
+
+        // STA $DC0D,X with X=0: the dummy read at the (un-carried == effective) address
+        // reads the ICR, clearing the pending flags, before the write stores the mask.
+        c64.Mem[0x2000] = 0x9D; // STA abs,X
+        c64.Mem[0x2001] = 0x0D;
+        c64.Mem[0x2002] = 0xDC;
+        c64.CPU.PC = 0x2000;
+        c64.CPU.X = 0x00;
+        c64.CPU.A = 0x00; // ICR mask write with bit 7 clear: clears no-op mask bits only
+        c64.CPU.ExecuteOneInstructionMinimal(c64.Mem);
+
+        // The flags are gone: a subsequent ICR read reports nothing pending.
+        Assert.Equal(0, c64.Mem[CiaAddr.CIA1_CIAICR] & 0b0000_0001);
+    }
+
+    [Fact]
+    public void Control_Case_Without_The_Store_The_Flag_Is_Pending_Until_Read()
+    {
+        var c64 = BuildC64();
+        RaiseTimerAInterruptFlag(c64);
+
+        // First ICR read reports the pending timer A flag (and clears it)...
+        Assert.Equal(1, c64.Mem[CiaAddr.CIA1_CIAICR] & 0b0000_0001);
+        // ...second read shows it was clear-on-read.
+        Assert.Equal(0, c64.Mem[CiaAddr.CIA1_CIAICR] & 0b0000_0001);
+    }
+
+    /// <summary>
+    /// Raises the CIA1 timer A interrupt flag through the public register interface:
+    /// program a 1-tick timer, start it, and advance time past the underflow.
+    /// (The interrupt MASK stays disabled, so only the flag is set — no IRQ fires.)
+    /// </summary>
+    private static void RaiseTimerAInterruptFlag(C64 c64)
+    {
+        c64.Mem[CiaAddr.CIA1_TIMALO] = 0x01;
+        c64.Mem[CiaAddr.CIA1_TIMAHI] = 0x00;
+        c64.Mem[CiaAddr.CIA1_CIACRA] = 0b0000_0001; // start timer A
+        c64.Cia1.ProcessTimers(cyclesExecuted: 3);
+    }
+
+    private static C64 BuildC64()
+        => C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            C64Model = "C64PAL",
+            Vic2Model = "PAL"
+        }, NullLoggerFactory.Instance);
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/CpuModelConfigTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/CpuModelConfigTests.cs
@@ -9,8 +9,8 @@ using Apple2System = Highbyte.DotNet6502.Systems.Apple2.Apple2;
 namespace Highbyte.DotNet6502.Systems.Tests;
 
 /// <summary>
-/// CPU model selection through system configuration (feature cpu-models-65c02, M1
-/// step 6): the Apple II and the Generic computer can be configured with the 65C02;
+/// CPU model selection through system configuration: the Apple II and the Generic
+/// computer can be configured with the 65C02;
 /// defaults stay NMOS. $9C (STZ abs, 3 bytes on a 65C02; undefined on NMOS profiles)
 /// is used as the observable model probe.
 /// </summary>

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/CpuModelSnapshotTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/CpuModelSnapshotTests.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Highbyte.DotNet6502.Systems.Tests.Snapshots;
 
 /// <summary>
-/// CPU model identity in snapshots (feature cpu-models-65c02, M1 step 5): the cpu-6502
+/// CPU model identity in snapshots: the cpu-6502
 /// module (v2) records which CPU model the state was captured on; restoring onto a
 /// different model is a hard error; v1 payloads (captured before CPU models existed)
 /// restore as nmos6502 — proven against a checked-in fixture written by the REAL v1

--- a/tests/Highbyte.DotNet6502.Tests/CpuBusAccessCharacterizationTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/CpuBusAccessCharacterizationTests.cs
@@ -1,0 +1,192 @@
+using Highbyte.DotNet6502.Tests.Helpers;
+using Highbyte.DotNet6502.Utils;
+
+namespace Highbyte.DotNet6502.Tests;
+
+/// <summary>
+/// Characterization tests locking in the CURRENT bus-access sequences of the
+/// instruction categories the ordered-bus-accesses work will deliberately change.
+/// Recorded via <see cref="BusAccessRecorder"/> (production memory-mapped-I/O,
+/// no tracing hooks).
+///
+/// Today the emulator performs the MINIMAL access sequence per instruction: one read
+/// and/or one write at the effective address. Real hardware does more:
+/// - NMOS RMW is read-write-write (original value written back, then the result);
+///   65C02 RMW is read-read-write.
+/// - Indexed reads that cross a page perform a dummy read at the un-carried address.
+/// - Indexed stores always perform a dummy read before the write.
+/// When M2 lands those sequences per model, each test here flips to the hardware
+/// sequence as an explicit, reviewed change — exactly like the JMP ($xxFF)
+/// characterization test did in M1.
+/// </summary>
+public class CpuBusAccessCharacterizationTests
+{
+    private const ushort StartPc = 0x1000;
+
+    private static (CPU cpu, Memory mem, BusAccessRecorder recorder) NewCpuWithRecorder(ushort watchStart, int watchLength)
+    {
+        var cpu = new CPU();
+        var mem = new Memory();
+        cpu.PC = StartPc;
+        cpu.SP = 0xFF;
+        var recorder = new BusAccessRecorder();
+        recorder.Watch(mem, watchStart, watchLength);
+        return (cpu, mem, recorder);
+    }
+
+    [Fact]
+    public void RMW_Zp_Currently_Does_One_Read_And_One_Write()
+    {
+        var (cpu, mem, recorder) = NewCpuWithRecorder(0x0040, 1);
+        recorder[0x0040] = 0x12;
+        mem[StartPc] = (byte)OpCodeId.INC_ZP;
+        mem[StartPc + 1] = 0x40;
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        // Real NMOS: R($40)=12, W($40)=12 (original written back), W($40)=13.
+        Assert.Equal(new[]
+        {
+            new BusAccessRecorder.BusAccess(IsRead: true, 0x0040, 0x12),
+            new BusAccessRecorder.BusAccess(IsRead: false, 0x0040, 0x13),
+        }, recorder.Accesses);
+    }
+
+    [Fact]
+    public void RMW_Abs_Currently_Does_One_Read_And_One_Write()
+    {
+        var (cpu, mem, recorder) = NewCpuWithRecorder(0x3000, 1);
+        recorder[0x3000] = 0b0100_0000;
+        mem[StartPc] = (byte)OpCodeId.ASL_ABS;
+        mem.WriteWord((ushort)(StartPc + 1), 0x3000);
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        Assert.Equal(new[]
+        {
+            new BusAccessRecorder.BusAccess(IsRead: true, 0x3000, 0b0100_0000),
+            new BusAccessRecorder.BusAccess(IsRead: false, 0x3000, 0b1000_0000),
+        }, recorder.Accesses);
+    }
+
+    [Fact]
+    public void RMW_AbsX_Currently_Does_One_Read_And_One_Write_At_The_Final_Address()
+    {
+        var (cpu, mem, recorder) = NewCpuWithRecorder(0x3000, 0x200);
+        recorder[0x30FF] = 0x10;
+        cpu.X = 0xFF;
+        mem[StartPc] = (byte)OpCodeId.INC_ABS_X;
+        mem.WriteWord((ushort)(StartPc + 1), 0x3000);
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        Assert.Equal(new[]
+        {
+            new BusAccessRecorder.BusAccess(IsRead: true, 0x30FF, 0x10),
+            new BusAccessRecorder.BusAccess(IsRead: false, 0x30FF, 0x11),
+        }, recorder.Accesses);
+    }
+
+    [Fact]
+    public void Indexed_Read_With_Page_Cross_Currently_Reads_Only_The_Final_Address()
+    {
+        var (cpu, mem, recorder) = NewCpuWithRecorder(0x3000, 0x200);
+        recorder[0x3101] = 0x42; // $30FF + 2 crosses into $31xx
+        cpu.X = 0x02;
+        mem[StartPc] = (byte)OpCodeId.LDA_ABS_X;
+        mem.WriteWord((ushort)(StartPc + 1), 0x30FF);
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        // Real NMOS: dummy read at $3001 (high byte not yet carried), then read $3101.
+        Assert.Equal(new[]
+        {
+            new BusAccessRecorder.BusAccess(IsRead: true, 0x3101, 0x42),
+        }, recorder.Accesses);
+        Assert.Equal(0x42, cpu.A);
+    }
+
+    [Fact]
+    public void Indexed_Store_Currently_Writes_Only_The_Final_Address()
+    {
+        var (cpu, mem, recorder) = NewCpuWithRecorder(0x3000, 0x200);
+        cpu.A = 0x77;
+        cpu.X = 0x02;
+        mem[StartPc] = (byte)OpCodeId.STA_ABS_X;
+        mem.WriteWord((ushort)(StartPc + 1), 0x30FF);
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        // Real NMOS: dummy read at $3001 first, then the write to $3101.
+        Assert.Equal(new[]
+        {
+            new BusAccessRecorder.BusAccess(IsRead: false, 0x3101, 0x77),
+        }, recorder.Accesses);
+    }
+
+    [Fact]
+    public void IndirectIndexed_Read_Currently_Reads_Pointer_Then_Final_Address_Only()
+    {
+        var (cpu, mem, recorder) = NewCpuWithRecorder(0x0040, 2);
+        var dataRecorder = new BusAccessRecorder();
+        dataRecorder.Watch(mem, 0x3000, 0x200);
+        recorder[0x0040] = 0xFF; // pointer low
+        recorder[0x0041] = 0x30; // pointer high -> $30FF
+        dataRecorder[0x3101] = 0x55;
+        cpu.Y = 0x02;
+        mem[StartPc] = (byte)OpCodeId.LDA_IND_IX;
+        mem[StartPc + 1] = 0x40;
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        // Pointer bytes read linearly from zero page...
+        Assert.Equal(new[]
+        {
+            new BusAccessRecorder.BusAccess(IsRead: true, 0x0040, 0xFF),
+            new BusAccessRecorder.BusAccess(IsRead: true, 0x0041, 0x30),
+        }, recorder.Accesses);
+        // ...then only the final data address (real NMOS: dummy read at $3001 first).
+        Assert.Equal(new[]
+        {
+            new BusAccessRecorder.BusAccess(IsRead: true, 0x3101, 0x55),
+        }, dataRecorder.Accesses);
+        Assert.Equal(0x55, cpu.A);
+    }
+
+    [Fact]
+    public void IRQ_Entry_Currently_Pushes_Three_Bytes_And_Reads_The_Vector()
+    {
+        var cpu = new CPU();
+        var mem = new Memory();
+        mem[0x1000] = (byte)OpCodeId.NOP;
+        cpu.PC = 0x1000;
+        cpu.SP = 0xFF;
+        cpu.ProcessorStatus.InterruptDisable = false;
+
+        var stackRecorder = new BusAccessRecorder();
+        stackRecorder.Watch(mem, 0x0100, 0x100);
+        var vectorRecorder = new BusAccessRecorder();
+        vectorRecorder.Watch(mem, CPU.BrkIRQHandlerVector, 2);
+        vectorRecorder[CPU.BrkIRQHandlerVector] = 0x00;
+        vectorRecorder[(ushort)(CPU.BrkIRQHandlerVector + 1)] = 0x40;
+
+        cpu.CPUInterrupts.SetIRQSourceActive("device", autoAcknowledge: true);
+        cpu.ProcessPendingInterrupts(mem);
+
+        // Stack: PC high, PC low, then status (with B clear). Real hardware also performs
+        // two dummy reads before the pushes (7-cycle sequence); those are absent today.
+        Assert.Equal(3, stackRecorder.Accesses.Count);
+        Assert.All(stackRecorder.Accesses, a => Assert.False(a.IsRead));
+        Assert.Equal(0x01FF, stackRecorder.Accesses[0].Address); // PC high
+        Assert.Equal(0x01FE, stackRecorder.Accesses[1].Address); // PC low
+        Assert.Equal(0x01FD, stackRecorder.Accesses[2].Address); // status
+
+        // Vector: low byte then high byte, one read each.
+        Assert.Equal(new[]
+        {
+            new BusAccessRecorder.BusAccess(IsRead: true, CPU.BrkIRQHandlerVector, 0x00),
+            new BusAccessRecorder.BusAccess(IsRead: true, (ushort)(CPU.BrkIRQHandlerVector + 1), 0x40),
+        }, vectorRecorder.Accesses);
+        Assert.Equal((ushort)0x4000, cpu.PC);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Tests/CpuBusAccessCharacterizationTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/CpuBusAccessCharacterizationTests.cs
@@ -283,7 +283,7 @@ public class CpuBusAccessCharacterizationTests
     }
 
     [Fact]
-    public void IRQ_Entry_Currently_Pushes_Three_Bytes_And_Reads_The_Vector()
+    public void IRQ_Entry_Is_Two_DummyReads_Three_Pushes_Then_Vector_Reads()
     {
         var cpu = new CPU();
         var mem = new Memory();
@@ -291,31 +291,88 @@ public class CpuBusAccessCharacterizationTests
         cpu.PC = 0x1000;
         cpu.SP = 0xFF;
         cpu.ProcessorStatus.InterruptDisable = false;
+        cpu.ExecuteOneInstructionMinimal(mem); // NOP -> PC = 0x1001
 
-        var stackRecorder = new BusAccessRecorder();
-        stackRecorder.Watch(mem, 0x0100, 0x100);
-        var vectorRecorder = new BusAccessRecorder();
-        vectorRecorder.Watch(mem, CPU.BrkIRQHandlerVector, 2);
-        vectorRecorder[CPU.BrkIRQHandlerVector] = 0x00;
-        vectorRecorder[(ushort)(CPU.BrkIRQHandlerVector + 1)] = 0x40;
+        // One recorder over the program byte, the stack page, and the vector, so the
+        // COMPLETE 7-access entry sequence is asserted in order.
+        var recorder = new BusAccessRecorder();
+        recorder.Watch(mem, 0x1001, 1);
+        recorder.Watch(mem, 0x0100, 0x100);
+        recorder.Watch(mem, CPU.BrkIRQHandlerVector, 2);
+        recorder[CPU.BrkIRQHandlerVector] = 0x00;
+        recorder[(ushort)(CPU.BrkIRQHandlerVector + 1)] = 0x40;
 
         cpu.CPUInterrupts.SetIRQSourceActive("device", autoAcknowledge: true);
         cpu.ProcessPendingInterrupts(mem);
 
-        // Stack: PC high, PC low, then status (with B clear). Real hardware also performs
-        // two dummy reads before the pushes (7-cycle sequence); those are absent today.
-        Assert.Equal(3, stackRecorder.Accesses.Count);
-        Assert.All(stackRecorder.Accesses, a => Assert.False(a.IsRead));
-        Assert.Equal(0x01FF, stackRecorder.Accesses[0].Address); // PC high
-        Assert.Equal(0x01FE, stackRecorder.Accesses[1].Address); // PC low
-        Assert.Equal(0x01FD, stackRecorder.Accesses[2].Address); // status
+        Assert.Equal(7, recorder.Accesses.Count);
+        // Two dummy reads of the next opcode byte while the interrupt takes over...
+        Assert.Equal(new BusAccessRecorder.BusAccess(IsRead: true, 0x1001, 0x00), recorder.Accesses[0]);
+        Assert.Equal(new BusAccessRecorder.BusAccess(IsRead: true, 0x1001, 0x00), recorder.Accesses[1]);
+        // ...then PC high, PC low, status (B clear)...
+        Assert.Equal((false, (ushort)0x01FF), (recorder.Accesses[2].IsRead, recorder.Accesses[2].Address));
+        Assert.Equal((false, (ushort)0x01FE), (recorder.Accesses[3].IsRead, recorder.Accesses[3].Address));
+        Assert.Equal((false, (ushort)0x01FD), (recorder.Accesses[4].IsRead, recorder.Accesses[4].Address));
+        // ...then the vector, low byte first.
+        Assert.Equal(new BusAccessRecorder.BusAccess(IsRead: true, CPU.BrkIRQHandlerVector, 0x00), recorder.Accesses[5]);
+        Assert.Equal(new BusAccessRecorder.BusAccess(IsRead: true, (ushort)(CPU.BrkIRQHandlerVector + 1), 0x40), recorder.Accesses[6]);
+        Assert.Equal((ushort)0x4000, cpu.PC);
+    }
 
-        // Vector: low byte then high byte, one read each.
-        Assert.Equal(new[]
-        {
-            new BusAccessRecorder.BusAccess(IsRead: true, CPU.BrkIRQHandlerVector, 0x00),
-            new BusAccessRecorder.BusAccess(IsRead: true, (ushort)(CPU.BrkIRQHandlerVector + 1), 0x40),
-        }, vectorRecorder.Accesses);
+    [Fact]
+    public void NMI_Entry_Is_Two_DummyReads_Three_Pushes_Then_Vector_Reads()
+    {
+        var cpu = new CPU();
+        var mem = new Memory();
+        mem[0x1000] = (byte)OpCodeId.NOP;
+        cpu.PC = 0x1000;
+        cpu.SP = 0xFF;
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        var recorder = new BusAccessRecorder();
+        recorder.Watch(mem, 0x1001, 1);
+        recorder.Watch(mem, 0x0100, 0x100);
+        recorder.Watch(mem, CPU.NonMaskableIRQHandlerVector, 2);
+        recorder[CPU.NonMaskableIRQHandlerVector] = 0x00;
+        recorder[(ushort)(CPU.NonMaskableIRQHandlerVector + 1)] = 0x50;
+
+        cpu.CPUInterrupts.SetNMISourceActive("device");
+        cpu.ProcessPendingInterrupts(mem);
+
+        Assert.Equal(7, recorder.Accesses.Count);
+        Assert.True(recorder.Accesses[0].IsRead && recorder.Accesses[0].Address == 0x1001);
+        Assert.True(recorder.Accesses[1].IsRead && recorder.Accesses[1].Address == 0x1001);
+        Assert.All(recorder.Accesses.Skip(2).Take(3), a => Assert.False(a.IsRead));
+        Assert.True(recorder.Accesses[5].IsRead && recorder.Accesses[5].Address == CPU.NonMaskableIRQHandlerVector);
+        Assert.True(recorder.Accesses[6].IsRead && recorder.Accesses[6].Address == CPU.NonMaskableIRQHandlerVector + 1);
+        Assert.Equal((ushort)0x5000, cpu.PC);
+    }
+
+    [Fact]
+    public void BRK_Reads_Its_Padding_Byte_As_A_Real_Bus_Access()
+    {
+        var cpu = new CPU();
+        var mem = new Memory();
+        cpu.PC = 0x1000;
+        cpu.SP = 0xFF;
+        mem[0x1000] = (byte)OpCodeId.BRK;
+        mem[0x1001] = 0xEA; // padding byte (fetched and discarded)
+        mem.WriteWord(CPU.BrkIRQHandlerVector, 0x4000);
+
+        var recorder = new BusAccessRecorder();
+        recorder.Watch(mem, 0x1000, 2);
+        recorder.Watch(mem, 0x0100, 0x100);
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        // Opcode fetch, padding-byte fetch, then the three pushes (vector unwatched).
+        Assert.Equal(5, recorder.Accesses.Count);
+        Assert.Equal(new BusAccessRecorder.BusAccess(IsRead: true, 0x1000, (byte)OpCodeId.BRK), recorder.Accesses[0]);
+        Assert.Equal(new BusAccessRecorder.BusAccess(IsRead: true, 0x1001, 0xEA), recorder.Accesses[1]);
+        Assert.All(recorder.Accesses.Skip(2), a => Assert.False(a.IsRead));
+        // Pushed return address is still PC+2 from the opcode (the byte AFTER the padding).
+        Assert.Equal(0x10, recorder[0x01FF]); // PC high
+        Assert.Equal(0x02, recorder[0x01FE]); // PC low
         Assert.Equal((ushort)0x4000, cpu.PC);
     }
 }

--- a/tests/Highbyte.DotNet6502.Tests/CpuBusAccessCharacterizationTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/CpuBusAccessCharacterizationTests.cs
@@ -4,20 +4,15 @@ using Highbyte.DotNet6502.Utils;
 namespace Highbyte.DotNet6502.Tests;
 
 /// <summary>
-/// Characterization tests locking in the CURRENT bus-access sequences of the
-/// instruction categories the ordered-bus-accesses work will deliberately change.
-/// Recorded via <see cref="BusAccessRecorder"/> (production memory-mapped-I/O,
-/// no tracing hooks).
-///
-/// Today the emulator performs the MINIMAL access sequence per instruction: one read
-/// and/or one write at the effective address. Real hardware does more:
+/// Locks in the per-model bus-access sequences of the ordered-bus-accesses work,
+/// recorded via <see cref="BusAccessRecorder"/> (production memory-mapped-I/O,
+/// no tracing hooks):
 /// - NMOS RMW is read-write-write (original value written back, then the result);
 ///   65C02 RMW is read-read-write.
-/// - Indexed reads that cross a page perform a dummy read at the un-carried address.
-/// - Indexed stores always perform a dummy read before the write.
-/// When M2 lands those sequences per model, each test here flips to the hardware
-/// sequence as an explicit, reviewed change — exactly like the JMP ($xxFF)
-/// characterization test did in M1.
+/// - NMOS indexed reads that cross a page dummy-read the un-carried address first;
+///   NMOS indexed stores and RMW always do.
+/// Interrupt-entry sequences are still the minimal form (their dummy reads are a
+/// later stage of this work).
 /// </summary>
 public class CpuBusAccessCharacterizationTests
 {
@@ -72,7 +67,7 @@ public class CpuBusAccessCharacterizationTests
     }
 
     [Fact]
-    public void Nmos_RMW_AbsX_Is_Read_WriteBack_Write_At_The_Final_Address()
+    public void Nmos_RMW_AbsX_Is_DummyRead_Read_WriteBack_Write()
     {
         var (cpu, mem, recorder) = NewCpuWithRecorder(0x3000, 0x200);
         recorder[0x30FF] = 0x10;
@@ -82,8 +77,11 @@ public class CpuBusAccessCharacterizationTests
 
         cpu.ExecuteOneInstructionMinimal(mem);
 
+        // Indexed NMOS RMW always dummy-reads the un-carried address first (== the
+        // effective address here, since no page is crossed) — the 7-cycle pattern.
         Assert.Equal(new[]
         {
+            new BusAccessRecorder.BusAccess(IsRead: true, 0x30FF, 0x10),
             new BusAccessRecorder.BusAccess(IsRead: true, 0x30FF, 0x10),
             new BusAccessRecorder.BusAccess(IsRead: false, 0x30FF, 0x10),
             new BusAccessRecorder.BusAccess(IsRead: false, 0x30FF, 0x11),
@@ -139,7 +137,7 @@ public class CpuBusAccessCharacterizationTests
     }
 
     [Fact]
-    public void Indexed_Read_With_Page_Cross_Currently_Reads_Only_The_Final_Address()
+    public void Nmos_Indexed_Read_With_Page_Cross_Dummy_Reads_The_Uncarried_Address()
     {
         var (cpu, mem, recorder) = NewCpuWithRecorder(0x3000, 0x200);
         recorder[0x3101] = 0x42; // $30FF + 2 crosses into $31xx
@@ -149,16 +147,35 @@ public class CpuBusAccessCharacterizationTests
 
         cpu.ExecuteOneInstructionMinimal(mem);
 
-        // Real NMOS: dummy read at $3001 (high byte not yet carried), then read $3101.
+        // Dummy read at $3001 (high byte not yet carried), then the real read at $3101.
         Assert.Equal(new[]
         {
+            new BusAccessRecorder.BusAccess(IsRead: true, 0x3001, 0x00),
             new BusAccessRecorder.BusAccess(IsRead: true, 0x3101, 0x42),
         }, recorder.Accesses);
         Assert.Equal(0x42, cpu.A);
     }
 
     [Fact]
-    public void Indexed_Store_Currently_Writes_Only_The_Final_Address()
+    public void Nmos_Indexed_Read_Without_Page_Cross_Reads_Once()
+    {
+        var (cpu, mem, recorder) = NewCpuWithRecorder(0x3000, 0x200);
+        recorder[0x3041] = 0x42;
+        cpu.X = 0x02;
+        mem[StartPc] = (byte)OpCodeId.LDA_ABS_X;
+        mem.WriteWord((ushort)(StartPc + 1), 0x303F);
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        // No page cross -> no dummy read (which is why the +1 cycle is conditional).
+        Assert.Equal(new[]
+        {
+            new BusAccessRecorder.BusAccess(IsRead: true, 0x3041, 0x42),
+        }, recorder.Accesses);
+    }
+
+    [Fact]
+    public void Nmos_Indexed_Store_Always_Dummy_Reads_Before_Writing()
     {
         var (cpu, mem, recorder) = NewCpuWithRecorder(0x3000, 0x200);
         cpu.A = 0x77;
@@ -168,15 +185,17 @@ public class CpuBusAccessCharacterizationTests
 
         cpu.ExecuteOneInstructionMinimal(mem);
 
-        // Real NMOS: dummy read at $3001 first, then the write to $3101.
+        // Dummy read at the un-carried $3001, then the write to $3101 — the reason
+        // indexed stores have no "+1 on page cross": the extra cycle always happens.
         Assert.Equal(new[]
         {
+            new BusAccessRecorder.BusAccess(IsRead: true, 0x3001, 0x00),
             new BusAccessRecorder.BusAccess(IsRead: false, 0x3101, 0x77),
         }, recorder.Accesses);
     }
 
     [Fact]
-    public void IndirectIndexed_Read_Currently_Reads_Pointer_Then_Final_Address_Only()
+    public void Nmos_IndirectIndexed_Read_With_Page_Cross_Dummy_Reads_The_Uncarried_Address()
     {
         var (cpu, mem, recorder) = NewCpuWithRecorder(0x0040, 2);
         var dataRecorder = new BusAccessRecorder();
@@ -196,12 +215,71 @@ public class CpuBusAccessCharacterizationTests
             new BusAccessRecorder.BusAccess(IsRead: true, 0x0040, 0xFF),
             new BusAccessRecorder.BusAccess(IsRead: true, 0x0041, 0x30),
         }, recorder.Accesses);
-        // ...then only the final data address (real NMOS: dummy read at $3001 first).
+        // ...then the dummy read at the un-carried $3001 and the real read at $3101.
         Assert.Equal(new[]
         {
+            new BusAccessRecorder.BusAccess(IsRead: true, 0x3001, 0x00),
             new BusAccessRecorder.BusAccess(IsRead: true, 0x3101, 0x55),
         }, dataRecorder.Accesses);
         Assert.Equal(0x55, cpu.A);
+    }
+
+    [Fact]
+    public void ZeroPage_Pointer_At_FF_Wraps_Within_Zero_Page_For_IndirectIndexed()
+    {
+        // A (zp),Y pointer at $FF takes its high byte from $00, not $0100 — true on
+        // NMOS and CMOS alike. (Same class of fix as the JMP ($xxFF) page wrap.)
+        var (cpu, mem, _) = NewCpuWithRecorder(0x3000, 0x100);
+        mem[0x00FF] = 0x40; // pointer low
+        mem[0x0000] = 0x30; // pointer high (wrapped) -> $3040
+        mem[0x0100] = 0x99; // the linear (wrong) high-byte location -> would give $9940
+        cpu.Y = 0x02;
+        mem[StartPc] = (byte)OpCodeId.LDA_IND_IX;
+        mem[StartPc + 1] = 0xFF;
+        mem[0x3042] = 0x5A;
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        Assert.Equal(0x5A, cpu.A);
+    }
+
+    [Fact]
+    public void ZeroPage_Pointer_At_FF_Wraps_Within_Zero_Page_For_IndexedIndirect()
+    {
+        // (zp,X): the indexed pointer location wraps within zero page, and so does the
+        // pointer's own high byte: pointer at $FF reads its high byte from $00.
+        var (cpu, mem, _) = NewCpuWithRecorder(0x3000, 0x100);
+        mem[0x00FF] = 0x40;
+        mem[0x0000] = 0x30; // -> $3040
+        mem[0x0100] = 0x99;
+        cpu.X = 0x0B;
+        mem[StartPc] = (byte)OpCodeId.LDA_IX_IND;
+        mem[StartPc + 1] = 0xF4; // $F4 + $0B = $FF
+        mem[0x3040] = 0x5B;
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        Assert.Equal(0x5B, cpu.A);
+    }
+
+    [Fact]
+    public void ZeroPage_Pointer_At_FF_Wraps_Within_Zero_Page_For_65c02_ZpIndirect()
+    {
+        var cpu = new CPU(new ExecState(), new Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory(),
+            CpuModelIds.Ncr65c02, CpuCompatibilityProfile.OfficialOnly);
+        var mem = new Memory();
+        cpu.PC = StartPc;
+        cpu.SP = 0xFF;
+        mem[0x00FF] = 0x40;
+        mem[0x0000] = 0x30; // -> $3040
+        mem[0x0100] = 0x99;
+        mem[StartPc] = 0xB2; // LDA (zp)
+        mem[StartPc + 1] = 0xFF;
+        mem[0x3040] = 0x5C;
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        Assert.Equal(0x5C, cpu.A);
     }
 
     [Fact]

--- a/tests/Highbyte.DotNet6502.Tests/CpuBusAccessCharacterizationTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/CpuBusAccessCharacterizationTests.cs
@@ -35,7 +35,7 @@ public class CpuBusAccessCharacterizationTests
     }
 
     [Fact]
-    public void RMW_Zp_Currently_Does_One_Read_And_One_Write()
+    public void Nmos_RMW_Zp_Is_Read_WriteBack_Write()
     {
         var (cpu, mem, recorder) = NewCpuWithRecorder(0x0040, 1);
         recorder[0x0040] = 0x12;
@@ -44,16 +44,17 @@ public class CpuBusAccessCharacterizationTests
 
         cpu.ExecuteOneInstructionMinimal(mem);
 
-        // Real NMOS: R($40)=12, W($40)=12 (original written back), W($40)=13.
+        // NMOS RMW: the modify cycle writes the unmodified value back before the result.
         Assert.Equal(new[]
         {
             new BusAccessRecorder.BusAccess(IsRead: true, 0x0040, 0x12),
+            new BusAccessRecorder.BusAccess(IsRead: false, 0x0040, 0x12),
             new BusAccessRecorder.BusAccess(IsRead: false, 0x0040, 0x13),
         }, recorder.Accesses);
     }
 
     [Fact]
-    public void RMW_Abs_Currently_Does_One_Read_And_One_Write()
+    public void Nmos_RMW_Abs_Is_Read_WriteBack_Write()
     {
         var (cpu, mem, recorder) = NewCpuWithRecorder(0x3000, 1);
         recorder[0x3000] = 0b0100_0000;
@@ -65,12 +66,13 @@ public class CpuBusAccessCharacterizationTests
         Assert.Equal(new[]
         {
             new BusAccessRecorder.BusAccess(IsRead: true, 0x3000, 0b0100_0000),
+            new BusAccessRecorder.BusAccess(IsRead: false, 0x3000, 0b0100_0000),
             new BusAccessRecorder.BusAccess(IsRead: false, 0x3000, 0b1000_0000),
         }, recorder.Accesses);
     }
 
     [Fact]
-    public void RMW_AbsX_Currently_Does_One_Read_And_One_Write_At_The_Final_Address()
+    public void Nmos_RMW_AbsX_Is_Read_WriteBack_Write_At_The_Final_Address()
     {
         var (cpu, mem, recorder) = NewCpuWithRecorder(0x3000, 0x200);
         recorder[0x30FF] = 0x10;
@@ -83,7 +85,56 @@ public class CpuBusAccessCharacterizationTests
         Assert.Equal(new[]
         {
             new BusAccessRecorder.BusAccess(IsRead: true, 0x30FF, 0x10),
+            new BusAccessRecorder.BusAccess(IsRead: false, 0x30FF, 0x10),
             new BusAccessRecorder.BusAccess(IsRead: false, 0x30FF, 0x11),
+        }, recorder.Accesses);
+    }
+
+    [Fact]
+    public void Nmos_Illegal_RMW_Also_Does_The_Double_Write()
+    {
+        // The undocumented RMW combos share the same silicon behavior; software uses
+        // e.g. DCP's double write deliberately.
+        var (cpu, mem, recorder) = NewCpuWithRecorder(0x0040, 1);
+        recorder[0x0040] = 0x12;
+        var cpuFull = new CPU(CpuCompatibilityProfile.FullUnofficial);
+        cpuFull.PC = StartPc;
+        cpuFull.SP = 0xFF;
+        mem[StartPc] = (byte)OpCodeId.DCP_ZP;
+        mem[StartPc + 1] = 0x40;
+
+        cpuFull.ExecuteOneInstructionMinimal(mem);
+
+        Assert.Equal(new[]
+        {
+            new BusAccessRecorder.BusAccess(IsRead: true, 0x0040, 0x12),
+            new BusAccessRecorder.BusAccess(IsRead: false, 0x0040, 0x12),
+            new BusAccessRecorder.BusAccess(IsRead: false, 0x0040, 0x11),
+        }, recorder.Accesses);
+    }
+
+    [Fact]
+    public void Cmos_RMW_Abs_Is_Read_Read_Write()
+    {
+        var cpu = new CPU(new ExecState(), new Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory(),
+            CpuModelIds.Ncr65c02, CpuCompatibilityProfile.OfficialOnly);
+        var mem = new Memory();
+        cpu.PC = StartPc;
+        cpu.SP = 0xFF;
+        var recorder = new BusAccessRecorder();
+        recorder.Watch(mem, 0x3000, 1);
+        recorder[0x3000] = 0x12;
+        mem[StartPc] = (byte)OpCodeId.INC_ABS;
+        mem.WriteWord((ushort)(StartPc + 1), 0x3000);
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        // 65C02 RMW: a second read replaces the NMOS write-back cycle.
+        Assert.Equal(new[]
+        {
+            new BusAccessRecorder.BusAccess(IsRead: true, 0x3000, 0x12),
+            new BusAccessRecorder.BusAccess(IsRead: true, 0x3000, 0x12),
+            new BusAccessRecorder.BusAccess(IsRead: false, 0x3000, 0x13),
         }, recorder.Accesses);
     }
 

--- a/tests/Highbyte.DotNet6502.Tests/CpuModelTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/CpuModelTests.cs
@@ -2,7 +2,7 @@ namespace Highbyte.DotNet6502.Tests;
 
 /// <summary>
 /// Tests for the internal CPU model definition seam introduced by the CPU model
-/// architecture work (feature cpu-models-65c02, M1 step 1).
+/// architecture work.
 /// </summary>
 public class CpuModelTests
 {

--- a/tests/Highbyte.DotNet6502.Tests/CpuNmosCharacterizationTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/CpuNmosCharacterizationTests.cs
@@ -4,7 +4,7 @@ namespace Highbyte.DotNet6502.Tests;
 
 /// <summary>
 /// Characterization tests locking in the current NMOS 6502 behavior of interrupt/BRK entry
-/// and Reset, recorded before the CPU model refactor (feature cpu-models-65c02).
+/// and Reset, recorded before the CPU model refactor.
 ///
 /// The refactor must keep every behavior below intact for the NMOS model. The 65C02 model
 /// deliberately differs on some of them (it clears the Decimal flag on IRQ/NMI/BRK entry

--- a/tests/Highbyte.DotNet6502.Tests/Functional_65C02_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Functional_65C02_test.cs
@@ -5,7 +5,7 @@ namespace Highbyte.DotNet6502.Tests;
 
 /// <summary>
 /// Klaus Dormann test binaries run against the ncr65c02 model — the external arbiter
-/// for the 65C02 implementation (feature cpu-models-65c02, M1 test gates).
+/// for the 65C02 implementation.
 ///
 /// Both tests assemble from the pinned source revision with settings changed from the
 /// source DEFAULTS, which target a Rockwell/WDC part: the base/NCR 65C02 must execute

--- a/tests/Highbyte.DotNet6502.Tests/Functional_65C02_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Functional_65C02_test.cs
@@ -16,6 +16,7 @@ namespace Highbyte.DotNet6502.Tests;
 /// (windows-latest).
 /// </summary>
 [Trait("TestType", "Integration")]
+[Collection(Helpers.KlausTestArtifactsCollection.Name)]
 public class Functional_65C02_test
 {
     private readonly ITestOutputHelper _output;

--- a/tests/Highbyte.DotNet6502.Tests/Functional_BCD_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Functional_BCD_test.cs
@@ -3,6 +3,7 @@ using Highbyte.DotNet6502.Utils;
 namespace Highbyte.DotNet6502.Tests;
 
 [Trait("TestType", "Integration")]
+[Collection(Helpers.KlausTestArtifactsCollection.Name)]
 public class Functional_BCD_test
 {
     private readonly ITestOutputHelper _output;

--- a/tests/Highbyte.DotNet6502.Tests/Functional_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Functional_test.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Highbyte.DotNet6502.Tests;
 
 [Trait("TestType", "Integration")]
+[Collection(Helpers.KlausTestArtifactsCollection.Name)]
 public class Functional_test
 {
     private readonly ITestOutputHelper _output;

--- a/tests/Highbyte.DotNet6502.Tests/Helpers/BusAccessRecorder.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Helpers/BusAccessRecorder.cs
@@ -1,0 +1,63 @@
+namespace Highbyte.DotNet6502.Tests.Helpers;
+
+/// <summary>
+/// Records the ordered bus accesses (reads and writes) a CPU makes to watched address
+/// ranges, for asserting instruction-atomic access SEQUENCES — the level-2 accuracy the
+/// ordered-bus-accesses work is about.
+///
+/// Implemented purely with the production memory-mapped-I/O mechanism
+/// (<see cref="Memory.MapReader"/>/<see cref="Memory.MapWriter"/>) — the same seam real
+/// devices use — so NO tracing hooks exist on the production memory path. Watched
+/// addresses behave as ordinary RAM (values seeded from the memory's current contents,
+/// writes stored and read back), with every access appended to <see cref="Accesses"/>.
+/// </summary>
+public sealed class BusAccessRecorder
+{
+    public readonly record struct BusAccess(bool IsRead, ushort Address, byte Value)
+    {
+        public override string ToString() => $"{(IsRead ? "R" : "W")} {Address:x4}={Value:x2}";
+    }
+
+    private readonly List<BusAccess> _accesses = new();
+    private readonly Dictionary<ushort, byte> _store = new();
+
+    public IReadOnlyList<BusAccess> Accesses => _accesses;
+
+    /// <summary>Watched-RAM contents (reflects writes made through the CPU).</summary>
+    public byte this[ushort address]
+    {
+        get => _store[address];
+        set => _store[address] = value;
+    }
+
+    /// <summary>
+    /// Starts recording accesses to <paramref name="length"/> addresses from
+    /// <paramref name="startAddress"/>. Current memory contents become the watched RAM's
+    /// initial values.
+    /// </summary>
+    public void Watch(Memory mem, ushort startAddress, int length)
+    {
+        for (var i = 0; i < length; i++)
+        {
+            var address = (ushort)(startAddress + i);
+            _store[address] = mem[address];
+            mem.MapReader(address, a =>
+            {
+                var value = _store[a];
+                _accesses.Add(new BusAccess(IsRead: true, a, value));
+                return value;
+            });
+            mem.MapWriter(address, (a, value) =>
+            {
+                _accesses.Add(new BusAccess(IsRead: false, a, value));
+                _store[a] = value;
+            });
+        }
+    }
+
+    /// <summary>Forget accesses recorded so far (watched RAM contents are kept).</summary>
+    public void Clear() => _accesses.Clear();
+
+    /// <summary>Compact "R f001=12 W f001=13" rendering for assertion failure messages.</summary>
+    public string Describe() => string.Join(" ", _accesses);
+}

--- a/tests/Highbyte.DotNet6502.Tests/Helpers/KlausTestArtifactsCollection.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Helpers/KlausTestArtifactsCollection.cs
@@ -1,0 +1,15 @@
+namespace Highbyte.DotNet6502.Tests.Helpers;
+
+/// <summary>
+/// xUnit collection serializing every test class that downloads/assembles Klaus test
+/// artifacts. They share files in the working directory — most critically the AS65
+/// assembler folder, which <see cref="FunctionalTestCompiler"/> deletes and re-extracts
+/// per build: if one test is EXECUTING as65.exe while another deletes the folder,
+/// Windows throws UnauthorizedAccessException (running executables are locked).
+/// Same-collection classes never run concurrently, eliminating the race.
+/// </summary>
+[CollectionDefinition(Name)]
+public class KlausTestArtifactsCollection
+{
+    public const string Name = "KlausTestArtifacts";
+}

--- a/tests/Highbyte.DotNet6502.Tests/Instructions/JMP_test.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Instructions/JMP_test.cs
@@ -102,7 +102,7 @@ public class JMP_test
     /// not from $3100. The emulator historically read linearly (CMOS/65C02-style); the
     /// NMOS model now implements the wrap via its $6C handler override
     /// (NmosHandlers.Jmp_Indirect) -- an explicit behavioral change made by the CPU model
-    /// architecture feature (design log: cpu-models-65c02, M1 step 3).
+    /// architecture work.
     /// </summary>
     [Fact]
     public void JMP_IND_With_Pointer_At_Page_End_Wraps_Within_Page_NMOS_Bug()

--- a/tests/Highbyte.DotNet6502.Tests/Ncr65c02ArithmeticAndCycleTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Ncr65c02ArithmeticAndCycleTests.cs
@@ -6,7 +6,7 @@ namespace Highbyte.DotNet6502.Tests;
 /// <summary>
 /// Tests for the 65C02's decimal-mode ADC/SBC (valid N/Z flags, own SBC correction
 /// sequence, +1 cycle) and the shift/rotate abs,X cycle change
-/// (feature cpu-models-65c02, M1 step 4). Counterparts of the NMOS decimal tests in
+/// during the CPU model architecture work. Counterparts of the NMOS decimal tests in
 /// ADC_test/SBC_test where the models deliberately differ.
 /// </summary>
 public class Ncr65c02ArithmeticAndCycleTests

--- a/tests/Highbyte.DotNet6502.Tests/Ncr65c02DisassemblyTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Ncr65c02DisassemblyTests.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Highbyte.DotNet6502.Tests;
 
 /// <summary>
-/// Model-aware disassembly tests (feature cpu-models-65c02, M1 step 7): the same byte
+/// Model-aware disassembly tests: the same byte
 /// must disassemble according to the CPU's model, new 65C02 addressing modes must
 /// format correctly, and listing advance must use per-model instruction sizes.
 /// </summary>

--- a/tests/Highbyte.DotNet6502.Tests/Ncr65c02ModelTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Ncr65c02ModelTests.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Highbyte.DotNet6502.Tests;
 
 /// <summary>
-/// Tests for the ncr65c02 CPU model (feature cpu-models-65c02, M1 step 4).
+/// Tests for the ncr65c02 CPU model.
 /// Counterparts of the NMOS baseline tests in <see cref="CpuNmosCharacterizationTests"/>
 /// where the 65C02 deliberately behaves differently.
 /// </summary>

--- a/tests/Highbyte.DotNet6502.Tests/Ncr65c02NewInstructionsTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/Ncr65c02NewInstructionsTests.cs
@@ -5,7 +5,7 @@ namespace Highbyte.DotNet6502.Tests;
 
 /// <summary>
 /// Tests for the 27 opcode bytes the NCR 65C02 adds over the NMOS 6502
-/// (feature cpu-models-65c02, M1 step 4).
+/// during the CPU model architecture work.
 /// </summary>
 public class Ncr65c02NewInstructionsTests
 {

--- a/tests/Highbyte.DotNet6502.Tests/RmwBusSequenceMatrixTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/RmwBusSequenceMatrixTests.cs
@@ -1,0 +1,145 @@
+using Highbyte.DotNet6502.Tests.Helpers;
+using Highbyte.DotNet6502.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Tests;
+
+/// <summary>
+/// Exhaustive guard for the per-model read-modify-write bus sequences: EVERY memory-RMW
+/// opcode byte must perform read-write(original)-write on NMOS models and
+/// read-read-write on the 65C02. The bytes are enumerated from each model's own
+/// descriptor table (by mnemonic), so a table refactor that accidentally leaves an RMW
+/// byte with the wrong model's sequence — e.g. a missed entry in the 65C02's CMOS
+/// re-binding — fails here rather than going unnoticed: result-level tests cannot see
+/// the difference, only the bus traffic can.
+/// </summary>
+public class RmwBusSequenceMatrixTests
+{
+    private const ushort StartPc = 0x1000;
+    private const byte InitialTargetValue = 0x41;
+
+    private static readonly string[] s_nmosRmwMnemonics =
+        { "ASL", "LSR", "ROL", "ROR", "INC", "DEC", "SLO", "SRE", "RLA", "RRA", "DCP", "ISC" };
+    private static readonly string[] s_cmosRmwMnemonics =
+        { "ASL", "LSR", "ROL", "ROR", "INC", "DEC", "TSB", "TRB" };
+
+    [Fact]
+    public void Every_Nmos_Rmw_Byte_Does_Read_WriteBack_Write()
+    {
+        var checkedBytes = 0;
+        var probe = new CPU(CpuCompatibilityProfile.FullUnofficial);
+        for (var code = 0; code <= 0xff; code++)
+        {
+            var descriptor = probe.Descriptors[(byte)code];
+            if (descriptor is null || !s_nmosRmwMnemonics.Contains(descriptor.Mnemonic)
+                || descriptor.Addressing == AddrMode.Accumulator)
+                continue;
+
+            var cpu = new CPU(CpuCompatibilityProfile.FullUnofficial);
+            var accesses = ExecuteAndRecordTargetAccesses(cpu, (byte)code, descriptor.Addressing);
+
+            Assert.True(accesses.Count == 3,
+                $"{descriptor.Mnemonic} ({code:x2}, {descriptor.Addressing}): expected 3 target accesses, got {accesses.Count}");
+            Assert.True(accesses[0].IsRead, $"{code:x2}: first access must be the read");
+            Assert.True(!accesses[1].IsRead && accesses[1].Value == InitialTargetValue,
+                $"{descriptor.Mnemonic} ({code:x2}): second access must write the ORIGINAL value back");
+            Assert.False(accesses[2].IsRead, $"{code:x2}: third access must write the result");
+            checkedBytes++;
+        }
+
+        // 24 official (6 ops x zp/zp,X/abs/abs,X) + 42 illegal (6 combos x 7 modes).
+        Assert.Equal(66, checkedBytes);
+    }
+
+    [Fact]
+    public void Every_Cmos_Rmw_Byte_Does_Read_Read_Write()
+    {
+        var checkedBytes = 0;
+        var probe = New65c02Cpu();
+        for (var code = 0; code <= 0xff; code++)
+        {
+            var descriptor = probe.Descriptors[(byte)code];
+            if (descriptor is null || !s_cmosRmwMnemonics.Contains(descriptor.Mnemonic)
+                || descriptor.Addressing == AddrMode.Accumulator)
+                continue;
+
+            var cpu = New65c02Cpu();
+            var accesses = ExecuteAndRecordTargetAccesses(cpu, (byte)code, descriptor.Addressing);
+
+            Assert.True(accesses.Count == 3,
+                $"{descriptor.Mnemonic} ({code:x2}, {descriptor.Addressing}): expected 3 target accesses, got {accesses.Count}");
+            Assert.True(accesses[0].IsRead && accesses[1].IsRead,
+                $"{descriptor.Mnemonic} ({code:x2}): first two accesses must be reads (65C02 replaces the NMOS write-back with a second read)");
+            Assert.False(accesses[2].IsRead, $"{code:x2}: third access must write the result");
+            checkedBytes++;
+        }
+
+        // 24 official RMW bytes + TSB zp/abs + TRB zp/abs.
+        Assert.Equal(28, checkedBytes);
+    }
+
+    private static CPU New65c02Cpu()
+        => new(new ExecState(), new NullLoggerFactory(), CpuModelIds.Ncr65c02, CpuCompatibilityProfile.OfficialOnly);
+
+    /// <summary>
+    /// Writes the instruction with operands arranged so its effective address is a single
+    /// watched target byte (indirect pointers and index registers live outside the watch),
+    /// executes it, and returns the recorded accesses at the target.
+    /// </summary>
+    private static IReadOnlyList<BusAccessRecorder.BusAccess> ExecuteAndRecordTargetAccesses(CPU cpu, byte opCode, AddrMode addressing)
+    {
+        var mem = new Memory();
+        cpu.PC = StartPc;
+        cpu.SP = 0xFF;
+        mem[StartPc] = opCode;
+
+        ushort target;
+        switch (addressing)
+        {
+            case AddrMode.ZP:
+                target = 0x0080;
+                mem[StartPc + 1] = 0x80;
+                break;
+            case AddrMode.ZP_X:
+                target = 0x0080;
+                cpu.X = 0x10;
+                mem[StartPc + 1] = 0x70;
+                break;
+            case AddrMode.ABS:
+                target = 0x3080;
+                mem.WriteWord((ushort)(StartPc + 1), 0x3080);
+                break;
+            case AddrMode.ABS_X:
+                target = 0x3080;
+                cpu.X = 0x10;
+                mem.WriteWord((ushort)(StartPc + 1), 0x3070);
+                break;
+            case AddrMode.ABS_Y:
+                target = 0x3080;
+                cpu.Y = 0x10;
+                mem.WriteWord((ushort)(StartPc + 1), 0x3070);
+                break;
+            case AddrMode.IX_IND:
+                target = 0x3080;
+                cpu.X = 0x04;
+                mem[StartPc + 1] = 0x40;
+                mem.WriteWord(0x0044, 0x3080);
+                break;
+            case AddrMode.IND_IX:
+                target = 0x3080;
+                cpu.Y = 0x10;
+                mem[StartPc + 1] = 0x40;
+                mem.WriteWord(0x0040, 0x3070);
+                break;
+            default:
+                throw new DotNet6502Exception($"Unexpected RMW addressing mode {addressing} for opcode {opCode:x2}.");
+        }
+
+        mem[target] = InitialTargetValue;
+        var recorder = new BusAccessRecorder();
+        recorder.Watch(mem, target, 1);
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+        return recorder.Accesses;
+    }
+}

--- a/tests/Highbyte.DotNet6502.Tests/RmwBusSequenceMatrixTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/RmwBusSequenceMatrixTests.cs
@@ -38,12 +38,19 @@ public class RmwBusSequenceMatrixTests
             var cpu = new CPU(CpuCompatibilityProfile.FullUnofficial);
             var accesses = ExecuteAndRecordTargetAccesses(cpu, (byte)code, descriptor.Addressing);
 
-            Assert.True(accesses.Count == 3,
-                $"{descriptor.Mnemonic} ({code:x2}, {descriptor.Addressing}): expected 3 target accesses, got {accesses.Count}");
-            Assert.True(accesses[0].IsRead, $"{code:x2}: first access must be the read");
-            Assert.True(!accesses[1].IsRead && accesses[1].Value == InitialTargetValue,
-                $"{descriptor.Mnemonic} ({code:x2}): second access must write the ORIGINAL value back");
-            Assert.False(accesses[2].IsRead, $"{code:x2}: third access must write the result");
+            // Indexed modes always start with the NMOS dummy read at the un-carried
+            // address (== the target here, since the setups never cross a page).
+            var isIndexed = descriptor.Addressing is AddrMode.ABS_X or AddrMode.ABS_Y or AddrMode.IND_IX;
+            var expectedCount = isIndexed ? 4 : 3;
+            Assert.True(accesses.Count == expectedCount,
+                $"{descriptor.Mnemonic} ({code:x2}, {descriptor.Addressing}): expected {expectedCount} target accesses, got {accesses.Count}");
+            var i = 0;
+            if (isIndexed)
+                Assert.True(accesses[i++].IsRead, $"{code:x2}: dummy read must come first");
+            Assert.True(accesses[i++].IsRead, $"{code:x2}: read must precede the writes");
+            Assert.True(!accesses[i].IsRead && accesses[i].Value == InitialTargetValue,
+                $"{descriptor.Mnemonic} ({code:x2}): must write the ORIGINAL value back before the result");
+            Assert.False(accesses[i + 1].IsRead, $"{code:x2}: final access must write the result");
             checkedBytes++;
         }
 


### PR DESCRIPTION
Makes CPU instructions perform their real per-model bus access sequences — every read and write in hardware order — so memory-mapped I/O with access side effects behaves as it does on real machines. Follow-up to the CPU model architecture PR (#288); milestone M2 of that work.

## Behavioral highlights

- **Read-modify-write sequences per model**: NMOS RMW instructions (official and undocumented) perform read-write-write — the unmodified value is written back before the result. The 65C02 performs read-read-write. Exhaustively guarded by a sequence matrix test over all 66 NMOS and 28 65C02 memory-RMW opcode bytes.
- **Apple II language card is now Sather-correct** (write-enable requires two consecutive odd READS; a write never completes the sequence — previously a read+write could unlock). Combined with the RMW sequences this makes `INC $C083` CPU-model observable: it unlocks the card on a 65C02 (read-read-write) but not on an NMOS 6502 (read-write-write) — exactly as on real hardware.
- **NMOS indexed dummy reads**: reads that cross a page touch the un-carried address first; indexed stores and RMW always do. Classic consequence now emulated: `STA $DC0D,X` with X=0 silently acknowledges pending C64 CIA interrupts through its dummy read (covered by an acceptance test).
- **Zero-page pointer wrap**: `(zp,X)`, `(zp),Y`, and 65C02 `(zp)` pointers at `$FF` take their high byte from `$00` (wrapping within zero page) instead of `$0100` — a result-level fix on both models, same class as the `JMP ($xxFF)` fix in #288.
- **Interrupt-entry sequences**: IRQ/NMI entry performs the two hardware dummy reads of the next opcode byte before the stack pushes and vector reads; BRK fetches its padding byte as a real bus access (pushed return address unchanged).

## Design

- Sequences are composed at CPU-construction time per model (a `PerformsIndexedDummyReads` model trait; single source of truth per model); the 65C02 keeps its own read-read-write RMW handlers. No model branches on the hot path, no tracing hooks on the memory path.
- Tests observe bus traffic via a `BusAccessRecorder` built purely on the production memory-mapped-I/O mechanism (`Memory.MapReader`/`MapWriter`).
- Language-card rules verified against Sather (Understanding the Apple IIe, 5-23) via two independent emulator implementations before coding.

## Deliberately deferred (documented in code)

- 65C02-specific dummy-read addresses (the CMOS part re-targeted them; no observable case yet).
- `zp,X` base-address dummy reads (not page-cross-related) and RTI/pull stack dummies.
- Interrupt-entry cycle accounting (entry currently consumes 0 cycles, real hardware 7) — pre-existing gap, discovered here; changing it shifts C64/VIC-20 frame timing so it needs its own decision.

## Tests & performance

- ~40 new/updated tests: per-model sequence characterization, exhaustive RMW matrix, pointer-wrap, language-card model divergence, C64 `$DC0D`, interrupt-entry ordering.
- All suites green incl. Klaus NMOS functional/BCD locally and the Klaus 65C02 extended-opcodes test on Windows CI.
- Benchmarks: representative C64 workload and hot-path benchmarks at or below the milestone baseline after all changes (per-part measurements recorded during development; no benchmark moved ≥5%).
