### PR TITLE
Account the 7-cycle hardware interrupt entry cost in cycle accounting

### DIFF
--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -229,7 +229,20 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup, ISyste
         // General emulator timing fix: devices tick after the CPU instruction has already
         // completed, so newly raised hardware IRQ/NMI lines must be serviced here to land
         // on the next instruction boundary instead of one instruction late.
-        CPU.ProcessPendingInterrupts(Mem);
+        var interruptCycles = CPU.ProcessPendingInterrupts(Mem);
+        if (interruptCycles > 0)
+        {
+            // The interrupt-entry sequence consumed real time: tick the same devices
+            // with it and fold it into this iteration's cycle count so the raster
+            // advance below and the caller's frame budget include it.
+            if (TimerMode == TimerMode.UpdateEachInstruction)
+            {
+                Cia1.ProcessTimers(interruptCycles);
+                Cia2.ProcessTimers(interruptCycles);
+            }
+            CartridgeSlot.Tick(interruptCycles);
+            instructionExecResult = instructionExecResult.WithAdditionalCycles(interruptCycles);
+        }
 
         // Advance video raster
         var cycleOnRasterLineBeforeInstruction = Vic2.CyclesConsumedCurrentVblank;
@@ -830,7 +843,9 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup, ISyste
             freezeVector);
         if (!CartridgeSlot.NmiLineActive)
             CPU.CPUInterrupts.SetNMISourceActive(freezeNmiSource);
-        CPU.ProcessPendingInterrupts(Mem);
+        // Freeze-button NMI delivery outside the normal execution loop: the 7-cycle
+        // entry cost is intentionally not fed into frame pacing here (one-shot event).
+        _ = CPU.ProcessPendingInterrupts(Mem);
         CPU.CPUInterrupts.SetNMISourceInactive(freezeNmiSource);
         return true;
     }

--- a/src/libraries/Highbyte.DotNet6502/CPU.cs
+++ b/src/libraries/Highbyte.DotNet6502/CPU.cs
@@ -265,10 +265,17 @@ public class CPU
 
         var instructionExecutionResult = _instructionExecutor.Execute(this, mem);
 
-        ExecState.UpdateTotal(instructionExecutionResult);
-
         if (!instructionExecutionResult.HaltedCpu)
-            ProcessInterrupts(mem);
+        {
+            // Fold the hardware interrupt-entry cost (when one was serviced at this
+            // boundary) into this instruction's result, so cycle totals and the
+            // system loops that pace devices/frame budgets by it see real elapsed time.
+            var interruptCycles = ProcessInterrupts(mem);
+            if (interruptCycles > 0)
+                instructionExecutionResult = instructionExecutionResult.WithAdditionalCycles(interruptCycles);
+        }
+
+        ExecState.UpdateTotal(instructionExecutionResult);
 
         return instructionExecutionResult;
     }
@@ -278,9 +285,14 @@ public class CPU
     /// Intended for system-level device ticking that occurs after instruction execution.
     /// </summary>
     /// <param name="mem"></param>
-    public void ProcessPendingInterrupts(Memory mem)
+    /// <returns>
+    /// Cycles the interrupt-entry sequence consumed (<see cref="InterruptEntryCycles"/> when an
+    /// interrupt was serviced, else 0). Callers that pace devices or frame budgets by cycles
+    /// should account for them — the entry sequence is real elapsed time.
+    /// </returns>
+    public ulong ProcessPendingInterrupts(Memory mem)
     {
-        ProcessInterrupts(mem);
+        return ProcessInterrupts(mem);
     }
 
     /// <summary>
@@ -338,6 +350,17 @@ public class CPU
 
             var instructionExecutionResult = _instructionExecutor.Execute(this, mem);
 
+            // Service pending hardware interrupts at this boundary and fold the entry
+            // cost into the instruction's result, so both ExecStates, evaluators, the
+            // InstructionExecuted event, and callers pacing by cycles see real elapsed
+            // time. (NmiAcknowledging consequently fires before InstructionExecuted.)
+            if (!instructionExecutionResult.HaltedCpu)
+            {
+                var interruptCycles = ProcessInterrupts(mem);
+                if (interruptCycles > 0)
+                    instructionExecutionResult = instructionExecutionResult.WithAdditionalCycles(interruptCycles);
+            }
+
             // Aggregate stats directly from the InstructionExecResult into both ExecStates;
             // the previous code path went via ExecStateAfterInstruction() which allocated
             // an ExecState per step.
@@ -359,8 +382,6 @@ public class CPU
             {
                 RaiseInstructionExecutedIfSubscribed(mem, instructionExecutionResult);
             }
-
-            ProcessInterrupts(mem);
         }
 
         // Return the per-invocation stats accumulated above.
@@ -377,10 +398,17 @@ public class CPU
         return false;
     }
 
-    private void ProcessInterrupts(Memory mem)
+    /// <summary>
+    /// Cycles a hardware IRQ/NMI entry sequence consumes on 6502-family CPUs:
+    /// two dummy opcode reads, three stack pushes, two vector reads.
+    /// </summary>
+    public const ulong InterruptEntryCycles = 7;
+
+    /// <returns>Cycles consumed: <see cref="InterruptEntryCycles"/> if an interrupt was serviced, else 0.</returns>
+    private ulong ProcessInterrupts(Memory mem)
     {
         if (IsHalted)
-            return;
+            return 0;
 
         if (CPUInterrupts.NMIPending)
         {
@@ -402,8 +430,10 @@ public class CPU
                     nmiVector,
                     nmiSources);
             }
+            return InterruptEntryCycles;
         }
-        else if (CPUInterrupts.IRQLineEnabled && !ProcessorStatus.InterruptDisable)
+
+        if (CPUInterrupts.IRQLineEnabled && !ProcessorStatus.InterruptDisable)
         {
             for (int i = CPUInterrupts.ActiveIRQSources.Count - 1; i >= 0; i--)
             {
@@ -415,7 +445,10 @@ public class CPU
                 }
             }
             ProcessHardwareIRQ(mem);
+            return InterruptEntryCycles;
         }
+
+        return 0;
     }
 
     /// <summary>

--- a/src/libraries/Highbyte.DotNet6502/InstructionExecResult.cs
+++ b/src/libraries/Highbyte.DotNet6502/InstructionExecResult.cs
@@ -18,6 +18,19 @@ public struct InstructionExecResult
     public ulong CyclesConsumed { get; private set; }
     public ushort AtPC { get; private set; }
 
+    /// <summary>
+    /// Returns a copy with additional cycles added to <see cref="CyclesConsumed"/>.
+    /// Used to fold the hardware interrupt-entry cost (<see cref="CPU.InterruptEntryCycles"/>)
+    /// serviced at the instruction boundary into the preceding instruction's result, so
+    /// cycle-paced consumers (device ticking, frame budgets, statistics) see real elapsed time.
+    /// </summary>
+    public InstructionExecResult WithAdditionalCycles(ulong additionalCycles)
+    {
+        var copy = this;
+        copy.CyclesConsumed += additionalCycles;
+        return copy;
+    }
+
     public InstructionExecResult(byte opCodeByte)
     {
         OpCodeByte = opCodeByte;

--- a/tests/Highbyte.DotNet6502.Tests/CPUInterruptBoundaryTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/CPUInterruptBoundaryTests.cs
@@ -15,6 +15,58 @@ namespace Highbyte.DotNet6502.Tests;
 /// </summary>
 public class CPUInterruptBoundaryTests
 {
+    [Fact]
+    public void Servicing_An_IRQ_Costs_Seven_Cycles_Folded_Into_The_Instruction_Result()
+    {
+        var (cpu, mem) = NewCpuAt(0x1000);
+        cpu.ProcessorStatus.InterruptDisable = false;
+        mem.WriteWord(CPU.BrkIRQHandlerVector, 0x4000);
+        cpu.CPUInterrupts.SetIRQSourceActive("device", autoAcknowledge: true);
+
+        var result = cpu.ExecuteOneInstructionMinimal(mem); // NOP (2) + IRQ entry (7)
+
+        Assert.Equal(2 + CPU.InterruptEntryCycles, result.CyclesConsumed);
+        Assert.Equal(2 + CPU.InterruptEntryCycles, cpu.ExecState.CyclesConsumed);
+        Assert.Equal((ushort)0x4000, cpu.PC);
+    }
+
+    [Fact]
+    public void Servicing_An_NMI_Costs_Seven_Cycles_On_The_Full_Execute_Path()
+    {
+        var (cpu, mem) = NewCpuAt(0x1000);
+        mem.WriteWord(CPU.NonMaskableIRQHandlerVector, 0x5000);
+        cpu.CPUInterrupts.SetNMISourceActive("device");
+
+        var execState = cpu.ExecuteOneInstruction(mem); // NOP (2) + NMI entry (7)
+
+        Assert.Equal(2 + CPU.InterruptEntryCycles, execState.CyclesConsumed);
+        Assert.Equal(2 + CPU.InterruptEntryCycles, execState.LastInstructionExecResult.CyclesConsumed);
+        Assert.Equal((ushort)0x5000, cpu.PC);
+    }
+
+    [Fact]
+    public void ProcessPendingInterrupts_Reports_Entry_Cycles_Only_When_Servicing()
+    {
+        var (cpu, mem) = NewCpuAt(0x1000);
+        cpu.ProcessorStatus.InterruptDisable = false;
+        mem.WriteWord(CPU.BrkIRQHandlerVector, 0x4000);
+
+        Assert.Equal(0ul, cpu.ProcessPendingInterrupts(mem)); // nothing pending
+
+        cpu.CPUInterrupts.SetIRQSourceActive("device", autoAcknowledge: true);
+        Assert.Equal(CPU.InterruptEntryCycles, cpu.ProcessPendingInterrupts(mem));
+    }
+
+    [Fact]
+    public void Instruction_Without_Pending_Interrupt_Keeps_Its_Own_Cycle_Count()
+    {
+        var (cpu, mem) = NewCpuAt(0x1000);
+
+        var result = cpu.ExecuteOneInstructionMinimal(mem); // plain NOP
+
+        Assert.Equal(2ul, result.CyclesConsumed);
+    }
+
     // Helper: place a NOP at the given address so the only PC change in a test comes from
     // interrupt servicing, not from a multi-byte/branching instruction.
     private static (CPU cpu, Memory mem) NewCpuAt(ushort pc)


### PR DESCRIPTION
Hardware IRQ/NMI entry previously consumed 0 cycles in cycle accounting; real 6502-family entry takes 7 (two dummy opcode reads, three stack pushes, two vector reads — the bus sequence itself was implemented in #289). Follow-up scheduled from that work.

## What changes

- `CPU.ProcessPendingInterrupts` (and the internal boundary servicing) returns the cycles consumed: new `CPU.InterruptEntryCycles` (7) when an interrupt was serviced, else 0.
- The entry cost is folded into the preceding instruction's `InstructionExecResult` (new `WithAdditionalCycles`) before statistics update, so every cycle-paced consumer sees real elapsed time with no further changes: `ExecState` totals (Apple II disk motor/speaker/game-port clocks), `LastInstructionExecResult` (Apple II / VIC-20 frame budgets and VIA ticking), evaluators, and the `InstructionExecuted` event.
- The C64's post-device-tick interrupt flush explicitly ticks CIA1/CIA2 and the cartridge slot with the entry cycles and includes them in the raster advance and frame budget. The freeze-button NMI delivery deliberately ignores them (one-shot event outside frame pacing; commented).
- Note: on the full `Execute` path, `NmiAcknowledging` now fires before `InstructionExecuted` (servicing moved before stats update); the only NmiAcknowledging consumer (C64) uses the minimal path and is unaffected.

## Impact

Frame budgets now fit ~7 fewer CPU cycles per serviced interrupt (~0.04% per raster-IRQ frame on C64) — matching real hardware. All existing C64/VIC-20/Apple II timing tests pass unchanged; benchmarks at parity (hot path gained only a return-value check).

## Tests

+4 in `CPUInterruptBoundaryTests`: IRQ entry costs 2+7 on the minimal path (result and ExecState views), NMI costs 2+7 on the full path, `ProcessPendingInterrupts` returns 7/0, and a no-interrupt control keeps plain instruction cycles.

Public API note: `ProcessPendingInterrupts` changed `void` → `ulong` (source-compatible for callers ignoring the result; package is alpha).
