### PR TITLE
Fix desktop error overlay MainView lookup

### DIFF
--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/OverlayDialogHelper.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/OverlayDialogHelper.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Embedding;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.VisualTree;
 using Highbyte.DotNet6502.App.Avalonia.Core.Views;
 
 namespace Highbyte.DotNet6502.App.Avalonia.Core;
@@ -155,11 +156,13 @@ public class OverlayDialogHelper
         MainView? mainView = null;
         if (_applicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            mainView = desktop.MainWindow?.Content as MainView;
+            mainView = desktop.MainWindow?.Content as MainView
+                ?? desktop.MainWindow?.FindDescendantOfType<MainView>();
         }
         else if (_applicationLifetime is ISingleViewApplicationLifetime singleViewPlatform)
         {
-            mainView = singleViewPlatform.MainView as MainView;
+            mainView = singleViewPlatform.MainView as MainView
+                ?? singleViewPlatform.MainView?.FindDescendantOfType<MainView>();
         }
         return mainView;
     }


### PR DESCRIPTION
## Summary

- preserve the direct `MainView` lookup as the fast path
- fall back to searching the visual tree when a wrapper contains `MainView`
- apply the same safe fallback to single-view application lifetimes

## Root cause

The desktop window now uses a `DockPanel` to host the update banner and `MainView`. `OverlayDialogHelper` assumed `MainWindow.Content` was directly a `MainView`, so every global error overlay failed with `A MainView was not found`.

## Impact

Global error handling can display its overlay again in the Avalonia desktop app even when `MainView` is nested inside the update-banner layout wrapper.

Fixes #294.

## Validation

- `dotnet build` for the Avalonia desktop project: passed with 0 warnings
- full solution test suite: 1,969 tests passed with 0 warnings
- live desktop error-overlay flow: tested successfully, including dismissing the overlay with Continue
