### PR TITLE
Add cycle engine prototype lab and record the chosen execution design

### DIFF
--- a/dotnet-6502.slnx
+++ b/dotnet-6502.slnx
@@ -34,6 +34,11 @@
   <Folder Name="/Benchmarks/">
     <Project Path="benchmarks/Highbyte.DotNet6502.Benchmarks/Highbyte.DotNet6502.Benchmarks.csproj" />
   </Folder>
+  <Folder Name="/Labs/">
+    <Project Path="labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Benchmarks/Highbyte.DotNet6502.CycleEnginePrototype.Benchmarks.csproj" />
+    <Project Path="labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Tests/Highbyte.DotNet6502.CycleEnginePrototype.Tests.csproj" />
+    <Project Path="labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.csproj" />
+  </Folder>
   <Folder Name="/Libs/">
     <Project Path="src/libraries/Highbyte.DotNet6502.AI/Highbyte.DotNet6502.AI.csproj" />
     <Project Path="src/libraries/Highbyte.DotNet6502.DebugAdapter/Highbyte.DotNet6502.DebugAdapter.csproj" />

--- a/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Benchmarks/EngineBenchmarks.cs
+++ b/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Benchmarks/EngineBenchmarks.cs
@@ -1,0 +1,79 @@
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+
+namespace Highbyte.DotNet6502.CycleEnginePrototype.Benchmarks;
+
+internal sealed class PrototypeConfig : ManualConfig
+{
+    public PrototypeConfig()
+    {
+        AddJob(Job.Default);
+        AddDiagnoser(MemoryDiagnoser.Default);
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            AddDiagnoser(new DisassemblyDiagnoser(new DisassemblyDiagnoserConfig(maxDepth: 2, exportHtml: true)));
+    }
+}
+
+/// <summary>
+/// Cost of the cycle-stamped engine's two device policies relative to the production executor, on the same slice loop:
+/// 100 iterations of 14 instructions, with the devices absent, ticking, or ticking with bad lines
+/// (so reads stall). Every engine runs its own CPU, memory and device stub.
+/// </summary>
+[Config(typeof(PrototypeConfig))]
+public class EngineBenchmarks
+{
+    public enum DeviceMode
+    {
+        None,
+        Ticking,
+        TickingWithBadLines,
+    }
+
+    private const int Iterations = 100;
+    private const int Instructions = Iterations * SliceProgram.InstructionsPerIteration;
+
+    [Params(DeviceMode.None, DeviceMode.Ticking, DeviceMode.TickingWithBadLines)]
+    public DeviceMode Devices { get; set; }
+
+    private ICycleEngine _legacy = default!;
+    private ICycleEngine _atomicPerCycle = default!;
+    private ICycleEngine _atomicLazy = default!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _legacy = Build(EngineKind.Legacy);
+        _atomicPerCycle = Build(EngineKind.AtomicPerCycle);
+        _atomicLazy = Build(EngineKind.AtomicLazy);
+    }
+
+    private ICycleEngine Build(EngineKind kind)
+    {
+        var cpu = new CPU(CpuCompatibilityProfile.FullUnofficial);
+        var mem = new Memory();
+        var system = new SystemStub(cpu.CPUInterrupts) { BadLinesEnabled = Devices == DeviceMode.TickingWithBadLines };
+        if (Devices != DeviceMode.None)
+            system.StartCiaTimer(3000);
+        SliceProgram.Assemble(mem, cpu);
+        return EngineFactory.Create(kind, cpu, mem, system, CpuFamily.Nmos, devicesEnabled: Devices != DeviceMode.None);
+    }
+
+    private static ulong Run(ICycleEngine engine)
+    {
+        for (var i = 0; i < Instructions; i++)
+            engine.RunInstruction();
+        return engine.Cycle;
+    }
+
+    [Benchmark(Baseline = true)]
+    public ulong Legacy() => Run(_legacy);
+
+    [Benchmark]
+    public ulong AtomicPerCycle() => Run(_atomicPerCycle);
+
+    [Benchmark]
+    public ulong AtomicLazy() => Run(_atomicLazy);
+}

--- a/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Benchmarks/Highbyte.DotNet6502.CycleEnginePrototype.Benchmarks.csproj
+++ b/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Benchmarks/Highbyte.DotNet6502.CycleEnginePrototype.Benchmarks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Highbyte.DotNet6502.CycleEnginePrototype\Highbyte.DotNet6502.CycleEnginePrototype.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Benchmarks/Program.cs
+++ b/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Benchmarks/Program.cs
@@ -1,0 +1,8 @@
+using BenchmarkDotNet.Running;
+using Highbyte.DotNet6502.CycleEnginePrototype.Benchmarks;
+
+// dotnet run -c Release --project labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Benchmarks
+if (args.Length > 0)
+    BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+else
+    BenchmarkRunner.Run<EngineBenchmarks>();

--- a/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Tests/BusTraceRecorder.cs
+++ b/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Tests/BusTraceRecorder.cs
@@ -1,0 +1,40 @@
+namespace Highbyte.DotNet6502.CycleEnginePrototype.Tests;
+
+/// <summary>
+/// Records the ordered bus accesses to watched addresses through the production memory-mapped
+/// I/O seam, the same way the main test suite's recorder does. Watched addresses behave as RAM.
+/// </summary>
+internal sealed class BusTraceRecorder
+{
+    public readonly record struct BusAccess(bool IsRead, ushort Address, byte Value)
+    {
+        public override string ToString() => $"{(IsRead ? "R" : "W")} {Address:x4}={Value:x2}";
+    }
+
+    private readonly List<BusAccess> _accesses = new();
+    private readonly Dictionary<ushort, byte> _store = new();
+
+    public IReadOnlyList<BusAccess> Accesses => _accesses;
+
+    public void Watch(Memory mem, ushort startAddress, int length)
+    {
+        for (var i = 0; i < length; i++)
+        {
+            var address = (ushort)(startAddress + i);
+            _store[address] = mem[address];
+            mem.MapReader(address, a =>
+            {
+                var value = _store[a];
+                _accesses.Add(new BusAccess(true, a, value));
+                return value;
+            });
+            mem.MapWriter(address, (a, value) =>
+            {
+                _accesses.Add(new BusAccess(false, a, value));
+                _store[a] = value;
+            });
+        }
+    }
+
+    public string Describe() => string.Join(" ", _accesses);
+}

--- a/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Tests/EngineFixture.cs
+++ b/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Tests/EngineFixture.cs
@@ -1,0 +1,95 @@
+using Highbyte.DotNet6502.Utils;
+
+namespace Highbyte.DotNet6502.CycleEnginePrototype.Tests;
+
+/// <summary>One CPU, memory, device stub and engine, arranged identically for every candidate.</summary>
+internal sealed class EngineFixture
+{
+    public const ushort Start = 0x1000;
+
+    public CPU Cpu { get; }
+    public Memory Mem { get; }
+    public SystemStub System { get; }
+    public BusTraceRecorder Recorder { get; } = new();
+    public ICycleEngine Engine { get; }
+
+    private EngineFixture(CPU cpu, Memory mem, SystemStub system, ICycleEngine engine)
+    {
+        Cpu = cpu;
+        Mem = mem;
+        System = system;
+        Engine = engine;
+    }
+
+    /// <summary>
+    /// Builds a fixture with <paramref name="code"/> at <see cref="Start"/>, arranges CPU and memory,
+    /// then starts recording the program page, the stack page, the data page and the vectors.
+    /// </summary>
+    public static EngineFixture Create(
+        EngineKind kind,
+        byte[] code,
+        Action<CPU>? arrangeCpu = null,
+        Action<Memory>? arrangeMem = null,
+        CpuFamily family = CpuFamily.Nmos,
+        bool badLines = false,
+        bool record = true)
+    {
+        var cpu = new CPU(CpuCompatibilityProfile.FullUnofficial);
+        var mem = new Memory();
+        var system = new SystemStub(cpu.CPUInterrupts) { BadLinesEnabled = badLines };
+
+        cpu.PC = Start;
+        cpu.SP = 0xFF;
+        cpu.ProcessorStatus.InterruptDisable = true;
+        for (var i = 0; i < code.Length; i++)
+            mem[(ushort)(Start + i)] = code[i];
+        arrangeCpu?.Invoke(cpu);
+        arrangeMem?.Invoke(mem);
+
+        var fixture = new EngineFixture(cpu, mem, system, EngineFactory.Create(kind, cpu, mem, system, family, devicesEnabled: true));
+        if (record)
+        {
+            fixture.Recorder.Watch(mem, 0x0F00, 0x0300);       // program area incl. the page below and above
+            fixture.Recorder.Watch(mem, 0x0100, 0x0100);       // stack
+            fixture.Recorder.Watch(mem, 0x1F00, 0x0100);       // subroutine / handler area
+            fixture.Recorder.Watch(mem, 0x2000, 0x0200);       // data
+            fixture.Recorder.Watch(mem, 0xFFFA, 6);            // vectors
+        }
+        return fixture;
+    }
+
+    public string Trace => Recorder.Describe();
+
+    public static IEnumerable<object[]> Candidates()
+        => EngineFactory.Candidates.Select(kind => new object[] { kind });
+
+    /// <summary>Registers, flags and cycles of the production executor after the same single instruction.</summary>
+    public static (byte A, byte X, byte Y, byte SP, ushort PC, byte PS, ulong Cycles) RunLegacy(
+        byte[] code, Action<CPU>? arrangeCpu = null, Action<Memory>? arrangeMem = null)
+    {
+        var cpu = new CPU(CpuCompatibilityProfile.FullUnofficial);
+        var mem = new Memory();
+        cpu.PC = Start;
+        cpu.SP = 0xFF;
+        cpu.ProcessorStatus.InterruptDisable = true;
+        for (var i = 0; i < code.Length; i++)
+            mem[(ushort)(Start + i)] = code[i];
+        arrangeCpu?.Invoke(cpu);
+        arrangeMem?.Invoke(mem);
+        var result = cpu.ExecuteOneInstructionMinimal(mem);
+        return (cpu.A, cpu.X, cpu.Y, cpu.SP, cpu.PC, cpu.ProcessorStatus.Value, result.CyclesConsumed);
+    }
+
+    public void AssertMatchesLegacy(byte[] code, Action<CPU>? arrangeCpu = null, Action<Memory>? arrangeMem = null, bool ignoreBreakAndUnused = false)
+    {
+        var legacy = RunLegacy(code, arrangeCpu, arrangeMem);
+        Assert.Equal(legacy.A, Cpu.A);
+        Assert.Equal(legacy.X, Cpu.X);
+        Assert.Equal(legacy.Y, Cpu.Y);
+        Assert.Equal(legacy.SP, Cpu.SP);
+        Assert.Equal(legacy.PC, Cpu.PC);
+        var mask = ignoreBreakAndUnused ? 0xCF : 0xFF;
+        Assert.Equal(legacy.PS & mask, Cpu.ProcessorStatus.Value & mask);
+        Assert.Equal(legacy.Cycles, Engine.Cycle);
+    }
+}

--- a/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Tests/GlobalUsings.cs
+++ b/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Tests/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using Xunit;
+global using Highbyte.DotNet6502.CycleEnginePrototype;

--- a/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Tests/Highbyte.DotNet6502.CycleEnginePrototype.Tests.csproj
+++ b/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Tests/Highbyte.DotNet6502.CycleEnginePrototype.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Highbyte.DotNet6502.CycleEnginePrototype\Highbyte.DotNet6502.CycleEnginePrototype.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Tests/InterruptAndStallTests.cs
+++ b/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Tests/InterruptAndStallTests.cs
@@ -1,0 +1,107 @@
+using Highbyte.DotNet6502.Utils;
+
+namespace Highbyte.DotNet6502.CycleEnginePrototype.Tests;
+
+public class InterruptAndStallTests
+{
+    public static IEnumerable<object[]> Candidates => EngineFixture.Candidates();
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Irq_Entry_Is_Seven_Bus_Cycles_Starting_With_Two_Reads_At_Pc(EngineKind kind)
+    {
+        byte[] code = [SliceOpcodes.Nop];
+        static void Cpu(CPU c)
+        {
+            c.ProcessorStatus.Value = 0x00;
+            c.CPUInterrupts.SetIRQSourceActive("device", autoAcknowledge: true);
+        }
+        static void Mem(Memory m) => m.WriteWord(CPU.BrkIRQHandlerVector, 0x1F80);
+        var f = EngineFixture.Create(kind, code, Cpu, Mem);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=ea R 1000=ea W 01ff=10 W 01fe=00 W 01fd=20 R fffe=80 R ffff=1f", f.Trace);
+        Assert.Equal(7ul, f.Engine.Cycle);
+        Assert.Equal((ushort)0x1F80, f.Cpu.PC);
+        Assert.True(f.Cpu.ProcessorStatus.InterruptDisable);
+        Assert.False(f.Cpu.CPUInterrupts.IRQLineEnabled);   // auto-acknowledged on service
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Nmi_Entry_Uses_The_Nmi_Vector_And_Clears_The_Latch(EngineKind kind)
+    {
+        byte[] code = [SliceOpcodes.Nop];
+        static void Cpu(CPU c) => c.CPUInterrupts.SetNMISourceActive("restore");
+        static void Mem(Memory m) => m.WriteWord(CPU.NonMaskableIRQHandlerVector, 0x1F90);
+        var f = EngineFixture.Create(kind, code, Cpu, Mem);
+
+        f.Engine.RunInstruction();
+
+        Assert.EndsWith("R fffa=90 R fffb=1f", f.Trace);
+        Assert.Equal(7ul, f.Engine.Cycle);
+        Assert.Equal((ushort)0x1F90, f.Cpu.PC);
+        Assert.False(f.Cpu.CPUInterrupts.NMIPending);
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Irq_Is_Held_Off_While_InterruptDisable_Is_Set(EngineKind kind)
+    {
+        byte[] code = [SliceOpcodes.Nop, 0x12];
+        static void Cpu(CPU c) => c.CPUInterrupts.SetIRQSourceActive("device", autoAcknowledge: true);
+        var f = EngineFixture.Create(kind, code, Cpu);     // fixture sets I
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=ea R 1001=12", f.Trace);
+        Assert.True(f.Cpu.CPUInterrupts.IRQLineEnabled);
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Read_Cycles_Stall_While_Ba_Is_Low(EngineKind kind)
+    {
+        // Bad line $33 (YSCROLL 3), positioned so the opcode fetch lands on cycle 9 and the
+        // operand fetch on cycle 12, where BA goes low until cycle 54: 42 stalled cycles.
+        byte[] code = [SliceOpcodes.LdaAbs, 0x00, 0x20];
+        var f = EngineFixture.Create(kind, code, badLines: true);
+        f.System.SetRasterPosition(0x33, 8);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=ad R 1001=00 R 1002=20 R 2000=00", f.Trace);
+        Assert.Equal(4ul + 42ul, f.Engine.Cycle);
+        f.Engine.FlushDevices();
+        Assert.Equal(f.Engine.Cycle, f.System.MasterCycle);
+        Assert.Equal(0x33, f.System.RasterLine);
+        Assert.Equal(8 + 46, f.System.RasterCycle);
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Write_Cycles_Do_Not_Stall_While_Ba_Is_Low(EngineKind kind)
+    {
+        // Opcode fetch on cycle 8, low/high on 9/10, dummy read on 11, and the write on cycle 12
+        // where BA is low: the write proceeds, no stall.
+        byte[] code = [SliceOpcodes.StaAbsX, 0x00, 0x20];
+        static void Cpu(CPU c) { c.X = 1; c.A = 0x77; }
+        var f = EngineFixture.Create(kind, code, Cpu, badLines: true);
+        f.System.SetRasterPosition(0x33, 7);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=9d R 1001=00 R 1002=20 R 2001=00 W 2001=77", f.Trace);
+        Assert.Equal(5ul, f.Engine.Cycle);
+        f.Engine.FlushDevices();
+        Assert.Equal(12, f.System.RasterCycle);
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void No_Stall_On_A_Line_That_Is_Not_A_Bad_Line(EngineKind kind)
+    {
+        byte[] code = [SliceOpcodes.LdaAbs, 0x00, 0x20];
+        var f = EngineFixture.Create(kind, code, badLines: true);
+        f.System.SetRasterPosition(0x34, 8);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal(4ul, f.Engine.Cycle);
+    }
+}

--- a/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Tests/SliceTraceTests.cs
+++ b/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Tests/SliceTraceTests.cs
@@ -1,0 +1,245 @@
+using Highbyte.DotNet6502.Utils;
+
+namespace Highbyte.DotNet6502.CycleEnginePrototype.Tests;
+
+/// <summary>
+/// Both device policies must produce the same ordered bus trace, cycle count and final state for each
+/// shape in the slice. Expected traces are hand-derived from the documented 6502 cycle sequences
+/// (one bus access per cycle, dummy reads included), so they are readable without decoding an
+/// external vector. Final state and total cycles are also checked against the production executor.
+/// </summary>
+public class SliceTraceTests
+{
+    public static IEnumerable<object[]> Candidates => EngineFixture.Candidates();
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Lda_Immediate(EngineKind kind)
+    {
+        byte[] code = [SliceOpcodes.LdaImm, 0x42];
+        var f = EngineFixture.Create(kind, code);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=a9 R 1001=42", f.Trace);
+        Assert.Equal(2ul, f.Engine.Cycle);
+        Assert.Equal(0x42, f.Cpu.A);
+        Assert.Equal((ushort)0x1002, f.Cpu.PC);
+        f.AssertMatchesLegacy(code);
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Lda_Absolute(EngineKind kind)
+    {
+        byte[] code = [SliceOpcodes.LdaAbs, 0x00, 0x20];
+        static void Mem(Memory m) => m[0x2000] = 0x33;
+        var f = EngineFixture.Create(kind, code, arrangeMem: Mem);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=ad R 1001=00 R 1002=20 R 2000=33", f.Trace);
+        Assert.Equal(4ul, f.Engine.Cycle);
+        Assert.Equal(0x33, f.Cpu.A);
+        f.AssertMatchesLegacy(code, arrangeMem: Mem);
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Lda_AbsoluteX_Without_Page_Cross_Reads_Once(EngineKind kind)
+    {
+        byte[] code = [SliceOpcodes.LdaAbsX, 0x00, 0x20];
+        static void Cpu(CPU c) => c.X = 1;
+        static void Mem(Memory m) => m[0x2001] = 0x44;
+        var f = EngineFixture.Create(kind, code, Cpu, Mem);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=bd R 1001=00 R 1002=20 R 2001=44", f.Trace);
+        Assert.Equal(4ul, f.Engine.Cycle);
+        Assert.Equal(0x44, f.Cpu.A);
+        f.AssertMatchesLegacy(code, Cpu, Mem);
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Lda_AbsoluteX_With_Page_Cross_Dummy_Reads_The_Uncarried_Address(EngineKind kind)
+    {
+        byte[] code = [SliceOpcodes.LdaAbsX, 0xFF, 0x20];
+        static void Cpu(CPU c) => c.X = 1;
+        static void Mem(Memory m) { m[0x2000] = 0x99; m[0x2100] = 0x55; }
+        var f = EngineFixture.Create(kind, code, Cpu, Mem);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=bd R 1001=ff R 1002=20 R 2000=99 R 2100=55", f.Trace);
+        Assert.Equal(5ul, f.Engine.Cycle);
+        Assert.Equal(0x55, f.Cpu.A);
+        f.AssertMatchesLegacy(code, Cpu, Mem);
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Sta_AbsoluteX_Always_Dummy_Reads_Then_Writes(EngineKind kind)
+    {
+        byte[] code = [SliceOpcodes.StaAbsX, 0xFF, 0x20];
+        static void Cpu(CPU c) { c.X = 1; c.A = 0x77; }
+        static void Mem(Memory m) => m[0x2000] = 0x99;
+        var f = EngineFixture.Create(kind, code, Cpu, Mem);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=9d R 1001=ff R 1002=20 R 2000=99 W 2100=77", f.Trace);
+        Assert.Equal(5ul, f.Engine.Cycle);
+        f.AssertMatchesLegacy(code, Cpu, Mem);
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Inc_Absolute_Nmos_Reads_Writes_Back_Then_Writes(EngineKind kind)
+    {
+        byte[] code = [SliceOpcodes.IncAbs, 0x00, 0x20];
+        static void Mem(Memory m) => m[0x2000] = 0x7F;
+        var f = EngineFixture.Create(kind, code, arrangeMem: Mem, family: CpuFamily.Nmos);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=ee R 1001=00 R 1002=20 R 2000=7f W 2000=7f W 2000=80", f.Trace);
+        Assert.Equal(6ul, f.Engine.Cycle);
+        Assert.True(f.Cpu.ProcessorStatus.Negative);
+        f.AssertMatchesLegacy(code, arrangeMem: Mem);
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Inc_Absolute_Cmos_Reads_Twice_Then_Writes(EngineKind kind)
+    {
+        byte[] code = [SliceOpcodes.IncAbs, 0x00, 0x20];
+        static void Mem(Memory m) => m[0x2000] = 0x7F;
+        var f = EngineFixture.Create(kind, code, arrangeMem: Mem, family: CpuFamily.Cmos);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=ee R 1001=00 R 1002=20 R 2000=7f R 2000=7f W 2000=80", f.Trace);
+        Assert.Equal(6ul, f.Engine.Cycle);
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Bne_Not_Taken(EngineKind kind)
+    {
+        byte[] code = [SliceOpcodes.Bne, 0x05];
+        static void Cpu(CPU c) => c.ProcessorStatus.Zero = true;
+        var f = EngineFixture.Create(kind, code, Cpu);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=d0 R 1001=05", f.Trace);
+        Assert.Equal(2ul, f.Engine.Cycle);
+        Assert.Equal((ushort)0x1002, f.Cpu.PC);
+        f.AssertMatchesLegacy(code, Cpu);
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Bne_Taken_Same_Page_Dummy_Reads_The_Next_Opcode(EngineKind kind)
+    {
+        byte[] code = [SliceOpcodes.Bne, 0x05, 0xEE];
+        static void Cpu(CPU c) => c.ProcessorStatus.Zero = false;
+        var f = EngineFixture.Create(kind, code, Cpu);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=d0 R 1001=05 R 1002=ee", f.Trace);
+        Assert.Equal(3ul, f.Engine.Cycle);
+        Assert.Equal((ushort)0x1007, f.Cpu.PC);
+        f.AssertMatchesLegacy(code, Cpu);
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Bne_Taken_Across_Page_Dummy_Reads_The_Wrong_Page(EngineKind kind)
+    {
+        // BNE at $1000 with offset -$10: target $0FF2, PCH fix-up read at $10F2.
+        byte[] code = [SliceOpcodes.Bne, 0xF0, 0xEE];
+        static void Cpu(CPU c) => c.ProcessorStatus.Zero = false;
+        static void Mem(Memory m) => m[0x10F2] = 0xAB;
+        var f = EngineFixture.Create(kind, code, Cpu, Mem);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=d0 R 1001=f0 R 1002=ee R 10f2=ab", f.Trace);
+        Assert.Equal(4ul, f.Engine.Cycle);
+        Assert.Equal((ushort)0x0FF2, f.Cpu.PC);
+        f.AssertMatchesLegacy(code, Cpu, Mem);
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Nop_Dummy_Reads_The_Next_Byte(EngineKind kind)
+    {
+        byte[] code = [SliceOpcodes.Nop, 0x12];
+        var f = EngineFixture.Create(kind, code);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=ea R 1001=12", f.Trace);
+        Assert.Equal(2ul, f.Engine.Cycle);
+        Assert.Equal((ushort)0x1001, f.Cpu.PC);
+        f.AssertMatchesLegacy(code);
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Pha_Dummy_Reads_Then_Pushes(EngineKind kind)
+    {
+        byte[] code = [SliceOpcodes.Pha, 0x12];
+        static void Cpu(CPU c) => c.A = 0x42;
+        var f = EngineFixture.Create(kind, code, Cpu);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=48 R 1001=12 W 01ff=42", f.Trace);
+        Assert.Equal(3ul, f.Engine.Cycle);
+        Assert.Equal(0xFE, f.Cpu.SP);
+        f.AssertMatchesLegacy(code, Cpu);
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Jsr_Reads_The_Stack_Before_Pushing_And_Fetches_High_Byte_Last(EngineKind kind)
+    {
+        byte[] code = [SliceOpcodes.Jsr, 0x00, 0x1F];
+        var f = EngineFixture.Create(kind, code);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=20 R 1001=00 R 01ff=00 W 01ff=10 W 01fe=02 R 1002=1f", f.Trace);
+        Assert.Equal(6ul, f.Engine.Cycle);
+        Assert.Equal((ushort)0x1F00, f.Cpu.PC);
+        Assert.Equal(0xFD, f.Cpu.SP);
+        f.AssertMatchesLegacy(code);
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Rts_Dummy_Reads_Pulls_And_Increments(EngineKind kind)
+    {
+        byte[] code = [SliceOpcodes.Rts, 0x12];
+        static void Cpu(CPU c) => c.SP = 0xFD;
+        static void Mem(Memory m) { m[0x01FE] = 0x02; m[0x01FF] = 0x10; m[0x1002] = 0x34; }
+        var f = EngineFixture.Create(kind, code, Cpu, Mem);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=60 R 1001=12 R 01fd=00 R 01fe=02 R 01ff=10 R 1002=34", f.Trace);
+        Assert.Equal(6ul, f.Engine.Cycle);
+        Assert.Equal((ushort)0x1003, f.Cpu.PC);
+        Assert.Equal(0xFF, f.Cpu.SP);
+        f.AssertMatchesLegacy(code, Cpu, Mem);
+    }
+
+    [Theory, MemberData(nameof(Candidates))]
+    public void Rti_Pulls_Status_Then_Return_Address(EngineKind kind)
+    {
+        byte[] code = [SliceOpcodes.Rti, 0x12];
+        static void Cpu(CPU c) => c.SP = 0xFC;
+        static void Mem(Memory m) { m[0x01FD] = 0x23; m[0x01FE] = 0x00; m[0x01FF] = 0x1F; }
+        var f = EngineFixture.Create(kind, code, Cpu, Mem);
+
+        f.Engine.RunInstruction();
+
+        Assert.Equal("R 1000=40 R 1001=12 R 01fc=00 R 01fd=23 R 01fe=00 R 01ff=1f", f.Trace);
+        Assert.Equal(6ul, f.Engine.Cycle);
+        Assert.Equal((ushort)0x1F00, f.Cpu.PC);
+        Assert.Equal(0xFF, f.Cpu.SP);
+        Assert.Equal(0x23 | 0x20, f.Cpu.ProcessorStatus.Value & 0xEF);
+        f.AssertMatchesLegacy(code, Cpu, Mem, ignoreBreakAndUnused: true);
+    }
+}

--- a/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Tests/WholeProgramEquivalenceTests.cs
+++ b/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Tests/WholeProgramEquivalenceTests.cs
@@ -1,0 +1,54 @@
+namespace Highbyte.DotNet6502.CycleEnginePrototype.Tests;
+
+/// <summary>
+/// Runs the slice loop for thousands of instructions with bad lines and a timer IRQ active, and
+/// requires both device policies to end in the same CPU state, at the same cycle, with the same
+/// device state. Per-cycle sync is the oracle; lazy sync must match it exactly: same stalls, same
+/// interrupt timing, same VIC fetches, just fewer scheduler calls. Any device's closed-form
+/// Advance and any stall watermark is validated this way.
+/// </summary>
+public class WholeProgramEquivalenceTests
+{
+    private const int Instructions = 5000;
+
+    private sealed record Outcome(ulong Cycle, byte A, byte X, byte SP, ushort PC, byte PS, ulong MasterCycle, long VicFetches, int CiaUnderflows, int RasterLine, int RasterCycle);
+
+    private static Outcome Run(EngineKind kind)
+    {
+        var cpu = new CPU(CpuCompatibilityProfile.FullUnofficial);
+        var mem = new Memory();
+        var system = new SystemStub(cpu.CPUInterrupts) { BadLinesEnabled = true };
+        system.StartCiaTimer(700);
+        SliceProgram.Assemble(mem, cpu);
+        var engine = EngineFactory.Create(kind, cpu, mem, system);
+
+        for (var i = 0; i < Instructions; i++)
+            engine.RunInstruction();
+        engine.FlushDevices();
+
+        return new Outcome(engine.Cycle, cpu.A, cpu.X, cpu.SP, cpu.PC, cpu.ProcessorStatus.Value,
+            system.MasterCycle, system.VicFetchAccumulator, system.CiaUnderflows, system.RasterLine, system.RasterCycle);
+    }
+
+    [Fact]
+    public void Lazy_Sync_Matches_PerCycle_Sync_On_Cpu_State_Cycle_Count_And_Device_State()
+    {
+        var reference = Run(EngineKind.AtomicPerCycle);
+
+        Assert.Equal(reference, Run(EngineKind.AtomicLazy));
+
+        Assert.Equal(reference.Cycle, reference.MasterCycle);
+        Assert.True(reference.CiaUnderflows > 10, "the timer IRQ should have fired many times");
+        Assert.True(reference.Cycle > (ulong)Instructions * 3, "stalls and dummy cycles should be included");
+    }
+
+    [Fact]
+    public void Legacy_Runs_The_Same_Program_Without_Stalls()
+    {
+        var legacy = Run(EngineKind.Legacy);
+        var candidate = Run(EngineKind.AtomicLazy);
+
+        Assert.True(legacy.Cycle < candidate.Cycle, "the legacy executor has no RDY stalls, so it must consume fewer cycles");
+        Assert.Equal(legacy.MasterCycle, legacy.Cycle);
+    }
+}

--- a/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype/AtomicStampedEngine.cs
+++ b/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype/AtomicStampedEngine.cs
@@ -1,0 +1,311 @@
+using Highbyte.DotNet6502.Utils;
+
+namespace Highbyte.DotNet6502.CycleEnginePrototype;
+
+/// <summary>
+/// The chosen design: the instruction stays atomic (one call executes it to completion, exactly like the
+/// production handlers), but every cycle is a real bus access that carries the cycle number, and
+/// the bus decides what a cycle costs. There is no resumable state and no per-cycle dispatch.
+///
+/// Two device-synchronization policies share the same handlers:
+/// <list type="bullet">
+/// <item><see cref="DeviceSync.PerCycle"/> ticks the devices once per bus access, i.e. it is the
+/// per-cycle scheduler expressed through the bus.</item>
+/// <item><see cref="DeviceSync.Lazy"/> lets the devices fall behind and catches them up in bulk at
+/// instruction boundaries, plus exactly when a read reaches the next cycle at which BA will be low
+/// (a watermark the devices can predict). This is the shape a C64 scheduler would use.</item>
+/// </list>
+/// Both produce the same cycle counts and the same device state; the tests hold them to each other.
+/// </summary>
+public sealed class AtomicStampedEngine : ICycleEngine
+{
+    public enum DeviceSync
+    {
+        PerCycle,
+        Lazy,
+    }
+
+    private readonly CPU _cpu;
+    private readonly Memory _mem;
+    private readonly SystemStub _sys;
+    private readonly DeviceSync _sync;
+    private readonly bool _devices;
+    private readonly bool _cmos;
+    private ulong _cycle;
+    private ulong _nextBaLowCycle;
+    private int _baWatermarkVersion;
+
+    public AtomicStampedEngine(CPU cpu, Memory mem, SystemStub system, DeviceSync sync, CpuFamily family, bool devicesEnabled)
+    {
+        _cpu = cpu;
+        _mem = mem;
+        _sys = system;
+        _sync = sync;
+        _cmos = family == CpuFamily.Cmos;
+        _devices = devicesEnabled;
+        RecomputeBaWatermark();
+    }
+
+    public string Name => _sync == DeviceSync.PerCycle ? "Atomic/PerCycle" : "Atomic/Lazy";
+    public CPU Cpu => _cpu;
+    public Memory Mem => _mem;
+    public SystemStub System => _sys;
+    public ulong Cycle => _cycle;
+
+    public void FlushDevices()
+    {
+        if (_devices && _sync == DeviceSync.Lazy)
+            CatchUpDevices(_cycle);
+    }
+
+    // ----- the bus -----
+
+    private byte Read(ushort address)
+    {
+        if (_devices)
+        {
+            if (_sync == DeviceSync.PerCycle)
+            {
+                _sys.Tick();
+                while (_sys.BaLow)
+                {
+                    _cycle++;       // stalled read cycle
+                    _sys.Tick();
+                }
+            }
+            else if (_cycle + 1 >= _nextBaLowCycle)
+            {
+                CatchUpDevices(_cycle + 1);
+                while (_sys.BaLow)
+                {
+                    _cycle++;
+                    _sys.Tick();
+                }
+                RecomputeBaWatermark();
+            }
+        }
+        var value = _mem.Read(address);
+        _cycle++;
+        return value;
+    }
+
+    private void Write(ushort address, byte value)
+    {
+        if (_devices && _sync == DeviceSync.PerCycle)
+            _sys.Tick();    // writes never stall on the 6510
+        _mem.Write(address, value);
+        _cycle++;
+    }
+
+    private void CatchUpDevices(ulong toMasterCycle)
+    {
+        var pending = (int)(toMasterCycle - _sys.MasterCycle);
+        if (pending > 0)
+            _sys.Advance(pending);
+    }
+
+    /// <summary>
+    /// The watermark is the absolute master cycle at which BA next goes low. It stays valid until
+    /// that cycle has passed or something other than time changed the device state, so it is only
+    /// recomputed then; a prediction per instruction would cost more than the ticks it saves.
+    /// </summary>
+    private void RecomputeBaWatermark()
+    {
+        var until = _devices ? _sys.CyclesUntilBaLow() : int.MaxValue;
+        _nextBaLowCycle = until == int.MaxValue ? ulong.MaxValue : _sys.MasterCycle + (ulong)until;
+        _baWatermarkVersion = _sys.StateVersion;
+    }
+
+    private void EnsureBaWatermarkIsCurrent()
+    {
+        if (_baWatermarkVersion != _sys.StateVersion || _sys.MasterCycle >= _nextBaLowCycle)
+            RecomputeBaWatermark();
+    }
+
+    // ----- execution -----
+
+    public void RunInstruction()
+    {
+        if (_devices && _sync == DeviceSync.Lazy)
+        {
+            CatchUpDevices(_cycle);     // interrupt lines must reflect every cycle already spent
+            EnsureBaWatermarkIsCurrent();
+        }
+
+        var interrupts = _cpu.CPUInterrupts;
+        if (interrupts.NMIPending)
+        {
+            interrupts.ClearPendingNMI();
+            InterruptEntry(CPU.NonMaskableIRQHandlerVector);
+            return;
+        }
+        if (interrupts.IRQLineEnabled && !_cpu.ProcessorStatus.InterruptDisable)
+        {
+            interrupts.AcknowledgeAutoAcknowledgingIRQSources();
+            InterruptEntry(CPU.BrkIRQHandlerVector);
+            return;
+        }
+
+        var opcode = Read(_cpu.PC++);
+        switch (opcode)
+        {
+            case SliceOpcodes.LdaImm:
+                LoadA(Read(_cpu.PC++));
+                break;
+
+            case SliceOpcodes.LdaAbs:
+            {
+                var address = FetchAbsolute();
+                LoadA(Read(address));
+                break;
+            }
+
+            case SliceOpcodes.LdaAbsX:
+            {
+                var (effective, uncarried, crossed) = FetchAbsoluteIndexedX();
+                var value = Read(uncarried);
+                if (crossed)
+                    value = Read(effective);
+                LoadA(value);
+                break;
+            }
+
+            case SliceOpcodes.StaAbsX:
+            {
+                var (effective, uncarried, _) = FetchAbsoluteIndexedX();
+                Read(uncarried);
+                Write(effective, _cpu.A);
+                break;
+            }
+
+            case SliceOpcodes.IncAbs:
+            {
+                var address = FetchAbsolute();
+                var value = Read(address);
+                if (_cmos)
+                    value = Read(address);
+                else
+                    Write(address, value);
+                value++;
+                BinaryArithmeticHelpers.SetFlagsAfterRegisterLoadIncDec(value, ref _cpu.ProcessorStatus);
+                Write(address, value);
+                break;
+            }
+
+            case SliceOpcodes.Bne:
+            {
+                var offset = (sbyte)Read(_cpu.PC++);
+                if (_cpu.ProcessorStatus.Zero)
+                    break;
+                Read(_cpu.PC);
+                var target = (ushort)(_cpu.PC + offset);
+                if ((target & 0xFF00) != (_cpu.PC & 0xFF00))
+                    Read((ushort)((_cpu.PC & 0xFF00) | (target & 0x00FF)));
+                _cpu.PC = target;
+                break;
+            }
+
+            case SliceOpcodes.Nop:
+                Read(_cpu.PC);
+                break;
+
+            case SliceOpcodes.Pha:
+                Read(_cpu.PC);
+                Push(_cpu.A);
+                break;
+
+            case SliceOpcodes.Jsr:
+            {
+                var low = Read(_cpu.PC++);
+                Read((ushort)(CPU.StackBaseAddress + _cpu.SP));
+                Push((byte)(_cpu.PC >> 8));
+                Push((byte)(_cpu.PC & 0xFF));
+                var high = Read(_cpu.PC);
+                _cpu.PC = (ushort)((high << 8) | low);
+                break;
+            }
+
+            case SliceOpcodes.Rts:
+            {
+                Read(_cpu.PC);
+                Read((ushort)(CPU.StackBaseAddress + _cpu.SP));
+                var low = Pull();
+                var high = Pull();
+                _cpu.PC = (ushort)((high << 8) | low);
+                Read(_cpu.PC);
+                _cpu.PC++;
+                break;
+            }
+
+            case SliceOpcodes.Rti:
+            {
+                Read(_cpu.PC);
+                Read((ushort)(CPU.StackBaseAddress + _cpu.SP));
+                var status = Pull();
+                var low = Pull();
+                var high = Pull();
+                _cpu.ProcessorStatus.Value = status;
+                _cpu.ProcessorStatus.Break = false;
+                _cpu.ProcessorStatus.Unused = true;
+                _cpu.PC = (ushort)((high << 8) | low);
+                break;
+            }
+
+            default:
+                throw new InvalidOperationException($"Opcode ${opcode:X2} is not part of the prototype slice.");
+        }
+    }
+
+    private void InterruptEntry(ushort vector)
+    {
+        Read(_cpu.PC);
+        Read(_cpu.PC);
+        Push((byte)(_cpu.PC >> 8));
+        Push((byte)(_cpu.PC & 0xFF));
+        var status = _cpu.ProcessorStatus;
+        status.Break = false;
+        status.Unused = true;
+        Push(status.Value);
+        _cpu.ProcessorStatus.InterruptDisable = true;
+        if (_cmos)
+            _cpu.ProcessorStatus.Decimal = false;
+        var low = Read(vector);
+        var high = Read((ushort)(vector + 1));
+        _cpu.PC = (ushort)((high << 8) | low);
+    }
+
+    private ushort FetchAbsolute()
+    {
+        var low = Read(_cpu.PC++);
+        var high = Read(_cpu.PC++);
+        return (ushort)((high << 8) | low);
+    }
+
+    private (ushort Effective, ushort Uncarried, bool Crossed) FetchAbsoluteIndexedX()
+    {
+        var low = Read(_cpu.PC++);
+        var high = Read(_cpu.PC++);
+        var baseAddress = (ushort)((high << 8) | low);
+        var crossed = low + _cpu.X > 0xFF;
+        var uncarried = (ushort)((baseAddress & 0xFF00) | ((baseAddress + _cpu.X) & 0x00FF));
+        return ((ushort)(baseAddress + _cpu.X), uncarried, crossed);
+    }
+
+    private void LoadA(byte value)
+    {
+        _cpu.A = value;
+        BinaryArithmeticHelpers.SetFlagsAfterRegisterLoadIncDec(value, ref _cpu.ProcessorStatus);
+    }
+
+    private void Push(byte value)
+    {
+        Write((ushort)(CPU.StackBaseAddress + _cpu.SP), value);
+        _cpu.SP--;
+    }
+
+    private byte Pull()
+    {
+        _cpu.SP++;
+        return Read((ushort)(CPU.StackBaseAddress + _cpu.SP));
+    }
+}

--- a/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype/EngineFactory.cs
+++ b/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype/EngineFactory.cs
@@ -1,0 +1,28 @@
+namespace Highbyte.DotNet6502.CycleEnginePrototype;
+
+public enum EngineKind
+{
+    Legacy,
+    AtomicPerCycle,
+    AtomicLazy,
+}
+
+public static class EngineFactory
+{
+    /// <summary>
+    /// The two device-synchronization policies of the chosen cycle-stamped atomic design. Per-cycle
+    /// sync is the reference oracle; lazy sync is the production policy. (Two resumable candidates,
+    /// a micro-operation table and a flattened state machine, were also prototyped and measured
+    /// here, then removed once the atomic design was chosen; see the repository history.)
+    /// </summary>
+    public static readonly EngineKind[] Candidates = [EngineKind.AtomicPerCycle, EngineKind.AtomicLazy];
+
+    public static ICycleEngine Create(EngineKind kind, CPU cpu, Memory mem, SystemStub system, CpuFamily family = CpuFamily.Nmos, bool devicesEnabled = true)
+        => kind switch
+        {
+            EngineKind.Legacy => new LegacyEngine(cpu, mem, system, devicesEnabled),
+            EngineKind.AtomicPerCycle => new AtomicStampedEngine(cpu, mem, system, AtomicStampedEngine.DeviceSync.PerCycle, family, devicesEnabled),
+            EngineKind.AtomicLazy => new AtomicStampedEngine(cpu, mem, system, AtomicStampedEngine.DeviceSync.Lazy, family, devicesEnabled),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+}

--- a/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.csproj
+++ b/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\libraries\Highbyte.DotNet6502\Highbyte.DotNet6502.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype/ICycleEngine.cs
+++ b/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype/ICycleEngine.cs
@@ -1,0 +1,39 @@
+namespace Highbyte.DotNet6502.CycleEnginePrototype;
+
+/// <summary>Which read-modify-write bus sequence the engine performs.</summary>
+public enum CpuFamily
+{
+    /// <summary>NMOS 6502/6510: read, write the unmodified value back, write the result.</summary>
+    Nmos,
+    /// <summary>65C02: read, read again, write the result; Decimal cleared on interrupt entry.</summary>
+    Cmos,
+}
+
+/// <summary>
+/// A candidate CPU execution engine. All candidates share the same <see cref="CPU"/> register
+/// file, the same <see cref="Memory"/>, and the same <see cref="SystemStub"/> devices, so their
+/// bus traces, final state, and cycle counts are directly comparable.
+/// </summary>
+public interface ICycleEngine
+{
+    string Name { get; }
+    CPU Cpu { get; }
+    Memory Mem { get; }
+    SystemStub System { get; }
+
+    /// <summary>Completed CPU clock cycles, stalled cycles included.</summary>
+    ulong Cycle { get; }
+
+    /// <summary>
+    /// Runs to the next instruction boundary. A pending NMI, or an IRQ with the interrupt-disable
+    /// flag clear, is taken at the boundary instead of fetching an opcode, and its seven-cycle
+    /// entry sequence counts as this call's work.
+    /// </summary>
+    void RunInstruction();
+
+    /// <summary>
+    /// Brings the devices up to <see cref="Cycle"/>. A no-op for engines that tick devices every
+    /// cycle; the lazily synchronizing engine advances them here so device state can be compared.
+    /// </summary>
+    void FlushDevices();
+}

--- a/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype/LegacyEngine.cs
+++ b/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype/LegacyEngine.cs
@@ -1,0 +1,40 @@
+namespace Highbyte.DotNet6502.CycleEnginePrototype;
+
+/// <summary>
+/// The production executor driven the way the C64 drives it today: one atomic instruction, then
+/// the devices advance by the returned cycle delta. The reference point every candidate's cost is
+/// expressed against. Its bus trace lacks the implied-mode, branch and stack dummy reads the
+/// cycle-stamped engine performs, so it is compared on final state and total cycles only.
+/// </summary>
+public sealed class LegacyEngine : ICycleEngine
+{
+    private readonly CPU _cpu;
+    private readonly Memory _mem;
+    private readonly SystemStub _sys;
+    private readonly bool _devices;
+    private ulong _cycle;
+
+    public LegacyEngine(CPU cpu, Memory mem, SystemStub system, bool devicesEnabled)
+    {
+        _cpu = cpu;
+        _mem = mem;
+        _sys = system;
+        _devices = devicesEnabled;
+    }
+
+    public string Name => "Legacy";
+    public CPU Cpu => _cpu;
+    public Memory Mem => _mem;
+    public SystemStub System => _sys;
+    public ulong Cycle => _cycle;
+
+    public void FlushDevices() { }
+
+    public void RunInstruction()
+    {
+        var result = _cpu.ExecuteOneInstructionMinimal(_mem);
+        _cycle += result.CyclesConsumed;
+        if (_devices)
+            _sys.Advance((int)result.CyclesConsumed);
+    }
+}

--- a/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype/SliceOpcodes.cs
+++ b/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype/SliceOpcodes.cs
@@ -1,0 +1,25 @@
+namespace Highbyte.DotNet6502.CycleEnginePrototype;
+
+/// <summary>
+/// The representative instruction slice every candidate engine implements. One shape of each
+/// kind that matters for cycle timing: immediate read, absolute read, indexed read with and
+/// without page crossing, indexed store with its unconditional dummy read, read-modify-write in
+/// both the NMOS and CMOS sequence, branch taken/not taken/across a page, implied with its
+/// dummy read, stack push, subroutine call and both returns, plus hardware interrupt entry.
+/// </summary>
+public static class SliceOpcodes
+{
+    public const byte LdaImm = 0xA9;
+    public const byte LdaAbs = 0xAD;
+    public const byte LdaAbsX = 0xBD;
+    public const byte StaAbsX = 0x9D;
+    public const byte IncAbs = 0xEE;
+    public const byte Bne = 0xD0;
+    public const byte Nop = 0xEA;
+    public const byte Pha = 0x48;
+    public const byte Jsr = 0x20;
+    public const byte Rts = 0x60;
+    public const byte Rti = 0x40;
+
+    public static readonly byte[] All = [LdaImm, LdaAbs, LdaAbsX, StaAbsX, IncAbs, Bne, Nop, Pha, Jsr, Rts, Rti];
+}

--- a/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype/SliceProgram.cs
+++ b/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype/SliceProgram.cs
@@ -1,0 +1,54 @@
+using Highbyte.DotNet6502.Utils;
+
+namespace Highbyte.DotNet6502.CycleEnginePrototype;
+
+/// <summary>
+/// A loop built only from the slice, used by the benchmarks and the whole-program equivalence
+/// tests. One iteration is 14 instructions (the subroutine's RTS included) and exercises every conditional cycle in the slice:
+/// indexed read without and with page crossing, indexed store, RMW, an implied instruction, a
+/// push, a subroutine call and return, a branch not taken, and a branch taken across a page.
+/// The IRQ vector points at an RTI so the system stub's timer interrupt is survivable.
+/// </summary>
+public static class SliceProgram
+{
+    public const ushort LoopStart = 0x10F0;      // body crosses into $1100 so the back-branch crosses a page
+    public const ushort DataBase = 0x2000;
+    public const ushort Subroutine = 0x1F00;
+    public const ushort IrqHandler = 0x1F80;
+    public const int InstructionsPerIteration = 14;
+
+    public static void Assemble(Memory mem, CPU cpu)
+    {
+        byte[] body =
+        [
+            SliceOpcodes.LdaImm, 0x01,
+            SliceOpcodes.LdaAbs, 0x00, 0x20,          // LDA $2000
+            SliceOpcodes.LdaAbsX, 0x00, 0x20,         // LDA $2000,X   X=1: no page cross
+            SliceOpcodes.LdaAbsX, 0xFF, 0x20,         // LDA $20FF,X   X=1: page cross
+            SliceOpcodes.StaAbsX, 0x00, 0x20,         // STA $2000,X
+            SliceOpcodes.IncAbs, 0x01, 0x20,          // INC $2001
+            SliceOpcodes.Nop,
+            SliceOpcodes.Pha,
+            SliceOpcodes.Jsr, 0x00, 0x1F,             // JSR $1F00
+            SliceOpcodes.LdaImm, 0x00,
+            SliceOpcodes.Bne, 0x02,                   // not taken (Z set)
+            SliceOpcodes.LdaImm, 0x01,
+            SliceOpcodes.Bne, 0x00,                   // back to LoopStart, patched below
+        ];
+        var branchEnd = LoopStart + body.Length;
+        body[^1] = (byte)(LoopStart - branchEnd);
+
+        for (var i = 0; i < body.Length; i++)
+            mem[(ushort)(LoopStart + i)] = body[i];
+
+        mem[Subroutine] = SliceOpcodes.Rts;
+        mem[IrqHandler] = SliceOpcodes.Rti;
+        mem.WriteWord(CPU.BrkIRQHandlerVector, IrqHandler);
+        mem.WriteWord(CPU.NonMaskableIRQHandlerVector, IrqHandler);
+
+        cpu.PC = LoopStart;
+        cpu.X = 1;
+        cpu.SP = 0xFF;
+        cpu.ProcessorStatus.InterruptDisable = false;
+    }
+}

--- a/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype/SystemStub.cs
+++ b/labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype/SystemStub.cs
@@ -1,0 +1,183 @@
+namespace Highbyte.DotNet6502.CycleEnginePrototype;
+
+/// <summary>
+/// Stand-in for the devices a C64 master clock would advance every cycle: a VIC-II that fetches
+/// one byte per cycle and pulls BA low during bad-line cycles, and a CIA timer that raises an IRQ
+/// on underflow. It exists so the engine comparison includes the cost shape of a per-cycle
+/// scheduler, not only CPU dispatch. Timing constants follow the PAL VIC-II (63 cycles per line,
+/// 312 lines, bad lines when the low three raster bits equal YSCROLL inside the display window,
+/// BA low from cycle 12 to 54 of a bad line). Sprite DMA is not modeled.
+///
+/// <see cref="Tick"/> advances one cycle. <see cref="Advance"/> advances many cycles in closed
+/// form (prefix sums for the fetches, arithmetic for the timer) and must produce exactly the state
+/// the same number of ticks would: that is the "batch mathematically equivalent spans" rule the
+/// lazily synchronizing engines rely on, and the equivalence tests check it.
+/// </summary>
+public sealed class SystemStub
+{
+    public const int CyclesPerLine = 63;
+    public const int LinesPerFrame = 312;
+    public const int CyclesPerFrame = CyclesPerLine * LinesPerFrame;
+    public const int FirstBadLineCandidate = 0x30;
+    public const int LastBadLineCandidate = 0xF7;
+    public const int BaLowFromCycle = 12;
+    public const int BaLowToCycle = 54;
+
+    private readonly byte[] _vicRam = new byte[0x4000];
+    private readonly long[] _fetchPrefix = new long[CyclesPerFrame + 1];   // sum of fetches for frame positions [0, t)
+    private readonly CPUInterrupts _interrupts;
+    private readonly InterruptSource _ciaIrq;
+    private int _framePosition;     // RasterLine * CyclesPerLine + RasterCycle
+    private int _ciaTimer;
+    private int _yScroll = 3;
+    private bool _badLinesEnabled = true;
+
+    public SystemStub(CPUInterrupts interrupts)
+    {
+        _interrupts = interrupts;
+        _ciaIrq = interrupts.GetSource("Stub.CIA.TimerA");
+        for (var i = 0; i < _vicRam.Length; i++)
+            _vicRam[i] = (byte)(i * 7);
+        for (var t = 0; t < CyclesPerFrame; t++)
+            _fetchPrefix[t + 1] = _fetchPrefix[t] + _vicRam[t & 0x3FFF];
+    }
+
+    /// <summary>Master cycles advanced so far.</summary>
+    public ulong MasterCycle { get; private set; }
+
+    public int RasterCycle => _framePosition % CyclesPerLine;
+    public int RasterLine => _framePosition / CyclesPerLine;
+
+    /// <summary>Bumped whenever something other than time changes the timing state; watermark caches key on it.</summary>
+    public int StateVersion { get; private set; }
+
+    public int YScroll
+    {
+        get => _yScroll;
+        set { _yScroll = value; StateVersion++; }
+    }
+
+    public bool BadLinesEnabled
+    {
+        get => _badLinesEnabled;
+        set { _badLinesEnabled = value; StateVersion++; }
+    }
+
+    /// <summary>True while the VIC-II holds BA low: CPU read cycles stall, writes proceed.</summary>
+    public bool BaLow => IsBadLine(RasterLine) && RasterCycle >= BaLowFromCycle && RasterCycle < BaLowToCycle;
+
+    /// <summary>Sum of the bytes the VIC-II fetched; keeps the fetch from being optimized away and lets tests compare device state.</summary>
+    public long VicFetchAccumulator { get; private set; }
+
+    public int CiaTimerLatch { get; set; } = 3000;
+    public bool CiaTimerRunning { get; set; }
+    public int CiaUnderflows { get; private set; }
+
+    public void SetRasterPosition(int line, int cycle)
+    {
+        _framePosition = line * CyclesPerLine + cycle;
+        StateVersion++;
+    }
+
+    public void StartCiaTimer(int latch)
+    {
+        CiaTimerLatch = latch;
+        _ciaTimer = latch;
+        CiaTimerRunning = true;
+    }
+
+    public bool IsBadLine(int line)
+        => _badLinesEnabled && line >= FirstBadLineCandidate && line <= LastBadLineCandidate && (line & 7) == _yScroll;
+
+    /// <summary>Advances every device by one master cycle (the phi1 half a CPU cycle starts with).</summary>
+    public void Tick()
+    {
+        MasterCycle++;
+
+        if (++_framePosition == CyclesPerFrame)
+            _framePosition = 0;
+        VicFetchAccumulator += _vicRam[_framePosition & 0x3FFF];
+
+        if (CiaTimerRunning && --_ciaTimer < 0)
+        {
+            _ciaTimer = CiaTimerLatch;
+            CiaUnderflows++;
+            _interrupts.SetIRQActive(_ciaIrq, autoAcknowledge: true);
+        }
+    }
+
+    /// <summary>Advances every device by <paramref name="cycles"/> master cycles in closed form.</summary>
+    public void Advance(int cycles)
+    {
+        if (cycles <= 0)
+            return;
+
+        MasterCycle += (ulong)cycles;
+
+        // VIC-II: fetches for frame positions (p, p + cycles], wrapping at the frame end.
+        var from = _framePosition + 1;
+        var to = _framePosition + cycles;           // inclusive
+        var wholeFrames = 0;
+        if (to >= CyclesPerFrame)
+        {
+            var beyond = to - CyclesPerFrame + 1;   // positions past the end of this frame
+            wholeFrames = beyond / CyclesPerFrame;
+            VicFetchAccumulator += _fetchPrefix[CyclesPerFrame] - _fetchPrefix[from];
+            VicFetchAccumulator += wholeFrames * _fetchPrefix[CyclesPerFrame];
+            VicFetchAccumulator += _fetchPrefix[beyond % CyclesPerFrame];
+        }
+        else
+        {
+            VicFetchAccumulator += _fetchPrefix[to + 1] - _fetchPrefix[from];
+        }
+        _framePosition = (_framePosition + cycles) % CyclesPerFrame;
+
+        // CIA: n decrements; the first underflow comes after (_ciaTimer + 1) decrements, then every (latch + 1).
+        if (CiaTimerRunning)
+        {
+            if (cycles <= _ciaTimer)
+            {
+                _ciaTimer -= cycles;
+            }
+            else
+            {
+                var period = CiaTimerLatch + 1;
+                var afterFirst = cycles - (_ciaTimer + 1);
+                CiaUnderflows += 1 + afterFirst / period;
+                _ciaTimer = CiaTimerLatch - afterFirst % period;
+                _interrupts.SetIRQActive(_ciaIrq, autoAcknowledge: true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Master cycles until BA is next low, counted from the current position; 0 when it is low now.
+    /// Closed form: the next bad line is the next line with the YSCROLL low bits inside the display
+    /// window, wrapping to the next frame.
+    /// </summary>
+    public int CyclesUntilBaLow()
+    {
+        if (!_badLinesEnabled)
+            return int.MaxValue;
+        if (BaLow)
+            return 0;
+
+        var line = RasterLine;
+        var cycle = RasterCycle;
+        if (IsBadLine(line) && cycle + 1 < BaLowToCycle)
+            return Math.Max(BaLowFromCycle, cycle + 1) - cycle;
+
+        var next = NextBadLineAfter(line);
+        var linesAhead = next > line ? next - line : LinesPerFrame - line + next;
+        return (CyclesPerLine - cycle) + (linesAhead - 1) * CyclesPerLine + BaLowFromCycle;
+    }
+
+    private int NextBadLineAfter(int line)
+    {
+        var candidate = Math.Max(line + 1, FirstBadLineCandidate);
+        var next = candidate + ((_yScroll - candidate) & 7);
+        if (next > LastBadLineCandidate)
+            next = FirstBadLineCandidate + ((_yScroll - FirstBadLineCandidate) & 7);
+        return next;
+    }
+}

--- a/labs/CycleEnginePrototype/README.md
+++ b/labs/CycleEnginePrototype/README.md
@@ -1,0 +1,94 @@
+# Cycle engine prototype
+
+A throwaway lab that compared candidate CPU execution engines for cycle-level timing before any
+of them was allowed to replace the production executor. It is deliberately isolated from the
+libraries: nothing under `src/` references it. The choice has been made: the cycle-stamped atomic
+design with lazy device synchronization. The two resumable candidates that were also built and
+measured (a micro-operation table and a flattened state machine) have been removed; their code is
+in the repository history and their numbers are kept below. What remains is the reference for
+migrating the design into `Highbyte.DotNet6502`, after which the lab is deleted.
+
+## Question it answers
+
+The production executor runs each instruction atomically through one pre-composed handler and
+returns the total cycle count; systems advance their devices afterwards by that delta. Cycle-level
+timing needs every bus access on its real cycle, read cycles that can stall while the VIC-II holds
+BA low, and devices interleaved with the CPU. Three designs can provide that, and they differ a lot
+in dispatch cost and in how much of the CPU has to be rewritten:
+
+| Engine | Class | Shape |
+| --- | --- | --- |
+| Atomic, cycle-stamped (chosen) | `AtomicStampedEngine` | Instruction stays atomic; every cycle is a bus access that carries the cycle number; the bus ticks devices and inserts stall cycles. Two device policies: **per-cycle** (tick per access; the simplest correct form, kept as the oracle) and **lazy** (catch-up in closed form at instruction boundaries and at the predicted next BA-low cycle; the production policy). |
+| Micro-operation table (removed) | – | Resumable: each opcode an array of micro-operation codes, one per cycle, run by one central switch. |
+| Flattened state machine (removed) | – | Resumable: nested switches on (opcode, cycle index), in the shape a source generator would emit. |
+| Legacy | `LegacyEngine` | The production executor driven the way the C64 drives it today. Reference for cost and final state. |
+
+All engines share the same register file (`CPU`), memory, and device stub (`SystemStub`: a
+PAL VIC-II that fetches one byte per cycle and pulls BA low on bad-line cycles 12–53, and a CIA
+timer that raises an IRQ on underflow).
+
+## The slice
+
+Every engine implements the same representative instructions, with one bus access per cycle
+and the documented dummy reads: `LDA #`, `LDA abs`, `LDA abs,X` (with and without page cross),
+`STA abs,X`, `INC abs` (NMOS read/write/write and CMOS read/read/write), `BNE` (not taken, taken,
+taken across a page), `NOP`, `PHA`, `JSR`, `RTS`, `RTI`, and hardware IRQ/NMI entry.
+
+## Running
+
+```sh
+dotnet test labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Tests
+dotnet run -c Release --project labs/CycleEnginePrototype/Highbyte.DotNet6502.CycleEnginePrototype.Benchmarks
+```
+
+The tests check both device policies against hand-derived bus traces and cycle counts, against the
+production executor's final state, against the stall rules (reads stall while BA is low, writes do
+not), and against each other over a long program with bad lines and timer interrupts active,
+including identical device state. The benchmarks run the same slice loop under three device modes
+(absent, ticking, ticking with bad lines) and report each policy relative to the legacy
+executor, with allocations.
+
+## Results (2026-09-02, Apple M1, .NET 10.0.7, Release, DefaultJob)
+
+1,400 instructions of the slice loop per invocation. Ratio is against the legacy executor in the
+same device mode. All rows allocate nothing. The two resumable rows were measured before those
+engines were removed and are kept as the evidence for the choice.
+
+| Engine | No devices | Devices ticking | Ticking with bad lines |
+| --- | ---: | ---: | ---: |
+| Legacy (reference) | 19.5 µs · 1.00 | 19.9 µs · 1.00 | 19.9 µs · 1.00 |
+| Atomic, cycle-stamped, per-cycle device sync | 20.4 µs · 1.05 | 28.6 µs · 1.44 | 29.8 µs · 1.50 |
+| Atomic, cycle-stamped, lazy device sync | 20.2 µs · 1.03 | 24.2 µs · 1.22 | 25.2 µs · 1.27 |
+| Micro-operation table (resumable) | 24.3 µs · 1.24 | 32.3 µs · 1.63 | 32.8 µs · 1.65 |
+| Flattened state machine (resumable) | 22.4 µs · 1.15 | 30.8 µs · 1.55 | 32.3 µs · 1.63 |
+
+Reading the table:
+
+- The candidates do strictly more work than the legacy executor: every cycle is a real bus access
+  (the legacy executor skips the implied-mode, branch and stack dummy reads), and in the bad-line
+  mode they also execute the stalled read cycles the legacy executor does not model (about 5% more
+  cycles). The ratios therefore overstate their cost per cycle.
+- With no devices, keeping the instruction atomic costs 3–5%, and making it resumable costs
+  15–24% on top of that. Per-cycle dispatch is the price of resumability, not of cycle accuracy.
+- With devices, the cost is dominated by how often the scheduler runs, not by the CPU: ticking the
+  devices on every cycle costs 40–65% regardless of engine, while advancing them in closed form at
+  instruction boundaries and only when a read can stall (lazy sync) keeps the whole thing at
+  22–27% over legacy with identical stalls, interrupts and device state (the equivalence tests
+  assert that).
+- In absolute terms even the slowest row is about 23 ns per instruction against 14 ns, which on a
+  C64 frame of ~6,500 instructions is under 60 µs of a 20 ms budget. Performance does not decide
+  between the designs; what does is how much of the CPU must be rewritten and what each design
+  makes possible.
+- The two resumable forms are within 8% of each other; the flattened switch is the faster one.
+  Measured with per-cycle device sync only; with lazy sync they would sit near their "no devices"
+  column, so the real gap to the chosen design is roughly 12% of CPU time.
+
+## Decision
+
+The cycle-stamped atomic design was chosen, with lazy device synchronization as the production
+policy and per-cycle synchronization kept as the test oracle. Cycle accuracy turned out to be
+nearly free; what a resumable engine buys (cycle-granular debugger stepping, mid-instruction save
+states, trivial lockstep with a second CPU) is not needed by the current goals, and its cost is a
+rewrite of every opcode. The migration path is: make every cycle a real bus access in the
+production handlers, thread the cycle number through the bus, and give each device a closed-form
+`Advance(n)` that the per-cycle oracle validates.


### PR DESCRIPTION
First increment on the `feature/cpu-cycle-engine` integration branch. Nothing here touches `src/`.

Adds `labs/CycleEnginePrototype/`: a self-contained lab that compared candidate CPU execution engines for cycle-level timing against the production executor on a representative instruction slice (immediate/absolute/indexed reads, indexed store with dummy read, NMOS and CMOS RMW, branches, NOP, PHA, JSR, RTS, RTI, IRQ/NMI entry), one bus access per cycle, driven through a device stub with a PAL VIC-II bad-line BA pattern and a CIA timer IRQ.

Outcome, recorded in the lab README with the measurements:

- The cycle-stamped atomic design is chosen: the instruction stays atomic, every cycle is a real bus access carrying the cycle number, and the bus inserts RDY stall cycles. Lazy device synchronization (closed-form device advance at instruction boundaries and predicted stall cycles) is the production policy; per-cycle synchronization is kept as the test oracle. Cost: 1.03x the current executor with no devices, 1.22–1.27x with per-cycle-exact devices, allocation-free.
- Two resumable candidates (a micro-operation table and a flattened state machine) were built, measured at 1.15–1.24x without devices and 1.55–1.65x with per-cycle device ticking, and removed once the choice was made. Their code is in this branch's history; their numbers stay in the README as the evidence.

Tests (44) hold both device policies to hand-derived bus traces, the production executor's final state and cycle totals, the stall rules (reads stall while BA is low, writes never), and to each other over a 5,000-instruction run with bad lines and timer interrupts, device state included. The lab projects are in the solution so the build-and-test job covers them.
