### PR TITLE
Advance VIC-II and CIAs to the exact bus cycle of each register access

### DIFF
--- a/docs/libraries/core/dotnet6502.md
+++ b/docs/libraries/core/dotnet6502.md
@@ -26,7 +26,10 @@ sequence.
 
 `CPU.BusCycles` counts those accesses. Because the count advanced by an instruction equals its
 cycle count, systems can derive elapsed cycles from bus activity, and the tests hold the two
-together for every opcode byte of every model and profile.
+together for every opcode byte of every model and profile. A system can therefore keep its
+devices exact to the cycle without stepping them every cycle: a memory-mapped register handler
+reads the counter, advances the device to the cycle of the access, and then applies the access.
+The C64 does this for the VIC-II, the CIAs and the SID.
 
 Verification, beyond the functional test programs:
 

--- a/docs/systems/c64/libraries.md
+++ b/docs/systems/c64/libraries.md
@@ -9,6 +9,18 @@ The C64 system logic — VIC2, CIA, SID, 1541 — lives in:
 
 This library has no UI, rendering, or I/O dependencies. It exposes abstractions that the implementation libraries below plug into.
 
+### Device timing
+
+The CPU executes one instruction at a time, but every cycle of it is a bus access counted by
+`CPU.BusCycles`. The VIC-II and the two CIAs are brought up to date lazily from that counter: at
+every instruction boundary, and at every access to one of their registers, to the cycle of the
+access. A read of `$D012` therefore returns the raster line at the cycle the read happens, a CIA
+timer read returns the count at that cycle, a raster-compare or timer-control write takes effect
+on its own cycle, and an interrupt that becomes due during an instruction is serviced right after
+it. The SID does the same through its audio provider (see below). Rendering still samples the
+VIC-II registers once per raster line, so a mid-line register change becomes visible on the next
+line.
+
 ## Implementation libraries
 
 C64-specific host code lives in its own **engine-plugin** libraries, one per host technology,

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -181,6 +181,18 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup, ISyste
     }
 
     /// <summary>
+    /// Align the VIC-II and CIA bus-cycle bookkeeping with the CPU without advancing them. The
+    /// CPU reset sequence performs bus accesses of its own (the reset vector fetch) that are not
+    /// machine time the devices should see.
+    /// </summary>
+    private void SyncDevicesToBusCycle()
+    {
+        Vic2.ResyncToBusCycle();
+        Cia1.ResyncToBusCycle();
+        Cia2.ResyncToBusCycle();
+    }
+
+    /// <summary>
     /// Executes on instruction, and all the processing needed after each instruction.
     /// </summary>
     /// <param name="systemRunner"></param>
@@ -212,14 +224,17 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup, ISyste
             }
         }
 
-        // Execute one CPU instruction
+        // Execute one CPU instruction. Accesses to VIC-II, CIA and SID registers during the
+        // instruction catch the device up to the cycle of the access (see the register mappings),
+        // so a device interrupt raised that way is serviced by the CPU right after this instruction.
         instructionExecResult = CPU.ExecuteOneInstructionMinimal(Mem);
 
-        // Update CIA timers
+        // Bring the CIA timers up to the end of the instruction. CPU.BusCycles counts one bus
+        // access per cycle, so its delta equals the instruction's cycle count.
         if (TimerMode == TimerMode.UpdateEachInstruction)
         {
-            Cia1.ProcessTimers(instructionExecResult.CyclesConsumed);
-            Cia2.ProcessTimers(instructionExecResult.CyclesConsumed);
+            Cia1.CatchUpTo(CPU.BusCycles);
+            Cia2.CatchUpTo(CPU.BusCycles);
         }
 
         // Update IEC bus devices
@@ -237,16 +252,15 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup, ISyste
             // advance below and the caller's frame budget include it.
             if (TimerMode == TimerMode.UpdateEachInstruction)
             {
-                Cia1.ProcessTimers(interruptCycles);
-                Cia2.ProcessTimers(interruptCycles);
+                Cia1.CatchUpTo(CPU.BusCycles);
+                Cia2.CatchUpTo(CPU.BusCycles);
             }
             CartridgeSlot.Tick(interruptCycles);
             instructionExecResult = instructionExecResult.WithAdditionalCycles(interruptCycles);
         }
 
-        // Advance video raster
-        var cycleOnRasterLineBeforeInstruction = Vic2.CyclesConsumedCurrentVblank;
-        Vic2.AdvanceRaster(instructionExecResult.CyclesConsumed);
+        // Bring the video raster up to the end of the instruction (including any interrupt entry).
+        Vic2.CatchUpTo(CPU.BusCycles);
 
         // Audio generation after each instruction (SID register writes happen between instructions).
         // _audioProvider is only set when audio is enabled (see ConfigureAudio).
@@ -403,6 +417,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup, ISyste
 
         // Set program counter on startup to the address specified at the 6502 reset vector.
         c64.CPU.Reset(c64.Mem);
+        c64.SyncDevicesToBusCycle();
 
         logger.LogInformation("C64 created.");
         return c64;
@@ -894,6 +909,7 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup, ISyste
         Array.Clear(IO);
         SetStartupBank(this);
         CPU.Reset(Mem);
+        SyncDevicesToBusCycle();
         _logger.LogDebug(
             "C64 hard reset complete. Cartridge={Cartridge}, Lines={Lines}, MemoryConfiguration={MemoryConfiguration}, ResetPC={PC:X4}",
             CartridgeSlot.AttachedCartridge?.Name ?? "none",

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Snapshots/C64CiaSnapshotModule.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Snapshots/C64CiaSnapshotModule.cs
@@ -53,6 +53,8 @@ public sealed class C64CiaSnapshotModule : ISnapshotModule
         var c64 = (C64)context.System;
         RestoreCia(reader, c64.Cia1);
         RestoreCia(reader, c64.Cia2);
+        c64.Cia1.ResyncToBusCycle();
+        c64.Cia2.ResyncToBusCycle();
 
         var portA = reader.ReadByte();
         var portB = reader.ReadByte();

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaBase.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaBase.cs
@@ -14,6 +14,12 @@ public abstract class CiaBase
     private readonly CiaIRQ _ciaIRQ;
     private readonly Dictionary<CiaTimerType, CiaTimer> _ciaTimers;
 
+    /// <summary>
+    /// The CPU bus cycle (<see cref="CPU.BusCycles"/>) the timers have been advanced to. See
+    /// <see cref="CatchUpTo"/>.
+    /// </summary>
+    private ulong _advancedToBusCycle;
+
     protected CiaBase(C64 c64, CiaIRQ ciaIRQ)
     {
         _c64 = c64;
@@ -41,9 +47,9 @@ public abstract class CiaBase
     internal CiaIRQ SnapshotIrq => _ciaIRQ;
 
     /// <summary>
-    /// Process timers for this CIA chip
+    /// Advance the timers by a number of cycles, independent of the CPU bus-cycle counter. The C64
+    /// drives the CIAs through <see cref="CatchUpTo"/>; this remains for tests and tooling.
     /// </summary>
-    /// <param name="cyclesExecuted"></param>
     public virtual void ProcessTimers(ulong cyclesExecuted)
     {
         foreach (var ciaTimer in _ciaTimers.Values)
@@ -51,6 +57,36 @@ public abstract class CiaBase
             ciaTimer.ProcessTimer(cyclesExecuted);
         }
     }
+
+    /// <summary>
+    /// Advance the timers to the given CPU bus cycle. No-op if they are already there. Depending
+    /// on <see cref="C64.TimerMode"/> the C64 calls this at every instruction boundary or at every
+    /// raster line change; every CIA register access calls it for the cycle of the access, so a
+    /// timer or interrupt-status read sees the count at its own cycle and a control write takes
+    /// effect on its own cycle.
+    /// </summary>
+    public void CatchUpTo(ulong busCycle)
+    {
+        if (busCycle <= _advancedToBusCycle)
+            return;
+        var cycles = busCycle - _advancedToBusCycle;
+        _advancedToBusCycle = busCycle;
+        ProcessTimers(cycles);
+    }
+
+    /// <summary>State as of the cycle of the bus access the CPU is performing right now.</summary>
+    private void CatchUpToCurrentAccess()
+    {
+        var busCycles = _c64.CPU.BusCycles;
+        if (busCycles > 0)
+            CatchUpTo(busCycles - 1);
+    }
+
+    /// <summary>
+    /// Realign the bus-cycle bookkeeping with the CPU without advancing the timers. Used after a
+    /// snapshot restore.
+    /// </summary>
+    internal void ResyncToBusCycle() => _advancedToBusCycle = _c64.CPU.BusCycles;
 
     /// <summary>
     /// Map IO locations for this CIA chip
@@ -61,16 +97,25 @@ public abstract class CiaBase
     /// <summary>
     /// Map one CIA register and all of its mirrors across the chip's 256-byte I/O page.
     /// The MOS 6526 only decodes the low 4 address bits, so $DC0D is also visible at
-    /// $DC1D, $DC2D, ..., $DCFD (and likewise for CIA #2 at $DDxx).
+    /// $DC1D, $DC2D, ..., $DCFD (and likewise for CIA #2 at $DDxx). Every access first advances
+    /// the timers to the cycle of the access.
     /// </summary>
-    protected static void MapRegisterMirrors(
+    protected void MapRegisterMirrors(
         Memory c64mem,
         ushort registerAddress,
         Memory.LoadByte reader,
         Memory.StoreByte writer)
     {
-        c64mem.MapReader(registerAddress, reader);
-        c64mem.MapWriter(registerAddress, writer);
+        Memory.LoadByte timedReader = _ =>
+        {
+            CatchUpToCurrentAccess();
+            return reader(registerAddress);
+        };
+        Memory.StoreByte timedWriter = (_, value) =>
+        {
+            CatchUpToCurrentAccess();
+            writer(registerAddress, value);
+        };
 
         var pageStart = registerAddress & 0xFF00;
         var registerOffset = registerAddress & 0x000F;
@@ -78,11 +123,8 @@ public abstract class CiaBase
         for (var offset = registerOffset; offset <= 0x00FF; offset += 0x10)
         {
             var mirrorAddress = (ushort)(pageStart + offset);
-            if (mirrorAddress == registerAddress)
-                continue;
-
-            c64mem.MapReader(mirrorAddress, _ => reader(registerAddress));
-            c64mem.MapWriter(mirrorAddress, (_, value) => writer(registerAddress, value));
+            c64mem.MapReader(mirrorAddress, timedReader);
+            c64mem.MapWriter(mirrorAddress, timedWriter);
         }
     }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2.cs
@@ -32,6 +32,15 @@ public class Vic2
 
     public ulong CyclesConsumedCurrentVblank { get; private set; } = 0;
 
+    /// <summary>
+    /// The CPU bus cycle (<see cref="CPU.BusCycles"/>) this VIC-II has been advanced to. The C64
+    /// catches the VIC-II up to the current bus cycle at every instruction boundary and, through
+    /// the register mappings, to the cycle of every VIC-II register access, so a raster read or a
+    /// raster-compare write sees the position at its own cycle instead of the previous
+    /// instruction boundary.
+    /// </summary>
+    private ulong _advancedToBusCycle;
+
     public byte CurrentVIC2Bank { get; private set; }
 
     public ushort VideoMatrixBaseAddress { get; private set; }
@@ -273,28 +282,35 @@ public class Vic2
         }
     }
 
+    /// <summary>
+    /// Map one VIC-II register and its mirrors across $D000-$D3FF. Every access first advances the
+    /// VIC-II to the cycle of the access, so reads and writes see and affect the raster state at
+    /// their own bus cycle.
+    /// </summary>
     private void MapRegisterMirrors(
         Memory c64Mem,
         ushort registerAddress,
         Memory.LoadByte reader,
         Memory.StoreByte writer)
     {
-        c64Mem.MapReader(registerAddress, reader);
-        c64Mem.MapWriter(registerAddress, writer);
+        Memory.LoadByte timedReader = _ =>
+        {
+            CatchUpToCurrentAccess();
+            return reader(registerAddress);
+        };
+        Memory.StoreByte timedWriter = (_, value) =>
+        {
+            CatchUpToCurrentAccess();
+            writer(registerAddress, value);
+        };
 
         var registerOffset = registerAddress & 0x003F;
 
         for (var offset = registerOffset; offset <= 0x03FF; offset += 0x40)
         {
             var mirrorAddress = (ushort)(0xD000 + offset);
-            if (mirrorAddress == registerAddress)
-                continue;
-
-            c64Mem.MapReader(mirrorAddress, _ => reader(registerAddress));
-            c64Mem.MapWriter(mirrorAddress, (_, value) =>
-            {
-                writer(registerAddress, value);
-            });
+            c64Mem.MapReader(mirrorAddress, timedReader);
+            c64Mem.MapWriter(mirrorAddress, timedWriter);
         }
     }
 
@@ -865,6 +881,43 @@ public class Vic2
         return value;
     }
 
+    /// <summary>
+    /// Advance the VIC-II to the given CPU bus cycle. No-op if it is already there. The C64 calls
+    /// this with <see cref="CPU.BusCycles"/> at each instruction boundary; register accesses call
+    /// <see cref="CatchUpToCurrentAccess"/>.
+    /// </summary>
+    public void CatchUpTo(ulong busCycle)
+    {
+        if (busCycle <= _advancedToBusCycle)
+            return;
+        var cycles = busCycle - _advancedToBusCycle;
+        _advancedToBusCycle = busCycle;
+        AdvanceRaster(cycles);
+    }
+
+    /// <summary>
+    /// Advance the VIC-II to the cycle of the bus access the CPU is performing right now: every
+    /// cycle before the current access has completed, the current one is in progress.
+    /// </summary>
+    private void CatchUpToCurrentAccess()
+    {
+        var busCycles = C64.CPU.BusCycles;
+        if (busCycles > 0)
+            CatchUpTo(busCycles - 1);
+    }
+
+    /// <summary>
+    /// Realign the bus-cycle bookkeeping with the CPU without advancing the raster. Used after a
+    /// snapshot restore, where the raster position comes from the snapshot but the bus-cycle
+    /// counter belongs to the machine being restored into.
+    /// </summary>
+    internal void ResyncToBusCycle() => _advancedToBusCycle = C64.CPU.BusCycles;
+
+    /// <summary>
+    /// Advance the raster by a number of cycles, independent of the CPU bus-cycle counter. The C64
+    /// drives the VIC-II through <see cref="CatchUpTo"/>; this remains for tests and tooling that
+    /// position the raster directly.
+    /// </summary>
     public void AdvanceRaster(ulong cyclesConsumed)
     {
         var cpu = C64.CPU;
@@ -888,11 +941,12 @@ public class Vic2
 
             _currentRasterLineInternal = newLine;
 
-            // Process timers
+            // Process timers. In this mode the CIAs are only advanced at raster line changes (and
+            // at their own register accesses), to the bus cycle the VIC-II has reached.
             if (C64.TimerMode == TimerMode.UpdateEachRasterLine)
             {
-                C64.Cia1.ProcessTimers(Vic2Model.CyclesPerLine);
-                C64.Cia2.ProcessTimers(Vic2Model.CyclesPerLine);
+                C64.Cia1.CatchUpTo(_advancedToBusCycle);
+                C64.Cia2.CatchUpTo(_advancedToBusCycle);
             }
 
             // Check if a IRQ should be issued for current raster line, and issue it.
@@ -941,6 +995,7 @@ public class Vic2
 
         var line = (ushort)(CyclesConsumedCurrentVblank / Vic2Model.CyclesPerLine);
         _currentRasterLineInternal = (ushort)Math.Clamp(line, 0, Vic2Model.TotalHeight - 1);
+        ResyncToBusCycle();
     }
 
     private void RaiseRasterIRQ(CPU cpu)

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64DeviceAccessTimingTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64DeviceAccessTimingTests.cs
@@ -1,0 +1,152 @@
+using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Systems.Commodore64.TimerAndPeripheral;
+using Highbyte.DotNet6502.Systems.Commodore64.Video;
+using Highbyte.DotNet6502.Systems.Snapshots;
+using Highbyte.DotNet6502.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64;
+
+/// <summary>
+/// VIC-II and CIA register accesses see the device state at the CPU bus cycle of the access,
+/// not at the previous instruction boundary. An absolute read (<c>LDA abs</c>, 4 cycles) reads
+/// on its 4th cycle, so three cycles have completed when the device is consulted; an indirect
+/// indexed read (<c>LDA (zp),Y</c>, 5 cycles) reads on its 5th.
+/// </summary>
+public class C64DeviceAccessTimingTests
+{
+    private const ushort Start = 0x1000;
+
+    private static C64 Build(byte[] program, TimerMode timerMode = TimerMode.UpdateEachRasterLine)
+    {
+        var c64 = C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            C64Model = "C64PAL",
+            Vic2Model = "PAL",
+            TimerMode = timerMode,
+        }, NullLoggerFactory.Instance);
+        c64.Mem.StoreData(Start, program);
+        c64.CPU.PC = Start;
+        return c64;
+    }
+
+    private static InstructionExecResult Step(C64 c64)
+    {
+        c64.ExecuteOneInstruction(out var result);
+        return result;
+    }
+
+    [Theory]
+    [InlineData(3, 1)]   // line changes on the read cycle itself: the read sees the new line
+    [InlineData(4, 0)]   // line changes one cycle after the read: the read sees the old line
+    public void Raster_register_read_sees_the_line_at_the_cycle_of_the_read(int cyclesToLineChangeAtStart, int expectedLine)
+    {
+        var c64 = Build([0xAD, 0x12, 0xD0]);   // LDA $D012
+        var cyclesPerLine = c64.Vic2.Vic2Model.CyclesPerLine;
+        c64.Vic2.AdvanceRaster(cyclesPerLine - (ulong)cyclesToLineChangeAtStart);
+
+        var result = Step(c64);
+
+        Assert.Equal(expectedLine, c64.CPU.A);
+        Assert.Equal(4UL, result.CyclesConsumed);
+        Assert.Equal(cyclesPerLine - (ulong)cyclesToLineChangeAtStart + 4, c64.Vic2.CyclesConsumedCurrentVblank);
+    }
+
+    [Fact]
+    public void Raster_read_cycle_depends_on_the_instruction_shape()
+    {
+        // LDA ($FB),Y with Y=0 reads on its 5th cycle, one cycle later than LDA abs.
+        var c64 = Build([0xB1, 0xFB]);
+        c64.Mem.WriteWord(0x00FB, Vic2Addr.CURRENT_RASTER_LINE);
+        c64.CPU.Y = 0;
+        var cyclesPerLine = c64.Vic2.Vic2Model.CyclesPerLine;
+        c64.Vic2.AdvanceRaster(cyclesPerLine - 4);
+
+        var result = Step(c64);
+
+        Assert.Equal(1, c64.CPU.A);            // LDA abs from the same position sees line 0 (theory above)
+        Assert.Equal(5UL, result.CyclesConsumed);
+    }
+
+    [Theory]
+    [InlineData(TimerMode.UpdateEachRasterLine)]
+    [InlineData(TimerMode.UpdateEachInstruction)]
+    public void Cia_timer_read_sees_the_count_at_the_cycle_of_the_read(TimerMode timerMode)
+    {
+        // LDA $DC04 ; LDA $DC04 — each reads on its 4th cycle.
+        var c64 = Build([0xAD, 0x04, 0xDC, 0xAD, 0x04, 0xDC], timerMode);
+        c64.Mem.Write(CiaAddr.CIA1_TIMALO, 0x00);
+        c64.Mem.Write(CiaAddr.CIA1_TIMAHI, 0x10);
+        c64.Mem.Write(CiaAddr.CIA1_CIACRA, 0x01);   // start, continuous
+
+        Step(c64);
+        Assert.Equal(0x1000 - 3 & 0xFF, c64.CPU.A);   // 3 cycles completed before the first read
+
+        Step(c64);
+        Assert.Equal(0x1000 - 7 & 0xFF, c64.CPU.A);   // 7 cycles completed before the second read
+    }
+
+    [Fact]
+    public void Cia_control_write_starts_the_timer_on_the_cycle_of_the_write()
+    {
+        // STA $DC0E writes on its 4th cycle; LDA $DC04 reads on its 4th cycle, four cycles later.
+        // The timer counts from the write's own cycle, so the read sees four counts. (The 6526's
+        // start-up pipeline delay is not modelled.)
+        var c64 = Build([0x8D, 0x0E, 0xDC, 0xAD, 0x04, 0xDC]);
+        c64.Mem.Write(CiaAddr.CIA1_TIMALO, 0x00);
+        c64.Mem.Write(CiaAddr.CIA1_TIMAHI, 0x10);
+        c64.CPU.A = 0x01;
+
+        Step(c64);
+        Step(c64);
+
+        Assert.Equal(0x1000 - 4 & 0xFF, c64.CPU.A);
+    }
+
+    [Fact]
+    public void Raster_interrupt_that_becomes_due_during_an_instruction_is_serviced_right_after_it()
+    {
+        var c64 = Build([0xAD, 0x12, 0xD0, 0xEA]);   // LDA $D012 ; NOP
+        c64.Mem.Write(0x0001, 0x35);                  // RAM under the KERNAL, I/O visible
+        c64.Mem.WriteWord(CPU.BrkIRQHandlerVector, 0x2000);
+        c64.Mem.Write(Vic2Addr.CURRENT_RASTER_LINE, 1);
+        c64.Mem.Write(Vic2Addr.SCROLL_Y_AND_SCREEN_CONTROL_REGISTER, 0x1B);
+        c64.Mem.Write(Vic2Addr.IRQ_MASK, 0x01);
+        c64.CPU.ProcessorStatus.InterruptDisable = false;
+        var cyclesPerLine = c64.Vic2.Vic2Model.CyclesPerLine;
+        c64.Vic2.AdvanceRaster(cyclesPerLine - 3);    // line 1 begins on the read cycle
+
+        var result = Step(c64);
+
+        Assert.Equal(1, c64.CPU.A);
+        Assert.Equal(0x2000, c64.CPU.PC);
+        Assert.Equal(4 + CPU.InterruptEntryCycles, result.CyclesConsumed);
+        Assert.Equal(cyclesPerLine - 3 + 4 + CPU.InterruptEntryCycles, c64.Vic2.CyclesConsumedCurrentVblank);
+    }
+
+    [Fact]
+    public void Devices_advance_by_exactly_the_instruction_cycles_after_a_snapshot_restore()
+    {
+        var source = Build([0xEA, 0xEA, 0xEA, 0xEA, 0xEA, 0xEA, 0xEA, 0xEA]);
+        for (var i = 0; i < 3; i++)
+            Step(source);
+
+        using var stream = new MemoryStream();
+        new SnapshotService().Save(source, stream);
+        stream.Position = 0;
+
+        // The target has run further than the source, so its bus-cycle counter is ahead.
+        var target = Build([0xEA, 0xEA, 0xEA, 0xEA, 0xEA, 0xEA, 0xEA, 0xEA]);
+        for (var i = 0; i < 6; i++)
+            Step(target);
+        new SnapshotService().Restore(target, stream);
+        var rasterAfterRestore = target.Vic2.CyclesConsumedCurrentVblank;
+        Assert.Equal(source.Vic2.CyclesConsumedCurrentVblank, rasterAfterRestore);
+
+        var result = Step(target);
+
+        Assert.Equal(rasterAfterRestore + result.CyclesConsumed, target.Vic2.CyclesConsumedCurrentVblank);
+    }
+}


### PR DESCRIPTION
## Summary

Extends the lazy device synchronization the SID uses to the VIC-II and both CIAs. Each device keeps the CPU bus cycle it has been advanced to; the C64 loop drives them from `CPU.BusCycles` instead of instruction cycle deltas (identical totals: every cycle is one bus access, interrupt entry included), and every VIC-II and CIA register mapping first catches the device up to the cycle of the access.

Before, a register access saw the device as it was at the previous instruction boundary.

## What changes for programs

- `$D012`/`$D011` reads return the raster line at the cycle of the read, so the instruction's shape matters as on hardware (`LDA abs` reads on its 4th cycle, `LDA (zp),Y` on its 5th).
- Raster-compare, `$D019` and `$D01A` writes act on their own cycle.
- CIA timer and interrupt-status reads see the count at the read cycle, in both timer modes; a control write starts counting on its cycle.
- A device interrupt that becomes due during an instruction is serviced right after that instruction, instead of one instruction later.
- In `UpdateEachRasterLine` mode the CIAs advance to the bus cycle of each raster line change (and at every CIA access) instead of by a fixed line length, so timer interrupts no longer arrive up to a line late when the program touches the CIA.

Rendering is unchanged: the rasterizer still samples registers once per raster line.

## Details

- The CPU reset's vector fetch is excluded from device time: devices are realigned with the bus counter after a reset and after a snapshot restore. No snapshot format change.
- `Vic2.AdvanceRaster` and `CiaBase.ProcessTimers` keep their delta semantics for tests and tooling; the C64 uses `CatchUpTo`.
- Not modelled: the 6526's start-up pipeline delay (a timer counts from the write's own cycle).

## Tests

New `C64DeviceAccessTimingTests`: raster read at the exact cycle (line change on vs. after the read cycle), read cycle depends on instruction shape, CIA timer reads at the read cycle in both timer modes, control write starting the timer, raster interrupt due mid-instruction serviced right after it, devices advancing by exactly the instruction's cycles after a snapshot restore. Systems suite: 1,208 passed, including the real-ROM boot tests.

## Performance

Measured on Apple M1 (MacBook Air), .NET 10.0.7, against the integration branch (`C64ExecuteFrameBenchmark`, `C64ExecuteInstructionBenchmark`), no allocations added:

| Benchmark | baseline | this branch | ratio |
|---|--:|--:|--:|
| Frame, CoreOnly | 221.6 us | 230.0 us | 1.04 |
| Frame, RenderOnly | 408.9 us | 403.2 us | 0.99 |
| Frame, AudioOnly (sprites) | 376.8 us | 375.3 us | 1.00 |
| Frame, RenderAndAudio | 627.3 us | 596.3 us | 0.95 |
| Frame, RenderAndAudio (sprites) | 620.6 us | 604.8 us | 0.97 |
| 1000 instructions, CoreOnly | 25.1 us | 25.0 us | 1.00 |
| 1000 instructions, RenderOnly | 46.4 us | 46.6 us | 1.00 |
| 1000 instructions, AudioOnly | 44.9 us | 43.0 us | 0.96 |
| 1000 instructions, RenderAndAudio | 72.7 us | 71.7 us | 0.99 |

Within run-to-run noise on this laptop. Cost per VIC-II or CIA register access is one bus-cycle comparison and, when cycles have passed, the existing advance code.

