### PR TITLE
Add cycle-timing baselines, bitmask interrupt lines, C64 ROM test provisioning, and benchmark CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,121 @@
+name: Benchmarks
+
+# Manually dispatched BenchmarkDotNet run. GitHub-hosted runners are shared hardware, so the
+# absolute numbers are noisy and must not be compared across runs; the run exists to (a) produce
+# the DisassemblyDiagnoser output that cannot be generated on macOS, (b) give a Linux/x64 data
+# point next to the Apple Silicon numbers recorded in benchmarks/.../RESULTS.md, and (c) run the
+# in-process baseline-vs-HEAD comparison (tools/perf-compare.sh) where the two sides share the
+# same machine and the same minute, which is the only cross-commit comparison worth reading here.
+
+on:
+  workflow_dispatch:
+    inputs:
+      filter:
+        description: "BenchmarkDotNet --filter globs (space separated)"
+        required: false
+        default: "*HotPathBenchmarks* *C64ExecuteFrameBenchmark* *C64ExecuteInstructionBenchmark*"
+      compare_with_base:
+        description: "Also run tools/perf-compare.sh against base_ref (doubles the run time)"
+        type: boolean
+        required: false
+        default: false
+      base_ref:
+        description: "Baseline ref for the comparison"
+        required: false
+        default: "origin/master"
+
+concurrency:
+  group: benchmarks-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: CI / Benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Record environment
+        shell: bash
+        env:
+          FILTER: ${{ inputs.filter }}
+        run: |
+          {
+            echo "## Benchmark environment"
+            echo
+            echo "- commit: \`$(git rev-parse HEAD)\`"
+            echo "- runner: ${{ runner.os }} / $(uname -m)"
+            echo "- cpu: $(grep -m1 'model name' /proc/cpuinfo | cut -d: -f2- | xargs)"
+            echo "- dotnet: $(dotnet --version)"
+            echo "- filter: \`$FILTER\`"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run benchmarks
+        shell: bash
+        env:
+          # Inputs go through env, never straight into the script, so a crafted input cannot
+          # inject shell.
+          FILTER: ${{ inputs.filter }}
+        run: |
+          # shellcheck disable=SC2086 -- the filter is a space-separated list of globs.
+          dotnet run -c Release --project benchmarks/Highbyte.DotNet6502.Benchmarks -- \
+            --filter $FILTER \
+            --exporters github fulljson \
+            --artifacts BenchmarkDotNet.Artifacts
+
+      - name: Publish results to the job summary
+        shell: bash
+        run: |
+          for f in BenchmarkDotNet.Artifacts/results/*-report-github.md; do
+            [ -f "$f" ] || continue
+            {
+              echo "### $(basename "$f" -report-github.md)"
+              echo
+              cat "$f"
+              echo
+            } >> "$GITHUB_STEP_SUMMARY"
+          done
+
+      - name: Compare against base ref
+        if: ${{ inputs.compare_with_base }}
+        shell: bash
+        env:
+          PERF_COMPARE_FILTER: ${{ inputs.filter }}
+          BASE_REF: ${{ inputs.base_ref }}
+        run: |
+          git fetch origin master
+          # The comparison re-runs both sides in this job so they share one machine. It exits
+          # non-zero on a >= 5% regression or a new allocation; that is reported, not failed,
+          # because shared-runner noise alone can trip the threshold.
+          tools/perf-compare.sh "$BASE_REF" | tee perf-compare.txt || true
+          {
+            echo "### perf-compare vs $BASE_REF"
+            echo
+            echo '```'
+            cat perf-compare.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: benchmark-results-${{ github.run_number }}
+          path: |
+            BenchmarkDotNet.Artifacts/results/
+            perf-compare.txt
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -48,5 +48,18 @@ jobs:
       run: dotnet restore dotnet-6502.slnx
     - name: Build
       run: dotnet build dotnet-6502.slnx --no-restore
+    # The C64 program-level integration tests boot the genuine KERNAL/BASIC/character ROMs.
+    # They are not in the repository; the test helper (tests/.../Commodore64/C64TestRoms.cs)
+    # downloads them from the same public archive the app uses when the variable below is set,
+    # verifies their SHA-1 against the checksums in C64SystemConfig, and skips visibly otherwise.
+    - name: Cache C64 test ROMs
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ${{ github.workspace }}/.test-roms
+        key: c64-test-roms-901227-03-901226-01-901225-01
+
     - name: Test
+      env:
+        DOTNET6502_C64_ROM_DIR: ${{ github.workspace }}/.test-roms/c64
+        DOTNET6502_DOWNLOAD_TEST_ROMS: "true"
       run: dotnet test dotnet-6502.slnx --no-build --verbosity normal

--- a/.github/workflows/wasm-aot-verify.yml
+++ b/.github/workflows/wasm-aot-verify.yml
@@ -123,6 +123,34 @@ jobs:
           WASM_SITE_ROOT: ${{ github.workspace }}/build/${{ matrix.app.name }}/wwwroot
         run: ./node_modules/.bin/playwright test "${{ matrix.app.spec }}"
 
+      # Informational only: records the host frame rate and emulator time per frame the
+      # published Blazor build reaches on this runner (tests/wasm-smoke/blazor-speed.spec.ts).
+      # Never gates the PR; shared-runner numbers are for trends, not thresholds.
+      - name: Emulated speed readout
+        if: steps.changes.outputs.relevant == 'true' && matrix.app.name == 'blazor'
+        continue-on-error: true
+        working-directory: tests/wasm-smoke
+        env:
+          WASM_SITE_ROOT: ${{ github.workspace }}/build/${{ matrix.app.name }}/wwwroot
+        run: |
+          ./node_modules/.bin/playwright test blazor-speed.spec.ts
+          {
+            echo "### Blazor WASM emulated speed (Generic system, ${{ runner.os }} runner)"
+            echo
+            cat speed-readout.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload speed readout
+        if: steps.changes.outputs.relevant == 'true' && matrix.app.name == 'blazor'
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-speed-readout-${{ github.run_number }}
+          path: |
+            tests/wasm-smoke/speed-readout.json
+            tests/wasm-smoke/speed-readout.md
+          if-no-files-found: ignore
+          retention-days: 90
+
       - name: Upload Playwright report on failure
         if: failure() && steps.changes.outputs.relevant == 'true'
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -300,3 +300,4 @@ src/apps/Avalonia/Highbyte.DotNet6502.App.Avalonia.Desktop/appsettings.Developme
 .venv-docs/
 
 .playwright-cli/
+.test-roms/

--- a/benchmarks/Highbyte.DotNet6502.Benchmarks/RESULTS.md
+++ b/benchmarks/Highbyte.DotNet6502.Benchmarks/RESULTS.md
@@ -303,11 +303,11 @@ the result tables. To verify the JIT folds those helpers back into the caller,
 open that file after a run and confirm none of the three helper names appear as
 separate call sites in the disassembly of `Check`.
 
-## Cycle-timing baseline (C0) — 2026-09-02 (master `29132270`, Apple M1)
+## Cycle-timing baseline — 2026-09-02 (master `29132270`, Apple M1)
 
-Recorded before any cycle-steppable/cycle-exact execution work, as required by the plan's C0
-milestone. Every number below is the reference the C1–C3 gates compare against. Re-record on the
-same machine (or record a second column for another machine) rather than editing these.
+Recorded before any cycle-steppable/cycle-exact execution work started. Every number below is the
+reference that work compares against. Re-record on the same machine (or record a second column
+for another machine) rather than editing these.
 
 Environment:
 
@@ -359,8 +359,8 @@ Observations that matter for the cycle work:
   inside the C64 `CoreOnly` loop (CIA, VIC-II raster, cartridge tick, interrupt flush). A C64
   frame is ~227 µs `CoreOnly` and ~580 µs with rasterizer and sample SID, against a 16.7 ms
   (NTSC) / 20 ms (PAL) real-time budget. A 3× slower CPU core would still be under 2% of that
-  budget on this machine; the per-cycle scheduler and VIC-II tick (C4/C5) are where headroom
-  will actually be spent.
+  budget on this machine; a per-cycle system scheduler and VIC-II tick are where headroom will
+  actually be spent.
 - `CPU_Execute_*` allocate 136 B per call (one `ExecState` per `Execute`), unchanged since the
   2026-06 analysis; the minimal path and every C64 path are allocation-free. That is the
   property the cycle engine must keep.

--- a/benchmarks/Highbyte.DotNet6502.Benchmarks/RESULTS.md
+++ b/benchmarks/Highbyte.DotNet6502.Benchmarks/RESULTS.md
@@ -6,8 +6,12 @@ future PR that touches the per-instruction hot path should:
 
 1. Re-run the suite (`dotnet run -c Release --project benchmarks/Highbyte.DotNet6502.Benchmarks`)
    with `HotPathBenchmarks` selected in `Program.cs` (the default).
-2. Or run `tools/perf-compare.sh` to diff against `master` automatically and flag
-   any regression ≥ 5% or any new allocation.
+2. Or run `tools/perf-compare.sh` (`tools/perf-compare.ps1` on Windows) to diff against
+   `master` automatically and flag any regression ≥ 5% or any new allocation. By default it
+   covers `HotPathBenchmarks` plus the C64 instruction and frame suites; set
+   `PERF_COMPARE_FILTER` to narrow it. The same comparison can be run on a Linux runner via
+   the manually dispatched `Benchmarks` workflow (`.github/workflows/benchmarks.yml`), which
+   also produces the DisassemblyDiagnoser output that cannot be generated on macOS.
 3. Update the relevant table below if the change is intentional (and explain
    why in the PR description).
 
@@ -298,6 +302,70 @@ The `LegacyExecEvaluator.Check` refactor split the original method into three
 the result tables. To verify the JIT folds those helpers back into the caller,
 open that file after a run and confirm none of the three helper names appear as
 separate call sites in the disassembly of `Check`.
+
+## Cycle-timing baseline (C0) — 2026-09-02 (master `29132270`, Apple M1)
+
+Recorded before any cycle-steppable/cycle-exact execution work, as required by the plan's C0
+milestone. Every number below is the reference the C1–C3 gates compare against. Re-record on the
+same machine (or record a second column for another machine) rather than editing these.
+
+Environment:
+
+- Commit `29132270` (master, "Fix docs dependency audit (#303)"), unchanged working tree
+- BenchmarkDotNet v0.15.6, macOS 26.6.2 (25G83) / Darwin 25.6.0
+- Apple M1, 1 CPU, 8 logical and 8 physical cores, on AC power, no other load
+- .NET SDK 10.0.203, runtime .NET 10.0.7, Arm64 RyuJIT armv8.0-a, Concurrent Workstation GC
+- Command: `dotnet run -c Release --project benchmarks/Highbyte.DotNet6502.Benchmarks -- --filter '*HotPathBenchmarks*' '*C64ExecuteFrameBenchmark*' '*C64ExecuteInstructionBenchmark*' --exporters github`
+
+`HotPathBenchmarks` (DefaultJob):
+
+| Method                                         |           Mean |     StdDev | Allocated |
+|------------------------------------------------|---------------:|-----------:|----------:|
+| `ExecEvaluator_Check_NotTriggered`             |      0.5124 ns |  0.0010 ns |         - |
+| `ExecEvaluator_Check_OneConditionConfigured`   |      5.6714 ns |  0.0090 ns |         - |
+| `ExecEvaluator_Check_AllConditionsConfigured`  |      9.8638 ns |  0.0241 ns |         - |
+| `InstructionExecutor_OneStep`                  |     17.4381 ns |  0.0650 ns |         - |
+| `CPU_Run_1000Instructions`                     | 13,024.98 ns   | 21.05 ns   |         - |
+| `CPU_Execute_NoSubscribers_1000Instructions`   | 14,279.37 ns   | 35.14 ns   |     136 B |
+| `CPU_Execute_WithSubscribers_1000Instructions` | 35,163.43 ns   | 128.27 ns  | 136,136 B |
+| `Memory_Read_TightLoop`                        |  1,687.32 ns   |  6.23 ns   |         - |
+| `Memory_Write_TightLoop`                       |  1,582.50 ns   |  2.09 ns   |         - |
+
+`C64ExecuteFrameBenchmark` (ShortRun, NTSC, one frame = 17,095 CPU cycles):
+
+| Scenario         | SpriteScenario        |     Mean |  StdDev | Allocated |
+|------------------|-----------------------|---------:|--------:|----------:|
+| `CoreOnly`       | `None`                | 226.8 µs | 1.79 µs |         - |
+| `CoreOnly`       | `MixedVisibleSprites` | 219.7 µs | 0.31 µs |         - |
+| `RenderOnly`     | `None`                | 389.4 µs | 0.37 µs |         - |
+| `RenderOnly`     | `MixedVisibleSprites` | 397.0 µs | 0.70 µs |         - |
+| `AudioOnly`      | `None`                | 357.8 µs | 0.14 µs |         - |
+| `AudioOnly`      | `MixedVisibleSprites` | 353.8 µs | 0.43 µs |         - |
+| `RenderAndAudio` | `None`                | 577.3 µs | 3.48 µs |         - |
+| `RenderAndAudio` | `MixedVisibleSprites` | 591.7 µs | 1.97 µs |         - |
+
+`C64ExecuteInstructionBenchmark` (ShortRun, 1,000 instructions):
+
+| Scenario         |         Mean |      StdDev | Allocated |
+|------------------|-------------:|------------:|----------:|
+| `CoreOnly`       | 24,661.86 ns |    56.75 ns |         - |
+| `RenderOnly`     | 47,147.60 ns |   368.92 ns |         - |
+| `AudioOnly`      | 41,484.42 ns |    64.99 ns |         - |
+| `RenderAndAudio` | 82,970.42 ns | 3,039.03 ns |         - |
+
+Observations that matter for the cycle work:
+
+- The CPU is a minor cost centre: ~13 ns per instruction in isolation, ~25 ns per instruction
+  inside the C64 `CoreOnly` loop (CIA, VIC-II raster, cartridge tick, interrupt flush). A C64
+  frame is ~227 µs `CoreOnly` and ~580 µs with rasterizer and sample SID, against a 16.7 ms
+  (NTSC) / 20 ms (PAL) real-time budget. A 3× slower CPU core would still be under 2% of that
+  budget on this machine; the per-cycle scheduler and VIC-II tick (C4/C5) are where headroom
+  will actually be spent.
+- `CPU_Execute_*` allocate 136 B per call (one `ExecState` per `Execute`), unchanged since the
+  2026-06 analysis; the minimal path and every C64 path are allocation-free. That is the
+  property the cycle engine must keep.
+- Apple M1 numbers are ~30–35% slower than the Apple M5 numbers in the sections above; compare
+  ratios, not absolutes, across machines.
 
 ## History
 

--- a/docs/home/development.md
+++ b/docs/home/development.md
@@ -70,6 +70,19 @@ cd tests/Highbyte.DotNet6502.Tests
 dotnet test --filter TestType=Integration
 ```
 
+### C64 program-level tests with the real ROMs
+
+`tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64RealRomBootTests.cs` boots the genuine KERNAL, BASIC and character ROMs to the `READY.` prompt. The ROMs are copyrighted and are not in the repository, so these tests are marked `[RequiresC64RomsFact]` and report as *skipped* (with the reason) when the ROMs are missing rather than passing without running. They are tagged `TestType=Integration`.
+
+The helper `C64TestRoms` looks for the ROM files (under the names the app's own ROM download writes) in the C64 ROM directory, or in `DOTNET6502_C64_ROM_DIR` when set, and verifies each file's SHA-1 against the checksums in `C64SystemConfig`. Set `DOTNET6502_DOWNLOAD_TEST_ROMS=1` to let the helper fetch missing files from the same public archive the app uses:
+
+```sh
+DOTNET6502_C64_ROM_DIR=/tmp/c64-roms DOTNET6502_DOWNLOAD_TEST_ROMS=1 \
+  dotnet test tests/Highbyte.DotNet6502.Systems.Tests --filter TestType=Integration
+```
+
+The `Build & run tests` workflow sets both variables (with the ROM directory cached between runs), so these tests run in CI. Use the same helper for any future C64 test that needs a booted machine, for example the VICE test programs planned for the cycle-exact work.
+
 ### WASM AOT publish smoke tests
 
 A [Playwright](https://playwright.dev/) suite under `tests/wasm-smoke/` publishes the Blazor WASM and Avalonia Browser apps with the same Release/AOT flags as the GitHub Pages release workflow, then verifies the published `wwwroot` boots in headless Chromium and that the system plug-ins are discovered. Catches trim/AOT-only regressions (missing trim roots, plug-in assemblies dropped from the bundle, ...) that `dotnet build` / `dotnet test` do not exercise.
@@ -89,6 +102,28 @@ cd tests/wasm-smoke
 ```
 
 The same flow runs automatically on pull requests (paths-filtered to WASM-relevant source) via the `.github/workflows/wasm-aot-verify.yml` workflow.
+
+The same workflow also runs `blazor-speed.spec.ts` against the published Blazor build: it starts the ROM-free Generic system, enables the in-app stats panel and records the host frame rate and emulator time per frame into the job summary and a `wasm-speed-readout` artifact. It is informational only (shared runners are noisy) and never fails the PR. The Avalonia Browser app has no headless stats channel yet, so it has no readout.
+
+## Benchmarks
+
+`benchmarks/Highbyte.DotNet6502.Benchmarks/` is a [BenchmarkDotNet](https://benchmarkdotnet.org/) project covering the CPU hot path (`HotPathBenchmarks`), the integrated C64 instruction and frame loops with and without render/audio providers, and focused CIA, sprite, rasterizer and SID benchmarks. Recorded baselines and their history live in `benchmarks/Highbyte.DotNet6502.Benchmarks/RESULTS.md`.
+
+Run a suite locally (Release build, no debugger attached, machine otherwise idle):
+
+```sh
+dotnet run -c Release --project benchmarks/Highbyte.DotNet6502.Benchmarks -- --filter '*HotPathBenchmarks*'
+```
+
+Compare the current branch against `master` on the same machine:
+
+```sh
+tools/perf-compare.sh            # or: tools/perf-compare.ps1
+```
+
+It runs the CPU hot-path, C64 instruction and C64 frame suites on both refs (set `PERF_COMPARE_FILTER` to a space-separated list of `--filter` globs to narrow it) and flags any benchmark that is 5% or more slower or that starts allocating. The working tree must be clean because it switches refs.
+
+The manually dispatched `Benchmarks` workflow (`.github/workflows/benchmarks.yml`) runs the same suites on a Linux runner, publishes the tables to the job summary, uploads the results including the DisassemblyDiagnoser HTML (which cannot be produced on macOS), and can optionally run the baseline comparison in the same job. Runner numbers are noisy; use them for the disassembly and for same-job ratios, not for cross-run comparisons.
 
 ## Code coverage report locally (`Highbyte.DotNet6502` library)
 

--- a/src/libraries/Highbyte.DotNet6502.Systems/Snapshots/Cpu6502SnapshotModule.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems/Snapshots/Cpu6502SnapshotModule.cs
@@ -81,15 +81,19 @@ public sealed class Cpu6502SnapshotModule : ISnapshotModule
         var interrupts = cpu.CPUInterrupts;
         writer.WriteBool(interrupts.NMIPending);
 
-        writer.WriteInt32(interrupts.ActiveIRQSources.Count);
-        foreach (var irq in interrupts.ActiveIRQSources)
+        // Wire format is unchanged: names plus acknowledge mode, so the line bit layout
+        // (which depends on registration order) never leaks into the snapshot.
+        var activeIrqSources = interrupts.ActiveIRQSources.ToList();
+        writer.WriteInt32(activeIrqSources.Count);
+        foreach (var irq in activeIrqSources)
         {
             writer.WriteString(irq.Key);
             writer.WriteBool(irq.Value); // autoAcknowledge
         }
 
-        writer.WriteInt32(interrupts.ActiveNMISources.Count);
-        foreach (var nmi in interrupts.ActiveNMISources)
+        var activeNmiSources = interrupts.ActiveNMISources.ToList();
+        writer.WriteInt32(activeNmiSources.Count);
+        foreach (var nmi in activeNmiSources)
             writer.WriteString(nmi);
 
         // v3: model-state payload, serialized by the model's own state object (e.g. the
@@ -184,9 +188,7 @@ public sealed class Cpu6502SnapshotModule : ISnapshotModule
         var capturedNmiPending = reader.ReadBool();
 
         // Reset any interrupt state on the freshly built CPU before re-applying the snapshot's.
-        interrupts.ActiveIRQSources.Clear();
-        interrupts.ActiveNMISources.Clear();
-        interrupts.ClearPendingNMI();
+        interrupts.ClearAll();
 
         int irqCount = reader.ReadInt32();
         for (int i = 0; i < irqCount; i++)

--- a/src/libraries/Highbyte.DotNet6502/CPU.cs
+++ b/src/libraries/Highbyte.DotNet6502/CPU.cs
@@ -435,15 +435,9 @@ public class CPU
 
         if (CPUInterrupts.IRQLineEnabled && !ProcessorStatus.InterruptDisable)
         {
-            for (int i = CPUInterrupts.ActiveIRQSources.Count - 1; i >= 0; i--)
-            {
-                var source = CPUInterrupts.ActiveIRQSources.ElementAt(i).Key;
-                // Automatically remove IRQ sources that should not manually be acknowledged.
-                if (CPUInterrupts.ActiveIRQSources[source])
-                {
-                    CPUInterrupts.SetIRQSourceInactive(source);
-                }
-            }
+            // Sources raised with autoAcknowledge are dropped now; manually acknowledged
+            // sources keep the line asserted until their device clears them.
+            CPUInterrupts.AcknowledgeAutoAcknowledgingIRQSources();
             ProcessHardwareIRQ(mem);
             return InterruptEntryCycles;
         }

--- a/src/libraries/Highbyte.DotNet6502/CPUInterrupts.cs
+++ b/src/libraries/Highbyte.DotNet6502/CPUInterrupts.cs
@@ -1,79 +1,224 @@
 namespace Highbyte.DotNet6502;
 
-public class CPUInterrupts
+/// <summary>
+/// The CPU's IRQ and NMI input lines.
+///
+/// Line state is held as bitmasks, one bit per registered source, so that the CPU's interrupt
+/// sampling is a couple of integer tests with no collection walking, no LINQ and no allocation.
+/// That matters today on the per-instruction path and is a prerequisite for sampling the lines
+/// per cycle.
+///
+/// Devices identify themselves by a source name. A name is registered on first use and mapped to
+/// one bit (see <see cref="GetSource(string)"/>); the string-based API remains for wiring code that
+/// runs on device events, while devices may hold the <see cref="InterruptSource"/> handle and use
+/// the handle-based overloads instead.
+///
+/// Line semantics:
+/// <list type="bullet">
+/// <item>IRQ is level-triggered: the line is asserted while any source is active. A source raised
+/// with <c>autoAcknowledge</c> is dropped by the CPU when it services the IRQ; every other source
+/// stays asserted until its device clears it.</item>
+/// <item>NMI is edge-triggered: a source transitioning from inactive to active latches
+/// <see cref="NMIPending"/> until the CPU services it. Keeping a source active does not retrigger
+/// NMI until it has been cleared and asserted again.</item>
+/// </list>
+/// </summary>
+public sealed class CPUInterrupts
 {
-    public bool IRQLineEnabled => ActiveIRQSources.Count > 0;
-    public bool NMILineEnabled => ActiveNMISources.Count > 0;
+    /// <summary>Maximum number of distinct sources one CPU can register (one bit each).</summary>
+    public const int MaxSources = 64;
 
-    // 6502 NMI is edge-triggered: once a source transitions active we latch a pending
-    // NMI until the CPU services it. Keeping a source active does not retrigger NMI
-    // until it has been cleared and asserted again.
+    // Hot-path state. Invariant: _irqAutoAcknowledgeMask is a subset of _irqLines.
+    private ulong _irqLines;
+    private ulong _irqAutoAcknowledgeMask;
+    private ulong _nmiLines;
+
+    // Registry. Only touched when a device wires itself up or uses the string overloads.
+    private readonly Dictionary<string, InterruptSource> _sourcesByName = new(StringComparer.Ordinal);
+    private readonly List<string> _sourceNames = new();
+
+    /// <summary>True while at least one IRQ source is active (the IRQ line is asserted).</summary>
+    public bool IRQLineEnabled => _irqLines != 0;
+
+    /// <summary>True while at least one NMI source is active (the NMI line is asserted).</summary>
+    public bool NMILineEnabled => _nmiLines != 0;
+
+    /// <summary>Latched NMI edge waiting to be serviced by the CPU.</summary>
     public bool NMIPending { get; private set; }
 
-    public Dictionary<string, bool> ActiveIRQSources { get; private set; } = new();
-    public HashSet<string> ActiveNMISources { get; private set; } = new();
+    /// <summary>Number of sources registered on this instance.</summary>
+    public int RegisteredSourceCount => _sourceNames.Count;
 
     /// <summary>
-    /// Sets an IRQ source active.
+    /// Returns the handle for a source name, registering the name on first use.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">More than <see cref="MaxSources"/> distinct names were registered.</exception>
+    public InterruptSource GetSource(string source)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(source);
+
+        if (_sourcesByName.TryGetValue(source, out var existing))
+            return existing;
+
+        if (_sourceNames.Count >= MaxSources)
+            throw new InvalidOperationException($"Cannot register interrupt source '{source}': at most {MaxSources} distinct sources are supported.");
+
+        var handle = new InterruptSource(_sourceNames.Count, source);
+        _sourceNames.Add(source);
+        _sourcesByName.Add(source, handle);
+        return handle;
+    }
+
+    /// <summary>Looks up a registered source without registering it.</summary>
+    public bool TryGetSource(string source, out InterruptSource handle)
+        => _sourcesByName.TryGetValue(source, out handle);
+
+    // ----- IRQ -----
+
+    /// <summary>
+    /// Sets an IRQ source active. If the source is already active its acknowledge mode is left unchanged.
     /// </summary>
     /// <param name="source">Unique name of source</param>
     /// <param name="autoAcknowledge">Set to true if the IRQ source should automatically be removed when processed by CPU.</param>
     public void SetIRQSourceActive(string source, bool autoAcknowledge)
+        => SetIRQActive(GetSource(source), autoAcknowledge);
+
+    /// <inheritdoc cref="SetIRQSourceActive(string, bool)"/>
+    public void SetIRQActive(InterruptSource source, bool autoAcknowledge)
     {
-        ActiveIRQSources.TryAdd(source, autoAcknowledge);
+        var mask = source.Mask;
+        if ((_irqLines & mask) != 0)
+            return;
+
+        _irqLines |= mask;
+        if (autoAcknowledge)
+            _irqAutoAcknowledgeMask |= mask;
+        else
+            _irqAutoAcknowledgeMask &= ~mask;
     }
 
     /// <summary>
     /// Removes an IRQ source.
-    /// This is typically done by IRQ sources that needs to be manually acknowledged by IRQ handler.
+    /// This is typically done by IRQ sources that need to be manually acknowledged by the IRQ handler.
+    /// Unknown names are ignored.
     /// </summary>
     /// <param name="source">Unique name of source</param>
     public void SetIRQSourceInactive(string source)
     {
-        ActiveIRQSources.Remove(source);
+        if (TryGetSource(source, out var handle))
+            SetIRQInactive(handle);
     }
 
-    /// <summary>
-    /// Returns true if the specified IRQ source is currently active.
-    /// </summary>
-    /// <param name="source"></param>
-    /// <returns></returns>
-    public bool IsIRQSourceActive(string source)
+    /// <inheritdoc cref="SetIRQSourceInactive(string)"/>
+    public void SetIRQInactive(InterruptSource source)
     {
-        return ActiveIRQSources.ContainsKey(source);
+        var mask = source.Mask;
+        _irqLines &= ~mask;
+        _irqAutoAcknowledgeMask &= ~mask;
     }
 
+    /// <summary>Returns true if the specified IRQ source is currently active.</summary>
+    public bool IsIRQSourceActive(string source)
+        => TryGetSource(source, out var handle) && IsIRQActive(handle);
+
+    /// <inheritdoc cref="IsIRQSourceActive(string)"/>
+    public bool IsIRQActive(InterruptSource source) => (_irqLines & source.Mask) != 0;
+
+    /// <summary>Returns true if the source is active and will be dropped when the CPU services the IRQ.</summary>
+    public bool IsIRQAutoAcknowledged(InterruptSource source) => (_irqAutoAcknowledgeMask & source.Mask) != 0;
+
     /// <summary>
-    /// Sets an NMI source active.
+    /// Drops every auto-acknowledging IRQ source. The CPU calls this when it services an IRQ;
+    /// manually acknowledged sources keep the line asserted until their device clears them.
+    /// </summary>
+    public void AcknowledgeAutoAcknowledgingIRQSources()
+    {
+        _irqLines &= ~_irqAutoAcknowledgeMask;
+        _irqAutoAcknowledgeMask = 0;
+    }
+
+    // ----- NMI -----
+
+    /// <summary>
+    /// Sets an NMI source active. Latches a pending NMI only on the inactive-to-active transition.
     /// </summary>
     /// <param name="source">Unique name of source</param>
     public void SetNMISourceActive(string source)
+        => SetNMIActive(GetSource(source));
+
+    /// <inheritdoc cref="SetNMISourceActive(string)"/>
+    public void SetNMIActive(InterruptSource source)
     {
-        if (ActiveNMISources.Add(source))
-            NMIPending = true;
+        var mask = source.Mask;
+        if ((_nmiLines & mask) != 0)
+            return;
+
+        _nmiLines |= mask;
+        NMIPending = true;
     }
 
-    /// <summary>
-    /// Removes an NMI source. 
-    /// </summary>
+    /// <summary>Removes an NMI source. Unknown names are ignored.</summary>
     /// <param name="source">Unique name of source</param>
     public void SetNMISourceInactive(string source)
     {
-        ActiveNMISources.Remove(source);
+        if (TryGetSource(source, out var handle))
+            SetNMIInactive(handle);
+    }
+
+    /// <inheritdoc cref="SetNMISourceInactive(string)"/>
+    public void SetNMIInactive(InterruptSource source) => _nmiLines &= ~source.Mask;
+
+    /// <summary>Returns true if the specified NMI source is currently active.</summary>
+    public bool IsNMISourceActive(string source)
+        => TryGetSource(source, out var handle) && IsNMIActive(handle);
+
+    /// <inheritdoc cref="IsNMISourceActive(string)"/>
+    public bool IsNMIActive(InterruptSource source) => (_nmiLines & source.Mask) != 0;
+
+    /// <summary>Clears the latched NMI edge. The CPU calls this when it services the NMI.</summary>
+    public void ClearPendingNMI()
+    {
+        NMIPending = false;
+    }
+
+    // ----- Diagnostics and snapshots (not for hot paths: enumeration allocates an iterator) -----
+
+    /// <summary>Active IRQ sources by name, with their auto-acknowledge mode.</summary>
+    public IEnumerable<KeyValuePair<string, bool>> ActiveIRQSources
+    {
+        get
+        {
+            for (var i = 0; i < _sourceNames.Count; i++)
+            {
+                var mask = 1UL << i;
+                if ((_irqLines & mask) != 0)
+                    yield return new KeyValuePair<string, bool>(_sourceNames[i], (_irqAutoAcknowledgeMask & mask) != 0);
+            }
+        }
+    }
+
+    /// <summary>Active NMI sources by name.</summary>
+    public IEnumerable<string> ActiveNMISources
+    {
+        get
+        {
+            for (var i = 0; i < _sourceNames.Count; i++)
+            {
+                if ((_nmiLines & (1UL << i)) != 0)
+                    yield return _sourceNames[i];
+            }
+        }
     }
 
     /// <summary>
-    /// Retyrns true if the specified NMI source is currently active.   
+    /// Deasserts both lines, drops all acknowledge flags and clears the pending NMI latch.
+    /// Registered source names (and their bit positions) are kept so handles held by devices stay valid.
     /// </summary>
-    /// <param name="source"></param>
-    /// <returns></returns>
-    public bool IsNMISourceActive(string source)
+    public void ClearAll()
     {
-        return ActiveNMISources.Contains(source);
-    }
-
-    public void ClearPendingNMI()
-    {
+        _irqLines = 0;
+        _irqAutoAcknowledgeMask = 0;
+        _nmiLines = 0;
         NMIPending = false;
     }
 }

--- a/src/libraries/Highbyte.DotNet6502/InterruptSource.cs
+++ b/src/libraries/Highbyte.DotNet6502/InterruptSource.cs
@@ -1,0 +1,34 @@
+namespace Highbyte.DotNet6502;
+
+/// <summary>
+/// Handle for one named interrupt source registered with a <see cref="CPUInterrupts"/> instance.
+/// Devices that raise or clear interrupt lines frequently should obtain the handle once (via
+/// <see cref="CPUInterrupts.GetSource(string)"/>) and use the handle-based overloads, which are a
+/// single mask operation with no dictionary lookup. The string-based overloads remain for wiring
+/// code that runs on device events and for diagnostics.
+/// </summary>
+public readonly struct InterruptSource : IEquatable<InterruptSource>
+{
+    /// <summary>Bit position of this source in the owning <see cref="CPUInterrupts"/> line masks.</summary>
+    public int Index { get; }
+
+    /// <summary>The name the source was registered under.</summary>
+    public string Name { get; }
+
+    /// <summary>Single-bit mask for this source.</summary>
+    public ulong Mask => 1UL << Index;
+
+    internal InterruptSource(int index, string name)
+    {
+        Index = index;
+        Name = name;
+    }
+
+    public bool Equals(InterruptSource other) => Index == other.Index && string.Equals(Name, other.Name, StringComparison.Ordinal);
+    public override bool Equals(object? obj) => obj is InterruptSource other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(Index, Name);
+    public override string ToString() => $"{Name} (#{Index})";
+
+    public static bool operator ==(InterruptSource left, InterruptSource right) => left.Equals(right);
+    public static bool operator !=(InterruptSource left, InterruptSource right) => !left.Equals(right);
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64RealRomBootTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64RealRomBootTests.cs
@@ -1,0 +1,103 @@
+using System.Text;
+using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Video;
+using Highbyte.DotNet6502.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64;
+
+/// <summary>
+/// Boot-to-BASIC verification against the genuine C64 ROMs. This is the first program-level C64
+/// oracle: everything the cycle-exact work later validates with VICE test programs runs through
+/// the same ROM boot, so this has to pass before those tests mean anything.
+///
+/// The ROMs are not checked in; see <see cref="C64TestRoms"/> for how they are located or fetched
+/// and why the tests skip visibly instead of passing empty.
+/// </summary>
+[Trait("TestType", "Integration")]
+public class C64RealRomBootTests
+{
+    /// <summary>Upper bound on frames to reach the READY prompt; a real PAL C64 gets there in about 2 s (~100 frames).</summary>
+    private const int MaxBootFrames = 400;
+
+    private readonly ITestOutputHelper _output;
+
+    public C64RealRomBootTests(ITestOutputHelper output) => _output = output;
+
+    [RequiresC64RomsFact]
+    public void Reset_Vector_Points_Into_The_Kernal()
+    {
+        var c64 = C64.BuildC64(C64TestRoms.CreateConfig(), NullLoggerFactory.Instance);
+
+        Assert.Equal((ushort)0xFCE2, c64.Mem.FetchWord(0xFFFC));
+    }
+
+    [RequiresC64RomsFact]
+    public void Boots_To_The_Basic_Ready_Prompt()
+    {
+        var c64 = C64.BuildC64(C64TestRoms.CreateConfig(), NullLoggerFactory.Instance);
+
+        var frames = 0;
+        while (!c64.HasBasicStarted() && frames < MaxBootFrames)
+        {
+            c64.ExecuteOneFrame();
+            frames++;
+        }
+        _output.WriteLine($"BASIC started after {frames} frames");
+        Assert.True(c64.HasBasicStarted(), $"BASIC did not initialise within {MaxBootFrames} frames.");
+
+        // Let the KERNAL finish printing the banner and the prompt.
+        for (var i = 0; i < 10; i++)
+            c64.ExecuteOneFrame();
+
+        var screen = ReadScreen(c64);
+        foreach (var row in screen.Where(r => r.Trim().Length > 0))
+            _output.WriteLine(row);
+
+        Assert.Contains(screen, row => row.Contains("COMMODORE 64 BASIC V2", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(screen, row => row.Contains("38911 BASIC BYTES FREE", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(screen, row => row.StartsWith("READY.", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [RequiresC64RomsFact]
+    public void Boot_Is_Deterministic()
+    {
+        var first = BootAndCountFrames();
+        var second = BootAndCountFrames();
+
+        Assert.Equal(first.Frames, second.Frames);
+        Assert.Equal(first.Cycles, second.Cycles);
+    }
+
+    private static (int Frames, ulong Cycles) BootAndCountFrames()
+    {
+        var c64 = C64.BuildC64(C64TestRoms.CreateConfig(), NullLoggerFactory.Instance);
+        var frames = 0;
+        while (!c64.HasBasicStarted() && frames < MaxBootFrames)
+        {
+            c64.ExecuteOneFrame();
+            frames++;
+        }
+        return (frames, c64.CPU.ExecState.CyclesConsumed);
+    }
+
+    /// <summary>The 25 text rows of the default screen at $0400, converted from screen codes to ASCII.</summary>
+    private static string[] ReadScreen(C64 c64)
+    {
+        const ushort screenBase = 0x0400;
+        var rows = new string[25];
+        for (var row = 0; row < 25; row++)
+        {
+            var bytes = c64.Mem.ReadData((ushort)(screenBase + row * 40), 40);
+            var sb = new StringBuilder(40);
+            foreach (var screenCode in bytes)
+            {
+                var petscii = Petscii.C64ScreenCodeToPetscII(screenCode);
+                sb.Append((char)Petscii.PetscIIToAscII(petscii));
+            }
+            rows[row] = sb.ToString();
+        }
+        return rows;
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64TestRoms.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64TestRoms.cs
@@ -1,0 +1,148 @@
+using System.Security.Cryptography;
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64;
+
+/// <summary>
+/// Locates, and optionally fetches, the KERNAL, BASIC and character ROMs the C64 program-level
+/// integration tests need. The ROMs are copyrighted and are not checked in; tests that need them
+/// skip visibly (see <see cref="RequiresC64RomsFactAttribute"/>) rather than pass without running,
+/// following the Apple II precedent in <c>Apple2TestRoms</c>.
+///
+/// Resolution order:
+/// <list type="number">
+/// <item><c>DOTNET6502_C64_ROM_DIR</c>, else the app's own C64 ROM directory
+/// (<see cref="C64SystemConfig.DefaultROMDirectory"/>), using the file names the app's ROM download
+/// writes.</item>
+/// <item>When <c>DOTNET6502_DOWNLOAD_TEST_ROMS</c> is <c>1</c>/<c>true</c>, missing or corrupt files
+/// are downloaded from the same public sources the app uses and written to that directory. CI sets
+/// this so the C64 tests have an oracle; developers opt in explicitly.</item>
+/// </list>
+/// Every file is verified against the SHA-1 checksums the C64 configuration already carries, so a
+/// wrong or truncated download is reported, not booted.
+/// </summary>
+internal static class C64TestRoms
+{
+    public const string RomDirectoryEnvironmentVariable = "DOTNET6502_C64_ROM_DIR";
+    public const string DownloadEnvironmentVariable = "DOTNET6502_DOWNLOAD_TEST_ROMS";
+
+    private sealed record RomSpec(string Name, RomDownloadSource Source, IReadOnlyDictionary<string, string> Checksums)
+    {
+        public string FileName => Source.ResolveFileName();
+    }
+
+    private static readonly RomSpec[] s_roms =
+    [
+        new(C64SystemConfig.KERNAL_ROM_NAME, new RomDownloadSource(C64SystemConfig.DEFAULT_KERNAL_ROM_DOWNLOAD_URL), C64SystemConfig.DefaultKernalROMChecksums),
+        new(C64SystemConfig.BASIC_ROM_NAME, new RomDownloadSource(C64SystemConfig.DEFAULT_BASIC_ROM_DOWNLOAD_URL), C64SystemConfig.DefaultBasicROMChecksums),
+        new(C64SystemConfig.CHARGEN_ROM_NAME, new RomDownloadSource(C64SystemConfig.DEFAULT_CHARGEN_ROM_DOWNLOAD_URL), C64SystemConfig.DefaultCharGenROMChecksums),
+    ];
+
+    private static readonly Lazy<string?> s_missingReason = new(Resolve, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    public static string RomDirectory
+    {
+        get
+        {
+            var fromEnvironment = Environment.GetEnvironmentVariable(RomDirectoryEnvironmentVariable);
+            return string.IsNullOrWhiteSpace(fromEnvironment) ? C64SystemConfig.DefaultROMDirectory : fromEnvironment;
+        }
+    }
+
+    public static bool DownloadEnabled
+    {
+        get
+        {
+            var value = Environment.GetEnvironmentVariable(DownloadEnvironmentVariable)?.Trim();
+            return value is not null && (value == "1" || value.Equals("true", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    /// <summary>Null when every ROM is present and verified; otherwise the skip reason.</summary>
+    public static string? MissingReason => s_missingReason.Value;
+
+    /// <summary>The ROM list a <see cref="C64Config"/> needs to load the verified files.</summary>
+    public static List<ROM> CreateRomList()
+        => s_roms.Select(rom => new ROM
+        {
+            Name = rom.Name,
+            File = rom.FileName,
+            ValidVersionChecksums = new Dictionary<string, string>(rom.Checksums),
+        }).ToList();
+
+    /// <summary>A PAL C64 configuration that boots the real ROMs from <see cref="RomDirectory"/>.</summary>
+    public static C64Config CreateConfig(string c64Model = "C64PAL", string vic2Model = "PAL")
+        => new()
+        {
+            LoadROMs = true,
+            ROMDirectory = RomDirectory,
+            ROMs = CreateRomList(),
+            C64Model = c64Model,
+            Vic2Model = vic2Model,
+        };
+
+    private static string? Resolve()
+    {
+        var directory = RomDirectory;
+        var missing = new List<string>();
+
+        foreach (var rom in s_roms)
+        {
+            var path = Path.Combine(directory, rom.FileName);
+            if (IsVerified(path, rom))
+                continue;
+
+            if (DownloadEnabled)
+            {
+                try
+                {
+                    Download(rom, path);
+                }
+                catch (Exception ex)
+                {
+                    return $"Download of C64 {rom.Name} ROM from {rom.Source.Url} failed: {ex.Message}";
+                }
+
+                if (IsVerified(path, rom))
+                    continue;
+                return $"Downloaded C64 {rom.Name} ROM ({path}) does not match any known checksum.";
+            }
+
+            missing.Add(rom.FileName);
+        }
+
+        if (missing.Count == 0)
+            return null;
+
+        return $"No verified C64 ROMs found in {directory} (missing or wrong checksum: {string.Join(", ", missing)}). " +
+               $"Set {RomDirectoryEnvironmentVariable} to a directory holding them, or set {DownloadEnvironmentVariable}=1 to fetch them from the public archive.";
+    }
+
+    private static bool IsVerified(string path, RomSpec rom)
+    {
+        if (!File.Exists(path))
+            return false;
+        var checksum = Convert.ToHexStringLower(SHA1.HashData(File.ReadAllBytes(path)));
+        return rom.Checksums.Values.Contains(checksum, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static void Download(RomSpec rom, string path)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        using var httpClient = new HttpClient();
+        var downloader = new RomDownloader(NullLoggerFactory.Instance, httpClient);
+        var bytes = downloader.DownloadRomAsync(rom.Name, rom.Source).GetAwaiter().GetResult();
+        File.WriteAllBytes(path, bytes);
+    }
+}
+
+/// <summary>A test needing the genuine C64 KERNAL, BASIC and character ROMs. Skips, visibly, when they are absent.</summary>
+public sealed class RequiresC64RomsFactAttribute : FactAttribute
+{
+    public RequiresC64RomsFactAttribute()
+    {
+        if (C64TestRoms.MissingReason is { } reason)
+            Skip = reason;
+    }
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/CpuInterruptSnapshotTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Snapshots/CpuInterruptSnapshotTests.cs
@@ -1,0 +1,103 @@
+using Highbyte.DotNet6502;
+using Highbyte.DotNet6502.Systems.Generic;
+using Highbyte.DotNet6502.Systems.Generic.Config;
+using Highbyte.DotNet6502.Systems.Snapshots;
+using Highbyte.DotNet6502.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Snapshots;
+
+/// <summary>
+/// Instruction-boundary snapshots carry the CPU's interrupt lines by source name with their
+/// acknowledge mode, plus the latched NMI edge — independent of the bit positions the sources
+/// happen to occupy on either machine.
+/// </summary>
+public class CpuInterruptSnapshotTests
+{
+    private static GenericComputer BuildComputer()
+    {
+        var computer = new GenericComputer(new GenericComputerConfig(), new NullLoggerFactory());
+        computer.Mem.StoreData(0xC000, [0xEA, 0x4C, 0x00, 0xC0]); // NOP; JMP $C000
+        computer.CPU.PC = 0xC000;
+        return computer;
+    }
+
+    private static GenericComputer RoundTrip(GenericComputer source, Action<GenericComputer>? prepareTarget = null)
+    {
+        using var stream = new MemoryStream();
+        new SnapshotService().Save(source, stream);
+        stream.Position = 0;
+
+        var target = BuildComputer();
+        prepareTarget?.Invoke(target);
+        new SnapshotService().Restore(target, stream);
+        return target;
+    }
+
+    [Fact]
+    public void Interrupt_Lines_And_Acknowledge_Modes_Round_Trip()
+    {
+        var source = BuildComputer();
+        source.CPU.ProcessorStatus.InterruptDisable = true; // keep the lines asserted across the save
+        source.CPU.CPUInterrupts.SetIRQSourceActive("VIC2.RasterCompare", autoAcknowledge: false);
+        source.CPU.CPUInterrupts.SetIRQSourceActive("CIA1.TimerA", autoAcknowledge: true);
+        source.CPU.CPUInterrupts.SetNMISourceActive("Keyboard.Restore");
+
+        var restored = RoundTrip(source);
+        var interrupts = restored.CPU.CPUInterrupts;
+
+        Assert.Equal(
+            [new("VIC2.RasterCompare", false), new("CIA1.TimerA", true)],
+            interrupts.ActiveIRQSources.ToArray());
+        Assert.Equal(["Keyboard.Restore"], interrupts.ActiveNMISources.ToArray());
+        Assert.True(interrupts.NMIPending);
+    }
+
+    [Fact]
+    public void Restore_Uses_Names_Not_Bit_Positions()
+    {
+        var source = BuildComputer();
+        source.CPU.CPUInterrupts.SetIRQSourceActive("second", autoAcknowledge: true);
+
+        // The target registered other sources first, so "second" lands on a different bit.
+        var restored = RoundTrip(source, target =>
+        {
+            target.CPU.CPUInterrupts.GetSource("first");
+            target.CPU.CPUInterrupts.GetSource("third");
+        });
+
+        var handle = restored.CPU.CPUInterrupts.GetSource("second");
+        Assert.Equal(2, handle.Index);
+        Assert.True(restored.CPU.CPUInterrupts.IsIRQActive(handle));
+        Assert.True(restored.CPU.CPUInterrupts.IsIRQAutoAcknowledged(handle));
+    }
+
+    [Fact]
+    public void Restore_Replaces_The_Targets_Existing_Line_State()
+    {
+        var source = BuildComputer(); // nothing asserted
+
+        var restored = RoundTrip(source, target =>
+        {
+            target.CPU.CPUInterrupts.SetIRQSourceActive("stale", autoAcknowledge: false);
+            target.CPU.CPUInterrupts.SetNMISourceActive("stale-nmi");
+        });
+
+        Assert.False(restored.CPU.CPUInterrupts.IRQLineEnabled);
+        Assert.False(restored.CPU.CPUInterrupts.NMILineEnabled);
+        Assert.False(restored.CPU.CPUInterrupts.NMIPending);
+    }
+
+    [Fact]
+    public void A_Serviced_Nmi_Edge_Stays_Serviced_After_Restore()
+    {
+        var source = BuildComputer();
+        source.CPU.CPUInterrupts.SetNMISourceActive("held");
+        source.CPU.CPUInterrupts.ClearPendingNMI(); // edge already taken, source still held active
+
+        var restored = RoundTrip(source);
+
+        Assert.True(restored.CPU.CPUInterrupts.NMILineEnabled);
+        Assert.False(restored.CPU.CPUInterrupts.NMIPending);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Tests/CPUInterruptsTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/CPUInterruptsTests.cs
@@ -1,0 +1,196 @@
+using Highbyte.DotNet6502.Utils;
+
+namespace Highbyte.DotNet6502.Tests;
+
+/// <summary>
+/// Contract of the bitmask-backed <see cref="CPUInterrupts"/>: named sources map to line bits,
+/// IRQ is level-triggered with per-source acknowledge mode, NMI is edge-latched, and the
+/// string-based API is a façade over the handle-based one.
+/// </summary>
+public class CPUInterruptsTests
+{
+    [Fact]
+    public void GetSource_Registers_Once_And_Returns_A_Stable_Handle()
+    {
+        var interrupts = new CPUInterrupts();
+
+        var first = interrupts.GetSource("VIC2.Raster");
+        var second = interrupts.GetSource("VIC2.Raster");
+        var other = interrupts.GetSource("CIA1.TimerA");
+
+        Assert.Equal(first, second);
+        Assert.Equal(0, first.Index);
+        Assert.Equal(1, other.Index);
+        Assert.Equal(1UL << 1, other.Mask);
+        Assert.Equal(2, interrupts.RegisteredSourceCount);
+    }
+
+    [Fact]
+    public void TryGetSource_Does_Not_Register_Unknown_Names()
+    {
+        var interrupts = new CPUInterrupts();
+
+        Assert.False(interrupts.TryGetSource("nope", out _));
+        Assert.False(interrupts.IsIRQSourceActive("nope"));
+        Assert.False(interrupts.IsNMISourceActive("nope"));
+        interrupts.SetIRQSourceInactive("nope");
+        interrupts.SetNMISourceInactive("nope");
+
+        Assert.Equal(0, interrupts.RegisteredSourceCount);
+    }
+
+    [Fact]
+    public void Registering_More_Than_MaxSources_Throws()
+    {
+        var interrupts = new CPUInterrupts();
+        for (var i = 0; i < CPUInterrupts.MaxSources; i++)
+            interrupts.GetSource($"source-{i}");
+
+        Assert.Throws<InvalidOperationException>(() => interrupts.GetSource("one-too-many"));
+    }
+
+    [Fact]
+    public void IRQ_Line_Is_Asserted_While_Any_Source_Is_Active()
+    {
+        var interrupts = new CPUInterrupts();
+        Assert.False(interrupts.IRQLineEnabled);
+
+        interrupts.SetIRQSourceActive("a", autoAcknowledge: false);
+        interrupts.SetIRQSourceActive("b", autoAcknowledge: true);
+        Assert.True(interrupts.IRQLineEnabled);
+
+        interrupts.SetIRQSourceInactive("a");
+        Assert.True(interrupts.IRQLineEnabled);
+        Assert.False(interrupts.IsIRQSourceActive("a"));
+        Assert.True(interrupts.IsIRQSourceActive("b"));
+
+        interrupts.SetIRQSourceInactive("b");
+        Assert.False(interrupts.IRQLineEnabled);
+    }
+
+    [Fact]
+    public void Servicing_Drops_Only_AutoAcknowledging_IRQ_Sources()
+    {
+        var interrupts = new CPUInterrupts();
+        var manual = interrupts.GetSource("manual");
+        var auto = interrupts.GetSource("auto");
+        interrupts.SetIRQActive(manual, autoAcknowledge: false);
+        interrupts.SetIRQActive(auto, autoAcknowledge: true);
+
+        interrupts.AcknowledgeAutoAcknowledgingIRQSources();
+
+        Assert.True(interrupts.IsIRQActive(manual));
+        Assert.False(interrupts.IsIRQActive(auto));
+        Assert.False(interrupts.IsIRQAutoAcknowledged(auto));
+        Assert.True(interrupts.IRQLineEnabled);
+    }
+
+    [Fact]
+    public void Reasserting_An_Active_IRQ_Source_Keeps_Its_Acknowledge_Mode()
+    {
+        var interrupts = new CPUInterrupts();
+        var source = interrupts.GetSource("device");
+        interrupts.SetIRQActive(source, autoAcknowledge: false);
+
+        interrupts.SetIRQActive(source, autoAcknowledge: true);
+
+        Assert.False(interrupts.IsIRQAutoAcknowledged(source));
+        interrupts.AcknowledgeAutoAcknowledgingIRQSources();
+        Assert.True(interrupts.IsIRQActive(source));
+    }
+
+    [Fact]
+    public void Clearing_An_IRQ_Source_Also_Clears_Its_Acknowledge_Mode()
+    {
+        var interrupts = new CPUInterrupts();
+        var source = interrupts.GetSource("device");
+        interrupts.SetIRQActive(source, autoAcknowledge: true);
+
+        interrupts.SetIRQInactive(source);
+        interrupts.SetIRQActive(source, autoAcknowledge: false);
+
+        Assert.False(interrupts.IsIRQAutoAcknowledged(source));
+    }
+
+    [Fact]
+    public void NMI_Is_Latched_On_The_Inactive_To_Active_Edge_Only()
+    {
+        var interrupts = new CPUInterrupts();
+
+        interrupts.SetNMISourceActive("restore");
+        Assert.True(interrupts.NMIPending);
+        Assert.True(interrupts.NMILineEnabled);
+
+        interrupts.ClearPendingNMI();
+        interrupts.SetNMISourceActive("restore"); // still held active: no new edge
+        Assert.False(interrupts.NMIPending);
+
+        interrupts.SetNMISourceInactive("restore");
+        Assert.False(interrupts.NMILineEnabled);
+        interrupts.SetNMISourceActive("restore");
+        Assert.True(interrupts.NMIPending);
+    }
+
+    [Fact]
+    public void Active_Source_Enumerations_Report_Names_And_Acknowledge_Modes()
+    {
+        var interrupts = new CPUInterrupts();
+        interrupts.SetIRQSourceActive("irq-manual", autoAcknowledge: false);
+        interrupts.SetIRQSourceActive("irq-auto", autoAcknowledge: true);
+        interrupts.SetIRQSourceActive("irq-cleared", autoAcknowledge: true);
+        interrupts.SetIRQSourceInactive("irq-cleared");
+        interrupts.SetNMISourceActive("nmi-a");
+        interrupts.SetNMISourceActive("nmi-b");
+        interrupts.SetNMISourceInactive("nmi-a");
+
+        Assert.Equal(
+            [new("irq-manual", false), new("irq-auto", true)],
+            interrupts.ActiveIRQSources.ToArray());
+        Assert.Equal(["nmi-b"], interrupts.ActiveNMISources.ToArray());
+    }
+
+    [Fact]
+    public void ClearAll_Deasserts_Lines_But_Keeps_Registered_Handles_Valid()
+    {
+        var interrupts = new CPUInterrupts();
+        var irq = interrupts.GetSource("irq");
+        var nmi = interrupts.GetSource("nmi");
+        interrupts.SetIRQActive(irq, autoAcknowledge: true);
+        interrupts.SetNMIActive(nmi);
+
+        interrupts.ClearAll();
+
+        Assert.False(interrupts.IRQLineEnabled);
+        Assert.False(interrupts.NMILineEnabled);
+        Assert.False(interrupts.NMIPending);
+        Assert.Equal(2, interrupts.RegisteredSourceCount);
+        Assert.Equal(irq, interrupts.GetSource("irq"));
+
+        interrupts.SetIRQActive(irq, autoAcknowledge: false);
+        Assert.True(interrupts.IsIRQSourceActive("irq"));
+        Assert.False(interrupts.IsIRQAutoAcknowledged(irq));
+    }
+
+    [Fact]
+    public void Cpu_Servicing_An_IRQ_Keeps_Manually_Acknowledged_Sources_Asserted()
+    {
+        var cpu = new CPU();
+        var mem = new Memory();
+        mem[0x1000] = (byte)OpCodeId.NOP;
+        cpu.PC = 0x1000;
+        cpu.ProcessorStatus.InterruptDisable = false;
+        mem.WriteWord(CPU.BrkIRQHandlerVector, 0x4000);
+        var manual = cpu.CPUInterrupts.GetSource("VIC2.RasterCompare");
+        var auto = cpu.CPUInterrupts.GetSource("CIA1.TimerA");
+        cpu.CPUInterrupts.SetIRQActive(manual, autoAcknowledge: false);
+        cpu.CPUInterrupts.SetIRQActive(auto, autoAcknowledge: true);
+
+        var result = cpu.ExecuteOneInstructionMinimal(mem);
+
+        Assert.Equal(2 + CPU.InterruptEntryCycles, result.CyclesConsumed);
+        Assert.Equal((ushort)0x4000, cpu.PC);
+        Assert.True(cpu.CPUInterrupts.IsIRQActive(manual));
+        Assert.False(cpu.CPUInterrupts.IsIRQActive(auto));
+        Assert.True(cpu.CPUInterrupts.IRQLineEnabled);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Tests/CpuExecutionContractCharacterizationTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/CpuExecutionContractCharacterizationTests.cs
@@ -1,0 +1,217 @@
+using Highbyte.DotNet6502.Utils;
+
+namespace Highbyte.DotNet6502.Tests;
+
+/// <summary>
+/// Characterizes the instruction-level execution contract of <see cref="CPU"/> as it is today:
+/// event ordering, evaluator timing, unknown-opcode and JAM behavior, counters, and cloning.
+///
+/// These tests pin observable behavior that the cycle-steppable execution work must preserve
+/// while it replaces the executor underneath the instruction API. A deliberate change to any of
+/// them is a public behavior change and must update the test together with the documentation.
+/// Interrupt-cycle attribution is characterized separately in <see cref="CPUInterruptBoundaryTests"/>,
+/// ordered bus accesses in <see cref="CpuBusAccessCharacterizationTests"/>.
+/// </summary>
+public class CpuExecutionContractCharacterizationTests
+{
+    private const ushort ProgramStart = 0x1000;
+
+    private static (CPU cpu, Memory mem) NewCpuWithNops(CpuCompatibilityProfile profile = CpuCompatibilityProfile.ExperimentalUnofficial)
+    {
+        var cpu = new CPU(profile);
+        var mem = new Memory();
+        for (ushort address = ProgramStart; address < ProgramStart + 0x100; address++)
+            mem[address] = (byte)OpCodeId.NOP;
+        cpu.PC = ProgramStart;
+        return (cpu, mem);
+    }
+
+    private sealed class RecordingEvaluator : IExecEvaluator
+    {
+        public List<ushort> PcAtCheck { get; } = new();
+        public int TriggerOnCheckNumber { get; init; } = int.MaxValue;
+
+        public ExecEvaluatorTriggerResult Check(ExecState execState, CPU cpu, Memory mem)
+        {
+            PcAtCheck.Add(cpu.PC);
+            return PcAtCheck.Count >= TriggerOnCheckNumber
+                ? ExecEvaluatorTriggerResult.CreateTrigger(ExecEvaluatorTriggerReasonType.Other, "test")
+                : ExecEvaluatorTriggerResult.NotTriggered;
+        }
+
+        public ExecEvaluatorTriggerResult Check(InstructionExecResult lastInstructionExecResult, CPU cpu, Memory mem)
+            => ExecEvaluatorTriggerResult.NotTriggered;
+    }
+
+    [Fact]
+    public void Execute_Fires_ToBeExecuted_Then_Executed_Exactly_Once_Per_Instruction()
+    {
+        var (cpu, mem) = NewCpuWithNops();
+        var log = new List<string>();
+        cpu.InstructionToBeExecuted += (_, e) => log.Add($"before@{e.CPU.PC:X4}");
+        cpu.InstructionExecuted += (_, e) => log.Add($"after@{e.CPU.PC:X4}:{e.InstructionExecState.InstructionsExecutionCount}");
+
+        var execState = cpu.Execute(mem, new LegacyExecEvaluator(new ExecOptions { MaxNumberOfInstructions = 3 }));
+
+        // The InstructionExecuted event carries the state of THAT instruction (count 1, its own
+        // cycles), not the running totals; the totals are on the CPU and the returned ExecState.
+        Assert.Equal(
+            ["before@1000", "after@1001:1", "before@1001", "after@1002:1", "before@1002", "after@1003:1"],
+            log);
+        Assert.Equal(3ul, execState.InstructionsExecutionCount);
+        Assert.Equal(3ul, cpu.ExecState.InstructionsExecutionCount);
+    }
+
+    [Fact]
+    public void Minimal_Path_Fires_No_Instruction_Events()
+    {
+        var (cpu, mem) = NewCpuWithNops();
+        var fired = 0;
+        cpu.InstructionToBeExecuted += (_, _) => fired++;
+        cpu.InstructionExecuted += (_, _) => fired++;
+        cpu.UnknownOpCodeDetected += (_, _) => fired++;
+        mem[ProgramStart + 1] = 0x02; // undefined below FullUnofficial
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        Assert.Equal(0, fired);
+        Assert.Equal(1ul, cpu.ExecState.UnknownOpCodeCount);
+    }
+
+    [Fact]
+    public void Evaluators_Run_Before_Each_Instruction_And_A_Trigger_Prevents_Execution()
+    {
+        var (cpu, mem) = NewCpuWithNops();
+        var evaluator = new RecordingEvaluator { TriggerOnCheckNumber = 3 };
+
+        var execState = cpu.Execute(mem, evaluator);
+
+        // Checked at $1000 (ran), $1001 (ran), $1002 (triggered, not run).
+        Assert.Equal([0x1000, 0x1001, 0x1002], evaluator.PcAtCheck);
+        Assert.Equal((ushort)0x1002, cpu.PC);
+        Assert.Equal(2ul, execState.InstructionsExecutionCount);
+        Assert.Equal(4ul, execState.CyclesConsumed);
+    }
+
+    [Fact]
+    public void Unknown_OpCode_Costs_One_Cycle_Advances_PC_By_One_And_Is_Reported_Once()
+    {
+        var (cpu, mem) = NewCpuWithNops();
+        mem[ProgramStart] = 0x02; // undefined below FullUnofficial
+        var reported = new List<byte>();
+        cpu.UnknownOpCodeDetected += (_, e) => reported.Add(e.OpCode);
+
+        var execState = cpu.Execute(mem, new LegacyExecEvaluator(new ExecOptions
+        {
+            MaxNumberOfInstructions = 1,
+            UnknownInstructionThrowsException = false,
+        }));
+
+        Assert.Equal([(byte)0x02], reported);
+        Assert.Equal((ushort)(ProgramStart + 1), cpu.PC);
+        Assert.Equal(1ul, execState.CyclesConsumed);
+        Assert.Equal(1ul, execState.UnknownOpCodeCount);
+        Assert.False(execState.LastOpCodeWasHandled);
+        Assert.True(execState.LastInstructionExecResult.UnknownInstruction);
+    }
+
+    [Fact]
+    public void Jam_Halts_The_Cpu_After_Two_Cycles_And_Halted_Steps_Cost_Nothing()
+    {
+        var (cpu, mem) = NewCpuWithNops(CpuCompatibilityProfile.FullUnofficial);
+        mem[ProgramStart] = 0x02; // JAM
+
+        var jam = cpu.ExecuteOneInstructionMinimal(mem);
+        var afterJam = cpu.ExecuteOneInstructionMinimal(mem);
+
+        Assert.True(cpu.IsHalted);
+        Assert.True(jam.HaltedCpu);
+        Assert.Equal(2ul, jam.CyclesConsumed);
+        Assert.Equal((ushort)(ProgramStart + 1), cpu.PC);
+
+        Assert.Equal(0ul, afterJam.CyclesConsumed);
+        Assert.False(afterJam.IsValid);
+        Assert.Equal(2ul, cpu.ExecState.CyclesConsumed);
+        Assert.Equal(1ul, cpu.ExecState.InstructionsExecutionCount);
+    }
+
+    [Fact]
+    public void Reset_Clears_A_Jam_Halt_And_Starts_At_The_Reset_Vector()
+    {
+        var (cpu, mem) = NewCpuWithNops(CpuCompatibilityProfile.FullUnofficial);
+        mem[ProgramStart] = 0x02; // JAM
+        mem.WriteWord(CPU.ResetVector, 0x2000);
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        cpu.Reset(mem);
+
+        Assert.False(cpu.IsHalted);
+        Assert.Equal((ushort)0x2000, cpu.PC);
+    }
+
+    [Fact]
+    public void Cumulative_Counters_Accumulate_Across_Both_Execution_Paths()
+    {
+        var (cpu, mem) = NewCpuWithNops();
+        mem[ProgramStart + 2] = 0x02; // undefined below FullUnofficial
+
+        cpu.ExecuteOneInstructionMinimal(mem);                              // NOP, 2 cycles
+        cpu.Execute(mem, new LegacyExecEvaluator(new ExecOptions           // NOP + unknown
+        {
+            MaxNumberOfInstructions = 2,
+            UnknownInstructionThrowsException = false,
+        }));
+        cpu.ExecuteOneInstruction(mem);                                     // NOP, 2 cycles
+
+        Assert.Equal(4ul, cpu.ExecState.InstructionsExecutionCount);
+        Assert.Equal(7ul, cpu.ExecState.CyclesConsumed);
+        Assert.Equal(1ul, cpu.ExecState.UnknownOpCodeCount);
+    }
+
+    [Fact]
+    public void Clone_Copies_Registers_Flags_Counters_Model_And_Profile()
+    {
+        var cpu = new CPU(CpuCompatibilityProfile.FullUnofficial)
+        {
+            PC = 0x1234, SP = 0xF0, A = 0x11, X = 0x22, Y = 0x33,
+        };
+        cpu.ProcessorStatus.Carry = true;
+        cpu.ProcessorStatus.Decimal = true;
+        var mem = new Memory();
+        mem[0x1234] = (byte)OpCodeId.NOP;
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        var clone = cpu.Clone();
+
+        Assert.Equal(cpu.PC, clone.PC);
+        Assert.Equal(cpu.SP, clone.SP);
+        Assert.Equal(cpu.A, clone.A);
+        Assert.Equal(cpu.X, clone.X);
+        Assert.Equal(cpu.Y, clone.Y);
+        Assert.Equal(cpu.ProcessorStatus.Value, clone.ProcessorStatus.Value);
+        Assert.Equal(cpu.ExecState.CyclesConsumed, clone.ExecState.CyclesConsumed);
+        Assert.Equal(cpu.ExecState.InstructionsExecutionCount, clone.ExecState.InstructionsExecutionCount);
+        Assert.Equal(cpu.CpuModelId, clone.CpuModelId);
+        Assert.Equal(cpu.CompatibilityProfile, clone.CompatibilityProfile);
+        Assert.NotSame(cpu.ExecState, clone.ExecState);
+    }
+
+    [Fact]
+    public void Clone_Does_Not_Copy_Interrupt_Lines_Today()
+    {
+        // Current behavior, recorded on purpose: a clone starts with deasserted interrupt lines
+        // and its own source registry. Whether a clone should carry pending interrupts is an
+        // open question for the cycle work; changing it must update this test deliberately.
+        var cpu = new CPU();
+        cpu.CPUInterrupts.SetIRQSourceActive("device", autoAcknowledge: false);
+        cpu.CPUInterrupts.SetNMISourceActive("nmi");
+
+        var clone = cpu.Clone();
+
+        Assert.NotSame(cpu.CPUInterrupts, clone.CPUInterrupts);
+        Assert.False(clone.CPUInterrupts.IRQLineEnabled);
+        Assert.False(clone.CPUInterrupts.NMIPending);
+        Assert.Equal(0, clone.CPUInterrupts.RegisteredSourceCount);
+    }
+}

--- a/tests/wasm-smoke/.gitignore
+++ b/tests/wasm-smoke/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 playwright-report/
 test-results/
 build/
+speed-readout.json
+speed-readout.md

--- a/tests/wasm-smoke/blazor-speed.spec.ts
+++ b/tests/wasm-smoke/blazor-speed.spec.ts
@@ -19,9 +19,10 @@ test('Blazor WASM emulated speed readout (Generic system)', async ({ page }) => 
   await page.goto('/?systemName=Generic&audioEnabled=false');
   await expect(page.locator('#system-selector')).toBeVisible({ timeout: 4 * 60 * 1000 });
 
-  await page.getByRole('button', { name: 'Start' }).click();
+  // exact: the page also has a "Load & start binary PRG file" button.
+  await page.getByRole('button', { name: 'Start', exact: true }).click();
   // The Stats button is only enabled once a system is running.
-  const statsButton = page.getByRole('button', { name: 'Stats' });
+  const statsButton = page.getByRole('button', { name: 'Stats', exact: true });
   await expect(statsButton).toBeEnabled({ timeout: 60 * 1000 });
   await statsButton.click();
 

--- a/tests/wasm-smoke/blazor-speed.spec.ts
+++ b/tests/wasm-smoke/blazor-speed.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test';
+import { writeFileSync } from 'node:fs';
+
+// Headless emulated-speed readout for the Blazor WASM (Mono AOT) build.
+//
+// Not a smoke test and not a gate: it starts the ROM-free Generic system, turns on the
+// in-app stats panel (which is what enables per-frame instrumentation) and records the
+// host frame rate and emulator time per frame that the app itself reports. The numbers
+// land in `speed-readout.json` and `speed-readout.md` in this directory; the workflow
+// appends the markdown to the job summary. Shared runners are noisy, so read trends and
+// ratios, never single runs. Only one assertion is made: the emulator actually runs.
+//
+// The stats panel renders `<span class="header">Name</span>: <span class="value">V</span>`
+// pairs joined by <br />; values are pre-formatted strings ("59.83", "3.21ms").
+
+const SETTLE_MS = Number(process.env.WASM_SPEED_SETTLE_MS ?? 8000);
+
+test('Blazor WASM emulated speed readout (Generic system)', async ({ page }) => {
+  await page.goto('/?systemName=Generic&audioEnabled=false');
+  await expect(page.locator('#system-selector')).toBeVisible({ timeout: 4 * 60 * 1000 });
+
+  await page.getByRole('button', { name: 'Start' }).click();
+  // The Stats button is only enabled once a system is running.
+  const statsButton = page.getByRole('button', { name: 'Stats' });
+  await expect(statsButton).toBeEnabled({ timeout: 60 * 1000 });
+  await statsButton.click();
+
+  const statsPanel = page.locator('.statsStyle .infobox-output');
+  await expect(statsPanel).toBeVisible({ timeout: 60 * 1000 });
+  await page.waitForTimeout(SETTLE_MS);
+
+  const stats: Record<string, string> = {};
+  const headers = statsPanel.locator('span.header');
+  const values = statsPanel.locator('span.value');
+  const count = await headers.count();
+  for (let i = 0; i < count; i++) {
+    stats[(await headers.nth(i).innerText()).trim()] = (await values.nth(i).innerText()).trim();
+  }
+
+  const fpsKey = Object.keys(stats).find(k => k.endsWith('OnUpdateFPS'));
+  const fps = fpsKey ? Number.parseFloat(stats[fpsKey]) : Number.NaN;
+  const systemTimeKey = Object.keys(stats).find(k => k === 'SystemTime' || k.endsWith('-SystemTime'));
+  const systemTimeMs = systemTimeKey ? Number.parseFloat(stats[systemTimeKey]) : Number.NaN;
+
+  const readout = {
+    app: 'blazor',
+    system: 'Generic',
+    userAgent: await page.evaluate(() => navigator.userAgent),
+    settleMs: SETTLE_MS,
+    hostFps: fps,
+    emulatorMsPerFrame: systemTimeMs,
+    stats,
+  };
+  writeFileSync('speed-readout.json', JSON.stringify(readout, null, 2));
+  writeFileSync(
+    'speed-readout.md',
+    [
+      '| Metric | Value |',
+      '| --- | --- |',
+      `| Host frame rate (OnUpdateFPS) | ${Number.isNaN(fps) ? 'n/a' : fps.toFixed(2)} |`,
+      `| Emulator time per frame (SystemTime) | ${Number.isNaN(systemTimeMs) ? 'n/a' : systemTimeMs.toFixed(2) + ' ms'} |`,
+      ...Object.entries(stats).map(([k, v]) => `| ${k} | ${v} |`),
+      '',
+    ].join('\n'),
+  );
+
+  expect(fpsKey, `No *OnUpdateFPS stat found. Stats seen: ${Object.keys(stats).join(', ')}`).toBeTruthy();
+  expect(fps, 'Emulator is not producing frames').toBeGreaterThan(1);
+});

--- a/tools/perf-compare.ps1
+++ b/tools/perf-compare.ps1
@@ -1,20 +1,21 @@
 #!/usr/bin/env pwsh
-# PowerShell sibling of tools/perf-compare.sh. Same behavior — see that file
-# for the full description.
+# PowerShell sibling of tools/perf-compare.sh. Same behavior — see that file for the full
+# description. Filter via -Filter or the PERF_COMPARE_FILTER environment variable.
 #
 # Usage:
-#   tools/perf-compare.ps1 [-BaselineRef <ref>]
+#   tools/perf-compare.ps1 [-BaselineRef <ref>] [-Filter '<globs>']
 
 [CmdletBinding()]
 param(
     [Parameter(Position = 0)]
-    [string]$BaselineRef = 'master'
+    [string]$BaselineRef = 'master',
+    [string]$Filter = $(if ($env:PERF_COMPARE_FILTER) { $env:PERF_COMPARE_FILTER } else { '*HotPathBenchmarks* *C64ExecuteFrameBenchmark* *C64ExecuteInstructionBenchmark*' })
 )
 
 $ErrorActionPreference = 'Stop'
 
 $Project = 'benchmarks/Highbyte.DotNet6502.Benchmarks/Highbyte.DotNet6502.Benchmarks.csproj'
-$ArtifactsDir = 'BenchmarkDotNet.Artifacts/results'
+$ArtifactsDir = 'BenchmarkDotNet.Artifacts'
 
 $RepoRoot = (& git rev-parse --show-toplevel).Trim()
 Set-Location $RepoRoot
@@ -32,15 +33,18 @@ New-Item -ItemType Directory -Path $OutDir | Out-Null
 
 try {
     function Invoke-Benchmark([string]$Label) {
+        $labelDir = Join-Path $OutDir $Label
+        New-Item -ItemType Directory -Path $labelDir | Out-Null
         Write-Output "perf-compare: running benchmarks on $Label..."
         if (Test-Path $ArtifactsDir) { Remove-Item -Recurse -Force $ArtifactsDir }
-        & dotnet run -c Release --project $Project -- --filter '*HotPathBenchmarks*' --exporters github | Out-Null
-        $csv = Get-ChildItem -Path $ArtifactsDir -Filter '*HotPathBenchmarks-report.csv' -ErrorAction SilentlyContinue | Select-Object -First 1
-        if (-not $csv) { throw "perf-compare: no benchmark CSV produced for $Label" }
-        Copy-Item $csv.FullName (Join-Path $OutDir "$Label.csv")
+        $filterArgs = $Filter -split '\s+' | Where-Object { $_ }
+        & dotnet run -c Release --project $Project -- --filter @filterArgs --exporters fulljson --artifacts $ArtifactsDir | Out-Null
+        $reports = Get-ChildItem -Path (Join-Path $ArtifactsDir 'results') -Filter '*-report-full.json' -ErrorAction SilentlyContinue
+        if (-not $reports) { throw "perf-compare: no benchmark JSON produced for $Label" }
+        foreach ($r in $reports) { Copy-Item $r.FullName $labelDir }
     }
 
-    Write-Output "perf-compare: baseline = $BaselineRef, head = $HeadRef"
+    Write-Output "perf-compare: baseline = $BaselineRef, head = $HeadRef, filter = $Filter"
 
     & git switch --detach $BaselineRef | Out-Null
     Invoke-Benchmark 'baseline'
@@ -50,65 +54,77 @@ try {
 
     & git switch $HeadRef 2>$null | Out-Null
 
-    function Parse-Time([string]$s) {
-        if (-not $s) { return $null }
-        $parts = $s -split '\s+'
-        if ($parts.Count -ne 2) { return $null }
-        $units = @{ 'ns' = 1.0; 'us' = 1000.0; 'ms' = 1000000.0; 's' = 1000000000.0 }
-        if (-not $units.ContainsKey($parts[1])) { return $null }
-        return ([double]($parts[0] -replace ',', '')) * $units[$parts[1]]
+    function Read-Results([string]$Dir) {
+        $rows = @{}
+        foreach ($file in Get-ChildItem -Path $Dir -Filter '*-report-full.json') {
+            $report = Get-Content $file.FullName -Raw | ConvertFrom-Json
+            foreach ($b in $report.Benchmarks) {
+                $mean = $null
+                if ($b.Statistics) { $mean = [double]$b.Statistics.Mean }
+                $alloc = 0.0
+                if ($b.Memory -and $null -ne $b.Memory.BytesAllocatedPerOperation) { $alloc = [double]$b.Memory.BytesAllocatedPerOperation }
+                $rows[$b.FullName] = @{ Mean = $mean; Alloc = $alloc }
+            }
+        }
+        return $rows
     }
 
-    function Parse-Alloc([string]$s) {
-        if (-not $s -or $s -eq '-') { return 0.0 }
-        $parts = $s -split '\s+'
-        if ($parts.Count -ne 2) { return $null }
-        $units = @{ 'B' = 1.0; 'KB' = 1024.0; 'MB' = 1048576.0 }
-        if (-not $units.ContainsKey($parts[1])) { return $null }
-        return ([double]($parts[0] -replace ',', '')) * $units[$parts[1]]
+    function Short-Name([string]$FullName) {
+        $idx = $FullName.IndexOf('(')
+        $head = if ($idx -ge 0) { $FullName.Substring(0, $idx) } else { $FullName }
+        $params = if ($idx -ge 0) { $FullName.Substring($idx) } else { '' }
+        $parts = $head -split '\.'
+        $tail = $parts[[Math]::Max(0, $parts.Count - 2)..($parts.Count - 1)] -join '.'
+        return $tail + $params
     }
 
-    $baseline = @{}
-    Import-Csv (Join-Path $OutDir 'baseline.csv') | ForEach-Object { $baseline[$_.Method] = $_ }
-    $head = @{}
-    Import-Csv (Join-Path $OutDir 'head.csv') | ForEach-Object { $head[$_.Method] = $_ }
+    function Format-Time($ns) {
+        if ($null -eq $ns) { return '?' }
+        if ($ns -ge 1e9) { return ('{0:N2} s' -f ($ns / 1e9)) }
+        if ($ns -ge 1e6) { return ('{0:N2} ms' -f ($ns / 1e6)) }
+        if ($ns -ge 1e3) { return ('{0:N2} us' -f ($ns / 1e3)) }
+        return ('{0:N2} ns' -f $ns)
+    }
+
+    $baseline = Read-Results (Join-Path $OutDir 'baseline')
+    $head = Read-Results (Join-Path $OutDir 'head')
 
     $RegressionRatio = 1.05
     $fail = $false
 
-    "{0,-45} {1,14} {2,14} {3,8} {4,10}" -f 'Method', 'baseline', 'head', 'ratio', 'alloc Δ' | Write-Output
-    '-' * 95 | Write-Output
+    "{0,-70} {1,12} {2,12} {3,7} {4,9}" -f 'Benchmark', 'baseline', 'head', 'ratio', 'alloc Δ' | Write-Output
+    '-' * 115 | Write-Output
 
-    foreach ($method in $head.Keys) {
-        $h = $head[$method]
-        $b = $baseline[$method]
+    foreach ($fullName in $head.Keys) {
+        $name = Short-Name $fullName
+        $h = $head[$fullName]
+        $b = $baseline[$fullName]
         if (-not $b) {
-            "{0,-45} {1,14} {2,14}" -f $method, '(new)', $h.Mean | Write-Output
+            "{0,-70} {1,12} {2,12}" -f $name, '(new)', (Format-Time $h.Mean) | Write-Output
             continue
         }
-        $bMean = Parse-Time $b.Mean
-        $hMean = Parse-Time $h.Mean
-        $bAlloc = Parse-Alloc $b.Allocated
-        $hAlloc = Parse-Alloc $h.Allocated
         $ratio = $null
         $ratioStr = '?'
-        if ($bMean -and $hMean) {
-            $ratio = $hMean / $bMean
+        if ($b.Mean -and $h.Mean) {
+            $ratio = $h.Mean / $b.Mean
             $ratioStr = '{0:N3}' -f $ratio
         }
-        $allocDelta = ''
-        if ($null -ne $bAlloc -and $null -ne $hAlloc) {
-            $delta = $hAlloc - $bAlloc
-            if ($delta -ne 0) { $allocDelta = ('{0:+0;-0;0}B' -f $delta) } else { $allocDelta = '0' }
-        }
-        "{0,-45} {1,14} {2,14} {3,8} {4,10}" -f $method, $b.Mean, $h.Mean, $ratioStr, $allocDelta | Write-Output
+        $delta = $h.Alloc - $b.Alloc
+        $allocStr = if ($delta -ne 0) { ('{0:+0;-0;0}B' -f $delta) } else { '0' }
+        "{0,-70} {1,12} {2,12} {3,7} {4,9}" -f $name, (Format-Time $b.Mean), (Format-Time $h.Mean), $ratioStr, $allocStr | Write-Output
         if ($ratio -and $ratio -ge $RegressionRatio) {
-            "  REGRESSION: $method is $([math]::Round(($ratio - 1) * 100, 1))% slower" | Write-Output
+            "  REGRESSION: $name is $([math]::Round(($ratio - 1) * 100, 1))% slower" | Write-Output
             $fail = $true
         }
-        if ($bAlloc -eq 0 -and $hAlloc -gt 0) {
-            "  REGRESSION: $method introduces $hAlloc B of allocations" | Write-Output
+        if ($b.Alloc -eq 0 -and $h.Alloc -gt 0) {
+            "  REGRESSION: $name introduces $($h.Alloc) B of allocations" | Write-Output
             $fail = $true
+        }
+    }
+
+    foreach ($fullName in $baseline.Keys) {
+        if (-not $head.ContainsKey($fullName)) {
+            "{0,-70} {1,12}" -f (Short-Name $fullName), '(removed)' | Write-Output
         }
     }
 

--- a/tools/perf-compare.sh
+++ b/tools/perf-compare.sh
@@ -1,23 +1,29 @@
 #!/usr/bin/env bash
-# Run the HotPathBenchmarks suite on a baseline ref (default: master) and on the
-# current HEAD, then print a side-by-side comparison of the mean times and
-# allocations. Flags any benchmark where HEAD is >= 5% slower than baseline or
-# where HEAD allocates and baseline did not.
+# Run a BenchmarkDotNet suite on a baseline ref (default: master) and on the current HEAD, then
+# print a side-by-side comparison of mean times and allocations. Flags any benchmark where HEAD is
+# >= 5% slower than baseline or where HEAD allocates and baseline did not.
+#
+# Covers the CPU hot-path suite and the integrated C64 instruction/frame suites by default; set
+# PERF_COMPARE_FILTER to a space-separated list of BenchmarkDotNet --filter globs to change that.
+# Benchmarks are keyed on their full name (class, method and parameters), so parameterised
+# suites compare row by row.
 #
 # Requirements:
-#   - dotnet SDK matching global.json.
+#   - dotnet SDK.
 #   - Clean working tree (script switches branches with `git switch --detach`).
-#   - python3 (for the table-diff step).
+#   - python3 (for the comparison step).
 #
 # Usage:
 #   tools/perf-compare.sh [BASELINE_REF]
 #     BASELINE_REF = git ref to compare against (default: master)
+#   PERF_COMPARE_FILTER='*HotPathBenchmarks*' tools/perf-compare.sh   # only the CPU suite
 
 set -euo pipefail
 
 BASELINE_REF="${1:-master}"
+FILTER="${PERF_COMPARE_FILTER:-*HotPathBenchmarks* *C64ExecuteFrameBenchmark* *C64ExecuteInstructionBenchmark*}"
 PROJECT="benchmarks/Highbyte.DotNet6502.Benchmarks/Highbyte.DotNet6502.Benchmarks.csproj"
-ARTIFACTS_DIR="BenchmarkDotNet.Artifacts/results"
+ARTIFACTS_DIR="BenchmarkDotNet.Artifacts"
 OUT_DIR="$(mktemp -d -t perf-compare.XXXXXX)"
 trap 'rm -rf "$OUT_DIR"' EXIT
 
@@ -36,25 +42,29 @@ fi
 
 run_benchmark() {
   local label="$1"
-  local outfile="$OUT_DIR/$label.csv"
-  echo "perf-compare: running benchmarks on $label..."
+  local outdir="$OUT_DIR/$label"
+  mkdir -p "$outdir"
+  echo "perf-compare: running benchmarks on $label ($(git rev-parse --short HEAD))..."
   rm -rf "$ARTIFACTS_DIR"
+  # shellcheck disable=SC2086 -- FILTER is a deliberate list of globs.
   dotnet run -c Release --project "$PROJECT" -- \
-    --filter '*HotPathBenchmarks*' \
-    --exporters github \
+    --filter $FILTER \
+    --exporters fulljson \
+    --artifacts "$ARTIFACTS_DIR" \
     >/dev/null
-  # BenchmarkDotNet writes results as <namespace>.HotPathBenchmarks-report-github.md
-  # plus a CSV. Grab the CSV for diffing.
-  local csv
-  csv=$(ls "$ARTIFACTS_DIR"/*HotPathBenchmarks-report.csv 2>/dev/null | head -1 || true)
-  if [[ -z "$csv" ]]; then
-    echo "perf-compare: no benchmark CSV produced for $label" >&2
+  local found=0
+  for f in "$ARTIFACTS_DIR"/results/*-report-full.json; do
+    [[ -f "$f" ]] || continue
+    cp "$f" "$outdir/"
+    found=1
+  done
+  if [[ "$found" -eq 0 ]]; then
+    echo "perf-compare: no benchmark JSON produced for $label" >&2
     exit 3
   fi
-  cp "$csv" "$outfile"
 }
 
-echo "perf-compare: baseline = $BASELINE_REF, head = $head_ref"
+echo "perf-compare: baseline = $BASELINE_REF, head = $head_ref, filter = $FILTER"
 
 git switch --detach "$BASELINE_REF"
 run_benchmark baseline
@@ -65,74 +75,78 @@ run_benchmark head
 # Restore the original branch (best effort -- detached state means we re-checkout).
 git switch "$head_ref" 2>/dev/null || true
 
-python3 - "$OUT_DIR/baseline.csv" "$OUT_DIR/head.csv" <<'PY'
-import csv
+python3 - "$OUT_DIR/baseline" "$OUT_DIR/head" <<'PY'
+import glob
+import json
+import os
 import sys
 
-baseline_path, head_path = sys.argv[1], sys.argv[2]
+baseline_dir, head_dir = sys.argv[1], sys.argv[2]
 
-def load(path):
-    with open(path, newline='') as f:
-        return {row['Method']: row for row in csv.DictReader(f)}
+def short_name(full_name):
+    # "Ns.Sub.Class.Method(Param: X)" -> "Class.Method(Param: X)"
+    head, sep, params = full_name.partition('(')
+    parts = head.split('.')
+    return '.'.join(parts[-2:]) + sep + params
 
-baseline = load(baseline_path)
-head = load(head_path)
+def load(directory):
+    rows = {}
+    for path in sorted(glob.glob(os.path.join(directory, '*-report-full.json'))):
+        with open(path, encoding='utf-8-sig') as f:
+            report = json.load(f)
+        for b in report.get('Benchmarks', []):
+            stats = b.get('Statistics') or {}
+            memory = b.get('Memory') or {}
+            rows[b['FullName']] = {
+                'mean_ns': stats.get('Mean'),
+                'alloc_b': memory.get('BytesAllocatedPerOperation'),
+            }
+    return rows
 
-def parse_time(s):
-    # BenchmarkDotNet writes durations like "12.34 ns" or "1.23 us".
-    units = {'ns': 1.0, 'us': 1_000.0, 'ms': 1_000_000.0, 's': 1_000_000_000.0}
-    if not s:
-        return None
-    parts = s.split()
-    if len(parts) != 2 or parts[1] not in units:
-        return None
-    return float(parts[0].replace(',', '')) * units[parts[1]]
+def fmt_time(ns):
+    if ns is None:
+        return '?'
+    for unit, div in (('s', 1e9), ('ms', 1e6), ('us', 1e3)):
+        if ns >= div:
+            return f"{ns / div:,.2f} {unit}"
+    return f"{ns:,.2f} ns"
 
-def parse_alloc(s):
-    if not s or s == '-':
-        return 0.0
-    units = {'B': 1.0, 'KB': 1024.0, 'MB': 1024.0 ** 2}
-    parts = s.split()
-    if len(parts) != 2 or parts[1] not in units:
-        return None
-    return float(parts[0].replace(',', '')) * units[parts[1]]
+baseline = load(baseline_dir)
+head = load(head_dir)
 
 REGRESSION_RATIO = 1.05
 fail = False
 
-header = f"{'Method':<45} {'baseline':>14} {'head':>14} {'ratio':>8} {'alloc Δ':>10}"
+header = f"{'Benchmark':<70} {'baseline':>12} {'head':>12} {'ratio':>7} {'alloc Δ':>9}"
 print(header)
 print('-' * len(header))
 
-for method, head_row in head.items():
-    baseline_row = baseline.get(method)
-    if baseline_row is None:
-        print(f"{method:<45} {'(new)':>14} {head_row.get('Mean', ''):>14}")
+for full_name, h in head.items():
+    name = short_name(full_name)
+    b = baseline.get(full_name)
+    if b is None:
+        print(f"{name:<70} {'(new)':>12} {fmt_time(h['mean_ns']):>12}")
         continue
-    b_mean = parse_time(baseline_row.get('Mean', ''))
-    h_mean = parse_time(head_row.get('Mean', ''))
-    b_alloc = parse_alloc(baseline_row.get('Allocated', ''))
-    h_alloc = parse_alloc(head_row.get('Allocated', ''))
-    if b_mean is None or h_mean is None:
-        ratio_s = '?'
-        ratio = None
-    else:
-        ratio = h_mean / b_mean
+    ratio = None
+    ratio_s = '?'
+    if b['mean_ns'] and h['mean_ns']:
+        ratio = h['mean_ns'] / b['mean_ns']
         ratio_s = f"{ratio:.3f}"
-    alloc_delta = ''
-    if b_alloc is not None and h_alloc is not None:
-        delta = h_alloc - b_alloc
-        if delta != 0:
-            alloc_delta = f"{delta:+.0f}B"
-        else:
-            alloc_delta = '0'
-    print(f"{method:<45} {baseline_row.get('Mean',''):>14} {head_row.get('Mean',''):>14} {ratio_s:>8} {alloc_delta:>10}")
+    b_alloc = b['alloc_b'] or 0
+    h_alloc = h['alloc_b'] or 0
+    delta = h_alloc - b_alloc
+    alloc_s = f"{delta:+.0f}B" if delta else '0'
+    print(f"{name:<70} {fmt_time(b['mean_ns']):>12} {fmt_time(h['mean_ns']):>12} {ratio_s:>7} {alloc_s:>9}")
     if ratio is not None and ratio >= REGRESSION_RATIO:
-        print(f"  REGRESSION: {method} is {((ratio - 1) * 100):.1f}% slower")
+        print(f"  REGRESSION: {name} is {((ratio - 1) * 100):.1f}% slower")
         fail = True
-    if b_alloc == 0 and h_alloc and h_alloc > 0:
-        print(f"  REGRESSION: {method} introduces {h_alloc:.0f}B of allocations")
+    if b_alloc == 0 and h_alloc > 0:
+        print(f"  REGRESSION: {name} introduces {h_alloc:.0f}B of allocations")
         fail = True
+
+for full_name in baseline:
+    if full_name not in head:
+        print(f"{short_name(full_name):<70} {'(removed)':>12}")
 
 sys.exit(1 if fail else 0)
 PY


### PR DESCRIPTION
Groundwork for cycle-level CPU and C64 timing work: a recorded performance baseline, interrupt-line storage that can be sampled cheaply, a real-ROM C64 test oracle in CI, and benchmark infrastructure.

- Record CPU and C64 benchmark baselines from master `29132270` in `RESULTS.md`.
- Replace `CPUInterrupts`' string-keyed collections with bitmask line state and `InterruptSource` handles; keep the string API as a façade; drop the LINQ loop from the IRQ servicing path. Snapshot wire format unchanged.
- Add characterization tests for instruction events, evaluator timing, unknown opcode, JAM, counters, clone, the interrupt storage, and interrupt-line snapshot round trips.
- Add `C64TestRoms`: locates the KERNAL/BASIC/character ROMs, downloads and SHA-1 verifies them when `DOTNET6502_DOWNLOAD_TEST_ROMS` is set, and skips visibly otherwise. First real-ROM boot tests. The CI test job opts in with a cached ROM directory.
- Add a manually dispatched `Benchmarks` workflow; rewrite `perf-compare` on JSON results keyed by full benchmark name across the CPU and C64 suites.
- Add a Blazor WASM emulated-speed readout spec to the WASM AOT workflow (informational, never gates).
- Document test ROMs, benchmarks, and the readout in the developer docs.

Public API note: `CPUInterrupts.ActiveIRQSources` and `ActiveNMISources` are now read-only enumerations instead of a mutable `Dictionary` and `HashSet`. No in-repo consumer mutated them; external callers that did would need to use the `Set*`/`ClearAll` methods.

Notes:
- The `Benchmarks` workflow can be dispatched only after this merges, since `workflow_dispatch` requires the file on the default branch.
- The Blazor speed readout runs in the WASM AOT workflow on this PR for the first time.
