### PR TITLE
Add Planeten to Oric Download & Run

### DIFF
--- a/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Oric/ViewModels/OricMenuViewModel.cs
+++ b/src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Shell.Oric/ViewModels/OricMenuViewModel.cs
@@ -43,6 +43,10 @@ public sealed class OricMenuViewModel : ViewModelBase, ISystemMenuContributor
         { "thehobbit", new OricDownloadProgramInfo(
             "The Hobbit",
             "https://cdn.oric.org/games/software/t/tansoft_editor/hobbit.tap") },
+        { "planeten", new OricDownloadProgramInfo(
+            "Planeten",
+            "https://www.skarstad.net/oric/tap/planeten.zip",
+            zipEntryName: "PLANETEN.TAP") },
         { "oricium", new OricDownloadProgramInfo(
             "Oricium",
             "https://raw.githubusercontent.com/Oric-Software-Development-Kit/Oric-Software/master/users/chema/Oricium/RELEASE/Oricium12.tap",

--- a/tools/cloudflare/cors-download-proxy/test/index.spec.ts
+++ b/tools/cloudflare/cors-download-proxy/test/index.spec.ts
@@ -70,6 +70,10 @@ describe("cors download proxy worker", () => {
 					hostname: "raw.githubusercontent.com",
 					pathname: "/Abdess/retrobios",
 				},
+				{
+					hostname: "www.skarstad.net",
+					pathname: "/oric/tap",
+				},
 			],
 		} as never;
 
@@ -99,6 +103,8 @@ describe("cors download proxy worker", () => {
 				config,
 			),
 		).toBe(false);
+		expect(isAllowedTargetUrl(new URL("https://www.skarstad.net/oric/tap/planeten.zip"), config)).toBe(true);
+		expect(isAllowedTargetUrl(new URL("https://www.skarstad.net/oric/books/manual.pdf"), config)).toBe(false);
 		expect(
 			isAllowedTargetUrl(
 				new URL("https://raw.githubusercontent.com/Oric-Software-Development-Kit/Other-Repo/file.tap"),
@@ -159,6 +165,10 @@ describe("cors download proxy worker", () => {
 					{
 						hostname: "raw.githubusercontent.com",
 						pathname: "/Abdess/retrobios",
+					},
+					{
+						hostname: "www.skarstad.net",
+						pathname: "/oric/tap",
 					},
 				],
 			},
@@ -244,6 +254,7 @@ describe("cors download proxy worker", () => {
 			allowedTargetPathPrefixes: [
 				"raw.githubusercontent.com/Oric-Software-Development-Kit/Oric-Software",
 				"raw.githubusercontent.com/Abdess/retrobios",
+				"www.skarstad.net/oric/tap",
 			],
 			rateLimits: {
 				burst: { limit: 8, periodSeconds: 10 },
@@ -301,6 +312,21 @@ describe("cors download proxy worker", () => {
 
 		expect(response.status).toBe(200);
 		expect(await response.text()).toBe("rom-bytes");
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("allows Planeten from the configured Swedish Oric tape archive", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("zip-bytes", { status: 200 }));
+		const request = new Request(
+			"https://proxy.test/fetch?url=https%3A%2F%2Fwww.skarstad.net%2Foric%2Ftap%2Fplaneten.zip",
+			{ headers: { Origin: "https://highbyte.se" } },
+		);
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, env, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("zip-bytes");
 		expect(fetchSpy).toHaveBeenCalledTimes(1);
 	});
 

--- a/tools/cloudflare/cors-download-proxy/worker-configuration.d.ts
+++ b/tools/cloudflare/cors-download-proxy/worker-configuration.d.ts
@@ -8,7 +8,7 @@ interface __BaseEnv_Env {
 	ALLOWED_ORIGINS: "https://highbyte.se";
 	ALLOW_LOCALHOST_ORIGINS: "true";
 	ALLOWED_TARGET_HOSTS: "www.zimmers.net,csdb.dk,compunet.live,highbyte.se,mirrors.apple2.org.za,archive.org,*.archive.org,cdn.oric.org";
-	ALLOWED_TARGET_PATH_PREFIXES: "raw.githubusercontent.com/Oric-Software-Development-Kit/Oric-Software,raw.githubusercontent.com/Abdess/retrobios";
+	ALLOWED_TARGET_PATH_PREFIXES: "raw.githubusercontent.com/Oric-Software-Development-Kit/Oric-Software,raw.githubusercontent.com/Abdess/retrobios,www.skarstad.net/oric/tap";
 	MAX_REDIRECTS: "5";
 	MAX_RESPONSE_BYTES: "33554432";
 }

--- a/tools/cloudflare/cors-download-proxy/wrangler.jsonc
+++ b/tools/cloudflare/cors-download-proxy/wrangler.jsonc
@@ -12,7 +12,7 @@
 		"ALLOWED_ORIGINS": "https://highbyte.se",
 		"ALLOW_LOCALHOST_ORIGINS": "true",
 		"ALLOWED_TARGET_HOSTS": "www.zimmers.net,csdb.dk,compunet.live,highbyte.se,mirrors.apple2.org.za,archive.org,*.archive.org,cdn.oric.org",
-		"ALLOWED_TARGET_PATH_PREFIXES": "raw.githubusercontent.com/Oric-Software-Development-Kit/Oric-Software,raw.githubusercontent.com/Abdess/retrobios",
+		"ALLOWED_TARGET_PATH_PREFIXES": "raw.githubusercontent.com/Oric-Software-Development-Kit/Oric-Software,raw.githubusercontent.com/Abdess/retrobios,www.skarstad.net/oric/tap",
 		"MAX_REDIRECTS": "5",
 		"MAX_RESPONSE_BYTES": "33554432"
 	},


### PR DESCRIPTION
## Summary

- Add Planeten to the Oric Download & Run catalog.
- Download its ZIP archive and select `PLANETEN.TAP` for loading.

## Validation

- Focused Oric Avalonia project build: 0 warnings, 0 errors.
- Downloaded the configured archive and confirmed it contains `PLANETEN.TAP`.
- `git diff --check` passed.
- Live UI verification was attempted, but macOS Screen Recording and Accessibility permissions were unavailable in the automation session.