### PR TITLE
Fix docs dependency audit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/jazzband/pip-tools
-    rev: v7.5.3
+    rev: v7.6.1
     hooks:
       - id: pip-compile
         name: pip-compile requirements-docs.in

--- a/requirements-docs.in
+++ b/requirements-docs.in
@@ -1,3 +1,4 @@
 mkdocs-material==9.7.6
+click>=8.3.3
 requests>=2.33.0
 urllib3>=2.7.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -152,10 +152,12 @@ charset-normalizer==3.4.7 \
     --hash=sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79 \
     --hash=sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464
     # via requests
-click==8.1.8 \
-    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
-    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
-    # via mkdocs
+click==8.5.0 \
+    --hash=sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360 \
+    --hash=sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34
+    # via
+    #   -r requirements-docs.in
+    #   mkdocs
 colorama==0.4.6 \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6


### PR DESCRIPTION
## Summary

- Pin Click to a patched minimum version and regenerate the hash-locked docs dependencies.
- Upgrade the pip-tools pre-commit hook to v7.6.1 for Pip 26.2 compatibility.

## Verification

- `pip-audit -r requirements-docs.txt`: no known vulnerabilities found.
- Hash-verified, binary-only install succeeds on Python 3.12.
- `mkdocs build --strict` succeeds.

Fixes #194