### PR TITLE
Fix C64 SID filter registers never reaching the audio core

### DIFF
--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Audio/Sample/SidSampleCore.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Audio/Sample/SidSampleCore.cs
@@ -88,8 +88,9 @@ public sealed class SidSampleCore
     // Chamberlin SVF state and cached coefficients (Auto mode only).
     private float _filterLow;        // y_lp accumulator
     private float _filterBand;       // y_bp accumulator
-    private float _filterCoefF;      // 2*sin(pi*fc/fs) — recomputed on cutoff write
-    private float _filterDamping;    // 1/Q — recomputed on resonance write
+    private float _filterCoefF;      // 2*sin(pi*fc/fs), limited for stability — recomputed on cutoff or resonance write
+    private float _filterCoefFRequested; // 2*sin(pi*fc/fs) as requested by the cutoff registers
+    private float _filterDamping = DampingForResonance(0); // 1/Q — recomputed on resonance write
     private byte _filterRoutingBits; // $D417 low 3 bits — V1/V2/V3 routing through filter
     private byte _filterTypeBits;    // $D418 bits 4-6 — LP/BP/HP enable
     private bool _voice3Off;         // $D418 bit 7 — silence V3 when not filtered
@@ -184,21 +185,36 @@ public sealed class SidSampleCore
         // Linear map 0..2047 → ~30 Hz..12 kHz. Real SID is non-linear and chip-variant; a fitted
         // 6581/8580 lookup table can be swapped in later for chip-accurate filter response.
         float fcHz = 30f + (fcReg / 2047f) * 12000f;
+        if (fcHz > _sampleRateHz * 0.5f) fcHz = _sampleRateHz * 0.5f;
 
-        // Cap at ~0.45 × output rate so the Chamberlin SVF stays well inside its stable region.
-        float maxFcHz = _sampleRateHz * 0.45f;
-        if (fcHz > maxFcHz) fcHz = maxFcHz;
-
-        _filterCoefF = 2f * MathF.Sin(MathF.PI * fcHz / _sampleRateHz);
+        _filterCoefFRequested = 2f * MathF.Sin(MathF.PI * fcHz / _sampleRateHz);
+        LimitFilterCoefficient();
     }
 
     private void RecalculateFilterDamping(byte resflt)
     {
-        int res = (resflt >> 4) & 0x0F;
-        // Damping = 1/Q. res=0 → Q≈0.67 (no audible peak), res=15 → Q≈10 (sharp resonance).
-        // Linear interpolation 1.5 → 0.1 across res=0..15 — coarse but stable for the full cutoff
-        // range we allow above.
-        _filterDamping = 1.5f - res * (1.5f - 0.1f) / 15f;
+        _filterDamping = DampingForResonance((resflt >> 4) & 0x0F);
+        LimitFilterCoefficient();
+    }
+
+    // Damping = 1/Q. res=0 → Q≈0.67 (no audible peak), res=15 → Q≈10 (sharp resonance).
+    // Linear interpolation 1.5 → 0.1 across res=0..15.
+    private static float DampingForResonance(int res) => 1.5f - res * (1.5f - 0.1f) / 15f;
+
+    /// <summary>
+    /// The Chamberlin SVF, ticked once per output sample, is only stable while
+    /// <c>F² + 2·F·D &lt; 4</c> (F = frequency coefficient, D = damping); past that its state
+    /// grows without bound and ends up NaN, which silences every filtered voice for good. Clamp F
+    /// to just inside that bound for the current damping, so a tune that opens the cutoff fully
+    /// gets the highest cutoff this filter can represent at the output rate instead of a dead
+    /// filter. At 44.1 kHz that is ~7 kHz with no resonance, rising toward 12 kHz as resonance
+    /// increases.
+    /// </summary>
+    private void LimitFilterCoefficient()
+    {
+        float d = _filterDamping;
+        float maxF = 0.95f * (MathF.Sqrt(d * d + 4f) - d);
+        _filterCoefF = _filterCoefFRequested < maxF ? _filterCoefFRequested : maxF;
     }
 
     /// <summary>
@@ -298,7 +314,8 @@ public sealed class SidSampleCore
         _filterLow = 0f;
         _filterBand = 0f;
         _filterCoefF = 0f;
-        _filterDamping = 0f;
+        _filterCoefFRequested = 0f;
+        _filterDamping = DampingForResonance(0);
         _filterRoutingBits = 0;
         _filterTypeBits = 0;
         _voice3Off = false;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Audio/Sid.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Audio/Sid.cs
@@ -95,6 +95,15 @@ public class Sid
 
 
         // Common audio registers
+        c64Mem.MapReader(SidAddr.CUTLO, (_) => 0);
+        c64Mem.MapWriter(SidAddr.CUTLO, InternalSidState.SetSidRegValue);
+
+        c64Mem.MapReader(SidAddr.CUTHI, (_) => 0);
+        c64Mem.MapWriter(SidAddr.CUTHI, InternalSidState.SetSidRegValue);
+
+        c64Mem.MapReader(SidAddr.RESON, (_) => 0);
+        c64Mem.MapWriter(SidAddr.RESON, InternalSidState.SetSidRegValue);
+
         c64Mem.MapReader(SidAddr.SIGVOL, (_) => 0);
         c64Mem.MapWriter(SidAddr.SIGVOL, InternalSidState.SetSidRegValue);
 

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Audio/SidFilterRegisterTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Audio/SidFilterRegisterTests.cs
@@ -1,0 +1,102 @@
+using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Audio;
+using Highbyte.DotNet6502.Systems.Commodore64.Audio.Sample;
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64.Audio;
+
+/// <summary>
+/// The filter registers $D415-$D417 must be routed through <see cref="InternalSidState"/> like every
+/// other SID register, otherwise the audio providers never see cutoff, resonance or routing changes.
+/// </summary>
+public class SidFilterRegisterTests
+{
+    private static C64 Build() =>
+        C64.BuildC64(new C64Config { LoadROMs = false, C64Model = "C64PAL", Vic2Model = "PAL" }, NullLoggerFactory.Instance);
+
+    [Theory]
+    [InlineData(SidAddr.CUTLO)]
+    [InlineData(SidAddr.CUTHI)]
+    [InlineData(SidAddr.RESON)]
+    public void Filter_register_writes_are_recorded_as_changed_sid_registers(ushort address)
+    {
+        var c64 = Build();
+        c64.Sid.InternalSidState.ClearAudioChanged();
+
+        c64.Mem.Write(address, 0x77);
+
+        Assert.True(c64.Sid.InternalSidState.IsRawSidRegChanged(address));
+        Assert.Equal(0x77, c64.Sid.InternalSidState.GetRawSidRegValue(address));
+        Assert.True(c64.Sid.InternalSidState.IsAudioChanged);
+    }
+
+    [Fact]
+    public void Filter_cutoff_written_through_memory_changes_the_filtered_output()
+    {
+        // A sawtooth voice routed through a low-pass filter: with the cutoff at its minimum almost
+        // nothing passes, with the cutoff at its maximum the waveform comes through. If the cutoff
+        // registers are not mapped, both runs produce identical output.
+        var closed = RenderRms(cutHi: 0x00);
+        var open = RenderRms(cutHi: 0xFF);
+
+        Assert.True(open > 0.001, $"open={open}");
+        Assert.True(open > closed * 2, $"open={open} closed={closed}");
+    }
+
+    [Theory]
+    [InlineData(0x00)]  // no resonance
+    [InlineData(0xF0)]  // maximum resonance
+    public void Fully_open_cutoff_keeps_the_filter_stable(byte resonance)
+    {
+        var core = new SidSampleCore(sampleRateHz: 22050);
+        core.WriteRegister(SidSampleCore.VolumeRegisterOffset, 0x1F);
+        core.WriteRegister(SidSampleCore.FilterCutLoOffset, 0x07);
+        core.WriteRegister(SidSampleCore.FilterCutHiOffset, 0xFF);
+        core.WriteRegister(SidSampleCore.FilterResRoutOffset, (byte)(resonance | 0x01));
+        core.WriteRegister(1, 0x40);   // voice 1 frequency
+        core.WriteRegister(6, 0xF0);   // sustain
+        core.WriteRegister(4, 0x21);   // sawtooth, gate on
+
+        var buffer = new float[4096];
+        for (var i = 0; i < 20; i++)
+        {
+            var n = core.AdvanceCycles(SidSampleCore.PalSidClockHz / 10, buffer);
+            for (var j = 0; j < n; j++)
+                Assert.True(float.IsFinite(buffer[j]) && MathF.Abs(buffer[j]) <= 1f, $"sample {j} in block {i} = {buffer[j]}");
+        }
+    }
+
+    private static double RenderRms(byte cutHi)
+    {
+        var c64 = Build();
+        var samples = new List<float>();
+        var provider = new C64SidSampleProvider(c64);
+        provider.Init(s => { samples.AddRange(s.ToArray()); return s.Length; });
+
+        c64.Mem.Write(SidAddr.SIGVOL, 0x1F);   // low-pass, full volume
+        c64.Mem.Write(SidAddr.CUTLO, 0x00);
+        c64.Mem.Write(SidAddr.CUTHI, cutHi);
+        c64.Mem.Write(SidAddr.RESON, 0x01);    // voice 1 through the filter, no resonance
+        c64.Mem.Write(SidAddr.FRELO1, 0x00);
+        c64.Mem.Write(SidAddr.FREHI1, 0x40);
+        c64.Mem.Write(SidAddr.ATDCY1, 0x00);
+        c64.Mem.Write(SidAddr.SUREL1, 0xF0);
+        c64.Mem.Write(SidAddr.VCREG1, 0x21);   // sawtooth, gate on
+
+        // NOP loop; each instruction advances the provider by its cycle count.
+        c64.Mem.StoreData(0x1000, [0xEA, 0x4C, 0x00, 0x10]);
+        c64.CPU.PC = 0x1000;
+        for (var i = 0; i < 20_000; i++)
+        {
+            c64.CPU.ExecuteOneInstructionMinimal(c64.Mem);
+            provider.OnAfterInstruction();
+        }
+
+        // Drop the attack transient, then measure the AC level (the $D418 DC term is identical in both runs).
+        var tail = samples.Skip(samples.Count / 2).ToArray();
+        var mean = tail.Average();
+        return Math.Sqrt(tail.Average(x => (x - mean) * (x - mean)));
+    }
+}


### PR DESCRIPTION
## Summary

Two related C64 SID audio fixes.

**Filter registers were unmapped.** `$D415`–`$D417` (filter cutoff low/high, resonance + voice routing) had no `MapReader`/`MapWriter` entries, so writes landed in IO storage and never reached `InternalSidState` or the audio providers. The SID filter was effectively inert for real software: cutoff sweeps, resonant bass and "wah" effects were simply absent. They are now mapped like every other SID register.

**Filter instability at high cutoff.** Once filter writes arrived, a fully open cutoff sent the sample core's Chamberlin state-variable filter to NaN within milliseconds, after which every filtered voice stayed silent for the rest of the session. The filter is ticked once per output sample and is only stable while `F² + 2·F·D < 4`; the old cap allowed `F ≈ 2` for every damping. The coefficient is now clamped just inside the bound for the current resonance, so a wide-open cutoff gives the highest cutoff this filter can represent at the output rate (about 7 kHz with no resonance at 44.1 kHz, rising toward 12 kHz as resonance increases). Reset also left damping at zero (an undamped resonator); it now starts at the resonance-0 value.

## User-visible effect

Any C64 program that uses the SID filter now sounds filtered. This is noticeable in a lot of game and demo music (confirmed in Giana Sisters).

## Tests

New `SidFilterRegisterTests`:
- filter writes through memory are recorded as changed SID registers
- a cutoff written through memory changes the filtered output
- a fully open cutoff stays finite at both resonance extremes

All three fail against the previous core. Systems test suite: 1,184 passed.

## Follow-up

Running the filter at 2× oversampling would raise the representable cutoff ceiling; left for a separate change.
