### PR TITLE
Mark CLI/SEI/PLP descriptors after binding instead of via a parameter

### DIFF
--- a/src/libraries/Highbyte.DotNet6502/CpuModels/InstructionBindings.cs
+++ b/src/libraries/Highbyte.DotNet6502/CpuModels/InstructionBindings.cs
@@ -137,8 +137,8 @@ internal static class InstructionBindings
         // --- Flag operations ---
         Implied(table, 0x18, "CLC", 2, InstructionCores.Clc);
         Implied(table, 0x38, "SEC", 2, InstructionCores.Sec);
-        Implied(table, 0x58, "CLI", 2, InstructionCores.Cli, changesInterruptDisableAfterPoll: true);
-        Implied(table, 0x78, "SEI", 2, InstructionCores.Sei, changesInterruptDisableAfterPoll: true);
+        Implied(table, 0x58, "CLI", 2, InstructionCores.Cli);
+        Implied(table, 0x78, "SEI", 2, InstructionCores.Sei);
         Implied(table, 0xB8, "CLV", 2, InstructionCores.Clv);
         Implied(table, 0xD8, "CLD", 2, InstructionCores.Cld);
         Implied(table, 0xF8, "SED", 2, InstructionCores.Sed);
@@ -147,7 +147,10 @@ internal static class InstructionBindings
         Bespoke(table, 0x48, "PHA", AddrMode.Implied, 1, 3, SharedHandlers.Pha);
         Bespoke(table, 0x68, "PLA", AddrMode.Implied, 1, 4, SharedHandlers.Pla);
         Bespoke(table, 0x08, "PHP", AddrMode.Implied, 1, 3, SharedHandlers.Php);
-        Bespoke(table, 0x28, "PLP", AddrMode.Implied, 1, 4, SharedHandlers.Plp, changesInterruptDisableAfterPoll: true);
+        Bespoke(table, 0x28, "PLP", AddrMode.Implied, 1, 4, SharedHandlers.Plp);
+
+        // CLI, SEI and PLP change the I flag in their last cycle, after the interrupt poll.
+        MarkChangesInterruptDisableAfterPoll(table, 0x58, 0x78, 0x28);
         Bespoke(table, 0x4C, "JMP", AddrMode.ABS, 3, 3, SharedHandlers.Jmp_Absolute);
         Bespoke(table, 0x20, "JSR", AddrMode.ABS, 3, 6, SharedHandlers.Jsr);
         Bespoke(table, 0x60, "RTS", AddrMode.Implied, 1, 6, SharedHandlers.Rts);
@@ -372,7 +375,7 @@ internal static class InstructionBindings
         };
 
     private static void Bespoke(OpCodeDescriptor?[] table, byte code, string mnemonic, AddrMode addressing,
-        byte size, byte baseCycles, ExecuteHandler handler, bool documented = true, bool changesInterruptDisableAfterPoll = false)
+        byte size, byte baseCycles, ExecuteHandler handler, bool documented = true)
         => table[code] = new OpCodeDescriptor
         {
             Code = code,
@@ -382,8 +385,29 @@ internal static class InstructionBindings
             BaseCycles = baseCycles,
             Documented = documented,
             Execute = handler,
-            ChangesInterruptDisableAfterPoll = changesInterruptDisableAfterPoll,
         };
+
+    /// <summary>
+    /// Re-issue already bound descriptors with <see cref="OpCodeDescriptor.ChangesInterruptDisableAfterPoll"/> set.
+    /// </summary>
+    private static void MarkChangesInterruptDisableAfterPoll(OpCodeDescriptor?[] table, params byte[] codes)
+    {
+        foreach (var code in codes)
+        {
+            var d = table[code] ?? throw new InvalidOperationException($"Opcode ${code:X2} is not bound.");
+            table[code] = new OpCodeDescriptor
+            {
+                Code = d.Code,
+                Mnemonic = d.Mnemonic,
+                Addressing = d.Addressing,
+                Size = d.Size,
+                BaseCycles = d.BaseCycles,
+                Documented = d.Documented,
+                Execute = d.Execute,
+                ChangesInterruptDisableAfterPoll = true,
+            };
+        }
+    }
 
     private static void Rmw(OpCodeDescriptor?[] table, byte code, string mnemonic, AddrMode addressing,
         byte size, byte baseCycles, RmwOperation core, bool cmosSequence, bool indexedDummyReads, bool addPageCrossCycle = false, bool documented = true)
@@ -441,8 +465,7 @@ internal static class InstructionBindings
         };
 
     private static void Implied(OpCodeDescriptor?[] table, byte code, string mnemonic,
-        byte baseCycles, ImpliedOperation core, AddrMode addressing = AddrMode.Implied, bool documented = true,
-        bool changesInterruptDisableAfterPoll = false)
+        byte baseCycles, ImpliedOperation core, AddrMode addressing = AddrMode.Implied, bool documented = true)
         => table[code] = new OpCodeDescriptor
         {
             Code = code,
@@ -452,6 +475,5 @@ internal static class InstructionBindings
             BaseCycles = baseCycles,
             Documented = documented,
             Execute = ComposeImplied(baseCycles, core),
-            ChangesInterruptDisableAfterPoll = changesInterruptDisableAfterPoll,
         };
 }


### PR DESCRIPTION
Follow-up to #311. The binding helper for implied instructions had grown to eight parameters (Sonar S107, Major). The three descriptors that change the I flag after the interrupt poll (CLI, SEI, PLP) are now re-issued with the marker set after they are bound, and the extra parameter is gone from the `Implied` and `Bespoke` helpers. No behaviour change; CPU suite 1,428 passed.