### PR TITLE
Add Oric snapshot support

### DIFF
--- a/docs/systems/oric/overview.md
+++ b/docs/systems/oric/overview.md
@@ -52,6 +52,8 @@ Core library: `Highbyte.DotNet6502.Systems.Oric`.
   socket selections are available both in the Avalonia sidebar and the Oric configuration dialog.
 - Remote control supports keyboard and joystick injection, paced text entry, BASIC readiness and
   source queries, direct TAP loading, and insert/rewind/eject/status control for the virtual tape.
+- Emulator-state snapshots preserve the CPU, 48 KB RAM, VIA timers and interrupts, AY register and
+  generator phase, PAL raster and renderer phase, and any inserted TAP image and tape position.
 - The 240 &times; 224 active display in text and 240 &times; 200 hires modes, including serial
   ink, paper, character and screen attributes, alternate character sets, inverse and flashing
   characters, and the three text rows below hires graphics.
@@ -67,9 +69,21 @@ Core library: `Highbyte.DotNet6502.Systems.Oric`.
   timed cassette signal, physical Play/Stop and continuous fast-forward/reverse controls do not
   apply.
 - Microdisc or Jasmin floppy controllers and disk images.
-- Printer output, snapshots and Oric-specific monitor commands.
+- Printer output and Oric-specific monitor commands.
 - Cycle-level ULA bus contention, sub-scanline pixel fetch timing, and analogue AY output filtering.
 - The Oric-1, Oric-1 16K, Pravetz and Telestrat variants.
+
+## Snapshots
+
+Oric `.d6502snap` snapshots restore the full Atmos execution state and embed an inserted TAP image,
+so a cassette operation can continue from the captured byte position. The raster resumes at the
+captured scanline and cycle, while the pixel and terminal renderers rebuild their presentation from
+the restored machine state.
+
+ROM bytes are not stored in a snapshot; the destination uses the Atmos ROM from its current
+configuration. When snapshot configuration is included, the portable block also carries audio,
+VSync modification, joystick interface, keyboard-joystick, and CPU compatibility settings. A
+snapshot restored through a host application remains paused until explicitly started.
 
 ## ROMs
 

--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Oric/Views/OricInfoView.axaml
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Oric/Views/OricInfoView.axaml
@@ -62,7 +62,7 @@
             <TextBlock Text="Alt" Classes="small"/>
           </Border>
           <Border Grid.Row="1" Grid.Column="3" Classes="table-cell-last-column">
-            <TextBlock Text="Option (⌥)" Classes="small"/>
+            <TextBlock Text="Option" Classes="small"/>
           </Border>
 
           <Border Grid.Row="2" Grid.Column="0" Classes="table-cell">
@@ -75,7 +75,7 @@
             <TextBlock Text="Backspace" Classes="small"/>
           </Border>
           <Border Grid.Row="2" Grid.Column="3" Classes="table-cell-last-column">
-            <TextBlock Text="Delete (⌫)" Classes="small"/>
+            <TextBlock Text="Delete" Classes="small"/>
           </Border>
 
           <Border Grid.Row="3" Grid.Column="0" Classes="table-cell">
@@ -88,7 +88,7 @@
             <TextBlock Text="Enter" Classes="small"/>
           </Border>
           <Border Grid.Row="3" Grid.Column="3" Classes="table-cell-last-column">
-            <TextBlock Text="Return (↩)" Classes="small"/>
+            <TextBlock Text="Return" Classes="small"/>
           </Border>
 
           <Border Grid.Row="4" Grid.Column="0" Classes="table-cell">

--- a/src/libraries/Highbyte.DotNet6502.Systems.Oric/Audio/Ay38912.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Oric/Audio/Ay38912.cs
@@ -212,4 +212,69 @@ public sealed class Ay38912
             _envelopeStep = _envelopeDirection > 0 ? 0 : 15;
         }
     }
+
+    internal Ay38912SnapshotState GetSnapshotState()
+        => new(
+            _registers.ToArray(),
+            SelectedRegister,
+            _toneCounter.ToArray(),
+            _toneHigh.ToArray(),
+            _sampleCycleAccumulator,
+            _noiseCounter,
+            _noiseHigh,
+            _noiseLfsr,
+            _envelopeCounter,
+            _envelopeStep,
+            _envelopeDirection,
+            _envelopeHolding);
+
+    internal void RestoreSnapshotState(Ay38912SnapshotState state)
+    {
+        if (state.Registers.Length != RegisterCount)
+            throw new ArgumentException($"AY snapshot must contain {RegisterCount} registers.", nameof(state));
+        if (state.ToneCounters.Length != 3 || state.ToneHigh.Length != 3)
+            throw new ArgumentException("AY snapshot must contain state for three tone channels.", nameof(state));
+        ArgumentOutOfRangeException.ThrowIfNegative(state.SelectedRegister);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(state.SelectedRegister, RegisterCount);
+        if (state.ToneCounters.Any(counter => counter <= 0) ||
+            !double.IsFinite(state.SampleCycleAccumulator) ||
+            state.SampleCycleAccumulator < 0 ||
+            state.SampleCycleAccumulator >= (double)_clockHz / _sampleRateHz ||
+            state.NoiseCounter <= 0 ||
+            state.NoiseLfsr is 0 or > 0x1ffff ||
+            state.EnvelopeCounter <= 0 ||
+            state.EnvelopeStep is < 0 or > 15 ||
+            state.EnvelopeDirection is not (-1 or 1))
+        {
+            throw new ArgumentException("AY snapshot contains an invalid generator phase.", nameof(state));
+        }
+
+        Array.Copy(state.Registers, _registers, RegisterCount);
+        SelectedRegister = state.SelectedRegister;
+        Array.Copy(state.ToneCounters, _toneCounter, _toneCounter.Length);
+        Array.Copy(state.ToneHigh, _toneHigh, _toneHigh.Length);
+        _sampleCycleAccumulator = state.SampleCycleAccumulator;
+        _noiseCounter = state.NoiseCounter;
+        _noiseHigh = state.NoiseHigh;
+        _noiseLfsr = state.NoiseLfsr;
+        _envelopeCounter = state.EnvelopeCounter;
+        _envelopeStep = state.EnvelopeStep;
+        _envelopeDirection = state.EnvelopeDirection;
+        _envelopeHolding = state.EnvelopeHolding;
+        PortAOutputChanged?.Invoke(PortAOutput);
+    }
 }
+
+internal readonly record struct Ay38912SnapshotState(
+    byte[] Registers,
+    int SelectedRegister,
+    int[] ToneCounters,
+    bool[] ToneHigh,
+    double SampleCycleAccumulator,
+    int NoiseCounter,
+    bool NoiseHigh,
+    uint NoiseLfsr,
+    int EnvelopeCounter,
+    int EnvelopeStep,
+    int EnvelopeDirection,
+    bool EnvelopeHolding);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Oric/Config/OricSystemConfig.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Oric/Config/OricSystemConfig.cs
@@ -3,13 +3,14 @@ using Highbyte.DotNet6502.Systems.Configuration;
 using Highbyte.DotNet6502.Systems.Oric.Audio;
 using Highbyte.DotNet6502.Systems.Oric.Input;
 using Highbyte.DotNet6502.Systems.Oric.Render;
+using Highbyte.DotNet6502.Systems.Snapshots;
 using Highbyte.DotNet6502.Utils;
 using OricMachine = Highbyte.DotNet6502.Systems.Oric.Oric;
 
 namespace Highbyte.DotNet6502.Systems.Oric.Config;
 
 /// <summary>User-facing configuration for the Oric family.</summary>
-public sealed class OricSystemConfig : ISystemConfig
+public sealed partial class OricSystemConfig : ISystemConfig, ISnapshotableConfig
 {
     public const string SystemRomName = "basic";
     public const string RomSourceInfoUrl = "https://abdess.github.io/retrobios/emulators/oricutron/";

--- a/src/libraries/Highbyte.DotNet6502.Systems.Oric/Config/OricSystemConfigSnapshot.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Oric/Config/OricSystemConfigSnapshot.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Highbyte.DotNet6502.Systems.Oric.Input;
+
+namespace Highbyte.DotNet6502.Systems.Oric.Config;
+
+/// <summary>Portable Oric settings optionally carried in a snapshot config block.</summary>
+public sealed partial class OricSystemConfig
+{
+    public string? ExportSnapshotSettings()
+    {
+        var settings = new OricSystemSnapshotSettings
+        {
+            AudioEnabled = AudioEnabled,
+            VSyncHackEnabled = VSyncHackEnabled,
+            JoystickInterface = JoystickInterface,
+            KeyboardJoystickEnabled = KeyboardJoystickEnabled,
+            KeyboardJoystick = KeyboardJoystick,
+            CpuCompatibilityProfile = CpuCompatibilityProfile,
+        };
+        return JsonSerializer.Serialize(
+            settings,
+            OricSystemSnapshotSettingsJsonContext.Default.OricSystemSnapshotSettings);
+    }
+
+    public void ApplySnapshotSettings(string payload)
+    {
+        var settings = JsonSerializer.Deserialize(
+            payload,
+            OricSystemSnapshotSettingsJsonContext.Default.OricSystemSnapshotSettings);
+        if (settings is null)
+            return;
+
+        AudioEnabled = settings.AudioEnabled;
+        VSyncHackEnabled = settings.VSyncHackEnabled;
+        JoystickInterface = settings.JoystickInterface;
+        KeyboardJoystickEnabled = settings.KeyboardJoystickEnabled;
+        KeyboardJoystick = settings.KeyboardJoystick;
+        CpuCompatibilityProfile = settings.CpuCompatibilityProfile;
+    }
+}
+
+internal sealed class OricSystemSnapshotSettings
+{
+    public bool AudioEnabled { get; set; } = true;
+    public bool VSyncHackEnabled { get; set; }
+    public OricJoystickInterface JoystickInterface { get; set; } = OricJoystickInterface.None;
+    public bool KeyboardJoystickEnabled { get; set; }
+    public int KeyboardJoystick { get; set; } = 1;
+    public CpuCompatibilityProfile CpuCompatibilityProfile { get; set; } = CpuCompatibilityProfile.StableUnofficial;
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(OricSystemSnapshotSettings))]
+internal partial class OricSystemSnapshotSettingsJsonContext : JsonSerializerContext
+{
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Oric/Hardware/OricRasterClock.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Oric/Hardware/OricRasterClock.cs
@@ -66,4 +66,16 @@ public sealed class OricRasterClock
         CycleInLine = 0;
         FrameNumber = 0;
     }
+
+    internal void RestoreSnapshotState(int rasterLine, int cycleInLine, ulong frameNumber)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(rasterLine);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rasterLine, OricConfig.LinesPerFrame);
+        ArgumentOutOfRangeException.ThrowIfNegative(cycleInLine);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(cycleInLine, OricConfig.CyclesPerLine);
+
+        RasterLine = rasterLine;
+        CycleInLine = cycleInLine;
+        FrameNumber = frameNumber;
+    }
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Oric/Hardware/Via6522.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Oric/Hardware/Via6522.cs
@@ -294,4 +294,78 @@ public sealed class Via6522
     }
 
     private void UpdateIrq() => _irqChanged(IrqActive);
+
+    internal Via6522SnapshotState GetSnapshotState()
+        => new(
+            _portA,
+            _portB,
+            _ddrA,
+            _ddrB,
+            _shiftRegister,
+            _acr,
+            _pcr,
+            _ifr,
+            _ier,
+            _timer1Counter,
+            _timer1Latch,
+            _timer2Counter,
+            _timer2LatchLow,
+            _timer1Running,
+            _timer2Running,
+            _ca1,
+            _cb1,
+            _ca2,
+            _cb2);
+
+    internal void RestoreSnapshotState(Via6522SnapshotState state)
+    {
+        _portA = state.PortA;
+        _portB = state.PortB;
+        _ddrA = state.DataDirectionA;
+        _ddrB = state.DataDirectionB;
+        _shiftRegister = state.ShiftRegister;
+        _acr = state.AuxiliaryControl;
+        _pcr = state.PeripheralControl;
+        _ifr = (byte)(state.InterruptFlags & 0x7f);
+        _ier = (byte)(state.InterruptEnable & 0x7f);
+        _timer1Counter = state.Timer1Counter;
+        _timer1Latch = state.Timer1Latch;
+        _timer2Counter = state.Timer2Counter;
+        _timer2LatchLow = state.Timer2LatchLow;
+        _timer1Running = state.Timer1Running;
+        _timer2Running = state.Timer2Running;
+        _ca1 = state.Ca1;
+        _cb1 = state.Cb1;
+        _ca2 = state.Ca2;
+        _cb2 = state.Cb2;
+
+        // Re-establish the board wiring derived from the chip pins and latches. The Oric callbacks
+        // update its AY bus control lines and CPU IRQ source without mutating the restored VIA state.
+        _writeCa2(_ca2);
+        _writeCb2(_cb2);
+        _writePortAOutput(_portA);
+        _writePortBOutput(_portB);
+        _irqChanged(IrqActive);
+    }
 }
+
+internal readonly record struct Via6522SnapshotState(
+    byte PortA,
+    byte PortB,
+    byte DataDirectionA,
+    byte DataDirectionB,
+    byte ShiftRegister,
+    byte AuxiliaryControl,
+    byte PeripheralControl,
+    byte InterruptFlags,
+    byte InterruptEnable,
+    ushort Timer1Counter,
+    ushort Timer1Latch,
+    ushort Timer2Counter,
+    byte Timer2LatchLow,
+    bool Timer1Running,
+    bool Timer2Running,
+    bool Ca1,
+    bool Cb1,
+    bool Ca2,
+    bool Cb2);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Oric/Oric.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Oric/Oric.cs
@@ -6,9 +6,11 @@ using Highbyte.DotNet6502.Systems.Oric.Config;
 using Highbyte.DotNet6502.Systems.Oric.Hardware;
 using Highbyte.DotNet6502.Systems.Oric.Input;
 using Highbyte.DotNet6502.Systems.Oric.Render;
+using Highbyte.DotNet6502.Systems.Oric.Snapshots;
 using Highbyte.DotNet6502.Systems.Oric.Tape;
 using Highbyte.DotNet6502.Systems.Oric.Utils;
 using Highbyte.DotNet6502.Systems.Rendering;
+using Highbyte.DotNet6502.Systems.Snapshots;
 using Highbyte.DotNet6502.Utils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -16,13 +18,14 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Highbyte.DotNet6502.Systems.Oric;
 
 /// <summary>Oric Atmos 48K with a PAL ULA, MOS 6522 and AY-3-8912.</summary>
-public sealed class Oric : ISystem, ITextMode, IScreen, ISystemState
+public sealed class Oric : ISystem, ITextMode, IScreen, ISystemState, ISystemSnapshotProvider
 {
     public const string SystemName = "Oric";
     public const ushort ViaStartAddress = 0x0300;
     public const ushort ViaEndAddress = 0x03ff;
     public const ushort SystemRomStartAddress = 0xc000;
     public const int SystemRomSize = 0x4000;
+    public const int RamSize = SystemRomStartAddress;
     public const ushort BasicProgramDefaultStartAddress = 0x0501;
     public const ushort BasicProgramStartPointerAddress = 0x009a;
     public const ushort BasicProgramEndPointerAddress = 0x009c;
@@ -132,6 +135,8 @@ public sealed class Oric : ISystem, ITextMode, IScreen, ISystemState
     public OricBasicTokenParser BasicTokenParser { get; }
     public OricTape Tape { get; }
     public bool HasSystemRom => _hasSystemRom;
+    internal bool VSyncHackEnabled => _vSyncHackEnabled;
+    internal byte[] SnapshotRam => _ram;
 
     public int TextCols => OricConfig.Columns;
     public int TextRows => OricConfig.VisibleHeight / OricConfig.CharacterHeight;
@@ -486,4 +491,27 @@ public sealed class Oric : ISystem, ITextMode, IScreen, ISystemState
         else
             CPU.CPUInterrupts.SetIRQSourceInactive(ViaIrqSource);
     }
+
+    // --- Snapshot support ---
+
+    public const int SnapshotVersion = 1;
+
+    private readonly IReadOnlyList<ISnapshotModule> _snapshotModules = new ISnapshotModule[]
+    {
+        new Cpu6502SnapshotModule(),
+        new OricCoreSnapshotModule(),
+        // The VIA callbacks restore the Oric-side AY bus control lines. The AY module follows it
+        // so any callback-triggered register access is overwritten by the exact captured AY state.
+        new OricViaSnapshotModule(),
+        new OricAySnapshotModule(),
+        new OricRasterSnapshotModule(),
+        new OricTapeSnapshotModule(),
+    };
+
+    public SnapshotMachineId MachineId => new(SystemName, SnapshotVersion);
+
+    public IReadOnlyList<ISnapshotModule> GetSnapshotModules() => _snapshotModules;
+
+    public SnapshotCompatibility ValidateSnapshot(SnapshotManifest manifest)
+        => SnapshotCompatibility.Compatible();
 }

--- a/src/libraries/Highbyte.DotNet6502.Systems.Oric/Render/OricRasterizer.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Oric/Render/OricRasterizer.cs
@@ -141,6 +141,24 @@ public sealed class OricRasterizer : IRenderProvider, IVideoFrameLayerProvider
         ClearBackBuffers();
     }
 
+    internal (byte ScreenAttributes, int FrameCounter, bool ProgressiveFrameActive) GetSnapshotState()
+        => (_screenAttributes, _frameCounter, _progressiveFrameActive);
+
+    internal void RestoreSnapshotState(byte screenAttributes, int frameCounter, bool progressiveFrameActive)
+    {
+        // Present a complete image immediately while retaining the captured serial attribute and
+        // frame phase for the next scanline. Earlier lines of a mid-frame raster-effect image are
+        // reconstructed from current RAM, matching the other renderers' restore-time rebuild model.
+        _frameCounter = frameCounter;
+        _screenAttributes = screenAttributes;
+        RasterizeFrame();
+        FlipBuffers();
+        _screenAttributes = screenAttributes;
+        RasterizeFrame();
+        _screenAttributes = screenAttributes;
+        _progressiveFrameActive = progressiveFrameActive;
+    }
+
     private void RasterizeFrame()
     {
         ClearBackBuffers();

--- a/src/libraries/Highbyte.DotNet6502.Systems.Oric/Render/OricVideoCommandStream.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Oric/Render/OricVideoCommandStream.cs
@@ -69,6 +69,18 @@ public sealed class OricVideoCommandStream : IRenderProvider, IVideoCommandStrea
         }
     }
 
+    internal int SnapshotFrameCounter => _frameCounter;
+
+    internal void RestoreSnapshotState(int frameCounter)
+    {
+        lock (_commandsLock)
+        {
+            _frameCounter = frameCounter;
+            _commands.Clear();
+            GenerateCommands();
+        }
+    }
+
     public static string ScreenCodeToUnicode(byte screenCode)
     {
         var character = (byte)(screenCode & 0x7f);

--- a/src/libraries/Highbyte.DotNet6502.Systems.Oric/Snapshots/OricAySnapshotModule.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Oric/Snapshots/OricAySnapshotModule.cs
@@ -1,0 +1,71 @@
+using Highbyte.DotNet6502.Systems.Oric.Audio;
+using Highbyte.DotNet6502.Systems.Snapshots;
+
+namespace Highbyte.DotNet6502.Systems.Oric.Snapshots;
+
+/// <summary>Snapshot module for AY-3-8912 registers and deterministic generator phase.</summary>
+public sealed class OricAySnapshotModule : ISnapshotModule
+{
+    public const string ModuleName = "oric-ay";
+
+    public string Name => ModuleName;
+    public int Version => 1;
+    public bool Required => true;
+
+    public void Capture(SnapshotModuleWriter writer, SnapshotCaptureContext context)
+    {
+        var state = ((Oric)context.System).Ay.GetSnapshotState();
+        writer.WriteBytes(state.Registers);
+        writer.WriteInt32(state.SelectedRegister);
+        for (var channel = 0; channel < state.ToneCounters.Length; channel++)
+        {
+            writer.WriteInt32(state.ToneCounters[channel]);
+            writer.WriteBool(state.ToneHigh[channel]);
+        }
+        writer.WriteUInt64(BitConverter.DoubleToUInt64Bits(state.SampleCycleAccumulator));
+        writer.WriteInt32(state.NoiseCounter);
+        writer.WriteBool(state.NoiseHigh);
+        writer.WriteUInt32(state.NoiseLfsr);
+        writer.WriteInt32(state.EnvelopeCounter);
+        writer.WriteInt32(state.EnvelopeStep);
+        writer.WriteInt32(state.EnvelopeDirection);
+        writer.WriteBool(state.EnvelopeHolding);
+    }
+
+    public void Restore(SnapshotModuleReader reader, SnapshotRestoreContext context)
+    {
+        var registers = reader.ReadBytes()
+            ?? throw new SnapshotException("oric-ay: register bytes were missing from the snapshot.");
+        var selectedRegister = reader.ReadInt32();
+        var toneCounters = new int[3];
+        var toneHigh = new bool[3];
+        for (var channel = 0; channel < toneCounters.Length; channel++)
+        {
+            toneCounters[channel] = reader.ReadInt32();
+            toneHigh[channel] = reader.ReadBool();
+        }
+
+        var state = new Ay38912SnapshotState(
+            Registers: registers,
+            SelectedRegister: selectedRegister,
+            ToneCounters: toneCounters,
+            ToneHigh: toneHigh,
+            SampleCycleAccumulator: BitConverter.UInt64BitsToDouble(reader.ReadUInt64()),
+            NoiseCounter: reader.ReadInt32(),
+            NoiseHigh: reader.ReadBool(),
+            NoiseLfsr: reader.ReadUInt32(),
+            EnvelopeCounter: reader.ReadInt32(),
+            EnvelopeStep: reader.ReadInt32(),
+            EnvelopeDirection: reader.ReadInt32(),
+            EnvelopeHolding: reader.ReadBool());
+
+        try
+        {
+            ((Oric)context.System).Ay.RestoreSnapshotState(state);
+        }
+        catch (ArgumentException exception)
+        {
+            throw new SnapshotException($"oric-ay: invalid generator state: {exception.Message}");
+        }
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Oric/Snapshots/OricCoreSnapshotModule.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Oric/Snapshots/OricCoreSnapshotModule.cs
@@ -1,0 +1,41 @@
+using Highbyte.DotNet6502.Systems.Snapshots;
+
+namespace Highbyte.DotNet6502.Systems.Oric.Snapshots;
+
+/// <summary>Snapshot module for the Oric's 48 KB RAM and fixed machine wiring.</summary>
+public sealed class OricCoreSnapshotModule : ISnapshotModule
+{
+    public const string ModuleName = "oric-core";
+
+    public string Name => ModuleName;
+    public int Version => 1;
+    public bool Required => true;
+
+    public void Capture(SnapshotModuleWriter writer, SnapshotCaptureContext context)
+    {
+        var oric = (Oric)context.System;
+        writer.WriteBool(oric.VSyncHackEnabled);
+        writer.WriteBytes(oric.SnapshotRam.AsSpan(0, Oric.RamSize).ToArray());
+    }
+
+    public void Restore(SnapshotModuleReader reader, SnapshotRestoreContext context)
+    {
+        var oric = (Oric)context.System;
+        var capturedVSyncHackEnabled = reader.ReadBool();
+        if (capturedVSyncHackEnabled != oric.VSyncHackEnabled)
+        {
+            context.AddWarning(
+                $"oric-core: snapshot VSync modification setting '{capturedVSyncHackEnabled}' differs from target '{oric.VSyncHackEnabled}'.");
+        }
+
+        var ram = reader.ReadBytes()
+            ?? throw new SnapshotException("oric-core: RAM bytes were missing from the snapshot.");
+        if (ram.Length != Oric.RamSize)
+        {
+            throw new SnapshotException(
+                $"oric-core: snapshot RAM size {ram.Length} does not match target {Oric.RamSize}.");
+        }
+
+        Array.Copy(ram, oric.SnapshotRam, ram.Length);
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Oric/Snapshots/OricRasterSnapshotModule.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Oric/Snapshots/OricRasterSnapshotModule.cs
@@ -1,0 +1,60 @@
+using Highbyte.DotNet6502.Systems.Oric.Render;
+using Highbyte.DotNet6502.Systems.Snapshots;
+
+namespace Highbyte.DotNet6502.Systems.Oric.Snapshots;
+
+/// <summary>Snapshot module for PAL raster position and renderer flash/attribute phase.</summary>
+public sealed class OricRasterSnapshotModule : ISnapshotModule
+{
+    public const string ModuleName = "oric-raster";
+
+    public string Name => ModuleName;
+    public int Version => 1;
+    public bool Required => true;
+
+    public void Capture(SnapshotModuleWriter writer, SnapshotCaptureContext context)
+    {
+        var oric = (Oric)context.System;
+        writer.WriteInt32(oric.RasterClock.RasterLine);
+        writer.WriteInt32(oric.RasterClock.CycleInLine);
+        writer.WriteUInt64(oric.RasterClock.FrameNumber);
+
+        var rasterizer = oric.RenderProviders.OfType<OricRasterizer>().Single();
+        var rasterizerState = rasterizer.GetSnapshotState();
+        writer.WriteByte(rasterizerState.ScreenAttributes);
+        writer.WriteInt32(rasterizerState.FrameCounter);
+        writer.WriteBool(rasterizerState.ProgressiveFrameActive);
+
+        var commandStream = oric.RenderProviders.OfType<OricVideoCommandStream>().Single();
+        writer.WriteInt32(commandStream.SnapshotFrameCounter);
+    }
+
+    public void Restore(SnapshotModuleReader reader, SnapshotRestoreContext context)
+    {
+        var oric = (Oric)context.System;
+        var rasterLine = reader.ReadInt32();
+        var cycleInLine = reader.ReadInt32();
+        var frameNumber = reader.ReadUInt64();
+        if (rasterLine < 0 || rasterLine >= OricConfig.LinesPerFrame ||
+            cycleInLine < 0 || cycleInLine >= OricConfig.CyclesPerLine)
+        {
+            throw new SnapshotException(
+                $"oric-raster: invalid raster position line {rasterLine}, cycle {cycleInLine}.");
+        }
+        oric.RasterClock.RestoreSnapshotState(rasterLine, cycleInLine, frameNumber);
+
+        var screenAttributes = reader.ReadByte();
+        var rasterizerFrameCounter = reader.ReadInt32();
+        var progressiveFrameActive = reader.ReadBool();
+        var commandStreamFrameCounter = reader.ReadInt32();
+        if ((screenAttributes & 0xf8) != 0)
+            throw new SnapshotException($"oric-raster: invalid screen attributes ${screenAttributes:X2}.");
+
+        oric.RenderProviders.OfType<OricRasterizer>().Single().RestoreSnapshotState(
+            screenAttributes,
+            rasterizerFrameCounter,
+            progressiveFrameActive);
+        oric.RenderProviders.OfType<OricVideoCommandStream>().Single().RestoreSnapshotState(
+            commandStreamFrameCounter);
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Oric/Snapshots/OricTapeSnapshotModule.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Oric/Snapshots/OricTapeSnapshotModule.cs
@@ -1,0 +1,56 @@
+using Highbyte.DotNet6502.Systems.Snapshots;
+
+namespace Highbyte.DotNet6502.Systems.Oric.Snapshots;
+
+/// <summary>Snapshot module for the inserted TAP image and its byte-level transport position.</summary>
+public sealed class OricTapeSnapshotModule : ISnapshotModule
+{
+    public const string ModuleName = "oric-tape";
+    public const string MediaId = "tape";
+    public const string MediaKind = "tap";
+
+    public string Name => ModuleName;
+    public int Version => 1;
+    public bool Required => true;
+
+    public void Capture(SnapshotModuleWriter writer, SnapshotCaptureContext context)
+    {
+        var tape = ((Oric)context.System).Tape;
+        var data = tape.SnapshotData;
+        writer.WriteBool(data is not null);
+        writer.WriteInt32(tape.Position);
+        writer.WriteString(tape.SourceName);
+        if (data is not null)
+            context.AddEmbeddedMedia(MediaId, MediaKind, tape.SourceName, data);
+    }
+
+    public void Restore(SnapshotModuleReader reader, SnapshotRestoreContext context)
+    {
+        var inserted = reader.ReadBool();
+        var position = reader.ReadInt32();
+        var sourceName = reader.ReadString();
+        var tape = ((Oric)context.System).Tape;
+
+        if (!inserted)
+        {
+            tape.RestoreSnapshotState(data: null, sourceName: null, position: 0);
+            return;
+        }
+
+        if (!context.TryGetEmbeddedMedia(MediaId, out var data))
+        {
+            tape.Eject();
+            context.AddWarning("oric-tape: snapshot marked a tape inserted but no embedded TAP image was found.");
+            return;
+        }
+
+        try
+        {
+            tape.RestoreSnapshotState(data, sourceName, position);
+        }
+        catch (Exception exception) when (exception is InvalidDataException or ArgumentOutOfRangeException)
+        {
+            throw new SnapshotException($"oric-tape: invalid transport state: {exception.Message}");
+        }
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Oric/Snapshots/OricViaSnapshotModule.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Oric/Snapshots/OricViaSnapshotModule.cs
@@ -1,0 +1,63 @@
+using Highbyte.DotNet6502.Systems.Oric.Hardware;
+using Highbyte.DotNet6502.Systems.Snapshots;
+
+namespace Highbyte.DotNet6502.Systems.Oric.Snapshots;
+
+/// <summary>Snapshot module for all live MOS 6522 register, timer, pin and interrupt state.</summary>
+public sealed class OricViaSnapshotModule : ISnapshotModule
+{
+    public const string ModuleName = "oric-via";
+
+    public string Name => ModuleName;
+    public int Version => 1;
+    public bool Required => true;
+
+    public void Capture(SnapshotModuleWriter writer, SnapshotCaptureContext context)
+    {
+        var state = ((Oric)context.System).Via.GetSnapshotState();
+        writer.WriteByte(state.PortA);
+        writer.WriteByte(state.PortB);
+        writer.WriteByte(state.DataDirectionA);
+        writer.WriteByte(state.DataDirectionB);
+        writer.WriteByte(state.ShiftRegister);
+        writer.WriteByte(state.AuxiliaryControl);
+        writer.WriteByte(state.PeripheralControl);
+        writer.WriteByte(state.InterruptFlags);
+        writer.WriteByte(state.InterruptEnable);
+        writer.WriteUInt16(state.Timer1Counter);
+        writer.WriteUInt16(state.Timer1Latch);
+        writer.WriteUInt16(state.Timer2Counter);
+        writer.WriteByte(state.Timer2LatchLow);
+        writer.WriteBool(state.Timer1Running);
+        writer.WriteBool(state.Timer2Running);
+        writer.WriteBool(state.Ca1);
+        writer.WriteBool(state.Cb1);
+        writer.WriteBool(state.Ca2);
+        writer.WriteBool(state.Cb2);
+    }
+
+    public void Restore(SnapshotModuleReader reader, SnapshotRestoreContext context)
+    {
+        var state = new Via6522SnapshotState(
+            PortA: reader.ReadByte(),
+            PortB: reader.ReadByte(),
+            DataDirectionA: reader.ReadByte(),
+            DataDirectionB: reader.ReadByte(),
+            ShiftRegister: reader.ReadByte(),
+            AuxiliaryControl: reader.ReadByte(),
+            PeripheralControl: reader.ReadByte(),
+            InterruptFlags: reader.ReadByte(),
+            InterruptEnable: reader.ReadByte(),
+            Timer1Counter: reader.ReadUInt16(),
+            Timer1Latch: reader.ReadUInt16(),
+            Timer2Counter: reader.ReadUInt16(),
+            Timer2LatchLow: reader.ReadByte(),
+            Timer1Running: reader.ReadBool(),
+            Timer2Running: reader.ReadBool(),
+            Ca1: reader.ReadBool(),
+            Cb1: reader.ReadBool(),
+            Ca2: reader.ReadBool(),
+            Cb2: reader.ReadBool());
+        ((Oric)context.System).Via.RestoreSnapshotState(state);
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502.Systems.Oric/Tape/OricTape.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Oric/Tape/OricTape.cs
@@ -116,6 +116,22 @@ public sealed class OricTape
         return true;
     }
 
+    internal byte[]? SnapshotData => _data?.ToArray();
+
+    internal void RestoreSnapshotState(byte[]? data, string? sourceName, int position)
+    {
+        if (data is null)
+        {
+            Eject();
+            return;
+        }
+
+        if (position < 0 || position > data.Length)
+            throw new ArgumentOutOfRangeException(nameof(position), position, "Tape position must be within the image.");
+        Insert(data, sourceName);
+        Position = position;
+    }
+
     private int GetPreviousRecordIndex()
     {
         var currentIndex = CurrentRecordIndex;

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/OricSnapshotRoundTripTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/OricSnapshotRoundTripTests.cs
@@ -1,0 +1,223 @@
+using System.Text;
+using Highbyte.DotNet6502.Systems.Oric;
+using Highbyte.DotNet6502.Systems.Oric.Audio;
+using Highbyte.DotNet6502.Systems.Oric.Render;
+using Highbyte.DotNet6502.Systems.Oric.Snapshots;
+using Highbyte.DotNet6502.Systems.Oric.Tape;
+using Highbyte.DotNet6502.Systems.Snapshots;
+using Microsoft.Extensions.Logging.Abstractions;
+using OricMachine = Highbyte.DotNet6502.Systems.Oric.Oric;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Snapshots;
+
+public sealed class OricSnapshotRoundTripTests
+{
+    private const ushort ProgramStart = 0x0600;
+
+    private static readonly byte[] s_program =
+    [
+        0xe8,                   // INX
+        0xc8,                   // INY
+        0xea,                   // NOP
+        0x4c, 0x00, 0x06,       // JMP $0600
+    ];
+
+    [Fact]
+    public void Oric_implements_snapshot_provider_with_all_machine_modules()
+    {
+        var provider = (ISystemSnapshotProvider)BuildOric();
+
+        Assert.Equal(OricMachine.SystemName, provider.MachineId.SystemName);
+        Assert.Equal(OricMachine.SnapshotVersion, provider.MachineId.SupportedSnapshotVersion);
+        Assert.Equal(
+            [
+                Cpu6502SnapshotModule.ModuleName,
+                OricCoreSnapshotModule.ModuleName,
+                OricViaSnapshotModule.ModuleName,
+                OricAySnapshotModule.ModuleName,
+                OricRasterSnapshotModule.ModuleName,
+                OricTapeSnapshotModule.ModuleName,
+            ],
+            provider.GetSnapshotModules().Select(module => module.Name));
+    }
+
+    [Fact]
+    public void Round_trip_restores_machine_timing_audio_and_inserted_tape_then_resumes_deterministically()
+    {
+        var source = BuildOric();
+        for (var index = 0; index < s_program.Length; index++)
+            source.Mem[(ushort)(ProgramStart + index)] = s_program[index];
+        source.Mem[0x9000] = 0xa5;
+        source.Mem[0xbb80] = (byte)'S';
+        source.CPU.PC = ProgramStart;
+        source.CPU.A = 0x42;
+
+        ConfigureVia(source);
+        ConfigureAy(source);
+
+        var firstTape = BuildTap("FIRST", [0x01, 0x02]);
+        var secondTape = BuildTap("SECOND", [0x03, 0x04, 0x05]);
+        byte[] tapeData = [.. firstTape, 0x00, .. secondTape];
+        source.InsertTape(tapeData, "session.tap");
+        Assert.True(source.SeekToNextTapeRecord());
+
+        for (var instruction = 0; instruction < 80; instruction++)
+            source.ExecuteOneInstruction(out _);
+
+        Span<float> warmupSamples = stackalloc float[128];
+        Assert.True(source.Ay.AdvanceCycles(1_234, warmupSamples) > 0);
+
+        using var snapshotStream = new MemoryStream();
+        var service = new SnapshotService();
+        service.Save(source, snapshotStream);
+
+        snapshotStream.Position = 0;
+        var restored = BuildOric();
+        var result = service.Restore(restored, snapshotStream);
+
+        Assert.Empty(result.Warnings);
+        Assert.Equal(OricMachine.SystemName, result.Manifest.Machine.SystemName);
+        Assert.Contains(result.Manifest.Media, media => media.Id == OricTapeSnapshotModule.MediaId);
+
+        Assert.Equal(source.CPU.PC, restored.CPU.PC);
+        Assert.Equal(source.CPU.A, restored.CPU.A);
+        Assert.Equal(source.CPU.X, restored.CPU.X);
+        Assert.Equal(source.CPU.Y, restored.CPU.Y);
+        Assert.Equal(source.CPU.ExecState.CyclesConsumed, restored.CPU.ExecState.CyclesConsumed);
+        Assert.Equal((byte)0xa5, restored.Mem[0x9000]);
+        Assert.Equal((byte)'S', restored.Mem[0xbb80]);
+
+        Assert.Equal(source.Via.PortAOutput, restored.Via.PortAOutput);
+        Assert.Equal(source.Via.PortBOutput, restored.Via.PortBOutput);
+        Assert.Equal(source.Via.DataDirectionA, restored.Via.DataDirectionA);
+        Assert.Equal(source.Via.DataDirectionB, restored.Via.DataDirectionB);
+        Assert.Equal(source.Via.InterruptEnable, restored.Via.InterruptEnable);
+        Assert.Equal(source.Via.InterruptFlags, restored.Via.InterruptFlags);
+        Assert.Equal(source.Via.Ca2, restored.Via.Ca2);
+        Assert.Equal(source.Via.Cb2, restored.Via.Cb2);
+        Assert.Equal(source.Via.Read(0x0a), restored.Via.Read(0x0a));
+        Assert.Equal(source.Via.Read(0x0b), restored.Via.Read(0x0b));
+        Assert.Equal(source.Via.Read(0x0c), restored.Via.Read(0x0c));
+
+        Assert.Equal(source.Ay.SelectedRegister, restored.Ay.SelectedRegister);
+        for (var register = 0; register < Ay38912.RegisterCount; register++)
+            Assert.Equal(source.Ay.ReadRegister(register), restored.Ay.ReadRegister(register));
+
+        Assert.Equal(source.RasterClock.FrameNumber, restored.RasterClock.FrameNumber);
+        Assert.Equal(source.RasterClock.RasterLine, restored.RasterClock.RasterLine);
+        Assert.Equal(source.RasterClock.CycleInLine, restored.RasterClock.CycleInLine);
+
+        Assert.True(restored.Tape.IsInserted);
+        Assert.Equal("session.tap", restored.Tape.SourceName);
+        Assert.Equal(source.Tape.Length, restored.Tape.Length);
+        Assert.Equal(source.Tape.Position, restored.Tape.Position);
+        Assert.Equal("SECOND", restored.Tape.CurrentFile?.Name);
+
+        for (var instruction = 0; instruction < 120; instruction++)
+        {
+            source.ExecuteOneInstruction(out _);
+            restored.ExecuteOneInstruction(out _);
+        }
+
+        Assert.Equal(source.CPU.PC, restored.CPU.PC);
+        Assert.Equal(source.CPU.X, restored.CPU.X);
+        Assert.Equal(source.CPU.Y, restored.CPU.Y);
+        Assert.Equal(source.RasterClock.RasterLine, restored.RasterClock.RasterLine);
+        Assert.Equal(source.RasterClock.CycleInLine, restored.RasterClock.CycleInLine);
+        Assert.Equal(ReadTimerOne(source), ReadTimerOne(restored));
+        Assert.Equal(ReadTimerTwo(source), ReadTimerTwo(restored));
+        Assert.Equal(source.Via.InterruptFlags, restored.Via.InterruptFlags);
+
+        source.ExecuteOneFrame();
+        restored.ExecuteOneFrame();
+        Assert.Equal(source.RasterClock.FrameNumber, restored.RasterClock.FrameNumber);
+        var sourceFrame = source.RenderProviders.OfType<OricRasterizer>().Single().CurrentFrontBuffer.ToArray();
+        var restoredFrame = restored.RenderProviders.OfType<OricRasterizer>().Single().CurrentFrontBuffer.ToArray();
+        Assert.Equal(sourceFrame, restoredFrame);
+
+        var sourceSamples = new float[128];
+        var restoredSamples = new float[128];
+        var sourceCount = source.Ay.AdvanceCycles(2_000, sourceSamples);
+        var restoredCount = restored.Ay.AdvanceCycles(2_000, restoredSamples);
+        Assert.Equal(sourceCount, restoredCount);
+        Assert.Equal(sourceSamples[..sourceCount], restoredSamples[..restoredCount]);
+    }
+
+    [Fact]
+    public void Restore_warns_when_target_vsync_modification_differs()
+    {
+        var source = BuildOric(vSyncHackEnabled: true);
+        using var snapshotStream = new MemoryStream();
+        var service = new SnapshotService();
+        service.Save(source, snapshotStream);
+
+        snapshotStream.Position = 0;
+        var result = service.Restore(BuildOric(vSyncHackEnabled: false), snapshotStream);
+
+        Assert.Contains(result.Warnings, warning => warning.Contains("VSync", StringComparison.Ordinal));
+    }
+
+    private static OricMachine BuildOric(bool vSyncHackEnabled = false)
+        => new(
+            new OricConfig { AudioEnabled = false, VSyncHackEnabled = vSyncHackEnabled },
+            NullLoggerFactory.Instance);
+
+    private static void ConfigureVia(OricMachine oric)
+    {
+        oric.Via.Write(0x03, 0xff);
+        oric.Via.Write(0x02, 0x1f);
+        oric.Via.Write(0x01, 0x0e);
+        oric.Via.Write(0x00, 0x13);
+        oric.Via.Write(0x0a, 0x5a);
+        oric.Via.Write(0x0b, 0x40);
+        oric.Via.Write(0x0c, 0xee);
+        oric.Via.Write(0x04, 0x56);
+        oric.Via.Write(0x05, 0x04);
+        oric.Via.Write(0x08, 0xaa);
+        oric.Via.Write(0x09, 0x08);
+        oric.Via.Write(0x0e, 0xe0);
+    }
+
+    private static void ConfigureAy(OricMachine oric)
+    {
+        oric.Ay.WriteRegister(0, 0x09);
+        oric.Ay.WriteRegister(1, 0x03);
+        oric.Ay.WriteRegister(6, 0x07);
+        oric.Ay.WriteRegister(7, 0x38);
+        oric.Ay.WriteRegister(8, 0x1f);
+        oric.Ay.WriteRegister(11, 0x34);
+        oric.Ay.WriteRegister(12, 0x02);
+        oric.Ay.WriteRegister(13, 0x0e);
+        oric.Ay.SelectRegister(9);
+    }
+
+    private static ushort ReadTimerOne(OricMachine oric)
+    {
+        var high = oric.Via.Read(0x05);
+        var low = oric.Via.Read(0x04);
+        return (ushort)((high << 8) | low);
+    }
+
+    private static ushort ReadTimerTwo(OricMachine oric)
+    {
+        var high = oric.Via.Read(0x09);
+        var low = oric.Via.Read(0x08);
+        return (ushort)((high << 8) | low);
+    }
+
+    private static byte[] BuildTap(string name, byte[] payload)
+    {
+        var startAddress = OricMachine.BasicProgramDefaultStartAddress;
+        var endAddress = (ushort)(startAddress + payload.Length - 1);
+        return
+        [
+            0x16, 0x16, 0x16, 0x24,
+            0x00, 0x00, OricTapFile.BasicFileType, 0x00,
+            (byte)(endAddress >> 8), (byte)endAddress,
+            (byte)(startAddress >> 8), (byte)startAddress,
+            0x00,
+            .. Encoding.ASCII.GetBytes(name), 0x00,
+            .. payload,
+        ];
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/OricSystemConfigSnapshotTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/OricSystemConfigSnapshotTests.cs
@@ -1,0 +1,58 @@
+using Highbyte.DotNet6502.Systems.Oric.Config;
+using Highbyte.DotNet6502.Systems.Oric.Input;
+using Highbyte.DotNet6502.Systems.Snapshots;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Snapshots;
+
+public sealed class OricSystemConfigSnapshotTests
+{
+    [Fact]
+    public void Portable_settings_round_trip_through_export_and_apply()
+    {
+        var source = new OricSystemConfig
+        {
+            AudioEnabled = false,
+            VSyncHackEnabled = true,
+            JoystickInterface = OricJoystickInterface.IJK,
+            KeyboardJoystickEnabled = true,
+            KeyboardJoystick = 2,
+            CpuCompatibilityProfile = CpuCompatibilityProfile.FullUnofficial,
+        };
+
+        var json = ((ISnapshotableConfig)source).ExportSnapshotSettings();
+        Assert.False(string.IsNullOrEmpty(json));
+
+        var target = new OricSystemConfig();
+        ((ISnapshotableConfig)target).ApplySnapshotSettings(json!);
+
+        Assert.False(target.AudioEnabled);
+        Assert.True(target.VSyncHackEnabled);
+        Assert.Equal(OricJoystickInterface.IJK, target.JoystickInterface);
+        Assert.True(target.KeyboardJoystickEnabled);
+        Assert.Equal(2, target.KeyboardJoystick);
+        Assert.Equal(CpuCompatibilityProfile.FullUnofficial, target.CpuCompatibilityProfile);
+    }
+
+    [Fact]
+    public void Applying_a_payload_with_unknown_fields_uses_portable_defaults()
+    {
+        var config = new OricSystemConfig
+        {
+            AudioEnabled = false,
+            VSyncHackEnabled = true,
+            JoystickInterface = OricJoystickInterface.PASE,
+            KeyboardJoystickEnabled = true,
+            KeyboardJoystick = 2,
+            CpuCompatibilityProfile = CpuCompatibilityProfile.FullUnofficial,
+        };
+
+        ((ISnapshotableConfig)config).ApplySnapshotSettings("{\"somethingElse\":123}");
+
+        Assert.True(config.AudioEnabled);
+        Assert.False(config.VSyncHackEnabled);
+        Assert.Equal(OricJoystickInterface.None, config.JoystickInterface);
+        Assert.False(config.KeyboardJoystickEnabled);
+        Assert.Equal(1, config.KeyboardJoystick);
+        Assert.Equal(CpuCompatibilityProfile.StableUnofficial, config.CpuCompatibilityProfile);
+    }
+}


### PR DESCRIPTION
## Summary

- Add versioned Oric snapshot modules for CPU/RAM, VIA, AY audio state, raster/render state, and inserted TAP media.
- Preserve portable Oric configuration and restore execution, cassette, audio, interrupt, and rendering state through round-trip snapshots.
- Fix unsupported Mac key symbols in the Oric keyboard mapping table for Avalonia Browser WASM.
- Document Oric snapshot behavior and limitations.

## Verification

- Solution build passed with zero warnings and errors.
- Full test suite passed: 2,161 passed and 9 expected skips.
- New Oric snapshot/config tests passed.
- Source and changed-test formatting checks passed.
- Strict MkDocs build passed.
- Avalonia Browser build passed: 30 projects, zero warnings and errors.
- Live WASM inspection confirmed Option, Delete, and Return render correctly with no clipping or overlap; browser console had no warnings or errors.