### PR TITLE
Fix VIC-II invalid-band resume alignment and grid sampling bounds with vertical fine scroll

### DIFF
--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/Rasterizer/Vic2RasterizerPixelGenerator.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/Rasterizer/Vic2RasterizerPixelGenerator.cs
@@ -372,15 +372,18 @@ public sealed class Vic2RasterizerUintPixelGenerator
                 // downward shift needed to clear the band - pushing by the full band height would
                 // over-shift and drop the rows below off the bottom border. Only ever non-zero after
                 // an invalid band, so normal (non-split) screens are unaffected.
-                if (_prevInvalidMode && !_invalidMode)
-                {
-                    var resumeDrawLine = screenLine - _screenLayoutInclNonVisibleScreenStartY;
-                    _charGridYOffset = ((resumeDrawLine % 8) + 8) % 8;
-                }
-                _prevInvalidMode = _invalidMode;
-
                 _scrollX = _c64.Vic2.GetScrollX();
                 _scrollY = _c64.Vic2.GetScrollY();
+
+                if (_prevInvalidMode && !_invalidMode)
+                {
+                    // The snap must account for the resume line's vertical fine scroll: gridLine
+                    // subtracts both _charGridYOffset and _scrollY, so the offset is chosen to make
+                    // gridLine land exactly on a character-row boundary at the resume line.
+                    var resumeDrawLine = screenLine - _screenLayoutInclNonVisibleScreenStartY;
+                    _charGridYOffset = (((resumeDrawLine - _scrollY) % 8) + 8) % 8;
+                }
+                _prevInvalidMode = _invalidMode;
 
                 _borderColor = _c64.ReadIOStorage(Vic2Addr.BORDER_COLOR);
 
@@ -1026,9 +1029,8 @@ public sealed class Vic2RasterizerUintPixelGenerator
         // display area outputs black at the physical raster line, regardless of screen/char/bitmap
         // memory. (Without this, the BMM bit alone makes us render garbage bitmap data - the cause of
         // the garbled band seen in e.g. Commando, which toggles this mode on for a few raster lines.)
-        // Fill the background layer black, and clear the foreground layer at the *unshifted* raster
-        // position: fine-scroll writes foreground from neighbouring lines shifted by ScrollY, which
-        // would otherwise bleed scrolled content (e.g. trees) into the black band. Clearing rather
+        // Fill the background layer black, and clear the foreground layer on the band's own raster
+        // lines so nothing drawn earlier this frame remains visible inside the band. Clearing rather
         // than painting black keeps the foreground transparent so sprites still composite normally.
         if (_invalidMode)
         {
@@ -1041,13 +1043,22 @@ public sealed class Vic2RasterizerUintPixelGenerator
         // Vertical fine scroll changes which character row/line is sampled at the current raster
         // line. Do not delay the destination Y write itself, because raster splits must affect the
         // pixels being drawn on this line instead of appearing a few lines later.
+        var backgroundIsPrefilled = _isTextMode && _characterMode == CharMode.Standard;
         var gridLine = drawLine - _charGridYOffset - _scrollY;
-        if (gridLine < 0)
+        if (gridLine < 0 || gridLine >= _drawableAreaHeight)
+        {
+            // The shifted sample position is above the first or below the last character row, where
+            // the real VIC-II pixel sequencer idles. Approximate idle output with the background
+            // color (never sample outside the video matrix), and clear the foreground so stale
+            // pixels cannot show through while keeping the line transparent for sprite compositing.
+            if (!backgroundIsPrefilled)
+                WriteToPixelArray(_oneLineSameColorPixels[_backgroundColor0], foreground: false, drawLine, col * 8, fnLength: 8, fnAdjustForScrollX: false, fnAdjustForScrollY: false);
+            WriteToPixelArray(_oneLineTransparentPixels, foreground: true, drawLine, col * 8, fnLength: 8, fnAdjustForScrollX: false, fnAdjustForScrollY: false);
             return;
+        }
 
         var characterRow = gridLine / 8;
         var characterLine = (ushort)(gridLine % 8);
-        var backgroundIsPrefilled = _isTextMode && _characterMode == CharMode.Standard;
 
         var characterAddress = (ushort)(_vic2VideoMatrixBaseAddress + characterRow * _vic2ScreenTextCols + col);
         var colorRamAddress = (ushort)(Vic2Addr.COLOR_RAM_START + characterRow * _vic2ScreenTextCols + col);

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Render/Vic2RasterizerPixelGeneratorTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Render/Vic2RasterizerPixelGeneratorTests.cs
@@ -63,6 +63,79 @@ public class Vic2RasterizerPixelGeneratorTests
         Assert.Equal(col38Layout.RightBorder.Start.X - 1, endX);
     }
 
+    [Fact]
+    public void DrawText_resumes_on_character_row_boundary_after_invalid_band_with_vertical_fine_scroll()
+    {
+        var c64 = BuildC64();
+        SetupRowBoundaryMarkerTextScreen(c64);
+        // The generator's internal drawLine is relative to the Visible layout's screen start; the
+        // rendered pixel position is relative to the VisibleNormalized layout's screen start.
+        var visibleLayout = c64.Vic2.ScreenLayouts.GetLayout(Vic2ScreenLayouts.LayoutType.Visible, for24RowMode: false, for38ColMode: false);
+        var normalizedLayout = c64.Vic2.ScreenLayouts.GetLayout(Vic2ScreenLayouts.LayoutType.VisibleNormalized, for24RowMode: false, for38ColMode: false);
+        const int bandStartDrawLine = 100;
+        const int resumeDrawLine = 116;
+        // SCROLLY=5 (= +2 relative to the default 3) below the band; invalid mode = ECM+BMM.
+        var (_, foreground) = RenderFrame(c64, rasterLine =>
+        {
+            var drawLine = c64.Vic2.Vic2Model.ConvertRasterLineToScreenLine(rasterLine) - visibleLayout.Screen.Start.Y;
+            if (drawLine < bandStartDrawLine)
+                return 0x1B;
+            if (drawLine < resumeDrawLine)
+                return 0x7B;
+            return 0x1D;
+        });
+
+        // The character grid snap must include the resume line's vertical fine scroll (SCROLLY=5 =>
+        // snap offset 2, drawing the resumed area from pixel row resumeDrawLine - 2). Without it the
+        // snap is 4, which draws the tail glyph lines of the character row the band should hide over
+        // the band's bottom rows - the garbled seam seen in e.g. Commando.
+        var width = c64.Screen.VisibleWidth;
+        var bandTopY = normalizedLayout.Screen.Start.Y + bandStartDrawLine;
+        var firstResumedY = normalizedLayout.Screen.Start.Y + resumeDrawLine - 2;
+        for (var y = bandTopY; y < firstResumedY; y++)
+        {
+            for (var x = normalizedLayout.Screen.Start.X; x <= normalizedLayout.Screen.End.X; x++)
+            {
+                Assert.Equal(0u, foreground[y * width + x]);
+            }
+        }
+
+        // The first resumed row must start on a character-row boundary: glyph line 0 is solid.
+        for (var x = normalizedLayout.Screen.Start.X; x < normalizedLayout.Screen.Start.X + 8; x++)
+        {
+            Assert.NotEqual(0u, foreground[firstResumedY * width + x]);
+        }
+    }
+
+    [Fact]
+    public void DrawText_does_not_sample_below_last_character_row_when_fine_scrolled_up()
+    {
+        var c64 = BuildC64();
+        SetupRowBoundaryMarkerTextScreen(c64);
+        var layout = c64.Vic2.ScreenLayouts.GetLayout(Vic2ScreenLayouts.LayoutType.VisibleNormalized, for24RowMode: false, for38ColMode: false);
+        // Fill the memory directly after the 1000-byte video matrix with characters that render
+        // solid pixels on every glyph line, so sampling past character row 24 becomes visible.
+        for (var i = 0; i < 40; i++)
+        {
+            c64.Vic2.Vic2Mem[(ushort)(0x0400 + 1000 + i)] = 2;
+        }
+
+        // SCROLLY=0 (= -3 relative to the default 3) on all lines samples 3 lines ahead.
+        var (_, foreground) = RenderFrame(c64, _ => 0x18);
+
+        // The last 3 main screen lines have no character row to sample; they must stay blank
+        // instead of rendering data from beyond the video matrix.
+        var width = c64.Screen.VisibleWidth;
+        for (var drawLine = 197; drawLine < 200; drawLine++)
+        {
+            var y = layout.Screen.Start.Y + drawLine;
+            for (var x = layout.Screen.Start.X; x <= layout.Screen.End.X; x++)
+            {
+                Assert.Equal(0u, foreground[y * width + x]);
+            }
+        }
+    }
+
     [Theory]
     [InlineData("C64PAL", "PAL")]
     [InlineData("C64NTSC", "NTSC")]
@@ -136,6 +209,13 @@ public class Vic2RasterizerPixelGeneratorTests
 
     private static uint[] RenderSprites(C64 c64)
     {
+        var (generator, _, foreground) = CreateGenerator(c64);
+        generator.DrawSpritesToBitmapBackedByPixelArray();
+        return foreground;
+    }
+
+    private static (Vic2RasterizerUintPixelGenerator Generator, uint[] Background, uint[] Foreground) CreateGenerator(C64 c64)
+    {
         var pixelCount = c64.Screen.VisibleWidth * c64.Screen.VisibleHeight;
         var background = new uint[pixelCount];
         var foreground = new uint[pixelCount];
@@ -153,9 +233,57 @@ public class Vic2RasterizerPixelGeneratorTests
             (destIndex, width) => background.AsSpan(destIndex, width).Clear(),
             (source, sourceIndex, destIndex, width) => source.Slice(sourceIndex, width).CopyTo(foreground.AsSpan(destIndex, width)),
             (destIndex, width) => foreground.AsSpan(destIndex, width).Clear());
+        return (generator, background, foreground);
+    }
 
-        generator.DrawSpritesToBitmapBackedByPixelArray();
-        return foreground;
+    /// <summary>
+    /// Standard text mode screen where every character cell renders a solid foreground line on
+    /// glyph line 0 and a sparse-but-visible pattern on glyph lines 1-7, making both character-row
+    /// boundaries and partial (mid-row) glyph lines observable.
+    /// Character code 2 renders solid pixels on all glyph lines (for out-of-matrix detection).
+    /// </summary>
+    private static void SetupRowBoundaryMarkerTextScreen(C64 c64)
+    {
+        // 40-column mode, no horizontal fine scroll (ROMs are not loaded, so nothing else sets it).
+        c64.Mem.Write(0xD016, 0xC8);
+        // Video matrix at 0x0400, charset at 0x2000 (plain RAM, avoids the char ROM shadow).
+        c64.Mem.Write(0xD018, 0x18);
+        var charsetAddress = (ushort)0x2000;
+        c64.Vic2.Vic2Mem[(ushort)(charsetAddress + 1 * 8)] = 0xFF;
+        for (var i = 1; i < 8; i++)
+        {
+            c64.Vic2.Vic2Mem[(ushort)(charsetAddress + 1 * 8 + i)] = 0x81;
+        }
+        for (var i = 0; i < 8; i++)
+        {
+            c64.Vic2.Vic2Mem[(ushort)(charsetAddress + 2 * 8 + i)] = 0xFF;
+        }
+
+        for (var i = 0; i < 1000; i++)
+        {
+            c64.Vic2.Vic2Mem[(ushort)(0x0400 + i)] = 1;
+            c64.WriteIOStorage((ushort)(Vic2Addr.COLOR_RAM_START + i), 1); // White
+        }
+    }
+
+    /// <summary>
+    /// Drives the pixel generator through one full frame the same way the emulator main loop does:
+    /// advance the raster one line at a time and let the generator process the elapsed cycles.
+    /// The optional callback supplies the $D011 value in effect while each raster line renders.
+    /// </summary>
+    private static (uint[] Background, uint[] Foreground) RenderFrame(C64 c64, Func<int, byte>? d011ForRasterLine = null)
+    {
+        var (generator, background, foreground) = CreateGenerator(c64);
+        var vic2 = c64.Vic2;
+        var cyclesPerLine = vic2.Vic2Model.CyclesPerLine;
+        for (var rasterLine = 0; rasterLine < vic2.Vic2Model.TotalHeight; rasterLine++)
+        {
+            if (d011ForRasterLine != null)
+                c64.Mem.Write(0xD011, d011ForRasterLine(rasterLine));
+            vic2.AdvanceRaster(cyclesPerLine);
+            generator.OnAfterInstruction();
+        }
+        return (background, foreground);
     }
 
     private static void SetAllScreenLinesToColumnMode(C64 c64, bool colMode40)


### PR DESCRIPTION
## Summary
- Fix a rendering regression introduced in v0.40.2-alpha (#244): in Commando, garbled pixels were drawn over the status text row directly below the black separator band between the scrolling play area and the status area (clean in v0.40.1-alpha after #243).
- Make the invalid-band resume snap scroll-aware: `_charGridYOffset` now includes the resume line's vertical fine scroll, so the resumed area starts on a character-row boundary instead of drawing the tail glyph lines of the row the band hides over the band's bottom rows.
- Bound `gridLine` at both ends: lines whose shifted sample position falls outside the character grid render background color 0 with transparent foreground (idle-sequencer approximation) instead of skipping writes (top) or sampling past the video matrix into sprite-pointer memory (bottom, SCROLLY < 3).

## Verification
- Two new regression tests driven by a full-frame harness with per-line $D011 values; both fail without the fix.
- A/B against real games (headless app + TCP remote control, `emu.loadsnapshot` → `emu.runframes` → `screenshot`): Commando's seam garble is gone (broken vs fixed builds differ on exactly 4 pixel rows at the band bottom); Paradroid renders pixel-identical to master across all stepped frames and during live scrolling, so the #244 fine-scroll fix is preserved.
- Full test suite passes (994 tests), solution builds with 0 warnings.