### PR TITLE
Add CPU model picker to Apple II config dialog and new Generic computer config dialog

### DIFF
--- a/docs/host-apps/avalonia/automation.md
+++ b/docs/host-apps/avalonia/automation.md
@@ -131,10 +131,56 @@ A non-exhaustive list of the most useful AutomationIds, grouped by view. All of 
   all — verified against this dialog, where every button and combobox enumerates but no checkbox
   does. Their AutomationIds are set correctly and are right for other hosts, but on macOS a
   checkbox has to be verified from a screenshot rather than from `inspect-ui`.
-- **CPU**: `CpuCompatibilityProfileComboBox`
+- **CPU**: `CpuModelComboBox` (NMOS 6502 or NCR 65C02 — the models an Apple II can have),
+  `CpuCompatibilityProfileComboBox`. The profile list is dependent on the selected model:
+  it only offers the profiles that model supports, and auto-corrects the selection when
+  the model changes (picking the 65C02 collapses it to "Official only").
 - **Messages**: `ConfigStatusMessageText` (non-error status), `ConfigErrorStatusMessageText`
   (error status), `ConfigValidationMessageText` (bulleted validation-error list)
 - **Footer**: `ResetToDefaultsButton`, `CancelButton`, `OkButton`
+
+### Vic20MenuView (sidebar)
+
+- **Root**: `Vic20MenuView`
+- **Basic clipboard**: `CopyBasicButton`, `PasteTextButton` (same ids as the other menus —
+  only one system's menu is visible at a time)
+- **Collapsible section headers**: `LoadSaveSectionHeader`, `LoadSaveSectionContent`,
+  `ConfigSectionHeader`, `ConfigSectionContent`. Unlike the C64 and Apple II menus these are
+  plain toggles, not an accordion — expanding one section does not collapse the other.
+- **Load/Save section**: `LoadBasicButton`, `SaveBasicButton`, `LoadBinaryButton`,
+  `AssemblyExampleComboBox`, `LoadAssemblyExampleButton`, `BasicExampleComboBox`,
+  `LoadBasicExampleButton`
+- **Configuration section**: `Vic20ConfigButton` (only enabled while the emulator is
+  stopped; no attention pulse — the VIC-20 menu does not use `ButtonFlashController`),
+  `ActiveJoystickComboBox`, `JoystickKeyboardCheckBox`, `KeyboardJoystickComboBox`
+
+### Vic20ConfigDialog / Vic20ConfigDialogView
+
+- **Window / root**: `Vic20ConfigDialog`, `Vic20ConfigDialogView`
+- **ROMs (dynamic per ROM)**: `Vic20RomFileTextBox.basic`, `Vic20RomFileTextBox.kernal`,
+  `Vic20RomFileTextBox.chargen`
+- **ROM actions**: `Vic20RomDirectoryTextBox`, `Vic20ClearRomsButton`, `Vic20LoadRomsButton`,
+  `Vic20DownloadRomsButton`, `Vic20DownloadRomFilesButton`
+- **CPU**: `Vic20CpuCompatibilityProfileComboBox` — profile only; the VIC-20's CPU model is
+  fixed (NMOS 6502, the machine's identity), so there is no model picker here.
+- **Video**: `Vic20RenderProviderComboBox`, `Vic20RenderTargetComboBox`
+- **Footer**: `Vic20ConfigResetToDefaultsButton`, `Vic20ConfigCancelButton`, `Vic20ConfigOkButton`
+
+### GenericComputerMenuView (sidebar)
+
+- **Root**: `GenericComputerMenuView`
+- **Collapsible section**: `GenericConfigSectionHeader`, `GenericConfigSectionContent`
+  (expanded by default; the Configuration section is the menu's only content)
+- **Configuration section**: `OpenGenericConfigButton` (only enabled while the emulator is
+  stopped)
+
+### GenericConfigDialog / GenericConfigDialogView
+
+- **Window / root**: `GenericConfigDialog`, `GenericConfigDialogView`
+- **CPU**: `GenericCpuModelComboBox` (all CPU models — the Generic machine has no fixed
+  identity), `GenericCpuCompatibilityProfileComboBox` (dependent on the selected model,
+  same auto-correcting behavior as the Apple II dialog)
+- **Footer**: `GenericConfigCancelButton`, `GenericConfigOkButton`
 
 ### EmulatorConfigUserControl (general settings)
 
@@ -246,6 +292,18 @@ peekaboo menu click --app "DotNet 6502 Emulator" --path "DotNet 6502 Emulator > 
 
 `Toggle Joystick KB` uses the same key as the C64's and VIC-20's, so the shortcut means the same
 thing whichever machine is loaded.
+
+### VIC-20 shortcuts (active when the VIC-20 system is selected — `VIC-20` menu)
+
+| Action                           | macOS               | Windows / Linux       |
+| -------------------------------- | ------------------- | --------------------- |
+| Toggle Load/Save section         | `⌘⌥⇧L`         | `Ctrl+Alt+Shift+L`    |
+| Toggle Configuration section     | `⌘⌥⇧C`         | `Ctrl+Alt+Shift+C`    |
+| Active joystick → Port 1         | `⌘⌥1`            | `Ctrl+Alt+1`          |
+| Active joystick → Port 2         | `⌘⌥2`            | `Ctrl+Alt+2`          |
+| Toggle Joystick KB               | `⌘⌥K`            | `Ctrl+Alt+K`          |
+| Keyboard joystick → Port 1       | `⌘⌥⇧1`         | `Ctrl+Alt+Shift+1`    |
+| Keyboard joystick → Port 2       | `⌘⌥⇧2`         | `Ctrl+Alt+Shift+2`    |
 
 **Testing the keyboard joystick from automation:** `apple2.type` will not do it. That command goes
 through the text-paste service, which writes ASCII straight to the keyboard latch and never becomes

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/CpuModelOption.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Core/ViewModels/CpuModelOption.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Linq;
+using Highbyte.DotNet6502;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
+
+/// <summary>
+/// Dropdown option for selecting a CPU model in a system config dialog. Model ids and
+/// display names come from <see cref="CpuModelInfo"/>; each system dialog picks the
+/// subset of models that makes sense for its machine via <see cref="ForModelIds"/>.
+/// </summary>
+public record CpuModelOption(string ModelId, string DisplayName, string HelpText)
+{
+    public static IReadOnlyList<CpuModelOption> All { get; } =
+        CpuModelInfo.AllModelIds.Select(modelId => new CpuModelOption(
+            modelId,
+            CpuModelInfo.GetDisplayName(modelId),
+            GetHelpText(modelId))).ToList();
+
+    public static CpuModelOption FromModelId(string modelId)
+        => All.Single(option => option.ModelId == modelId);
+
+    /// <summary>The options for a system-specific allow-list of model ids, in the given order.</summary>
+    public static IReadOnlyList<CpuModelOption> ForModelIds(params string[] modelIds)
+        => modelIds.Select(FromModelId).ToList();
+
+    private static string GetHelpText(string modelId) => modelId switch
+    {
+        CpuModelIds.Nmos6502 => "The classic NMOS 6502, including profile-selectable undocumented opcodes.",
+        CpuModelIds.Mos6510 => "NMOS 6502 core with the 6510's on-chip I/O port at $00/$01 (the C64's CPU).",
+        CpuModelIds.Ncr65c02 => "CMOS 65C02 with new and redefined instructions. Supports only the official-only compatibility profile.",
+        _ => string.Empty,
+    };
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/ViewModels/Apple2ConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/ViewModels/Apple2ConfigDialogViewModel.cs
@@ -48,6 +48,7 @@ public class Apple2ConfigDialogViewModel : ViewModelBase
     private RenderProviderOption? _selectedRenderProvider;
     private RenderTargetOption? _selectedRenderTarget;
     private bool _suppressRenderTargetUpdate;
+    private CpuModelOption? _selectedCpuModel;
     private CpuCompatibilityProfileOption? _selectedCpuCompatibilityProfile;
     private MonitorColorOption? _selectedMonitorColor;
     private string _selectedKeyboardLayout = AutoKeyboardLayoutLabel;
@@ -120,6 +121,11 @@ public class Apple2ConfigDialogViewModel : ViewModelBase
     public ObservableCollection<AudioProviderOption> AudioProviders { get; } = new();
     public ObservableCollection<AudioTargetOption> AudioTargets { get; } = new();
     public ObservableCollection<RenderTargetOption> RenderTargets { get; } = new();
+    // Models an Apple II can have: NMOS 6502 (II/II+/unenhanced IIe) or 65C02 (enhanced
+    // IIe). The 6510 is deliberately absent — no Apple ever shipped one.
+    public ObservableCollection<CpuModelOption> CpuModels { get; } =
+        new(CpuModelOption.ForModelIds(CpuModelIds.Nmos6502, CpuModelIds.Ncr65c02));
+    // Repopulated per selected CPU model (e.g. the 65C02 supports only OfficialOnly).
     public ObservableCollection<CpuCompatibilityProfileOption> CpuCompatibilityProfiles { get; } =
         new(CpuCompatibilityProfileOption.All);
     public ObservableCollection<MonitorColorOption> MonitorColors { get; } = new(MonitorColorOption.All);
@@ -341,6 +347,28 @@ public class Apple2ConfigDialogViewModel : ViewModelBase
 
     public string SelectedRenderTargetHelpText => SelectedRenderTarget?.HelpText ?? string.Empty;
 
+    public CpuModelOption? SelectedCpuModel
+    {
+        get => _selectedCpuModel;
+        set
+        {
+            if (ReferenceEquals(_selectedCpuModel, value))
+                return;
+
+            this.RaiseAndSetIfChanged(ref _selectedCpuModel, value);
+
+            if (value != null)
+            {
+                _workingConfig.SystemConfig.CpuModelId = value.ModelId;
+                UpdateCompatibilityProfilesForModel(value.ModelId);
+            }
+
+            this.RaisePropertyChanged(nameof(SelectedCpuModelHelpText));
+        }
+    }
+
+    public string SelectedCpuModelHelpText => SelectedCpuModel?.HelpText ?? string.Empty;
+
     public CpuCompatibilityProfileOption? SelectedCpuCompatibilityProfile
     {
         get => _selectedCpuCompatibilityProfile;
@@ -359,6 +387,25 @@ public class Apple2ConfigDialogViewModel : ViewModelBase
     }
 
     public string SelectedCpuCompatibilityProfileHelpText => SelectedCpuCompatibilityProfile?.HelpText ?? string.Empty;
+
+    /// <summary>
+    /// Constrains the profile dropdown to the profiles the selected model supports, and
+    /// auto-corrects the selection when the current profile is no longer among them
+    /// (e.g. picking the 65C02 forces "Official only") — the UI can never produce a
+    /// model/profile pairing that config validation would reject.
+    /// </summary>
+    private void UpdateCompatibilityProfilesForModel(string cpuModelId)
+    {
+        var supportedProfiles = CpuModelInfo.GetSupportedProfiles(cpuModelId);
+
+        CpuCompatibilityProfiles.Clear();
+        foreach (var option in CpuCompatibilityProfileOption.All.Where(o => supportedProfiles.Contains(o.Profile)))
+            CpuCompatibilityProfiles.Add(option);
+
+        var currentProfile = _workingConfig.SystemConfig.CpuCompatibilityProfile;
+        SelectedCpuCompatibilityProfile = CpuCompatibilityProfiles.FirstOrDefault(o => o.Profile == currentProfile)
+            ?? CpuCompatibilityProfiles.First();
+    }
 
     public MonitorColorOption? SelectedMonitorColor
     {
@@ -580,6 +627,7 @@ public class Apple2ConfigDialogViewModel : ViewModelBase
 
             _originalConfig.SystemConfig.ROMDirectory = _workingConfig.SystemConfig.ROMDirectory;
             _originalConfig.SystemConfig.ROMs = ROM.Clone(_workingConfig.SystemConfig.ROMs);
+            _originalConfig.SystemConfig.CpuModelId = _workingConfig.SystemConfig.CpuModelId;
             _originalConfig.SystemConfig.CpuCompatibilityProfile = _workingConfig.SystemConfig.CpuCompatibilityProfile;
             _originalConfig.SystemConfig.MonitorColor = _workingConfig.SystemConfig.MonitorColor;
             _originalConfig.SystemConfig.KeyboardJoystickEnabled = _workingConfig.SystemConfig.KeyboardJoystickEnabled;
@@ -619,6 +667,8 @@ public class Apple2ConfigDialogViewModel : ViewModelBase
     private void LoadFromWorkingConfig()
     {
         RomDirectory = _workingConfig.SystemConfig.ROMDirectory;
+        // Model first: it constrains the profile list the profile selection lands in.
+        SelectedCpuModel = CpuModelOption.FromModelId(_workingConfig.SystemConfig.CpuModelId);
         SelectedCpuCompatibilityProfile = CpuCompatibilityProfileOption.FromProfile(_workingConfig.SystemConfig.CpuCompatibilityProfile);
         SelectedMonitorColor = MonitorColorOption.FromMonitorColor(_workingConfig.SystemConfig.MonitorColor);
         SelectedKeyboardLayout = _workingConfig.InputConfig.KeyboardLayout?.ToString() ?? AutoKeyboardLayoutLabel;

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/Views/Apple2ConfigDialogView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Apple2/Views/Apple2ConfigDialogView.axaml
@@ -144,11 +144,23 @@
                 <TextBlock Text="CPU"
                             Classes=""/>
 
-                <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto" Classes="spacing-tight">
+                <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto" Classes="spacing-tight">
                     <TextBlock Grid.Row="0" Grid.Column="0"
-                                Text="Profile:"
+                                Text="Model:"
                                 Classes="secondary-text"/>
                     <ComboBox Grid.Row="0" Grid.Column="1"
+                            AutomationProperties.AutomationId="CpuModelComboBox"
+                            AutomationProperties.Name="CPU model"
+                            ItemsSource="{Binding CpuModels}"
+                            SelectedItem="{Binding SelectedCpuModel}"
+                            DisplayMemberBinding="{Binding DisplayName}"
+                            ToolTip.Tip="{Binding SelectedCpuModelHelpText}"
+                            Classes="h-stretch"
+                            MaxDropDownHeight="200"/>
+                    <TextBlock Grid.Row="1" Grid.Column="0"
+                                Text="Profile:"
+                                Classes="secondary-text"/>
+                    <ComboBox Grid.Row="1" Grid.Column="1"
                             AutomationProperties.AutomationId="CpuCompatibilityProfileComboBox"
                             AutomationProperties.Name="CPU opcode compatibility profile"
                             ItemsSource="{Binding CpuCompatibilityProfiles}"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/GenericComputerAvaloniaShellPlugin.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/GenericComputerAvaloniaShellPlugin.cs
@@ -1,4 +1,5 @@
 using System;
+using Highbyte.DotNet6502.App.Avalonia.Shell.Generic.ViewModels;
 using Highbyte.DotNet6502.Systems.Generic;
 using Highbyte.DotNet6502.Systems.Plugins;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,11 +12,11 @@ namespace Highbyte.DotNet6502.App.Avalonia.Shell.Generic;
 /// Shell-side plugin for the Generic computer on the Avalonia host.
 /// </summary>
 /// <remarks>
-/// The Generic computer has no system-specific UI surfaces, so this plugin contributes nothing —
-/// the menu, info and config dialog contributions are all null and the host renders only its
-/// system-agnostic chrome. The engine-side wiring (the <c>ISystemConfigurer</c>) lives in the
-/// engine plugin <c>GenericAvaloniaEnginePlugin</c> (Impl.Avalonia.Generic). The plugin is kept
-/// (rather than deleted) so the Generic system has a discoverable shell-side presence.
+/// The Generic computer has no media (no PRG/disk/tape), so its menu is minimal: a
+/// Configuration section opening the config dialog (CPU model and compatibility
+/// profile). The info contribution stays null. The engine-side wiring (the
+/// <c>ISystemConfigurer</c>) lives in the engine plugin
+/// <c>GenericAvaloniaEnginePlugin</c> (Impl.Avalonia.Generic).
 /// </remarks>
 public sealed class GenericComputerAvaloniaShellPlugin : ISystemShellPlugin
 {
@@ -25,12 +26,13 @@ public sealed class GenericComputerAvaloniaShellPlugin : ISystemShellPlugin
 
     public void RegisterShellServices(IServiceCollection services)
     {
-        // No UI services — the Generic computer has no Avalonia-specific shell UI.
+        services.AddTransient<GenericComputerMenuViewModel>();
+        services.AddTransient<GenericComputerConfigDialogViewModel>();
     }
 
-    public object? CreateMenuContribution(IServiceProvider sp) => null;
+    public object? CreateMenuContribution(IServiceProvider sp) => sp.GetService<GenericComputerMenuViewModel>();
 
     public object? CreateInfoContribution(IServiceProvider sp) => null;
 
-    public object? CreateConfigDialogContribution(IServiceProvider sp) => null;
+    public object? CreateConfigDialogContribution(IServiceProvider sp) => sp.GetService<GenericComputerConfigDialogViewModel>();
 }

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/Highbyte.DotNet6502.App.Avalonia.Shell.Generic.csproj
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/Highbyte.DotNet6502.App.Avalonia.Shell.Generic.csproj
@@ -4,9 +4,12 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Avalonia" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/ViewModels/GenericComputerConfigDialogViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/ViewModels/GenericComputerConfigDialogViewModel.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reactive;
+using System.Threading.Tasks;
+using Highbyte.DotNet6502.App.Avalonia.Core;
+using Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
+using Highbyte.DotNet6502.Impl.Avalonia;
+using Highbyte.DotNet6502.Impl.Avalonia.Generic;
+using ReactiveUI;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Shell.Generic.ViewModels;
+
+/// <summary>
+/// Generic computer configuration dialog: CPU model and CPU compatibility profile. The
+/// Generic machine has no fixed identity, so every CPU model is selectable; everything
+/// else about the machine (memory layout, screen, example programs) stays JSON-config
+/// only.
+/// </summary>
+public class GenericComputerConfigDialogViewModel : ViewModelBase
+{
+    private readonly AvaloniaHostApp _hostApp;
+    private readonly GenericComputerHostConfig _originalConfig;
+    private readonly GenericComputerHostConfig _workingConfig;
+
+    private bool _isBusy;
+    private string? _statusMessage;
+    private string? _validationMessage;
+    private CpuModelOption? _selectedCpuModel;
+    private CpuCompatibilityProfileOption? _selectedCpuCompatibilityProfile;
+
+    public ReactiveCommand<Unit, Unit> SaveCommand { get; }
+    public ReactiveCommand<Unit, Unit> CancelCommand { get; }
+
+    public GenericComputerConfigDialogViewModel(AvaloniaHostApp hostApp)
+    {
+        _hostApp = hostApp ?? throw new ArgumentNullException(nameof(hostApp));
+        _originalConfig = hostApp.CurrentHostSystemConfig as GenericComputerHostConfig
+            ?? throw new Exception("hostApp.CurrentHostSystemConfig must be type GenericComputerHostConfig");
+        _workingConfig = (GenericComputerHostConfig)_originalConfig.Clone();
+
+        // Model first: it constrains the profile list the profile selection lands in.
+        SelectedCpuModel = CpuModelOption.FromModelId(_workingConfig.SystemConfig.CpuModelId);
+        SelectedCpuCompatibilityProfile = CpuCompatibilityProfileOption.FromProfile(_workingConfig.SystemConfig.CpuCompatibilityProfile);
+
+        SaveCommand = ReactiveCommandHelper.CreateSafeCommand(
+            async () =>
+            {
+                if (await TryApplyChangesAsync())
+                    ConfigurationChanged?.Invoke(this, true);
+            },
+            outputScheduler: RxSchedulers.MainThreadScheduler);
+
+        CancelCommand = ReactiveCommandHelper.CreateSafeCommand(
+            () =>
+            {
+                ConfigurationChanged?.Invoke(this, false);
+                return Task.CompletedTask;
+            },
+            outputScheduler: RxSchedulers.MainThreadScheduler);
+    }
+
+    public event EventHandler<bool>? ConfigurationChanged;
+
+    // The Generic machine has no fixed CPU identity — offer every known model.
+    public ObservableCollection<CpuModelOption> CpuModels { get; } = new(CpuModelOption.All);
+    // Repopulated per selected CPU model (e.g. the 65C02 supports only OfficialOnly).
+    public ObservableCollection<CpuCompatibilityProfileOption> CpuCompatibilityProfiles { get; } =
+        new(CpuCompatibilityProfileOption.All);
+
+    public bool IsRunningInWebAssembly { get; } = PlatformDetection.IsRunningInWebAssembly();
+
+    public bool IsBusy
+    {
+        get => _isBusy;
+        private set
+        {
+            if (_isBusy == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _isBusy, value);
+            this.RaisePropertyChanged(nameof(IsNotBusy));
+            this.RaisePropertyChanged(nameof(CanSave));
+        }
+    }
+
+    public bool IsNotBusy => !IsBusy;
+
+    public bool CanSave => IsNotBusy;
+
+    public string? StatusMessage
+    {
+        get => _statusMessage;
+        private set
+        {
+            if (_statusMessage == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _statusMessage, value);
+            this.RaisePropertyChanged(nameof(HasStatusMessage));
+        }
+    }
+
+    public string? ValidationMessage
+    {
+        get => _validationMessage;
+        private set
+        {
+            if (_validationMessage == value)
+                return;
+
+            this.RaiseAndSetIfChanged(ref _validationMessage, value);
+            this.RaisePropertyChanged(nameof(HasValidationMessage));
+        }
+    }
+
+    public bool HasStatusMessage => !string.IsNullOrEmpty(StatusMessage);
+    public bool HasValidationMessage => !string.IsNullOrEmpty(ValidationMessage);
+
+    public string OkButtonText => IsRunningInWebAssembly ? "Save" : "Ok";
+
+    public CpuModelOption? SelectedCpuModel
+    {
+        get => _selectedCpuModel;
+        set
+        {
+            if (ReferenceEquals(_selectedCpuModel, value))
+                return;
+
+            this.RaiseAndSetIfChanged(ref _selectedCpuModel, value);
+
+            if (value != null)
+            {
+                _workingConfig.SystemConfig.CpuModelId = value.ModelId;
+                UpdateCompatibilityProfilesForModel(value.ModelId);
+            }
+
+            this.RaisePropertyChanged(nameof(SelectedCpuModelHelpText));
+        }
+    }
+
+    public string SelectedCpuModelHelpText => SelectedCpuModel?.HelpText ?? string.Empty;
+
+    public CpuCompatibilityProfileOption? SelectedCpuCompatibilityProfile
+    {
+        get => _selectedCpuCompatibilityProfile;
+        set
+        {
+            if (ReferenceEquals(_selectedCpuCompatibilityProfile, value))
+                return;
+
+            this.RaiseAndSetIfChanged(ref _selectedCpuCompatibilityProfile, value);
+
+            if (value != null)
+                _workingConfig.SystemConfig.CpuCompatibilityProfile = value.Profile;
+
+            this.RaisePropertyChanged(nameof(SelectedCpuCompatibilityProfileHelpText));
+        }
+    }
+
+    public string SelectedCpuCompatibilityProfileHelpText => SelectedCpuCompatibilityProfile?.HelpText ?? string.Empty;
+
+    /// <summary>
+    /// Constrains the profile dropdown to the profiles the selected model supports, and
+    /// auto-corrects the selection when the current profile is no longer among them
+    /// (e.g. picking the 65C02 forces "Official only") — the UI can never produce a
+    /// model/profile pairing that config validation would reject.
+    /// </summary>
+    private void UpdateCompatibilityProfilesForModel(string cpuModelId)
+    {
+        var supportedProfiles = CpuModelInfo.GetSupportedProfiles(cpuModelId);
+
+        CpuCompatibilityProfiles.Clear();
+        foreach (var option in CpuCompatibilityProfileOption.All.Where(o => supportedProfiles.Contains(o.Profile)))
+            CpuCompatibilityProfiles.Add(option);
+
+        var currentProfile = _workingConfig.SystemConfig.CpuCompatibilityProfile;
+        SelectedCpuCompatibilityProfile = CpuCompatibilityProfiles.FirstOrDefault(o => o.Profile == currentProfile)
+            ?? CpuCompatibilityProfiles.First();
+    }
+
+    public async Task<bool> TryApplyChangesAsync()
+    {
+        try
+        {
+            IsBusy = true;
+            StatusMessage = "Saving...";
+            ValidationMessage = string.Empty;
+
+            if (!_workingConfig.IsValid(out var validationErrors))
+            {
+                StatusMessage = null;
+                ValidationMessage = string.Join(Environment.NewLine, validationErrors);
+                return false;
+            }
+
+            _originalConfig.SystemConfig.CpuModelId = _workingConfig.SystemConfig.CpuModelId;
+            _originalConfig.SystemConfig.CpuCompatibilityProfile = _workingConfig.SystemConfig.CpuCompatibilityProfile;
+
+            _hostApp.UpdateHostSystemConfig(_originalConfig);
+            await _hostApp.PersistCurrentHostSystemConfig();
+
+            StatusMessage = "Configuration saved.";
+            return true;
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Error saving config: {ex.Message}";
+            return false;
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/ViewModels/GenericComputerMenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/ViewModels/GenericComputerMenuViewModel.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Reactive;
+using System.Threading.Tasks;
+using Highbyte.DotNet6502.App.Avalonia.Core;
+using Highbyte.DotNet6502.App.Avalonia.Core.ViewModels;
+using Highbyte.DotNet6502.Impl.Avalonia;
+using Highbyte.DotNet6502.Systems;
+using ReactiveUI;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Shell.Generic.ViewModels;
+
+/// <summary>
+/// Generic computer sidebar menu. The Generic machine has no media (no PRG/disk/tape),
+/// so the menu's only job is hosting the Configuration section that opens the config
+/// dialog.
+/// </summary>
+public class GenericComputerMenuViewModel : ViewModelBase
+{
+    private readonly AvaloniaHostApp _hostApp;
+    private bool _isConfigSectionExpanded = true;
+
+    public AvaloniaHostApp HostApp => _hostApp;
+
+    public ReactiveCommand<Unit, Unit> ToggleConfigSectionCommand { get; }
+
+    public GenericComputerMenuViewModel(AvaloniaHostApp hostApp)
+    {
+        _hostApp = hostApp ?? throw new ArgumentNullException(nameof(hostApp));
+
+        _hostApp
+            .WhenAnyValue(x => x.EmulatorState)
+            .Subscribe(_ => this.RaisePropertyChanged(nameof(IsGenericConfigEnabled)));
+
+        ToggleConfigSectionCommand = ReactiveCommandHelper.CreateSafeCommand(
+            () =>
+            {
+                IsConfigSectionExpanded = !IsConfigSectionExpanded;
+                return Task.CompletedTask;
+            },
+            outputScheduler: RxSchedulers.MainThreadScheduler);
+    }
+
+    public bool IsConfigSectionExpanded
+    {
+        get => _isConfigSectionExpanded;
+        private set => this.RaiseAndSetIfChanged(ref _isConfigSectionExpanded, value);
+    }
+
+    /// <summary>The config dialog edits the system's construction-time settings, so it only opens while stopped.</summary>
+    public bool IsGenericConfigEnabled => _hostApp.EmulatorState == EmulatorState.Uninitialized;
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/Views/GenericComputerConfigDialog.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/Views/GenericComputerConfigDialog.axaml
@@ -1,0 +1,22 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:Highbyte.DotNet6502.App.Avalonia.Shell.Generic.ViewModels"
+        xmlns:views="using:Highbyte.DotNet6502.App.Avalonia.Shell.Generic.Views"
+        x:Class="Highbyte.DotNet6502.App.Avalonia.Shell.Generic.Views.GenericComputerConfigDialog"
+        x:DataType="vm:GenericComputerConfigDialogViewModel"
+        AutomationProperties.AutomationId="GenericConfigDialog"
+        AutomationProperties.Name="Generic computer configuration"
+        Title="Generic Computer Configuration"
+        Width="460"
+        Height="360"
+        MinWidth="400"
+        MinHeight="300"
+        WindowStartupLocation="CenterOwner"
+        CanResize="True"
+        WindowDecorations="Full"
+        ShowInTaskbar="False"
+        Background="{DynamicResource ViewDefaultBg}">
+
+    <views:GenericComputerConfigDialogView x:Name="ConfigView"
+                                           ConfigurationChanged="OnConfigurationChanged"/>
+</Window>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/Views/GenericComputerConfigDialog.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/Views/GenericComputerConfigDialog.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Shell.Generic.Views;
+
+public partial class GenericComputerConfigDialog : Window
+{
+    public bool? DialogResultValue { get; private set; }
+
+    public GenericComputerConfigDialog()
+    {
+        InitializeComponent();
+        DialogResultValue = false;
+    }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    public void OnConfigurationChanged(object? sender, bool saved)
+    {
+        DialogResultValue = saved;
+        Close(saved);
+    }
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/Views/GenericComputerConfigDialogView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/Views/GenericComputerConfigDialogView.axaml
@@ -1,0 +1,79 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:Highbyte.DotNet6502.App.Avalonia.Shell.Generic.ViewModels"
+             x:Class="Highbyte.DotNet6502.App.Avalonia.Shell.Generic.Views.GenericComputerConfigDialogView"
+             x:DataType="vm:GenericComputerConfigDialogViewModel"
+             AutomationProperties.AutomationId="GenericConfigDialogView"
+             AutomationProperties.Name="Generic computer configuration panel"
+             Focusable="False">
+
+    <Grid RowDefinitions="Auto,*,Auto,Auto" Margin="8,0,8,8" MaxWidth="420">
+        <Border Grid.Row="0" CornerRadius="4" Classes="panel-container">
+            <TextBlock Text="Generic Computer Configuration"
+                       Classes="h-center h2"/>
+        </Border>
+
+        <ScrollViewer Grid.Row="1" Classes="vertical-only">
+            <StackPanel Classes="wrap-item">
+                <Border Classes="content-section">
+                    <StackPanel Classes="spacing-tight">
+                        <TextBlock Text="CPU"/>
+
+                        <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto" Classes="spacing-tight">
+                            <TextBlock Grid.Row="0" Grid.Column="0"
+                                       Text="Model:"
+                                       Classes="secondary-text"/>
+                            <ComboBox Grid.Row="0" Grid.Column="1"
+                                      AutomationProperties.AutomationId="GenericCpuModelComboBox"
+                                      AutomationProperties.Name="Generic computer CPU model"
+                                      ItemsSource="{Binding CpuModels}"
+                                      SelectedItem="{Binding SelectedCpuModel}"
+                                      DisplayMemberBinding="{Binding DisplayName}"
+                                      ToolTip.Tip="{Binding SelectedCpuModelHelpText}"
+                                      Classes="h-stretch"
+                                      MaxDropDownHeight="200"/>
+                            <TextBlock Grid.Row="1" Grid.Column="0"
+                                       Text="Profile:"
+                                       Classes="secondary-text"/>
+                            <ComboBox Grid.Row="1" Grid.Column="1"
+                                      AutomationProperties.AutomationId="GenericCpuCompatibilityProfileComboBox"
+                                      AutomationProperties.Name="Generic computer CPU opcode compatibility profile"
+                                      ItemsSource="{Binding CpuCompatibilityProfiles}"
+                                      SelectedItem="{Binding SelectedCpuCompatibilityProfile}"
+                                      DisplayMemberBinding="{Binding DisplayName}"
+                                      ToolTip.Tip="{Binding SelectedCpuCompatibilityProfileHelpText}"
+                                      Classes="h-stretch"
+                                      MaxDropDownHeight="200"/>
+                        </Grid>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </ScrollViewer>
+
+        <TextBlock Grid.Row="2"
+                   Text="{Binding ValidationMessage}"
+                   TextWrapping="Wrap"
+                   Foreground="#F56565"
+                   Classes="small"
+                   IsVisible="{Binding HasValidationMessage}"/>
+
+        <Grid Grid.Row="3" ColumnDefinitions="*,Auto,Auto" Classes="spacing-normal">
+            <TextBlock Grid.Column="0"
+                       Text="{Binding StatusMessage}"
+                       Classes="small secondary-text"
+                       IsVisible="{Binding HasStatusMessage}"/>
+            <Button Grid.Column="1"
+                    Content="Cancel"
+                    AutomationProperties.AutomationId="GenericConfigCancelButton"
+                    Command="{Binding CancelCommand}"
+                    Classes="cancel"
+                    IsEnabled="{Binding IsNotBusy}"/>
+            <Button Grid.Column="2"
+                    Content="{Binding OkButtonText}"
+                    AutomationProperties.AutomationId="GenericConfigOkButton"
+                    Command="{Binding SaveCommand}"
+                    Classes="primary"
+                    IsEnabled="{Binding CanSave}"/>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/Views/GenericComputerConfigDialogView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/Views/GenericComputerConfigDialogView.axaml
@@ -57,7 +57,7 @@
                    Classes="small"
                    IsVisible="{Binding HasValidationMessage}"/>
 
-        <Grid Grid.Row="3" ColumnDefinitions="*,Auto,Auto" Classes="spacing-normal">
+        <Grid Grid.Row="3" ColumnDefinitions="*,Auto,Auto" Classes="spacing-wide">
             <TextBlock Grid.Column="0"
                        Text="{Binding StatusMessage}"
                        Classes="small secondary-text"

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/Views/GenericComputerConfigDialogView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/Views/GenericComputerConfigDialogView.axaml.cs
@@ -1,0 +1,50 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Highbyte.DotNet6502.App.Avalonia.Shell.Generic.ViewModels;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Shell.Generic.Views;
+
+public partial class GenericComputerConfigDialogView : UserControl
+{
+    private GenericComputerConfigDialogViewModel? _previousViewModel;
+    private GenericComputerConfigDialogViewModel? ViewModel => DataContext as GenericComputerConfigDialogViewModel;
+    private EventHandler<bool>? _configurationChangedHandlers;
+
+    // Forwards to the view model's event, resubscribing when the DataContext changes so
+    // handlers added before the DataContext is set still fire.
+    public event EventHandler<bool>? ConfigurationChanged
+    {
+        add
+        {
+            _configurationChangedHandlers += value;
+            if (ViewModel != null)
+                ViewModel.ConfigurationChanged += value;
+        }
+        remove
+        {
+            _configurationChangedHandlers -= value;
+            if (ViewModel != null)
+                ViewModel.ConfigurationChanged -= value;
+        }
+    }
+
+    public GenericComputerConfigDialogView()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (_previousViewModel != null && _configurationChangedHandlers != null)
+            _previousViewModel.ConfigurationChanged -= _configurationChangedHandlers;
+
+        if (ViewModel != null && _configurationChangedHandlers != null)
+            ViewModel.ConfigurationChanged += _configurationChangedHandlers;
+
+        _previousViewModel = ViewModel;
+    }
+}

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/Views/GenericComputerMenuView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/Views/GenericComputerMenuView.axaml
@@ -1,0 +1,49 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:Highbyte.DotNet6502.App.Avalonia.Shell.Generic.ViewModels"
+             xmlns:controls="using:Highbyte.DotNet6502.App.Avalonia.Core.Controls"
+             x:Class="Highbyte.DotNet6502.App.Avalonia.Shell.Generic.Views.GenericComputerMenuView"
+             x:DataType="vm:GenericComputerMenuViewModel"
+             AutomationProperties.AutomationId="GenericComputerMenuView"
+             AutomationProperties.Name="Generic computer menu">
+
+    <StackPanel Classes="spacing-tight">
+        <!-- Configuration -->
+        <Button Name="GenericConfigSectionHeader"
+                AutomationProperties.AutomationId="GenericConfigSectionHeader"
+                AutomationProperties.Name="Toggle Configuration section"
+                Classes="section-toggle"
+                Command="{Binding ToggleConfigSectionCommand}">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <Grid Width="10" Height="10" VerticalAlignment="Center">
+                    <controls:SymbolIcon Width="8" Height="8"
+                                         Kind="TriangleRight"
+                                         IsVisible="{Binding !IsConfigSectionExpanded}"/>
+                    <controls:SymbolIcon Width="8" Height="8"
+                                         Kind="TriangleDown"
+                                         IsVisible="{Binding IsConfigSectionExpanded}"/>
+                </Grid>
+                <TextBlock Text="Configuration" VerticalAlignment="Center"/>
+            </StackPanel>
+        </Button>
+
+        <Border Name="GenericConfigSectionContent"
+                AutomationProperties.AutomationId="GenericConfigSectionContent"
+                Classes="collapsible-content"
+                IsVisible="{Binding IsConfigSectionExpanded}">
+            <StackPanel Classes="spacing-tight">
+                <Button Content="Generic Computer config…"
+                        Name="OpenGenericConfigButton"
+                        AutomationProperties.AutomationId="OpenGenericConfigButton"
+                        AutomationProperties.Name="Open Generic computer configuration"
+                        Classes="small"
+                        IsEnabled="{Binding IsGenericConfigEnabled}"
+                        Click="OpenGenericConfig_Click"/>
+
+                <TextBlock Text="CPU model and opcode compatibility. Only editable while the emulator is stopped."
+                           Classes="small secondary-text"
+                           TextWrapping="Wrap"/>
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</UserControl>

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/Views/GenericComputerMenuView.axaml.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Generic/Views/GenericComputerMenuView.axaml.cs
@@ -1,0 +1,101 @@
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Highbyte.DotNet6502.App.Avalonia.Core;
+using Highbyte.DotNet6502.App.Avalonia.Shell.Generic.ViewModels;
+using Highbyte.DotNet6502.Impl.Avalonia;
+using Highbyte.DotNet6502.Impl.Avalonia.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using AvaloniaApp = Highbyte.DotNet6502.App.Avalonia.Core.App;
+
+namespace Highbyte.DotNet6502.App.Avalonia.Shell.Generic.Views;
+
+public partial class GenericComputerMenuView : UserControl
+{
+    private ILogger? _logger;
+    private ILogger Logger => _logger ??= AppLogger.CreateLogger(nameof(GenericComputerMenuView));
+
+    private GenericComputerMenuViewModel? ViewModel => DataContext as GenericComputerMenuViewModel;
+
+    public GenericComputerMenuView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    private void OpenGenericConfig_Click(object? sender, RoutedEventArgs e)
+        => SafeAsyncHelper.Execute(async () =>
+        {
+            if (ViewModel?.HostApp == null)
+                return;
+
+            if (ViewModel.HostApp.CurrentHostSystemConfig is not GenericComputerHostConfig)
+                return;
+
+            // The browser host has no separate windows, so the same view is shown as an overlay.
+            if (PlatformDetection.IsRunningInWebAssembly())
+                await GenericConfigUserControlOverlayAsync();
+            else
+                await ShowGenericConfigDialogAsync();
+        });
+
+    private async Task ShowGenericConfigDialogAsync()
+    {
+        var dialog = new GenericComputerConfigDialog
+        {
+            DataContext = new GenericComputerConfigDialogViewModel(ViewModel!.HostApp)
+        };
+
+        bool? result;
+        if (TopLevel.GetTopLevel(this) is Window owner)
+        {
+            result = await dialog.ShowDialog<bool?>(owner);
+        }
+        else
+        {
+            var tcs = new TaskCompletionSource<bool?>();
+            dialog.Closed += (_, _) => tcs.TrySetResult(dialog.DialogResultValue);
+            dialog.Show();
+            result = await tcs.Task;
+        }
+
+        if (result == true)
+            await ViewModel!.HostApp.ValidateConfigAsync();
+    }
+
+    private async Task GenericConfigUserControlOverlayAsync()
+    {
+        var serviceProvider = (Application.Current as AvaloniaApp)?.GetServiceProvider();
+        if (serviceProvider == null)
+        {
+            Logger.LogError("Could not get service provider");
+            return;
+        }
+
+        var configControl = new GenericComputerConfigDialogView
+        {
+            DataContext = new GenericComputerConfigDialogViewModel(ViewModel!.HostApp)
+        };
+
+        var taskCompletionSource = new TaskCompletionSource<bool>();
+        configControl.ConfigurationChanged += (_, saved) => taskCompletionSource.TrySetResult(saved);
+
+        var overlayDialogHelper = serviceProvider.GetRequiredService<OverlayDialogHelper>();
+        var overlayPanel = overlayDialogHelper.BuildOverlayDialogPanel(configControl);
+        var mainGrid = overlayDialogHelper.ShowOverlayDialog(overlayPanel, this);
+
+        try
+        {
+            if (await taskCompletionSource.Task)
+                await ViewModel!.HostApp.ValidateConfigAsync();
+        }
+        finally
+        {
+            mainGrid.Children.Remove(overlayPanel);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Makes the CPU model selectable from the UI (previously JSON-config only), building on the CPU model architecture work (#288–#297).

- **Apple II config dialog**: new CPU model dropdown (`CpuModelComboBox`) offering NMOS 6502 and NCR 65C02 (no 6510 — no Apple ever shipped one). The compatibility-profile dropdown is now dependent on the selected model: constrained to `CpuModelInfo.GetSupportedProfiles`, auto-correcting when the model changes (picking the 65C02 collapses it to "Official only"), so the UI can never produce a model/profile pairing config validation would reject.
- **New Generic computer config dialog**: the Generic shell previously contributed no UI at all. It now has a minimal sidebar menu (Configuration section) and a config dialog exposing the CPU model (all three models — the Generic machine has no fixed identity) with the same dependent-profile behavior. Desktop opens a dialog window; the browser host uses the shared overlay. No audio toggle (`GenericComputerHostConfig.AudioSupported` is false) and no reset-to-defaults (a fresh host config would not preserve example-program settings).
- **Shared `CpuModelOption`** view-model record in Avalonia.Core, built from `CpuModelInfo` (ids/display names not duplicated), with per-system allow-lists via `ForModelIds`.
- **UI automation catalog** (`docs/host-apps/avalonia/automation.md`): new controls documented; also backfills the previously missing VIC-20 sections (menu, config dialog, shortcuts table) and notes the VIC-20 menu's non-accordion sections.
- C64 and VIC-20 dialogs unchanged: their CPU models are the machines' identity.

## Test plan

- Full solution builds with 0 warnings (rebased on current master incl. #297).
- Live UI verification via accessibility automation against the running desktop app: 11/11 criteria PASS (both dialogs: control presence, model allow-lists, dependent-profile collapse/auto-correct in both directions), plus a follow-up pass confirming a footer-spacing fix (12 px Cancel→Ok gap, matching the Apple II dialog).
- Windows CI run green; SonarCloud branch analysis clean at MAJOR threshold.