### PR TITLE
Stall the CPU during VIC-II bad lines and sprite DMA

### DIFF
--- a/benchmarks/Highbyte.DotNet6502.Benchmarks/RESULTS.md
+++ b/benchmarks/Highbyte.DotNet6502.Benchmarks/RESULTS.md
@@ -369,6 +369,35 @@ Observations that matter for the cycle work:
 
 ## History
 
+### 2026-09-03 — VIC-II bus stalls (bad lines and sprite DMA)
+
+The CPU can now be stalled by a bus master through `CPU.BusStallSource`: before a read it asks
+how long the bus is busy, the read happens at the release cycle and the waiting cycles count as
+instruction cycles without accesses. The C64 wires the VIC-II in: 40 cycles on every bad line
+(BA low from cycle 12, video matrix fetches in cycles 15-54) and two cycles per sprite with DMA
+on, BA low three cycles ahead, derived from the read's raster position and the live registers.
+The mechanism costs one comparison per read plus one window evaluation per raster line. The
+benchmark machine has the display off, so its frames contain no stalls and the comparison below
+measures overhead only; the last column shows the same branch with `$D011 = $1B` (display on,
+as the KERNAL leaves it): the CPU then loses its cycles to the VIC-II as on hardware and the
+frame has less CPU work in it. Apple M1, .NET 10.0.7, same session.
+
+| Benchmark | Baseline | After | Δ | After, display on |
+|-----------|---------:|------:|--:|------------------:|
+| `InstructionExecutor_OneStep` | 20.1 ns | 20.8 ns | +3% | — |
+| `CPU_Run_1000Instructions` | 15.13 µs | 16.20 µs | +7% | — |
+| `CPU_Execute_NoSubscribers_1000Instructions` | 16.66 µs | 17.00 µs | +2% | — |
+| `Memory_Read_TightLoop` / `Memory_Write_TightLoop` | 1.71 / 1.57 µs | 1.67 / 1.57 µs | 0% | — |
+| C64 frame `CoreOnly` / `None` | 231.0 µs | 231.2 µs | 0% | 218.3 µs |
+| C64 frame `RenderOnly` / `None` | 399.9 µs | 401.2 µs | 0% | 388.1 µs |
+| C64 frame `AudioOnly` / `None` | 374.4 µs | 373.7 µs | 0% | 362.2 µs |
+| C64 frame `RenderAndAudio` / `None` | 590.0 µs | 604.4 µs | +2% | 585.3 µs |
+| C64 frame `RenderAndAudio` / `MixedVisibleSprites` | 598.9 µs | 609.3 µs | +2% | 594.5 µs |
+
+Accepted: the per-read comparison is the whole overhead (a NOP is two reads, hence the CPU loop
+rows), frames move within noise, and with the display on the stalls take about 6% of the
+CPU's frame time, which is the hardware's share for 25 bad lines.
+
 ### 2026-09-03 — CIAs exact at every instruction, timer mode retired
 
 The CIAs used to be advanced either after every instruction or, in the default mode, once per

--- a/docs/libraries/core/dotnet6502.md
+++ b/docs/libraries/core/dotnet6502.md
@@ -31,6 +31,13 @@ devices exact to the cycle without stepping them every cycle: a memory-mapped re
 reads the counter, advances the device to the cycle of the access, and then applies the access.
 The C64 does this for the VIC-II, the CIAs and the SID.
 
+A system can also stall the CPU the way a bus master holding RDY does, through
+`CPU.BusStallSource`: before a read the CPU asks how many cycles the bus is busy, the read then
+happens at the cycle the bus is released, and the waiting cycles count as instruction cycles
+without accesses (so `BusCycles` is then the cycle count, of which the accesses are a subset).
+Writes are never stalled, as on the 6510. The source names the next cycle at which it wants to be
+asked again, so the check costs one comparison per read in between.
+
 Interrupts follow the hardware sampling rule. The 6502 polls its IRQ and NMI inputs at the end
 of an instruction's second-to-last cycle (a taken branch that does not cross a page polls at the
 end of its first cycle), so a line that goes active during the last cycle is only seen after the

--- a/docs/systems/c64/libraries.md
+++ b/docs/systems/c64/libraries.md
@@ -23,6 +23,15 @@ next one. The SID does the same through its audio provider (see below). Renderin
 the VIC-II registers once per raster line, so a mid-line register change becomes visible on the
 next line.
 
+The VIC-II also takes the bus from the CPU as on hardware: 40 cycles on every bad line (BA low
+from cycle 12, video matrix fetches in cycles 15-54) and two cycles per sprite with DMA on, BA
+low three cycles ahead. A CPU read that falls inside such a window waits until the window ends;
+writes do not wait. Bad lines follow the DEN bit and YSCROLL. Sprite DMA switches on when an
+enabled sprite's Y register equals the raster line as the VIC-II compares them and then runs for
+the sprite's 21 rows (42 when Y-expanded) whatever the registers do meanwhile, so a Y written to
+a line the raster has already passed costs nothing until the raster comes round again. Not
+modelled: the DEN latch at line $30 and the display-off idle state.
+
 ## Implementation libraries
 
 C64-specific host code lives in its own **engine-plugin** libraries, one per host technology,

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/C64.cs
@@ -417,6 +417,8 @@ public class C64 : ISystem, ISystemMonitor, ISystemState, ISystemCleanup, ISyste
         // Set program counter on startup to the address specified at the 6502 reset vector.
         c64.CPU.Reset(c64.Mem);
         c64.SyncDevicesToBusCycle();
+        // The VIC-II stalls CPU reads during bad lines and sprite DMA.
+        c64.CPU.BusStallSource = new Vic2BusStalls(c64.Vic2);
 
         logger.LogInformation("C64 created.");
         return c64;

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2.cs
@@ -40,6 +40,20 @@ public class Vic2
     /// instruction boundary.
     /// </summary>
     private ulong _advancedToBusCycle;
+    internal ulong AdvancedToBusCycle => _advancedToBusCycle;
+
+    /// <summary>
+    /// Sprites whose DMA is on during the current raster line (bit n = sprite n), and during the
+    /// previous one. Sprite DMA switches on when the sprite is enabled and its Y register equals the
+    /// low byte of the raster line as the VIC-II compares them, and then runs for the sprite's 21
+    /// rows (42 when Y-expanded) no matter how the registers change in the meantime; a Y written
+    /// to a line the raster has already passed does nothing until the raster comes round again.
+    /// Maintained by the per-line work in <see cref="AdvanceRaster(ulong)"/>; consumed by the bus
+    /// stall model.
+    /// </summary>
+    public byte SpriteDmaMask { get; private set; }
+    public byte SpriteDmaMaskPreviousLine { get; private set; }
+    private readonly byte[] _spriteDmaLinesLeft = new byte[8];
 
     public byte CurrentVIC2Bank { get; private set; }
 
@@ -302,6 +316,8 @@ public class Vic2
         {
             CatchUpToCurrentAccess();
             writer(registerAddress, value);
+            // Register state decides bad lines and sprite DMA: re-evaluate CPU stalls.
+            C64.CPU.RequestBusStallCheck();
         };
 
         var registerOffset = registerAddress & 0x003F;
@@ -911,7 +927,11 @@ public class Vic2
     /// snapshot restore, where the raster position comes from the snapshot but the bus-cycle
     /// counter belongs to the machine being restored into.
     /// </summary>
-    internal void ResyncToBusCycle() => _advancedToBusCycle = C64.CPU.BusCycles;
+    internal void ResyncToBusCycle()
+    {
+        _advancedToBusCycle = C64.CPU.BusCycles;
+        C64.CPU.RequestBusStallCheck();
+    }
 
     /// <summary>
     /// Advance the raster by a number of cycles, independent of the CPU bus-cycle counter. The C64
@@ -930,32 +950,47 @@ public class Vic2
 
         CyclesConsumedCurrentVblank += cyclesConsumed;
 
-        // Raster line housekeeping.
-        // Calculate the raster line based on how man CPU cycles has been executed this frame
-        var newLine = (ushort)(CyclesConsumedCurrentVblank / Vic2Model.CyclesPerLine);
-        //if (newLine >= Vic2Model.TotalHeight)
-        //    Debugger.Break(); // Rasterline overflow
-        newLine = (ushort)Math.Clamp(newLine, 0, Vic2Model.TotalHeight - 1);
-
-        if (newLine != _currentRasterLineInternal)
+        // Frame end. Keep the cycles that ran past it: they belong to the new frame, and dropping
+        // them would put the CPU ahead of the raster by up to an instruction's length (which, with
+        // bus stalls, can be most of a raster line). Wrapping before the line is derived below makes
+        // line 0 current, and its raster interrupt due, in this same advance.
+        if (CyclesConsumedCurrentVblank >= Vic2Model.CyclesPerFrame)
         {
-#if DEBUG
-            if (newLine > Vic2Model.TotalHeight)
-                throw new DotNet6502Exception($"Internal error. Unreachable scan line: {newLine}. The CPU probably executed more cycles current frame than allowed.");
-#endif
+            CyclesConsumedCurrentVblank -= Vic2Model.CyclesPerFrame;
+            // The bus-cycle to frame-position mapping moved: re-evaluate CPU stalls.
+            cpu.RequestBusStallCheck();
+        }
 
-            _currentRasterLineInternal = newLine;
+        // Raster line housekeeping. The line is derived from the cycle count; every line crossed
+        // since the last advance gets its per-line work, not just the line we land on: a CPU read
+        // stalled by a bad line with sprite DMA can span a whole line, and a raster interrupt or a
+        // per-line sprite snapshot for a line jumped over must not be lost.
+        var newLine = (ushort)Math.Min(CyclesConsumedCurrentVblank / Vic2Model.CyclesPerLine, (ulong)Vic2Model.TotalHeight - 1);
+        if (newLine == _currentRasterLineInternal)
+            return;
 
-            // Check if a IRQ should be issued for current raster line, and issue it, dated to the
-            // cycle on which the line began: the line has been current for `cyclesIntoLine`
-            // completed cycles, so it began during the cycle before those.
-            var cyclesIntoLine = CyclesConsumedCurrentVblank - (ulong)newLine * Vic2Model.CyclesPerLine;
+        var totalLines = (ushort)Vic2Model.TotalHeight;
+        var line = _currentRasterLineInternal;
+        var remaining = totalLines;   // never loop more than one frame's worth of lines
+        do
+        {
+            line = line >= totalLines - 1 ? (ushort)0 : (ushort)(line + 1);   // MaxValue (unset) wraps to 0 too
+            _currentRasterLineInternal = line;
+
+            // Date the line's start: it began `cyclesIntoLine` completed cycles ago, counted from the
+            // current position (adding a frame for lines before the wrap).
+            var lineStart = (ulong)line * Vic2Model.CyclesPerLine;
+            var cyclesIntoLine = CyclesConsumedCurrentVblank >= lineStart
+                ? CyclesConsumedCurrentVblank - lineStart
+                : CyclesConsumedCurrentVblank + Vic2Model.CyclesPerFrame - lineStart;
             var lineStartBusCycle = endBusCycle + 1 > cyclesIntoLine ? endBusCycle + 1 - cyclesIntoLine : 0;
             RaiseRasterIRQ(cpu, lineStartBusCycle);
 
+            UpdateSpriteDma(line);
+
             // Remember colors and other IO registers for each raster line
             if (C64.RememberVic2RegistersPerRasterLine)
-                StoreRasterLineIORegisters(_currentRasterLineInternal);
+                StoreRasterLineIORegisters(line);
 
             // Per-line sprite processing (rendering + collision are gated by the same config flag).
             // Capture the shared start-of-line sprite snapshot once here; both the per-line collision
@@ -964,15 +999,10 @@ public class Vic2
             if (SpriteManager.PerLineCollisionEnabled)
             {
                 SpriteManager.CaptureLineSpriteSnapshot();
-                SpriteManager.AccumulatePerLineCollisions(_currentRasterLineInternal);
+                SpriteManager.AccumulatePerLineCollisions(line);
             }
         }
-
-        // Check if we have reached the end of the frame.
-        if (CyclesConsumedCurrentVblank >= Vic2Model.CyclesPerFrame)
-        {
-            CyclesConsumedCurrentVblank = 0;
-        }
+        while (line != newLine && --remaining > 0);
     }
 
     // --- Snapshot support (consumed by the c64-vic2 snapshot module in the same assembly) ---
@@ -997,6 +1027,28 @@ public class Vic2
         var line = (ushort)(CyclesConsumedCurrentVblank / Vic2Model.CyclesPerLine);
         _currentRasterLineInternal = (ushort)Math.Clamp(line, 0, Vic2Model.TotalHeight - 1);
         ResyncToBusCycle();
+    }
+
+    // Advance the sprite DMA state into the given line: sprites whose run ended switch off, and a
+    // sprite whose Y matches this line switches on (or restarts) for its rows.
+    private void UpdateSpriteDma(ushort line)
+    {
+        SpriteDmaMaskPreviousLine = SpriteDmaMask;
+        var enabled = C64.ReadIOStorage(Vic2Addr.SPRITE_ENABLE);
+        var expanded = C64.ReadIOStorage(Vic2Addr.SPRITE_Y_EXPAND);
+        var lineLow = (byte)line;
+        byte mask = 0;
+        for (var n = 0; n < 8; n++)
+        {
+            var bit = 1 << n;
+            if (_spriteDmaLinesLeft[n] > 0)
+                _spriteDmaLinesLeft[n]--;
+            if ((enabled & bit) != 0 && C64.ReadIOStorage((ushort)(Vic2Addr.SPRITE_0_Y + n * 2)) == lineLow)
+                _spriteDmaLinesLeft[n] = (expanded & bit) != 0 ? (byte)42 : (byte)21;
+            if (_spriteDmaLinesLeft[n] > 0)
+                mask |= (byte)bit;
+        }
+        SpriteDmaMask = mask;
     }
 
     private void RaiseRasterIRQ(CPU cpu, ulong atBusCycle)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2BusStalls.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2BusStalls.cs
@@ -1,0 +1,162 @@
+namespace Highbyte.DotNet6502.Systems.Commodore64.Video;
+
+/// <summary>
+/// The VIC-II's claim on the bus, as seen by the CPU. On a bad line the VIC-II fetches the 40
+/// video matrix bytes during cycles 15-54 and pulls BA low three cycles earlier (cycle 12); for
+/// every sprite with DMA on it fetches the sprite pointer and three data bytes in two cycles, BA
+/// low three cycles ahead. The 6510 stalls on its first read while BA is low and resumes when BA
+/// goes high, so a read that lands inside such a window waits until the window ends; writes are
+/// never stalled. Windows are derived from the raster position of the read and the current VIC-II
+/// registers.
+///
+/// <para>Sprite DMA comes from the VIC-II's per-sprite DMA state (<see cref="Vic2.SpriteDmaMask"/>),
+/// which switches on at the Y compare and runs for the sprite's rows; the VIC-II is caught up to
+/// the read's cycle first so that state is current. Approximations: the DEN bit is read live
+/// instead of being latched during line $30; the bad-line condition does not model the
+/// display-off idle state.</para>
+///
+/// <para>Cycle numbering follows the usual VIC-II documentation: cycle 1 is the first cycle of a
+/// line. Internally 0-based offsets within the line are used.</para>
+/// </summary>
+internal sealed class Vic2BusStalls : IBusStallSource
+{
+    private const int BadLineBaLowOffset = 11;    // cycle 12
+    private const int BadLineBaHighOffset = 54;   // cycle 55
+    private const int BadLineFirstLine = 0x30;
+    private const int BadLineLastLine = 0xF7;
+    private const int SpriteBaLeadCycles = 3;
+    private const int SpriteDmaCycles = 2;
+
+    private readonly Vic2 _vic2;
+    private readonly C64 _c64;
+    private readonly int _cyclesPerLine;
+
+    // Merged BA-low windows for one line, as 0-based offsets from the line start; ends exclusive.
+    private readonly (int Start, int End)[] _windows = new (int, int)[16];
+    private int _windowCount;
+
+    public Vic2BusStalls(Vic2 vic2)
+    {
+        _vic2 = vic2;
+        _c64 = vic2.C64;
+        _cyclesPerLine = (int)vic2.Vic2Model.CyclesPerLine;
+    }
+
+    public ulong StallCyclesForRead(ulong busCycle, out ulong nextCheckBusCycle)
+    {
+        // Bring the VIC-II to the cycle this read occupies (busCycle - 1 cycles have completed), so
+        // its raster line and sprite DMA state are those of the read.
+        _vic2.CatchUpTo(busCycle - 1);
+        var frameIndex = _vic2.CyclesConsumedCurrentVblank;
+
+        var line = (int)(frameIndex / (ulong)_cyclesPerLine);
+        var offset = (int)(frameIndex % (ulong)_cyclesPerLine);
+
+        BuildWindows(line);
+
+        for (var i = 0; i < _windowCount; i++)
+        {
+            var (start, end) = _windows[i];
+            if (offset < start)
+            {
+                // Bus is free now; ask again when this window begins.
+                nextCheckBusCycle = busCycle + (ulong)(start - offset);
+                return 0;
+            }
+            if (offset < end)
+            {
+                var stall = (ulong)(end - offset);
+                // The read completes at `end`; the next window (if any) begins after it.
+                var nextStart = i + 1 < _windowCount ? _windows[i + 1].Start : _cyclesPerLine;
+                nextCheckBusCycle = busCycle + stall + (ulong)(nextStart - end);
+                return stall;
+            }
+        }
+
+        // No window left on this line: re-evaluate at the start of the next line.
+        nextCheckBusCycle = busCycle + (ulong)(_cyclesPerLine - offset);
+        return 0;
+    }
+
+    /// <summary>
+    /// The BA-low windows that can cover cycles of the given line: the line's own bad-line window
+    /// and sprite DMA (sprites 0-2 fetch at the end of the line, 3-7 at the start of the next), and
+    /// the previous line's sprite 3-7 DMA that runs into this line. Windows beyond the line are
+    /// kept (a stall may run past the line end); overlapping and adjacent windows are merged.
+    /// </summary>
+    private void BuildWindows(int line)
+    {
+        _windowCount = 0;
+
+        var activePrevious = _vic2.SpriteDmaMaskPreviousLine;
+        for (var n = 3; n < 8; n++)
+            if ((activePrevious & (1 << n)) != 0)
+                AddWindow(SpritePointerOffset(n) - _cyclesPerLine);
+
+        if (IsBadLine(line))
+            AddRange(BadLineBaLowOffset, BadLineBaHighOffset);
+
+        var active = _vic2.SpriteDmaMask;
+        for (var n = 0; n < 8; n++)
+            if ((active & (1 << n)) != 0)
+                AddWindow(SpritePointerOffset(n));
+
+        SortAndMerge();
+    }
+
+    // 0-based offset (from the line start) of the sprite pointer fetch. Sprites 0-2 at the end of
+    // the line (cycles CPL-5, CPL-3, CPL-1), sprites 3-7 at cycles 1, 3, 5, 7, 9 of the next line.
+    private int SpritePointerOffset(int sprite)
+        => sprite < 3
+            ? _cyclesPerLine - 6 + 2 * sprite
+            : _cyclesPerLine + 2 * (sprite - 3);
+
+    private void AddWindow(int pointerOffset)
+        => AddRange(pointerOffset - SpriteBaLeadCycles, pointerOffset + SpriteDmaCycles);
+
+    private void AddRange(int start, int end)
+    {
+        if (end <= 0 || _windowCount == _windows.Length)
+            return;
+        _windows[_windowCount++] = (start, end);
+    }
+
+    private void SortAndMerge()
+    {
+        for (var i = 1; i < _windowCount; i++)
+        {
+            var w = _windows[i];
+            var j = i - 1;
+            while (j >= 0 && _windows[j].Start > w.Start)
+            {
+                _windows[j + 1] = _windows[j];
+                j--;
+            }
+            _windows[j + 1] = w;
+        }
+
+        var merged = 0;
+        for (var i = 0; i < _windowCount; i++)
+        {
+            if (merged > 0 && _windows[i].Start <= _windows[merged - 1].End)
+            {
+                if (_windows[i].End > _windows[merged - 1].End)
+                    _windows[merged - 1].End = _windows[i].End;
+            }
+            else
+            {
+                _windows[merged++] = _windows[i];
+            }
+        }
+        _windowCount = merged;
+    }
+
+    private bool IsBadLine(int line)
+    {
+        if (line < BadLineFirstLine || line > BadLineLastLine)
+            return false;
+        var control = _c64.ReadIOStorage(Vic2Addr.SCROLL_Y_AND_SCREEN_CONTROL_REGISTER);
+        var displayEnabled = (control & 0x10) != 0;
+        return displayEnabled && (line & 7) == (control & 7);
+    }
+}

--- a/src/libraries/Highbyte.DotNet6502/CPU.cs
+++ b/src/libraries/Highbyte.DotNet6502/CPU.cs
@@ -127,6 +127,39 @@ public class CPU
     /// </summary>
     public ulong BusCycles { get; private set; }
 
+    /// <summary>
+    /// Optional bus master that can stall reads (see <see cref="IBusStallSource"/>). While a read is
+    /// stalled <see cref="BusCycles"/> advances without an access, so the count is then the cycle
+    /// count, of which the accesses are a subset. Stall cycles are added to the instruction's
+    /// reported cycles.
+    /// </summary>
+    public IBusStallSource? BusStallSource
+    {
+        get => _busStallSource;
+        set
+        {
+            _busStallSource = value;
+            _readStallCheckFromBusCycle = value is null ? ulong.MaxValue : 0;
+        }
+    }
+    private IBusStallSource? _busStallSource;
+
+    // The earliest bus cycle at which a read must consult the stall source (ulong.MaxValue: none).
+    private ulong _readStallCheckFromBusCycle = ulong.MaxValue;
+
+    // Stall cycles accumulated since the current instruction (or interrupt entry) began.
+    private ulong _stallCycles;
+
+    /// <summary>
+    /// Ask the stall source again on the next read. Systems call this when the state that decides
+    /// stalls changes (a VIC-II register write, a frame wrap, a snapshot restore).
+    /// </summary>
+    public void RequestBusStallCheck()
+    {
+        if (_busStallSource is not null)
+            _readStallCheckFromBusCycle = 0;
+    }
+
     public CpuCompatibilityProfile CompatibilityProfile { get; private set; }
 
     /// <summary>
@@ -290,7 +323,10 @@ public class CPU
             return InstructionExecResult.CpuAlreadyHaltedResult(PC);
 
         var interruptDisableBefore = ProcessorStatus.InterruptDisable;
+        _stallCycles = 0;
         var instructionExecutionResult = _instructionExecutor.Execute(this, mem);
+        if (_stallCycles > 0)
+            instructionExecutionResult = instructionExecutionResult.WithAdditionalCycles(_stallCycles);
 
         if (!instructionExecutionResult.HaltedCpu)
         {
@@ -380,7 +416,10 @@ public class CPU
             RaiseInstructionToBeExecutedIfSubscribed(mem);
 
             var interruptDisableBefore = ProcessorStatus.InterruptDisable;
+            _stallCycles = 0;
             var instructionExecutionResult = _instructionExecutor.Execute(this, mem);
+            if (_stallCycles > 0)
+                instructionExecutionResult = instructionExecutionResult.WithAdditionalCycles(_stallCycles);
 
             // Service pending hardware interrupts at this boundary and fold the entry
             // cost into the instruction's result, so both ExecStates, evaluators, the
@@ -465,6 +504,7 @@ public class CPU
         if (IsHalted)
             return 0;
 
+        _stallCycles = 0;   // the entry sequence's reads can be stalled too; report those cycles with it
         if (CPUInterrupts.NMIPending && CPUInterrupts.NMIPendingAtBusCycle <= _interruptPollBusCycle)
         {
             OnNmiAcknowledging();
@@ -486,7 +526,7 @@ public class CPU
                     nmiSources);
             }
             RecordInterruptPollPointAfterInterruptEntry();
-            return InterruptEntryCycles;
+            return InterruptEntryCycles + _stallCycles;
         }
 
         if (CPUInterrupts.IRQLineEnabled
@@ -498,7 +538,7 @@ public class CPU
             CPUInterrupts.AcknowledgeAutoAcknowledgingIRQSources();
             ProcessHardwareIRQ(mem);
             RecordInterruptPollPointAfterInterruptEntry();
-            return InterruptEntryCycles;
+            return InterruptEntryCycles + _stallCycles;
         }
 
         return 0;
@@ -714,7 +754,20 @@ public class CPU
     public byte FetchByte(Memory mem, ushort address)
     {
         BusCycles++;
+        if (BusCycles >= _readStallCheckFromBusCycle)
+            StallRead();
         return mem.FetchByte(address);
+    }
+
+    // A bus master holds the CPU: the read happens once the bus is released, and the cycles in
+    // between are time without accesses.
+    private void StallRead()
+    {
+        var stall = _busStallSource!.StallCyclesForRead(BusCycles, out _readStallCheckFromBusCycle);
+        if (stall == 0)
+            return;
+        BusCycles += stall;
+        _stallCycles += stall;
     }
 
     /// <summary>

--- a/src/libraries/Highbyte.DotNet6502/CPU.cs
+++ b/src/libraries/Highbyte.DotNet6502/CPU.cs
@@ -322,23 +322,7 @@ public class CPU
         if (IsHalted)
             return InstructionExecResult.CpuAlreadyHaltedResult(PC);
 
-        var interruptDisableBefore = ProcessorStatus.InterruptDisable;
-        _stallCycles = 0;
-        var instructionExecutionResult = _instructionExecutor.Execute(this, mem);
-        if (_stallCycles > 0)
-            instructionExecutionResult = instructionExecutionResult.WithAdditionalCycles(_stallCycles);
-
-        if (!instructionExecutionResult.HaltedCpu)
-        {
-            RecordInterruptPollPoint(instructionExecutionResult, interruptDisableBefore);
-
-            // Fold the hardware interrupt-entry cost (when one was serviced at this
-            // boundary) into this instruction's result, so cycle totals and the
-            // system loops that pace devices/frame budgets by it see real elapsed time.
-            var interruptCycles = ProcessInterrupts(mem);
-            if (interruptCycles > 0)
-                instructionExecutionResult = instructionExecutionResult.WithAdditionalCycles(interruptCycles);
-        }
+        var instructionExecutionResult = ExecuteInstructionAndServiceInterrupts(mem);
 
         ExecState.UpdateTotal(instructionExecutionResult);
 
@@ -415,23 +399,8 @@ public class CPU
 
             RaiseInstructionToBeExecutedIfSubscribed(mem);
 
-            var interruptDisableBefore = ProcessorStatus.InterruptDisable;
-            _stallCycles = 0;
-            var instructionExecutionResult = _instructionExecutor.Execute(this, mem);
-            if (_stallCycles > 0)
-                instructionExecutionResult = instructionExecutionResult.WithAdditionalCycles(_stallCycles);
-
-            // Service pending hardware interrupts at this boundary and fold the entry
-            // cost into the instruction's result, so both ExecStates, evaluators, the
-            // InstructionExecuted event, and callers pacing by cycles see real elapsed
-            // time. (NmiAcknowledging consequently fires before InstructionExecuted.)
-            if (!instructionExecutionResult.HaltedCpu)
-            {
-                RecordInterruptPollPoint(instructionExecutionResult, interruptDisableBefore);
-                var interruptCycles = ProcessInterrupts(mem);
-                if (interruptCycles > 0)
-                    instructionExecutionResult = instructionExecutionResult.WithAdditionalCycles(interruptCycles);
-            }
+            // (NmiAcknowledging consequently fires before InstructionExecuted.)
+            var instructionExecutionResult = ExecuteInstructionAndServiceInterrupts(mem);
 
             // Aggregate stats directly from the InstructionExecResult into both ExecStates;
             // the previous code path went via ExecStateAfterInstruction() which allocated
@@ -526,7 +495,7 @@ public class CPU
                     nmiSources);
             }
             RecordInterruptPollPointAfterInterruptEntry();
-            return InterruptEntryCycles + _stallCycles;
+            return InterruptEntryCycles + TakeStallCycles();
         }
 
         if (CPUInterrupts.IRQLineEnabled
@@ -538,7 +507,7 @@ public class CPU
             CPUInterrupts.AcknowledgeAutoAcknowledgingIRQSources();
             ProcessHardwareIRQ(mem);
             RecordInterruptPollPointAfterInterruptEntry();
-            return InterruptEntryCycles + _stallCycles;
+            return InterruptEntryCycles + TakeStallCycles();
         }
 
         return 0;
@@ -757,6 +726,42 @@ public class CPU
         if (BusCycles >= _readStallCheckFromBusCycle)
             StallRead();
         return mem.FetchByte(address);
+    }
+
+    /// <summary>
+    /// Runs one instruction, records its interrupt poll point and services a pending hardware
+    /// interrupt at the boundary. The entry sequence's cost is folded into the instruction's
+    /// result, so cycle totals and the system loops that pace devices and frame budgets by it see
+    /// real elapsed time.
+    /// </summary>
+    private InstructionExecResult ExecuteInstructionAndServiceInterrupts(Memory mem)
+    {
+        var interruptDisableBefore = ProcessorStatus.InterruptDisable;
+        var result = ExecuteInstructionWithStalls(mem);
+        if (result.HaltedCpu)
+            return result;
+
+        RecordInterruptPollPoint(result, interruptDisableBefore);
+        var interruptCycles = ProcessInterrupts(mem);
+        return interruptCycles > 0 ? result.WithAdditionalCycles(interruptCycles) : result;
+    }
+
+    // Runs one instruction and folds the cycles its reads were stalled by (accumulated by
+    // StallRead through the memory access helpers) into the reported cycle count.
+    private InstructionExecResult ExecuteInstructionWithStalls(Memory mem)
+    {
+        _stallCycles = 0;
+        var result = _instructionExecutor.Execute(this, mem);
+        var stalled = TakeStallCycles();
+        return stalled > 0 ? result.WithAdditionalCycles(stalled) : result;
+    }
+
+    // Returns the stall cycles accumulated since the last reset and clears them.
+    private ulong TakeStallCycles()
+    {
+        var stalled = _stallCycles;
+        _stallCycles = 0;
+        return stalled;
     }
 
     // A bus master holds the CPU: the read happens once the bus is released, and the cycles in

--- a/src/libraries/Highbyte.DotNet6502/IBusStallSource.cs
+++ b/src/libraries/Highbyte.DotNet6502/IBusStallSource.cs
@@ -1,0 +1,19 @@
+namespace Highbyte.DotNet6502;
+
+/// <summary>
+/// Lets a system stall the CPU on a read, the way a bus master that holds BA/RDY low does (the
+/// C64's VIC-II during bad lines and sprite DMA). The 6510 keeps executing writes while RDY is
+/// low and freezes on its next read until the line is released, so only reads consult this.
+/// </summary>
+public interface IBusStallSource
+{
+    /// <summary>
+    /// Called before a read that happens at <paramref name="busCycle"/> (the 1-based cycle number
+    /// the read would occupy, see <see cref="CPU.BusCycles"/>). Returns how many cycles the CPU
+    /// waits before the read takes place: 0 if the bus is free. <paramref name="nextCheckBusCycle"/>
+    /// is the earliest bus cycle at which the source wants to be consulted again; the CPU skips the
+    /// call for reads before it. <see cref="ulong.MaxValue"/> means never, until
+    /// <see cref="CPU.RequestBusStallCheck"/> is called.
+    /// </summary>
+    ulong StallCyclesForRead(ulong busCycle, out ulong nextCheckBusCycle);
+}

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64DeviceAccessTimingTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/C64DeviceAccessTimingTests.cs
@@ -166,6 +166,20 @@ public class C64DeviceAccessTimingTests
     }
 
     [Fact]
+    public void An_instruction_running_past_the_frame_end_carries_its_remainder_into_the_next_frame()
+    {
+        // NOP (2 cycles) starting on the frame's last cycle: one cycle belongs to the new frame.
+        var c64 = Build([0xEA]);
+        var cyclesPerFrame = c64.Vic2.Vic2Model.CyclesPerFrame;
+        c64.Vic2.AdvanceRaster(cyclesPerFrame - 1);
+
+        Step(c64);
+
+        Assert.Equal(1UL, c64.Vic2.CyclesConsumedCurrentVblank);
+        Assert.Equal(0, c64.Vic2.CurrentRasterLine);
+    }
+
+    [Fact]
     public void Devices_advance_by_exactly_the_instruction_cycles_after_a_snapshot_restore()
     {
         var source = Build([0xEA, 0xEA, 0xEA, 0xEA, 0xEA, 0xEA, 0xEA, 0xEA]);

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Video/Vic2BusStallTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Video/Vic2BusStallTests.cs
@@ -1,0 +1,252 @@
+using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Systems.Commodore64.Video;
+using Highbyte.DotNet6502.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64.Video;
+
+/// <summary>
+/// The VIC-II steals the bus from the CPU: 40 cycles on every bad line (BA low from cycle 12,
+/// video matrix fetches in cycles 15-54, BA high at 55) and two cycles per sprite with DMA on,
+/// BA low three cycles ahead. A CPU read inside such a window waits until the window ends; writes
+/// do not wait. Cycle numbers below are 1-based as in the VIC-II documentation; the raster is
+/// positioned with 0-based offsets.
+/// </summary>
+public class Vic2BusStallTests
+{
+    private const ushort Start = 0x1000;
+    private const int BadLine = 0x33;          // YSCROLL 3: lines $33, $3B, ... are bad lines
+
+    private static C64 Build(byte[] program)
+    {
+        var c64 = C64.BuildC64(new C64Config { LoadROMs = false, C64Model = "C64PAL", Vic2Model = "PAL" }, NullLoggerFactory.Instance);
+        c64.Mem.StoreData(Start, program);
+        c64.CPU.PC = Start;
+        return c64;
+    }
+
+    private static ulong Step(C64 c64)
+    {
+        c64.ExecuteOneInstruction(out var result);
+        return result.CyclesConsumed;
+    }
+
+    /// <summary>Position the raster so that the next bus cycle is the given 1-based cycle of the line.</summary>
+    private static void PositionAt(C64 c64, int line, int cycle)
+        => c64.Vic2.AdvanceRaster((ulong)line * c64.Vic2.Vic2Model.CyclesPerLine + (ulong)(cycle - 1));
+
+    private static void EnableDisplay(C64 c64, int yScroll = 3)
+        => c64.Mem.Write(Vic2Addr.SCROLL_Y_AND_SCREEN_CONTROL_REGISTER, (byte)(0x18 | yScroll));
+
+    [Theory]
+    [InlineData(12, 43)]   // BA goes low on cycle 12: a read there waits until cycle 55
+    [InlineData(14, 41)]
+    [InlineData(15, 40)]
+    [InlineData(54, 1)]
+    [InlineData(55, 0)]    // BA is high again
+    [InlineData(11, 43)]   // the opcode fetch is free, but NOP's second read lands on cycle 12
+    [InlineData(10, 0)]
+    public void Read_on_a_bad_line_waits_until_the_video_matrix_fetch_is_over(int cycle, int expectedStall)
+    {
+        var c64 = Build([0xEA]);   // NOP: two reads, on its first and second cycle
+        EnableDisplay(c64);
+        PositionAt(c64, BadLine, cycle);
+
+        var cycles = Step(c64);
+
+        Assert.Equal(2 + (ulong)expectedStall, cycles);
+        Assert.Equal((ulong)BadLine * 63 + (ulong)(cycle - 1) + cycles, c64.Vic2.CyclesConsumedCurrentVblank);
+    }
+
+    [Fact]
+    public void Writes_are_not_stalled_but_the_next_read_is()
+    {
+        // STA $2000 with its write on cycle 12 (reads on 9-11) runs at full speed; the NOP that
+        // follows reads on cycle 13 and waits.
+        var c64 = Build([0x8D, 0x00, 0x20, 0xEA]);
+        EnableDisplay(c64);
+        PositionAt(c64, BadLine, 9);
+
+        Assert.Equal(4UL, Step(c64));
+        Assert.Equal(2 + 42UL, Step(c64));
+    }
+
+    [Theory]
+    [InlineData(0x0B, BadLine)]        // display disabled
+    [InlineData(0x1B, BadLine + 1)]    // display enabled, but (line & 7) != YSCROLL
+    [InlineData(0x1B, 0x2B)]           // matching YSCROLL, but above the bad-line range
+    [InlineData(0x1B, 0xFB)]           // matching YSCROLL, but below the bad-line range
+    public void No_bad_line_no_stall(byte control, int line)
+    {
+        var c64 = Build([0xEA]);
+        c64.Mem.Write(Vic2Addr.SCROLL_Y_AND_SCREEN_CONTROL_REGISTER, control);
+        PositionAt(c64, line, 12);
+
+        Assert.Equal(2UL, Step(c64));
+    }
+
+    [Fact]
+    public void Bad_line_follows_a_change_of_yscroll()
+    {
+        var c64 = Build([0xEA]);
+        EnableDisplay(c64, yScroll: 4);
+        PositionAt(c64, BadLine, 12);      // $33 is not a bad line with YSCROLL 4 ...
+
+        Assert.Equal(2UL, Step(c64));
+
+        c64 = Build([0xEA]);
+        EnableDisplay(c64, yScroll: 4);
+        PositionAt(c64, BadLine + 1, 12);  // ... but $34 is
+
+        Assert.Equal(2 + 43UL, Step(c64));
+    }
+
+    [Theory]
+    [InlineData(55, 5)]   // sprite 0: pointer fetch on cycle 58, BA low from 55, high at 60
+    [InlineData(58, 2)]
+    [InlineData(60, 0)]
+    public void Read_during_sprite_0_dma_waits_until_its_fetch_is_over(int cycle, int expectedStall)
+    {
+        var c64 = Build([0xEA]);
+        c64.Mem.Write(Vic2Addr.SPRITE_ENABLE, 0x01);
+        c64.Mem.Write(Vic2Addr.SPRITE_0_Y, (byte)BadLine);   // DMA on for lines $33..$47
+        PositionAt(c64, BadLine + 5, cycle);
+
+        Assert.Equal(2 + (ulong)expectedStall, Step(c64));
+    }
+
+    [Fact]
+    public void Adjacent_sprites_keep_BA_low_across_their_fetches()
+    {
+        // Sprites 0 and 1: windows 55-59 and 57-61 merge into 55-61.
+        var c64 = Build([0xEA]);
+        c64.Mem.Write(Vic2Addr.SPRITE_ENABLE, 0x03);
+        c64.Mem.Write(Vic2Addr.SPRITE_0_Y, (byte)BadLine);
+        c64.Mem.Write(Vic2Addr.SPRITE_0_Y + 2, (byte)BadLine);
+        PositionAt(c64, BadLine + 5, 55);
+
+        Assert.Equal(2 + 7UL, Step(c64));
+    }
+
+    [Fact]
+    public void Sprite_3_dma_at_the_start_of_the_next_line_pulls_BA_low_at_the_end_of_this_one()
+    {
+        // Sprite 3's pointer fetch is on cycle 1 of the following line; BA is low from cycle 61 of
+        // this line until cycle 3 of the next.
+        var c64 = Build([0xEA, 0xEA]);
+        c64.Mem.Write(Vic2Addr.SPRITE_ENABLE, 0x08);
+        c64.Mem.Write(Vic2Addr.SPRITE_0_Y + 6, (byte)BadLine);
+        PositionAt(c64, BadLine + 5, 62);
+
+        Assert.Equal(2 + 4UL, Step(c64));                 // cycle 62 -> the read happens on cycle 3 of the next line
+        Assert.Equal((ulong)(BadLine + 6) * 63 + 4, c64.Vic2.CyclesConsumedCurrentVblank);   // NOP's second read on cycle 4
+    }
+
+    [Fact]
+    public void Sprite_dma_ends_after_21_lines_or_42_when_y_expanded()
+    {
+        var c64 = Build([0xEA]);
+        c64.Mem.Write(Vic2Addr.SPRITE_ENABLE, 0x01);
+        c64.Mem.Write(Vic2Addr.SPRITE_0_Y, (byte)BadLine);
+        PositionAt(c64, BadLine + 21, 58);
+        Assert.Equal(2UL, Step(c64));
+
+        c64 = Build([0xEA]);
+        c64.Mem.Write(Vic2Addr.SPRITE_ENABLE, 0x01);
+        c64.Mem.Write(Vic2Addr.SPRITE_Y_EXPAND, 0x01);
+        c64.Mem.Write(Vic2Addr.SPRITE_0_Y, (byte)BadLine);
+        PositionAt(c64, BadLine + 21, 58);
+        Assert.Equal(2 + 2UL, Step(c64));
+    }
+
+    [Fact]
+    public void Disabling_a_sprite_mid_run_does_not_stop_its_dma()
+    {
+        // The enable bit only gates the switch-on; a sprite already fetching keeps its DMA for the
+        // rest of its rows. STA $D015 with A=0 writes on cycle 54; the NOP that follows reads on
+        // cycle 55, where sprite 0's window starts as before.
+        var c64 = Build([0x8D, 0x15, 0xD0, 0xEA]);
+        c64.Mem.Write(Vic2Addr.SPRITE_ENABLE, 0x01);
+        c64.Mem.Write(Vic2Addr.SPRITE_0_Y, (byte)BadLine);
+        c64.CPU.A = 0;
+        PositionAt(c64, BadLine + 5, 51);
+
+        Assert.Equal(4UL, Step(c64));
+        Assert.Equal(2 + 5UL, Step(c64));
+    }
+
+    [Fact]
+    public void A_y_position_written_after_the_raster_passed_it_does_not_start_dma()
+    {
+        // Parking sprites at a line the raster has already passed (a multiplexer's habit) costs the
+        // CPU nothing until the raster comes round to that line again.
+        var c64 = Build([0xEA]);
+        c64.Mem.Write(Vic2Addr.SPRITE_ENABLE, 0xFF);
+        PositionAt(c64, 40, 1);
+        for (var n = 0; n < 8; n++)
+            c64.Mem.Write((ushort)(Vic2Addr.SPRITE_0_Y + n * 2), 30);   // 30 < 40: missed the compare
+        c64.Vic2.AdvanceRaster(63 * 5 + 54);                             // line 45, cycle 55
+
+        Assert.Equal(2UL, Step(c64));
+        Assert.Equal(0, c64.Vic2.SpriteDmaMask);
+    }
+
+    [Fact]
+    public void Dma_switches_on_when_the_raster_reaches_the_sprite_y()
+    {
+        var c64 = Build([0xEA]);
+        c64.Mem.Write(Vic2Addr.SPRITE_ENABLE, 0x01);
+        c64.Mem.Write(Vic2Addr.SPRITE_0_Y, 100);
+        PositionAt(c64, 99, 1);
+        Assert.Equal(0, c64.Vic2.SpriteDmaMask);
+
+        c64.Vic2.AdvanceRaster(63);                                       // into line 100
+        Assert.Equal(1, c64.Vic2.SpriteDmaMask);
+
+        c64.Vic2.AdvanceRaster(63 * 20);                                  // line 120: last row
+        Assert.Equal(1, c64.Vic2.SpriteDmaMask);
+        c64.Vic2.AdvanceRaster(63);                                       // line 121: off
+        Assert.Equal(0, c64.Vic2.SpriteDmaMask);
+    }
+
+    [Fact]
+    public void A_raster_interrupt_on_a_line_jumped_over_by_a_long_stall_is_still_raised()
+    {
+        // Bad line plus eight sprites: BA is low from cycle 12 through cycle 13 of the next line, so
+        // NOP's read on cycle 12 spans the whole of line $33 and lands on line $34. A raster
+        // interrupt configured for line $34 must still fire, dated to that line's first cycle.
+        var c64 = Build([0xEA, 0xEA]);
+        EnableDisplay(c64);
+        c64.Mem.Write(Vic2Addr.SPRITE_ENABLE, 0xFF);
+        for (var n = 0; n < 8; n++)
+            c64.Mem.Write((ushort)(Vic2Addr.SPRITE_0_Y + n * 2), (byte)BadLine);
+        c64.Mem.Write(Vic2Addr.CURRENT_RASTER_LINE, BadLine + 1);
+        c64.Mem.Write(Vic2Addr.SCROLL_Y_AND_SCREEN_CONTROL_REGISTER, 0x1B);
+        c64.Mem.Write(Vic2Addr.IRQ_MASK, 0x01);
+        PositionAt(c64, BadLine, 12);
+
+        var cycles = Step(c64);
+
+        Assert.True(cycles > 63, $"expected a stall spanning the line, got {cycles} cycles");
+        Assert.Equal(BadLine + 1, c64.Vic2.CurrentRasterLine);
+        Assert.True(c64.Vic2.Vic2IRQ.IsTriggered(IRQSource.RasterCompare));
+        Assert.True(c64.CPU.IRQ);
+    }
+
+    [Fact]
+    public void A_frame_with_the_display_on_still_ends_on_the_frame_boundary()
+    {
+        // NOP loop. With DEN set the CPU loses 40-43 cycles on each of the 25 bad lines; the frame
+        // loop must still hand back exactly one frame of raster time.
+        var c64 = Build([0xEA, 0x4C, 0x00, 0x10]);
+        EnableDisplay(c64);
+
+        c64.ExecuteOneFrame();
+        var afterFirst = c64.Vic2.CyclesConsumedCurrentVblank;
+        c64.ExecuteOneFrame();
+
+        Assert.True(afterFirst < 8, $"raster position after a frame: {afterFirst}");
+        Assert.True(c64.Vic2.CyclesConsumedCurrentVblank < 8);
+    }
+}

--- a/tests/Highbyte.DotNet6502.Tests/CPUBusStallTests.cs
+++ b/tests/Highbyte.DotNet6502.Tests/CPUBusStallTests.cs
@@ -1,0 +1,131 @@
+using Highbyte.DotNet6502.Utils;
+
+namespace Highbyte.DotNet6502.Tests;
+
+/// <summary>
+/// A bus master can stall CPU reads through <see cref="IBusStallSource"/>: the read happens once
+/// the bus is released, the waiting cycles count as instruction cycles without accesses, and
+/// writes are never stalled.
+/// </summary>
+public class CPUBusStallTests
+{
+    private const ushort Start = 0x1000;
+
+    private sealed class ScriptedStalls : IBusStallSource
+    {
+        private readonly Dictionary<ulong, ulong> _stallAtBusCycle;
+        public List<ulong> Consulted { get; } = new();
+
+        public ScriptedStalls(params (ulong busCycle, ulong stall)[] stalls)
+            => _stallAtBusCycle = stalls.ToDictionary(s => s.busCycle, s => s.stall);
+
+        public ulong StallCyclesForRead(ulong busCycle, out ulong nextCheckBusCycle)
+        {
+            Consulted.Add(busCycle);
+            nextCheckBusCycle = 0;   // consult on every read
+            return _stallAtBusCycle.TryGetValue(busCycle, out var stall) ? stall : 0;
+        }
+    }
+
+    private static (CPU cpu, Memory mem) NewCpu(params byte[] program)
+    {
+        var cpu = new CPU();
+        var mem = new Memory();
+        mem.StoreData(Start, program);
+        cpu.PC = Start;
+        cpu.SP = 0xFF;
+        return (cpu, mem);
+    }
+
+    [Fact]
+    public void A_stalled_read_adds_the_wait_to_the_bus_cycles_and_the_instruction()
+    {
+        var (cpu, mem) = NewCpu(0xEA, 0xEA);   // NOP ; NOP
+        cpu.BusStallSource = new ScriptedStalls((busCycle: 3, stall: 40));   // the second NOP's opcode fetch
+
+        var first = cpu.ExecuteOneInstructionMinimal(mem);
+        var second = cpu.ExecuteOneInstructionMinimal(mem);
+
+        Assert.Equal(2UL, first.CyclesConsumed);
+        Assert.Equal(2 + 40UL, second.CyclesConsumed);
+        Assert.Equal(2 + 2 + 40UL, cpu.BusCycles);
+    }
+
+    [Fact]
+    public void A_stall_shifts_the_cycles_of_the_accesses_that_follow_it()
+    {
+        // LDA $D012 -> the operand fetches are at bus cycles 2 and 3, the data read at 4.
+        // Stalling cycle 2 by 10 moves the data read to cycle 14, which a mapped reader observes.
+        var (cpu, mem) = NewCpu(0xAD, 0x12, 0xD0);
+        ulong readAt = 0;
+        mem.MapReader(0xD012, _ => { readAt = cpu.BusCycles; return 0x42; });
+        cpu.BusStallSource = new ScriptedStalls((busCycle: 2, stall: 10));
+
+        var result = cpu.ExecuteOneInstructionMinimal(mem);
+
+        Assert.Equal(0x42, cpu.A);
+        Assert.Equal(14UL, readAt);
+        Assert.Equal(4 + 10UL, result.CyclesConsumed);
+    }
+
+    [Fact]
+    public void Writes_do_not_consult_the_stall_source()
+    {
+        // STA $2000: reads at bus cycles 1-3, the write at 4.
+        var (cpu, mem) = NewCpu(0x8D, 0x00, 0x20);
+        var stalls = new ScriptedStalls((busCycle: 4, stall: 99));
+        cpu.BusStallSource = stalls;
+
+        var result = cpu.ExecuteOneInstructionMinimal(mem);
+
+        Assert.Equal(4UL, result.CyclesConsumed);
+        Assert.Equal(new ulong[] { 1, 2, 3 }, stalls.Consulted);
+    }
+
+    [Fact]
+    public void The_source_is_not_consulted_before_the_cycle_it_asked_for()
+    {
+        var (cpu, mem) = NewCpu(0xEA, 0xEA, 0xEA);
+        var calls = new List<ulong>();
+        cpu.BusStallSource = new DelegateStalls((busCycle, out next) => { calls.Add(busCycle); next = busCycle + 4; return 0; });
+
+        for (var i = 0; i < 3; i++)
+            cpu.ExecuteOneInstructionMinimal(mem);   // bus cycles 1-6
+
+        Assert.Equal(new ulong[] { 1, 5 }, calls);
+    }
+
+    [Fact]
+    public void RequestBusStallCheck_consults_the_source_on_the_next_read()
+    {
+        var (cpu, mem) = NewCpu(0xEA, 0xEA);
+        var calls = new List<ulong>();
+        cpu.BusStallSource = new DelegateStalls((busCycle, out next) => { calls.Add(busCycle); next = ulong.MaxValue; return 0; });
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+        cpu.RequestBusStallCheck();
+        cpu.ExecuteOneInstructionMinimal(mem);
+
+        Assert.Equal(new ulong[] { 1, 3 }, calls);
+    }
+
+    [Fact]
+    public void Removing_the_source_stops_stalling()
+    {
+        var (cpu, mem) = NewCpu(0xEA, 0xEA);
+        cpu.BusStallSource = new ScriptedStalls((busCycle: 3, stall: 40));
+        cpu.BusStallSource = null;
+
+        cpu.ExecuteOneInstructionMinimal(mem);
+        var second = cpu.ExecuteOneInstructionMinimal(mem);
+
+        Assert.Equal(2UL, second.CyclesConsumed);
+    }
+
+    private delegate ulong StallFunc(ulong busCycle, out ulong nextCheckBusCycle);
+
+    private sealed class DelegateStalls(StallFunc func) : IBusStallSource
+    {
+        public ulong StallCyclesForRead(ulong busCycle, out ulong nextCheckBusCycle) => func(busCycle, out nextCheckBusCycle);
+    }
+}


### PR DESCRIPTION
## Summary

The VIC-II takes the bus from the CPU on hardware: 40 cycles on every bad line (BA low from cycle 12, video matrix fetches in cycles 15–54) and two cycles per sprite with DMA on, BA low three cycles ahead. The 6510 freezes on its first read while BA is low and resumes when it goes high; writes never stall. Nothing modelled this, so the CPU ran 10–15% faster than the machine and raster effects that depend on bad-line timing landed in the wrong place. This PR models it.

- **CPU** (`IBusStallSource`, `CPU.BusStallSource`): before a read the CPU asks how long the bus is busy (one comparison per read against a next-check cycle the source names), adds the wait to `BusCycles` and to the instruction's cycles, and performs the read at the release cycle. Interrupt-entry reads can be stalled too. Writes are untouched.
- **VIC-II** (`Vic2BusStalls`): the BA-low windows of a raster line come from the read's raster position and the current registers — the bad-line window when DEN is set and `(line & 7) == YSCROLL` within `$30`–`$F7`, and per sprite with DMA on a window around its pointer fetch (sprites 0–2 at the end of the line, 3–7 at the start of the next, so the previous line's sprites spill into the first cycles); overlapping windows merge so adjacent sprites keep BA low.
- **Sprite DMA is per-sprite state** on `Vic2` (`SpriteDmaMask`): it switches on when an enabled sprite's Y equals the raster line at the compare and runs for the sprite's 21 rows (42 when Y-expanded) whatever the registers do meanwhile, as on the 6569. A Y written to a line the raster has already passed costs nothing until the raster comes round again — multiplexers rely on this (Commando parks its sprites at Y=30 from a handler running at line 30). Disabling a sprite mid-run does not stop its fetch.
- **`AdvanceRaster` processes every line an advance crosses**, not only the one it lands on. A read stalled by a bad line with sprites can span a whole raster line, and a skipped line used to lose its raster compare and per-line sprite snapshot.
- **Frame wrap** keeps the cycles an instruction ran past the frame end (previously dropped; with stalls that could be most of a line) and happens before the line is derived, so line 0 and a line-0 raster interrupt are current in the same advance.

Register writes, the frame wrap and a resync invalidate the CPU's next-check cycle.

## Field tests

- **Commando (in-game, PAL and NTSC)**: an earlier version of the sprite model ("DMA on while the line is within 21 of Y", live registers) charged eight sprites' fetches to lines the hardware never spends them on; the game's interrupt chain lost a frame every other frame (sprites vanished, status bar mangled, half speed). Reproduced headlessly from a snapshot (298 of 300 frames alternating), bisected to sprite stalls, traced to the late arming of the line-50 interrupt, fixed by the per-sprite DMA state above. Now 0 alternating frames, same as the integration branch; confirmed on the desktop.
- **Giana Sisters title, PAL**: clean before and after.
- **Giana Sisters title, NTSC**: one-frame white cells in the big scroller every eight frames. This is the PAL title's raster-timed column update overrunning the shorter NTSC frame once the CPU loses its bad-line cycles; the old, faster CPU hid it. Hardware overruns here too, but shows the old column for a row because it latches the video matrix per character row during the bad line; our rasterizer reads screen/colour RAM live per line, so the same overrun shows as a mixed cell. The per-row matrix latch is the natural next render-side step. The app's default variant is NTSC; most C64 software is PAL.

## Not modelled

The DEN latch during line `$30` and the display-off idle state (live DEN is used).

## Performance

Apple M1 (MacBook Air), .NET 10.0.7, same session, no allocations added. The benchmark machine has the display off, so the frame columns measure overhead only; the last column is the same branch with `$D011 = $1B`.

| Benchmark | Baseline | After | Δ | After, display on |
|---|--:|--:|--:|--:|
| `CPU_Run_1000Instructions` | 15.13 µs | 16.20 µs | +7% | — |
| `CPU_Execute_NoSubscribers_1000Instructions` | 16.66 µs | 17.00 µs | +2% | — |
| C64 frame `CoreOnly` / `None` | 231.0 µs | 231.2 µs | 0% | 218.3 µs |
| C64 frame `RenderOnly` / `None` | 399.9 µs | 401.2 µs | 0% | 388.1 µs |
| C64 frame `RenderAndAudio` / `None` | 590.0 µs | 604.4 µs | +2% | 585.3 µs |
| C64 frame `RenderAndAudio` / `MixedVisibleSprites` | 598.9 µs | 609.3 µs | +2% | 594.5 µs |

The per-read comparison is the whole overhead (a NOP is two reads, hence the CPU loop rows). With the display on the stalls take about 6% of the CPU's frame, the hardware's share for 25 bad lines. Recorded in the RESULTS.md history.

## Tests

`CPUBusStallTests` (6, scripted source): stall adds to bus cycles and the instruction, shifts later accesses, writes not consulted, next-check honoured, `RequestBusStallCheck`, source removal. `Vic2BusStallTests` (24): bad-line window edges, unstalled writes, no-bad-line cases, YSCROLL change, sprite 0 / adjacent sprites / sprite 3 wrap into the next line, 21/42-line DMA span, DMA switching on at the compare and off after its rows, a late Y write doing nothing, disable mid-run not stopping DMA, a raster interrupt on a line jumped over by a stall, frame boundary. Plus the wrap-remainder test in `C64DeviceAccessTimingTests`. Solution: 2,834 passed (6 projects).
