### PR TITLE
Sample interrupts at the cycle the 6502 polls them

### DIFF
--- a/docs/libraries/core/dotnet6502.md
+++ b/docs/libraries/core/dotnet6502.md
@@ -31,6 +31,16 @@ devices exact to the cycle without stepping them every cycle: a memory-mapped re
 reads the counter, advances the device to the cycle of the access, and then applies the access.
 The C64 does this for the VIC-II, the CIAs and the SID.
 
+Interrupts follow the hardware sampling rule. The 6502 polls its IRQ and NMI inputs at the end
+of an instruction's second-to-last cycle (a taken branch that does not cross a page polls at the
+end of its first cycle), so a line that goes active during the last cycle is only seen after the
+following instruction. A device reports the bus cycle on which it asserted the line, through the
+`CPUInterrupts` overloads that take a cycle, and the CPU takes the interrupt at a boundary only if
+that cycle is at or before the poll point. A source set active without a cycle is taken at the
+next boundary. `CLI`, `SEI` and `PLP` change the I flag after the poll, so their effect on
+interrupt recognition is one instruction late; `RTI` changes it in time. Not modelled: an NMI
+hijacking an interrupt sequence already in progress.
+
 Verification, beyond the functional test programs:
 
 - A pinned subset of the SingleStepTests corpus, which records the exact bus cycles of the

--- a/docs/systems/c64/libraries.md
+++ b/docs/systems/c64/libraries.md
@@ -16,10 +16,12 @@ The CPU executes one instruction at a time, but every cycle of it is a bus acces
 every instruction boundary, and at every access to one of their registers, to the cycle of the
 access. A read of `$D012` therefore returns the raster line at the cycle the read happens, a CIA
 timer read returns the count at that cycle, a raster-compare or timer-control write takes effect
-on its own cycle, and an interrupt that becomes due during an instruction is serviced right after
-it. The SID does the same through its audio provider (see below). Rendering still samples the
-VIC-II registers once per raster line, so a mid-line register change becomes visible on the next
-line.
+on its own cycle. A raster or CIA timer interrupt is dated to the cycle on which the raster line
+began or the timer underflowed, and the CPU applies its sampling rule to that cycle: taken after
+the current instruction if it fell at or before the second-to-last cycle, otherwise after the
+next one. The SID does the same through its audio provider (see below). Rendering still samples
+the VIC-II registers once per raster line, so a mid-line register change becomes visible on the
+next line.
 
 ## Implementation libraries
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -180,6 +180,17 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup, ISyste
         return ExecEvaluatorTriggerResult.NotTriggered;
     }
 
+    private void AdvanceDevicesToCurrentBusCycle()
+    {
+        var busCycles = CPU.BusCycles;
+        if (TimerMode == TimerMode.UpdateEachInstruction)
+        {
+            Cia1.CatchUpTo(busCycles);
+            Cia2.CatchUpTo(busCycles);
+        }
+        Vic2.CatchUpTo(busCycles);
+    }
+
     /// <summary>
     /// Align the VIC-II and CIA bus-cycle bookkeeping with the CPU without advancing them. The
     /// CPU reset sequence performs bus accesses of its own (the reset vector fetch) that are not
@@ -229,38 +240,27 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup, ISyste
         // so a device interrupt raised that way is serviced by the CPU right after this instruction.
         instructionExecResult = CPU.ExecuteOneInstructionMinimal(Mem);
 
-        // Bring the CIA timers up to the end of the instruction. CPU.BusCycles counts one bus
-        // access per cycle, so its delta equals the instruction's cycle count.
-        if (TimerMode == TimerMode.UpdateEachInstruction)
-        {
-            Cia1.CatchUpTo(CPU.BusCycles);
-            Cia2.CatchUpTo(CPU.BusCycles);
-        }
+        // Bring the VIC-II and the CIA timers up to the end of the instruction. CPU.BusCycles
+        // counts one bus access per cycle, so its delta equals the instruction's cycle count.
+        AdvanceDevicesToCurrentBusCycle();
 
         // Update IEC bus devices
         IECBus.TickDevices();
         CartridgeSlot.Tick(instructionExecResult.CyclesConsumed);
 
-        // General emulator timing fix: devices tick after the CPU instruction has already
-        // completed, so newly raised hardware IRQ/NMI lines must be serviced here to land
-        // on the next instruction boundary instead of one instruction late.
+        // Devices caught up above may have asserted an interrupt line, dated to the cycle within
+        // the instruction on which the condition arose. The CPU services it now if that cycle is
+        // at or before the instruction's interrupt poll point (its second-to-last cycle), and
+        // otherwise at the next boundary, as on hardware.
         var interruptCycles = CPU.ProcessPendingInterrupts(Mem);
         if (interruptCycles > 0)
         {
-            // The interrupt-entry sequence consumed real time: tick the same devices
-            // with it and fold it into this iteration's cycle count so the raster
-            // advance below and the caller's frame budget include it.
-            if (TimerMode == TimerMode.UpdateEachInstruction)
-            {
-                Cia1.CatchUpTo(CPU.BusCycles);
-                Cia2.CatchUpTo(CPU.BusCycles);
-            }
+            // The interrupt-entry sequence consumed real time: bring the devices up to its end
+            // and fold it into this iteration's cycle count so the caller's frame budget includes it.
+            AdvanceDevicesToCurrentBusCycle();
             CartridgeSlot.Tick(interruptCycles);
             instructionExecResult = instructionExecResult.WithAdditionalCycles(interruptCycles);
         }
-
-        // Bring the video raster up to the end of the instruction (including any interrupt entry).
-        Vic2.CatchUpTo(CPU.BusCycles);
 
         // Audio generation after each instruction (SID register writes happen between instructions).
         // _audioProvider is only set when audio is enabled (see ConfigureAudio).

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaBase.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaBase.cs
@@ -50,11 +50,13 @@ public abstract class CiaBase
     /// Advance the timers by a number of cycles, independent of the CPU bus-cycle counter. The C64
     /// drives the CIAs through <see cref="CatchUpTo"/>; this remains for tests and tooling.
     /// </summary>
-    public virtual void ProcessTimers(ulong cyclesExecuted)
+    public virtual void ProcessTimers(ulong cyclesExecuted) => ProcessTimers(cyclesExecuted, _c64.CPU.BusCycles);
+
+    private void ProcessTimers(ulong cyclesExecuted, ulong endBusCycle)
     {
         foreach (var ciaTimer in _ciaTimers.Values)
         {
-            ciaTimer.ProcessTimer(cyclesExecuted);
+            ciaTimer.ProcessTimer(cyclesExecuted, endBusCycle);
         }
     }
 
@@ -71,7 +73,7 @@ public abstract class CiaBase
             return;
         var cycles = busCycle - _advancedToBusCycle;
         _advancedToBusCycle = busCycle;
-        ProcessTimers(cycles);
+        ProcessTimers(cycles, busCycle);
     }
 
     /// <summary>State as of the cycle of the bus access the CPU is performing right now.</summary>

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaIRQ.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaIRQ.cs
@@ -30,7 +30,17 @@ public class CiaIRQ
         }
     }
 
-    public void Trigger(IRQSource source, CPU cpu)
+    /// <summary>
+    /// Assert the chip's interrupt output for a source. Without a cycle the CPU takes the interrupt
+    /// at its next instruction boundary.
+    /// </summary>
+    public void Trigger(IRQSource source, CPU cpu) => Trigger(source, cpu, atBusCycle: 0);
+
+    /// <summary>
+    /// Assert the chip's interrupt output for a source that arose during the given bus cycle; the
+    /// CPU applies its end-of-instruction sampling rule to that cycle.
+    /// </summary>
+    public void Trigger(IRQSource source, CPU cpu, ulong atBusCycle)
     {
         _sourceConditionStatus[IRQSource.Any] = true;
         var interruptSourceName = GetInterruptSourceName(source);
@@ -38,12 +48,12 @@ public class CiaIRQ
         if (_useNMI)
         {
             // Raise NMI (Non-Maskable Interrupt)
-            cpu.CPUInterrupts.SetNMISourceActive(interruptSourceName);
+            cpu.CPUInterrupts.SetNMISourceActive(interruptSourceName, atBusCycle);
         }
         else
         {
             // Raise IRQ (Interrupt Request)
-            cpu.CPUInterrupts.SetIRQSourceActive(interruptSourceName, autoAcknowledge: true);
+            cpu.CPUInterrupts.SetIRQSourceActive(interruptSourceName, autoAcknowledge: true, atBusCycle);
         }
     }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaTimer.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/TimerAndPeripheral/CiaTimer.cs
@@ -90,7 +90,12 @@ public class CiaTimer
         _timerIsRunning = running;
     }
 
-    public void ProcessTimer(ulong cyclesExecuted)
+    public void ProcessTimer(ulong cyclesExecuted) => ProcessTimer(cyclesExecuted, _c64.CPU.BusCycles);
+
+    /// <param name="cyclesExecuted">Cycles to advance.</param>
+    /// <param name="endBusCycle">The CPU bus cycle the advance ends at; an underflow is dated to
+    /// the cycle it happened on so the interrupt carries its real cycle.</param>
+    public void ProcessTimer(ulong cyclesExecuted, ulong endBusCycle)
     {
         if (!TimerControl.IsBitSet(_timerControlStartBit) || !_timerIsRunning || cyclesExecuted == 0)
             return;
@@ -106,6 +111,7 @@ public class CiaTimer
             }
 
             cyclesRemaining -= cyclesUntilUnderflow;
+            var underflowBusCycle = endBusCycle > cyclesRemaining ? endBusCycle - cyclesRemaining : 0;
             InternalTimer = 0xffff;
             _ciaIRQ.ConditionSet(_iRQSource);
 
@@ -113,7 +119,7 @@ public class CiaTimer
             {
                 // Timer has reached zero. Trigger interrupt if enabled.
                 if (_ciaIRQ.IsEnabled(_iRQSource))
-                    _ciaIRQ.Trigger(_iRQSource, _c64.CPU);
+                    _ciaIRQ.Trigger(_iRQSource, _c64.CPU, underflowBusCycle);
 
                 // Check if timer should be reloaded from latch. If Timer A RunMode bit is clear, timer should be continously reloaded from latch.
                 if (!TimerControl.IsBitSet(_timerControlRunModeBit))

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2.cs
@@ -892,7 +892,7 @@ public class Vic2
             return;
         var cycles = busCycle - _advancedToBusCycle;
         _advancedToBusCycle = busCycle;
-        AdvanceRaster(cycles);
+        AdvanceRaster(cycles, busCycle);
     }
 
     /// <summary>
@@ -918,7 +918,12 @@ public class Vic2
     /// drives the VIC-II through <see cref="CatchUpTo"/>; this remains for tests and tooling that
     /// position the raster directly.
     /// </summary>
-    public void AdvanceRaster(ulong cyclesConsumed)
+    public void AdvanceRaster(ulong cyclesConsumed) => AdvanceRaster(cyclesConsumed, C64.CPU.BusCycles);
+
+    /// <param name="cyclesConsumed">Cycles to advance.</param>
+    /// <param name="endBusCycle">The CPU bus cycle the advance ends at; used to date the cycle on
+    /// which a raster line began, so a raster interrupt is stamped with its real cycle.</param>
+    private void AdvanceRaster(ulong cyclesConsumed, ulong endBusCycle)
     {
         var cpu = C64.CPU;
         var mem = C64.Mem;
@@ -949,8 +954,12 @@ public class Vic2
                 C64.Cia2.CatchUpTo(_advancedToBusCycle);
             }
 
-            // Check if a IRQ should be issued for current raster line, and issue it.
-            RaiseRasterIRQ(cpu);
+            // Check if a IRQ should be issued for current raster line, and issue it, dated to the
+            // cycle on which the line began: the line has been current for `cyclesIntoLine`
+            // completed cycles, so it began during the cycle before those.
+            var cyclesIntoLine = CyclesConsumedCurrentVblank - (ulong)newLine * Vic2Model.CyclesPerLine;
+            var lineStartBusCycle = endBusCycle + 1 > cyclesIntoLine ? endBusCycle + 1 - cyclesIntoLine : 0;
+            RaiseRasterIRQ(cpu, lineStartBusCycle);
 
             // Remember colors and other IO registers for each raster line
             if (C64.RememberVic2RegistersPerRasterLine)
@@ -998,7 +1007,7 @@ public class Vic2
         ResyncToBusCycle();
     }
 
-    private void RaiseRasterIRQ(CPU cpu)
+    private void RaiseRasterIRQ(CPU cpu, ulong atBusCycle)
     {
         // Check if a IRQ should be issued
         var source = IRQSource.RasterCompare;
@@ -1006,7 +1015,7 @@ public class Vic2
             || (!Vic2IRQ.ConfiguredIRQRasterLine.HasValue & _currentRasterLineInternal >= Vic2Model.TotalHeight))
             && !Vic2IRQ.IsTriggered(source))
         {
-            Vic2IRQ.Trigger(source, cpu);
+            Vic2IRQ.Trigger(source, cpu, atBusCycle);
         }
     }
 

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2IRQ.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2IRQ.cs
@@ -35,11 +35,15 @@ public class Vic2IRQ
     {
         return _sourceEnableStatus[source];
     }
+    /// <summary>
+    /// Enable a source. If it is already latched the IRQ line goes active now, on the cycle of the
+    /// register write that enabled it.
+    /// </summary>
     public void Enable(IRQSource source, CPU cpu)
     {
         _sourceEnableStatus[source] = true;
         if (_sourceTriggerStatus[source])
-            cpu.CPUInterrupts.SetIRQSourceActive(GetInterruptSourceName(source), autoAcknowledge: false);
+            cpu.CPUInterrupts.SetIRQSourceActive(GetInterruptSourceName(source), autoAcknowledge: false, cpu.BusCycles);
     }
     public void Disable(IRQSource source, CPU cpu)
     {
@@ -62,11 +66,26 @@ public class Vic2IRQ
         _sourceTriggerStatus[source] = triggered;
     }
 
+    /// <summary>
+    /// Latch a source; asserts the IRQ line if the source is enabled. Without a cycle the CPU takes
+    /// the interrupt at its next instruction boundary.
+    /// </summary>
     public void Trigger(IRQSource source, CPU cpu)
     {
         _sourceTriggerStatus[source] = true;
         if (_sourceEnableStatus[source])
             cpu.CPUInterrupts.SetIRQSourceActive(GetInterruptSourceName(source), autoAcknowledge: false);
+    }
+
+    /// <summary>
+    /// Latch a source that arose during the given bus cycle; the CPU applies its end-of-instruction
+    /// sampling rule to that cycle (see <see cref="CPUInterrupts.SetIRQSourceActive(string, bool, ulong)"/>).
+    /// </summary>
+    public void Trigger(IRQSource source, CPU cpu, ulong atBusCycle)
+    {
+        _sourceTriggerStatus[source] = true;
+        if (_sourceEnableStatus[source])
+            cpu.CPUInterrupts.SetIRQSourceActive(GetInterruptSourceName(source), autoAcknowledge: false, atBusCycle);
     }
     public void ClearTrigger(IRQSource source, CPU cpu)
     {

--- a/src/libraries/Highbyte.DotNet6502/CPU.cs
+++ b/src/libraries/Highbyte.DotNet6502/CPU.cs
@@ -75,6 +75,23 @@ public class CPU
     public CPUInterrupts CPUInterrupts { get; private set; } = new CPUInterrupts();
 
     /// <summary>
+    /// The bus cycle at which the last instruction polled its interrupt lines. The 6502 samples
+    /// IRQ and NMI at the end of an instruction's second-to-last cycle (for a taken branch that
+    /// does not cross a page, at the end of its first cycle), so a line that goes active during
+    /// the last cycle is only seen after the following instruction. A device reports the cycle it
+    /// asserted the line on (see <see cref="CPUInterrupts.SetIRQSourceActive(string, bool, ulong)"/>);
+    /// an interrupt is taken at a boundary only if that cycle is at or before this one.
+    /// </summary>
+    private ulong _interruptPollBusCycle;
+
+    /// <summary>
+    /// The I flag as seen by the last poll, when it differs from the live flag: CLI, SEI and PLP
+    /// change the flag after the poll, so the interrupt decision at their boundary uses the value
+    /// from before the instruction. Null means "use the live flag" (RTI changes it in time).
+    /// </summary>
+    private bool? _interruptDisableAtPoll;
+
+    /// <summary>
     /// Is True when a IRQ (Interrupt Request) has been raised.
     /// Raising a NMI is done by setting a NMI source active, which is done by calling CPUInterrupts.SetNMISourceActive(source).
     /// 
@@ -272,10 +289,13 @@ public class CPU
         if (IsHalted)
             return InstructionExecResult.CpuAlreadyHaltedResult(PC);
 
+        var interruptDisableBefore = ProcessorStatus.InterruptDisable;
         var instructionExecutionResult = _instructionExecutor.Execute(this, mem);
 
         if (!instructionExecutionResult.HaltedCpu)
         {
+            RecordInterruptPollPoint(instructionExecutionResult, interruptDisableBefore);
+
             // Fold the hardware interrupt-entry cost (when one was serviced at this
             // boundary) into this instruction's result, so cycle totals and the
             // system loops that pace devices/frame budgets by it see real elapsed time.
@@ -292,6 +312,8 @@ public class CPU
     /// <summary>
     /// Services any pending hardware interrupts at the current instruction boundary.
     /// Intended for system-level device ticking that occurs after instruction execution.
+    /// An interrupt whose device reported an assertion cycle later than the instruction's poll
+    /// point (its last cycle) is left pending for the next boundary, as on hardware.
     /// </summary>
     /// <param name="mem"></param>
     /// <returns>
@@ -357,6 +379,7 @@ public class CPU
 
             RaiseInstructionToBeExecutedIfSubscribed(mem);
 
+            var interruptDisableBefore = ProcessorStatus.InterruptDisable;
             var instructionExecutionResult = _instructionExecutor.Execute(this, mem);
 
             // Service pending hardware interrupts at this boundary and fold the entry
@@ -365,6 +388,7 @@ public class CPU
             // time. (NmiAcknowledging consequently fires before InstructionExecuted.)
             if (!instructionExecutionResult.HaltedCpu)
             {
+                RecordInterruptPollPoint(instructionExecutionResult, interruptDisableBefore);
                 var interruptCycles = ProcessInterrupts(mem);
                 if (interruptCycles > 0)
                     instructionExecutionResult = instructionExecutionResult.WithAdditionalCycles(interruptCycles);
@@ -413,13 +437,35 @@ public class CPU
     /// </summary>
     public const ulong InterruptEntryCycles = 7;
 
+    private void RecordInterruptPollPoint(InstructionExecResult result, bool interruptDisableBefore)
+    {
+        var descriptor = Descriptors[result.OpCodeByte];
+        var poll = BusCycles > 0 ? BusCycles - 1 : 0;
+        // A relative branch taken without a page crossing (3 cycles: not taken is 2, taken across
+        // a page is 4) polls interrupts only at the end of its first cycle. The descriptor table
+        // decides what is a branch for this model ($80 is BRA on the 65C02, a NOP on the NMOS 6502).
+        if (result.CyclesConsumed == 3 && poll > 0 && descriptor?.Addressing == AddrMode.Relative)
+            poll--;
+        _interruptPollBusCycle = poll;
+        // CLI, SEI and PLP (per the model's table) change the I flag after the poll.
+        _interruptDisableAtPoll = descriptor?.ChangesInterruptDisableAfterPoll == true ? interruptDisableBefore : null;
+    }
+
+    private void RecordInterruptPollPointAfterInterruptEntry()
+    {
+        // The entry sequence behaves like an instruction: lines are polled again at its end, and
+        // the I flag it set is what the next decision sees.
+        _interruptPollBusCycle = BusCycles > 0 ? BusCycles - 1 : 0;
+        _interruptDisableAtPoll = null;
+    }
+
     /// <returns>Cycles consumed: <see cref="InterruptEntryCycles"/> if an interrupt was serviced, else 0.</returns>
     private ulong ProcessInterrupts(Memory mem)
     {
         if (IsHalted)
             return 0;
 
-        if (CPUInterrupts.NMIPending)
+        if (CPUInterrupts.NMIPending && CPUInterrupts.NMIPendingAtBusCycle <= _interruptPollBusCycle)
         {
             OnNmiAcknowledging();
             // The vector is read exactly once, inside ProcessHardwareNMI (as on real hardware,
@@ -439,15 +485,19 @@ public class CPU
                     nmiVector,
                     nmiSources);
             }
+            RecordInterruptPollPointAfterInterruptEntry();
             return InterruptEntryCycles;
         }
 
-        if (CPUInterrupts.IRQLineEnabled && !ProcessorStatus.InterruptDisable)
+        if (CPUInterrupts.IRQLineEnabled
+            && CPUInterrupts.IRQAssertedAtBusCycle <= _interruptPollBusCycle
+            && !(_interruptDisableAtPoll ?? ProcessorStatus.InterruptDisable))
         {
             // Sources raised with autoAcknowledge are dropped now; manually acknowledged
             // sources keep the line asserted until their device clears them.
             CPUInterrupts.AcknowledgeAutoAcknowledgingIRQSources();
             ProcessHardwareIRQ(mem);
+            RecordInterruptPollPointAfterInterruptEntry();
             return InterruptEntryCycles;
         }
 
@@ -528,6 +578,8 @@ public class CPU
             ProcessorStatus.Decimal = false;
         // Change PC to address found at BRK/IRQ handler vector
         PC = FetchWord(mem, CPU.ResetVector);
+        _interruptPollBusCycle = BusCycles;
+        _interruptDisableAtPoll = null;
         IsHalted = false;
     }
 

--- a/src/libraries/Highbyte.DotNet6502/CPUInterrupts.cs
+++ b/src/libraries/Highbyte.DotNet6502/CPUInterrupts.cs
@@ -46,6 +46,18 @@ public sealed class CPUInterrupts
     /// <summary>Latched NMI edge waiting to be serviced by the CPU.</summary>
     public bool NMIPending { get; private set; }
 
+    /// <summary>
+    /// The CPU bus cycle (<see cref="CPU.BusCycles"/>, the 1-based number of the access in
+    /// progress) during which the IRQ line went active, as reported by the device that asserted
+    /// it. 0 when the device gave no cycle, which the CPU treats as "before its last poll", so the
+    /// interrupt is taken at the next instruction boundary as before. See
+    /// <see cref="CPU.ProcessPendingInterrupts"/> for the sampling rule.
+    /// </summary>
+    public ulong IRQAssertedAtBusCycle { get; private set; }
+
+    /// <summary>The bus cycle during which the pending NMI edge was detected; 0 if not given.</summary>
+    public ulong NMIPendingAtBusCycle { get; private set; }
+
     /// <summary>Number of sources registered on this instance.</summary>
     public int RegisteredSourceCount => _sourceNames.Count;
 
@@ -81,15 +93,34 @@ public sealed class CPUInterrupts
     /// <param name="source">Unique name of source</param>
     /// <param name="autoAcknowledge">Set to true if the IRQ source should automatically be removed when processed by CPU.</param>
     public void SetIRQSourceActive(string source, bool autoAcknowledge)
-        => SetIRQActive(GetSource(source), autoAcknowledge);
+        => SetIRQActive(GetSource(source), autoAcknowledge, assertedAtBusCycle: 0);
+
+    /// <summary>
+    /// Sets an IRQ source active and records the bus cycle during which the line went active,
+    /// so the CPU can apply its end-of-instruction sampling rule (an interrupt asserted during an
+    /// instruction's last cycle is taken after the following instruction).
+    /// </summary>
+    /// <param name="assertedAtBusCycle">The <see cref="CPU.BusCycles"/> value during the access
+    /// on which the device asserted the line; a device catching up at an instruction boundary
+    /// passes the cycle at which the condition arose.</param>
+    public void SetIRQSourceActive(string source, bool autoAcknowledge, ulong assertedAtBusCycle)
+        => SetIRQActive(GetSource(source), autoAcknowledge, assertedAtBusCycle);
 
     /// <inheritdoc cref="SetIRQSourceActive(string, bool)"/>
     public void SetIRQActive(InterruptSource source, bool autoAcknowledge)
+        => SetIRQActive(source, autoAcknowledge, assertedAtBusCycle: 0);
+
+    /// <inheritdoc cref="SetIRQSourceActive(string, bool, ulong)"/>
+    public void SetIRQActive(InterruptSource source, bool autoAcknowledge, ulong assertedAtBusCycle)
     {
         var mask = source.Mask;
         if ((_irqLines & mask) != 0)
             return;
 
+        // The line is level-sensitive: its assertion cycle is that of the first source to pull
+        // it low. A source added while the line is already low does not move it.
+        if (_irqLines == 0)
+            IRQAssertedAtBusCycle = assertedAtBusCycle;
         _irqLines |= mask;
         if (autoAcknowledge)
             _irqAutoAcknowledgeMask |= mask;
@@ -144,16 +175,29 @@ public sealed class CPUInterrupts
     /// </summary>
     /// <param name="source">Unique name of source</param>
     public void SetNMISourceActive(string source)
-        => SetNMIActive(GetSource(source));
+        => SetNMIActive(GetSource(source), pendingAtBusCycle: 0);
+
+    /// <summary>
+    /// Sets an NMI source active and records the bus cycle during which the edge occurred (see
+    /// <see cref="SetIRQSourceActive(string, bool, ulong)"/> for the sampling rule).
+    /// </summary>
+    public void SetNMISourceActive(string source, ulong pendingAtBusCycle)
+        => SetNMIActive(GetSource(source), pendingAtBusCycle);
 
     /// <inheritdoc cref="SetNMISourceActive(string)"/>
     public void SetNMIActive(InterruptSource source)
+        => SetNMIActive(source, pendingAtBusCycle: 0);
+
+    /// <inheritdoc cref="SetNMISourceActive(string, ulong)"/>
+    public void SetNMIActive(InterruptSource source, ulong pendingAtBusCycle)
     {
         var mask = source.Mask;
         if ((_nmiLines & mask) != 0)
             return;
 
         _nmiLines |= mask;
+        if (!NMIPending)
+            NMIPendingAtBusCycle = pendingAtBusCycle;
         NMIPending = true;
     }
 

--- a/src/libraries/Highbyte.DotNet6502/CpuModels/InstructionBindings.cs
+++ b/src/libraries/Highbyte.DotNet6502/CpuModels/InstructionBindings.cs
@@ -137,8 +137,8 @@ internal static class InstructionBindings
         // --- Flag operations ---
         Implied(table, 0x18, "CLC", 2, InstructionCores.Clc);
         Implied(table, 0x38, "SEC", 2, InstructionCores.Sec);
-        Implied(table, 0x58, "CLI", 2, InstructionCores.Cli);
-        Implied(table, 0x78, "SEI", 2, InstructionCores.Sei);
+        Implied(table, 0x58, "CLI", 2, InstructionCores.Cli, changesInterruptDisableAfterPoll: true);
+        Implied(table, 0x78, "SEI", 2, InstructionCores.Sei, changesInterruptDisableAfterPoll: true);
         Implied(table, 0xB8, "CLV", 2, InstructionCores.Clv);
         Implied(table, 0xD8, "CLD", 2, InstructionCores.Cld);
         Implied(table, 0xF8, "SED", 2, InstructionCores.Sed);
@@ -147,7 +147,7 @@ internal static class InstructionBindings
         Bespoke(table, 0x48, "PHA", AddrMode.Implied, 1, 3, SharedHandlers.Pha);
         Bespoke(table, 0x68, "PLA", AddrMode.Implied, 1, 4, SharedHandlers.Pla);
         Bespoke(table, 0x08, "PHP", AddrMode.Implied, 1, 3, SharedHandlers.Php);
-        Bespoke(table, 0x28, "PLP", AddrMode.Implied, 1, 4, SharedHandlers.Plp);
+        Bespoke(table, 0x28, "PLP", AddrMode.Implied, 1, 4, SharedHandlers.Plp, changesInterruptDisableAfterPoll: true);
         Bespoke(table, 0x4C, "JMP", AddrMode.ABS, 3, 3, SharedHandlers.Jmp_Absolute);
         Bespoke(table, 0x20, "JSR", AddrMode.ABS, 3, 6, SharedHandlers.Jsr);
         Bespoke(table, 0x60, "RTS", AddrMode.Implied, 1, 6, SharedHandlers.Rts);
@@ -372,7 +372,7 @@ internal static class InstructionBindings
         };
 
     private static void Bespoke(OpCodeDescriptor?[] table, byte code, string mnemonic, AddrMode addressing,
-        byte size, byte baseCycles, ExecuteHandler handler, bool documented = true)
+        byte size, byte baseCycles, ExecuteHandler handler, bool documented = true, bool changesInterruptDisableAfterPoll = false)
         => table[code] = new OpCodeDescriptor
         {
             Code = code,
@@ -382,6 +382,7 @@ internal static class InstructionBindings
             BaseCycles = baseCycles,
             Documented = documented,
             Execute = handler,
+            ChangesInterruptDisableAfterPoll = changesInterruptDisableAfterPoll,
         };
 
     private static void Rmw(OpCodeDescriptor?[] table, byte code, string mnemonic, AddrMode addressing,
@@ -440,7 +441,8 @@ internal static class InstructionBindings
         };
 
     private static void Implied(OpCodeDescriptor?[] table, byte code, string mnemonic,
-        byte baseCycles, ImpliedOperation core, AddrMode addressing = AddrMode.Implied, bool documented = true)
+        byte baseCycles, ImpliedOperation core, AddrMode addressing = AddrMode.Implied, bool documented = true,
+        bool changesInterruptDisableAfterPoll = false)
         => table[code] = new OpCodeDescriptor
         {
             Code = code,
@@ -450,5 +452,6 @@ internal static class InstructionBindings
             BaseCycles = baseCycles,
             Documented = documented,
             Execute = ComposeImplied(baseCycles, core),
+            ChangesInterruptDisableAfterPoll = changesInterruptDisableAfterPoll,
         };
 }

--- a/src/libraries/Highbyte.DotNet6502/CpuModels/OpCodeDescriptor.cs
+++ b/src/libraries/Highbyte.DotNet6502/CpuModels/OpCodeDescriptor.cs
@@ -34,4 +34,11 @@ internal sealed class OpCodeDescriptor
 
     /// <summary>The complete instruction execution, addressing included.</summary>
     public required ExecuteHandler Execute { get; init; }
+
+    /// <summary>
+    /// True for instructions that change the I flag in their last cycle, after the CPU has polled
+    /// its interrupt lines (CLI, SEI, PLP): the interrupt decision at their boundary uses the flag
+    /// as it was before the instruction. RTI changes the flag before the poll and is not marked.
+    /// </summary>
+    public bool ChangesInterruptDisableAfterPoll { get; init; }
 }

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64DeviceAccessTimingTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64DeviceAccessTimingTests.cs
@@ -105,10 +105,15 @@ public class C64DeviceAccessTimingTests
         Assert.Equal(0x1000 - 4 & 0xFF, c64.CPU.A);
     }
 
-    [Fact]
-    public void Raster_interrupt_that_becomes_due_during_an_instruction_is_serviced_right_after_it()
+    [Theory]
+    [InlineData(new byte[] { 0xAD, 0x12, 0xD0 }, 2, true)]    // LDA $D012: line 1 begins on cycle 3 (second-to-last) -> taken after this instruction
+    [InlineData(new byte[] { 0xAD, 0x12, 0xD0 }, 3, false)]   // LDA $D012: line 1 begins on cycle 4 (last) -> taken after the next instruction
+    [InlineData(new byte[] { 0xAD, 0x00, 0x10 }, 2, true)]    // LDA $1000 (no I/O): the boundary catch-up dates the line change to cycle 3 -> taken now
+    [InlineData(new byte[] { 0xAD, 0x00, 0x10 }, 3, false)]   // LDA $1000: line change on the last cycle -> next boundary
+    public void Raster_interrupt_is_taken_after_the_instruction_only_if_due_by_its_second_to_last_cycle(byte[] instruction, int cyclesToLineChangeAtStart, bool takenAfterThisInstruction)
     {
-        var c64 = Build([0xAD, 0x12, 0xD0, 0xEA]);   // LDA $D012 ; NOP
+        var program = instruction.Concat(new byte[] { 0xEA }).ToArray();   // ... ; NOP
+        var c64 = Build(program);
         c64.Mem.Write(0x0001, 0x35);                  // RAM under the KERNAL, I/O visible
         c64.Mem.WriteWord(CPU.BrkIRQHandlerVector, 0x2000);
         c64.Mem.Write(Vic2Addr.CURRENT_RASTER_LINE, 1);
@@ -116,14 +121,53 @@ public class C64DeviceAccessTimingTests
         c64.Mem.Write(Vic2Addr.IRQ_MASK, 0x01);
         c64.CPU.ProcessorStatus.InterruptDisable = false;
         var cyclesPerLine = c64.Vic2.Vic2Model.CyclesPerLine;
-        c64.Vic2.AdvanceRaster(cyclesPerLine - 3);    // line 1 begins on the read cycle
+        c64.Vic2.AdvanceRaster(cyclesPerLine - (ulong)cyclesToLineChangeAtStart);
 
-        var result = Step(c64);
+        var first = Step(c64);
 
-        Assert.Equal(1, c64.CPU.A);
+        Assert.True(c64.CPU.IRQ);   // the line is asserted either way
+        if (takenAfterThisInstruction)
+        {
+            Assert.Equal(0x2000, c64.CPU.PC);
+            Assert.Equal(4 + CPU.InterruptEntryCycles, first.CyclesConsumed);
+        }
+        else
+        {
+            Assert.Equal(Start + 3, c64.CPU.PC);
+            Assert.Equal(4UL, first.CyclesConsumed);
+
+            var second = Step(c64);   // the NOP runs, then the interrupt is taken
+            Assert.Equal(0x2000, c64.CPU.PC);
+            Assert.Equal(2 + CPU.InterruptEntryCycles, second.CyclesConsumed);
+        }
+    }
+
+    [Fact]
+    public void Cia_timer_interrupt_is_dated_to_the_underflow_cycle()
+    {
+        // Timer A latch 5, started by a direct write: it underflows after 6 counted cycles, i.e.
+        // during cycle 6 of the program below. NOP NOP NOP = cycles 1-2, 3-4, 5-6: the underflow
+        // falls on the last cycle of the third NOP, so the IRQ is taken after the fourth.
+        // (In UpdateEachRasterLine mode the CIAs are only advanced at raster line changes and CIA
+        // accesses, so an underflow between those is discovered at the next line change.)
+        var c64 = Build([0xEA, 0xEA, 0xEA, 0xEA, 0xEA], TimerMode.UpdateEachInstruction);
+        c64.Mem.Write(0x0001, 0x35);
+        c64.Mem.WriteWord(CPU.BrkIRQHandlerVector, 0x2000);
+        c64.CPU.ProcessorStatus.InterruptDisable = false;
+        c64.Mem.Write(CiaAddr.CIA1_TIMALO, 0x05);
+        c64.Mem.Write(CiaAddr.CIA1_TIMAHI, 0x00);
+        c64.Mem.Write(CiaAddr.CIA1_CIAICR, 0x81);      // enable timer A interrupt
+        c64.Mem.Write(CiaAddr.CIA1_CIACRA, 0x09);   // one-shot, start
+
+        Step(c64); Step(c64);
+        var third = Step(c64);
+        Assert.Equal(2UL, third.CyclesConsumed);
+        Assert.Equal(Start + 3, c64.CPU.PC);          // underflow on the last cycle: not yet
+        Assert.True(c64.CPU.IRQ);
+
+        var fourth = Step(c64);
+        Assert.Equal(2 + CPU.InterruptEntryCycles, fourth.CyclesConsumed);
         Assert.Equal(0x2000, c64.CPU.PC);
-        Assert.Equal(4 + CPU.InterruptEntryCycles, result.CyclesConsumed);
-        Assert.Equal(cyclesPerLine - 3 + 4 + CPU.InterruptEntryCycles, c64.Vic2.CyclesConsumedCurrentVblank);
     }
 
     [Fact]

--- a/tests/Highbyte.DotNet6502.Tests/CPUInterruptSamplingCycleTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/CPUInterruptSamplingCycleTests.cs
@@ -1,0 +1,196 @@
+using Highbyte.DotNet6502.Utils;
+
+namespace Highbyte.DotNet6502.Tests;
+
+/// <summary>
+/// The 6502 samples its IRQ and NMI inputs at the end of an instruction's second-to-last cycle
+/// (a taken branch that does not cross a page: at the end of its first cycle). A line that goes
+/// active during the last cycle is therefore only seen after the following instruction. Devices
+/// report the bus cycle they asserted the line on; a source set active without a cycle is taken
+/// at the next boundary as before. CLI, SEI and PLP change the I flag after the poll, RTI before it.
+/// </summary>
+public class CPUInterruptSamplingCycleTests
+{
+    private const ushort Start = 0x1000;
+    private const ushort IrqHandler = 0x4000;
+    private const ushort NmiHandler = 0x5000;
+
+    private static (CPU cpu, Memory mem) NewCpu(params byte[] program)
+    {
+        var cpu = new CPU();
+        var mem = new Memory();
+        mem.StoreData(Start, program);
+        mem.WriteWord(CPU.BrkIRQHandlerVector, IrqHandler);
+        mem.WriteWord(CPU.NonMaskableIRQHandlerVector, NmiHandler);
+        cpu.PC = Start;
+        cpu.SP = 0xFF;
+        cpu.ProcessorStatus.InterruptDisable = false;
+        return (cpu, mem);
+    }
+
+    [Theory]
+    [InlineData(1, true)]    // asserted during cycle 1 of a 2-cycle NOP (second-to-last): taken after it
+    [InlineData(2, false)]   // asserted during cycle 2 (last): taken after the next instruction
+    public void IRQ_is_taken_after_an_instruction_only_if_asserted_by_its_second_to_last_cycle(ulong assertedAtBusCycle, bool takenNow)
+    {
+        var (cpu, mem) = NewCpu(0xEA, 0xEA);   // NOP ; NOP
+
+        cpu.ExecuteOneInstructionMinimal(mem);                      // bus cycles 1-2
+        cpu.CPUInterrupts.SetIRQSourceActive("device", autoAcknowledge: true, assertedAtBusCycle);
+        var entry = cpu.ProcessPendingInterrupts(mem);
+
+        Assert.Equal(takenNow ? CPU.InterruptEntryCycles : 0UL, entry);
+        Assert.Equal(takenNow ? IrqHandler : (ushort)(Start + 1), cpu.PC);
+
+        if (!takenNow)
+        {
+            var result = cpu.ExecuteOneInstructionMinimal(mem);      // the second NOP, then the IRQ
+            Assert.Equal(2 + CPU.InterruptEntryCycles, result.CyclesConsumed);
+            Assert.Equal(IrqHandler, cpu.PC);
+        }
+    }
+
+    [Fact]
+    public void IRQ_asserted_without_a_cycle_is_taken_at_the_next_boundary()
+    {
+        var (cpu, mem) = NewCpu(0xEA);
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        cpu.CPUInterrupts.SetIRQSourceActive("device", autoAcknowledge: true);
+
+        Assert.Equal(CPU.InterruptEntryCycles, cpu.ProcessPendingInterrupts(mem));
+        Assert.Equal(IrqHandler, cpu.PC);
+    }
+
+    [Theory]
+    [InlineData(2, false)]   // asserted during cycle 2 of a 2-cycle NOP: deferred
+    [InlineData(1, true)]
+    public void NMI_edge_follows_the_same_sampling_rule(ulong pendingAtBusCycle, bool takenNow)
+    {
+        var (cpu, mem) = NewCpu(0xEA, 0xEA);
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        cpu.CPUInterrupts.SetNMISourceActive("device", pendingAtBusCycle);
+        cpu.ProcessPendingInterrupts(mem);
+
+        Assert.Equal(takenNow ? NmiHandler : (ushort)(Start + 1), cpu.PC);
+        if (!takenNow)
+        {
+            cpu.ExecuteOneInstructionMinimal(mem);
+            Assert.Equal(NmiHandler, cpu.PC);
+        }
+    }
+
+    [Fact]
+    public void The_assertion_cycle_is_that_of_the_first_source_to_pull_the_line_low()
+    {
+        var (cpu, mem) = NewCpu(0xEA);
+        cpu.ExecuteOneInstructionMinimal(mem);                      // bus cycles 1-2
+
+        cpu.CPUInterrupts.SetIRQSourceActive("early", autoAcknowledge: false, 1);
+        cpu.CPUInterrupts.SetIRQSourceActive("late", autoAcknowledge: false, 2);
+
+        Assert.Equal(1UL, cpu.CPUInterrupts.IRQAssertedAtBusCycle);
+        Assert.Equal(CPU.InterruptEntryCycles, cpu.ProcessPendingInterrupts(mem));
+    }
+
+    [Theory]
+    [InlineData(1, true)]    // taken branch, no page crossing (3 cycles): polls at the end of its first cycle
+    [InlineData(2, false)]   // asserted during its second cycle: not seen until the next instruction
+    public void Taken_branch_without_page_crossing_polls_only_at_the_end_of_its_first_cycle(ulong assertedAtBusCycle, bool takenNow)
+    {
+        var (cpu, mem) = NewCpu(0xD0, 0x01, 0xEA, 0xEA);   // BNE +1 ; NOP ; NOP
+        cpu.ProcessorStatus.Zero = false;
+
+        var branch = cpu.ExecuteOneInstructionMinimal(mem);          // bus cycles 1-3
+        Assert.Equal(3UL, branch.CyclesConsumed);
+        cpu.CPUInterrupts.SetIRQSourceActive("device", autoAcknowledge: true, assertedAtBusCycle);
+        cpu.ProcessPendingInterrupts(mem);
+
+        Assert.Equal(takenNow ? IrqHandler : (ushort)(Start + 3), cpu.PC);
+    }
+
+    [Fact]
+    public void Taken_branch_with_page_crossing_polls_at_its_second_to_last_cycle()
+    {
+        // BNE at $10FD with offset +1 lands on $1100: taken, page crossed, 4 cycles.
+        var cpu = new CPU();
+        var mem = new Memory();
+        mem[0x10FD] = 0xD0; mem[0x10FE] = 0x01; mem[0x1100] = 0xEA;
+        mem.WriteWord(CPU.BrkIRQHandlerVector, IrqHandler);
+        cpu.PC = 0x10FD; cpu.SP = 0xFF;
+        cpu.ProcessorStatus.InterruptDisable = false;
+        cpu.ProcessorStatus.Zero = false;
+
+        var branch = cpu.ExecuteOneInstructionMinimal(mem);          // bus cycles 1-4
+        Assert.Equal(4UL, branch.CyclesConsumed);
+        cpu.CPUInterrupts.SetIRQSourceActive("device", autoAcknowledge: true, 3);
+
+        Assert.Equal(CPU.InterruptEntryCycles, cpu.ProcessPendingInterrupts(mem));
+        Assert.Equal(IrqHandler, cpu.PC);
+    }
+
+    [Fact]
+    public void CLI_takes_effect_one_instruction_late()
+    {
+        var (cpu, mem) = NewCpu(0x58, 0xEA, 0xEA);   // CLI ; NOP ; NOP
+        cpu.ProcessorStatus.InterruptDisable = true;
+        cpu.CPUInterrupts.SetIRQSourceActive("device", autoAcknowledge: true);
+
+        var cli = cpu.ExecuteOneInstructionMinimal(mem);
+        Assert.False(cpu.ProcessorStatus.InterruptDisable);
+        Assert.Equal(2UL, cli.CyclesConsumed);              // the poll saw I still set
+        Assert.Equal(Start + 1, cpu.PC);
+
+        var nop = cpu.ExecuteOneInstructionMinimal(mem);
+        Assert.Equal(2 + CPU.InterruptEntryCycles, nop.CyclesConsumed);
+        Assert.Equal(IrqHandler, cpu.PC);
+    }
+
+    [Fact]
+    public void SEI_still_lets_a_pending_IRQ_through_after_it()
+    {
+        var (cpu, mem) = NewCpu(0x78, 0xEA);   // SEI ; NOP
+        cpu.CPUInterrupts.SetIRQSourceActive("device", autoAcknowledge: true);
+
+        var sei = cpu.ExecuteOneInstructionMinimal(mem);
+
+        Assert.Equal(2 + CPU.InterruptEntryCycles, sei.CyclesConsumed);   // the poll saw I still clear
+        Assert.Equal(IrqHandler, cpu.PC);
+        Assert.True(cpu.ProcessorStatus.InterruptDisable);
+    }
+
+    [Fact]
+    public void PLP_clearing_I_takes_effect_one_instruction_late()
+    {
+        var (cpu, mem) = NewCpu(0x28, 0xEA, 0xEA);   // PLP ; NOP ; NOP
+        cpu.ProcessorStatus.InterruptDisable = true;
+        mem[0x01FF] = 0x00;                            // status with I clear
+        cpu.SP = 0xFE;
+        cpu.CPUInterrupts.SetIRQSourceActive("device", autoAcknowledge: true);
+
+        var plp = cpu.ExecuteOneInstructionMinimal(mem);
+        Assert.False(cpu.ProcessorStatus.InterruptDisable);
+        Assert.Equal(4UL, plp.CyclesConsumed);
+        Assert.Equal(Start + 1, cpu.PC);
+
+        var nop = cpu.ExecuteOneInstructionMinimal(mem);
+        Assert.Equal(2 + CPU.InterruptEntryCycles, nop.CyclesConsumed);
+    }
+
+    [Fact]
+    public void RTI_clearing_I_takes_effect_immediately()
+    {
+        var (cpu, mem) = NewCpu(0x40, 0xEA);   // RTI
+        cpu.ProcessorStatus.InterruptDisable = true;
+        mem[0x01FD] = 0x00;                     // status with I clear
+        mem.WriteWord(0x01FE, 0x3000);          // return address
+        cpu.SP = 0xFC;
+        cpu.CPUInterrupts.SetIRQSourceActive("device", autoAcknowledge: true);
+
+        var rti = cpu.ExecuteOneInstructionMinimal(mem);
+
+        Assert.Equal(6 + CPU.InterruptEntryCycles, rti.CyclesConsumed);
+        Assert.Equal(IrqHandler, cpu.PC);
+    }
+}


### PR DESCRIPTION
## Summary

The CPU took any active IRQ or NMI at the next instruction boundary. The 6502 polls its interrupt inputs at the end of an instruction's **second-to-last** cycle (a taken branch that does not cross a page: at the end of its first cycle), so a line that goes active during the last cycle is only seen after the following instruction. This PR models that.

- **Assertion cycles.** `CPUInterrupts` records the bus cycle on which the IRQ line went active (first source to pull it low) and on which the NMI edge was latched, via new overloads taking a cycle. Sources set without a cycle keep the previous next-boundary behaviour, so other systems and cartridges are unaffected.
- **Poll point.** The CPU records each instruction's poll point from `CPU.BusCycles` and takes an interrupt at a boundary only if the assertion cycle is at or before it. After an interrupt entry the poll is re-armed at its end.
- **CLI, SEI, PLP vs RTI.** The first three change the I flag after the poll, so their boundary decision uses the flag from before the instruction (CLI's effect is one instruction late, an IRQ pending at SEI is still taken). RTI changes it in time. Which opcodes are branches or flag-changers comes from the model's opcode descriptor table (`Addressing == Relative`, new `ChangesInterruptDisableAfterPoll` marker), not from opcode literals in the CPU.
- **C64 devices date their assertions**: the VIC-II to the cycle the raster line began, CIA timers to the underflow cycle, a `$D01A` enable to the write cycle. The C64 loop now catches the VIC-II up **before** the pending-interrupt check, which closes the case the previous increment left open: an interrupt due during an instruction with no I/O access is serviced right after it instead of one instruction later.

Reference: nesdev "CPU interrupts" (agrees with 64doc) for the poll point, the taken-branch case and the CLI/SEI/PLP/RTI behaviour.

## Not modelled

- NMI hijacking an interrupt sequence already in progress.
- The 6526's one-cycle delay between flag and IRQ output.
- Pre-existing: enabling a CIA mask bit while its flag is already set does not assert the line.
- In the default `UpdateEachRasterLine` timer mode a CIA underflow between line changes is still discovered at the next line change (that mode's known laziness).

## Tests

- New `CPUInterruptSamplingCycleTests` (13): IRQ and NMI asserted on the second-to-last vs the last cycle, the unstamped default, first-source-wins, taken branch with and without page crossing, CLI, SEI, PLP, RTI.
- C64 `C64DeviceAccessTimingTests`: raster interrupt due on cycle 3 vs cycle 4 of a 4-cycle instruction, with and without an I/O access; CIA timer interrupt dated to its underflow cycle.
- Solution: 2,800 tests passed (6 projects).

## Performance

Apple M1 (MacBook Air), .NET 10.0.7, same machine for both runs, no allocations added:

| Benchmark | integration branch | this branch | ratio |
|---|--:|--:|--:|
| CPU, 1000 NOPs, `ExecuteOneInstructionMinimal` | 15.16 us | 15.61 us | 1.03 |
| CPU, 1000 NOPs, `Execute` | 15.89 us | 16.36 us | 1.03 |
| C64, 1000 instructions, core only | 25.15 us | 24.21 us | 0.96 |
| C64, 1000 instructions, render and audio | 71.78 us | 71.55 us | 1.00 |

About half a nanosecond per instruction on the bare CPU loop (the poll-point bookkeeping), within noise at C64 level.
