### PR TITLE
Place the C64 display window at its hardware offset into the raster line

### DIFF
--- a/docs/systems/c64/libraries.md
+++ b/docs/systems/c64/libraries.md
@@ -24,7 +24,12 @@ write to the border or background colour registers (`$D020`-`$D024`) from the cy
 write lands, so a colour change in the middle of a line splits that line at the write's pixel
 position, as on hardware; the VIC-II reports each register write with its frame cycle for this.
 The other display registers (mode, scroll, 38/24-column, memory setup) are still sampled once per
-raster line, so a mid-line change to one of those becomes visible on the next line. The
+raster line, so a mid-line change to one of those becomes visible on the next line. Where a cycle's
+pixels land follows the chip: the display window's first pixel is 124 pixels into the raster line
+on both PAL and NTSC, taken from the VIC-II's display window at X 24 and where X 0 falls relative to
+the line's first cycle. How much border is drawn around that window is a presentation choice, since
+real sets showed different amounts. A colour register write is shown a few pixels away from the
+cycle boundary it lands on, by a per-variant amount calibrated against VICE. The
 rasterizer does hold a character row's 40 screen codes and colour nibbles the way
 the VIC-II does: fetched on the row's first line and shown for its remaining seven, so a screen
 write made after that fetch appears from the next row on. When a CPU read is stalled, the VIC-II

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Models/Vic2Models.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Models/Vic2Models.cs
@@ -19,6 +19,10 @@ public class Vic2ModelNTSC_old : Vic2ModelBase
 
     public override int FirstRasterLineOfMainScreen => 51; // TODO: Verify
 
+    // DisplayWindowStartX is left at the base class default: the 6567R56A's X coordinate for the
+    // start of its first cycle has not been established here, and this variant is unfinished anyway
+    // (ConvertRasterLineToScreenLine throws).
+
     public override int HBlankWidth => TotalWidth - MaxVisibleWidth;
     public override int VBlankHeight => TotalHeight - MaxVisibleHeight;
 
@@ -45,6 +49,19 @@ public class Vic2ModelNTSC : Vic2ModelBase
     // MaxVisibleWidth (418) and MaxVisibleHeight (235) inherited from TvModel.Ntsc.
 
     public override int FirstRasterLineOfMainScreen => 51;
+
+    // The 6567R8's first cycle starts at X coordinate $19c (412), and its X counter wraps to 0 after
+    // 511, not after the line's 520 pixels: the 8 extra pixels of line come from one X value being
+    // held later in the line, past the display window. So X 0 is 100 pixels after the start of the
+    // first cycle, as on PAL, and the display window's first pixel is at 124, four pixels into the
+    // line's 16th cycle. (Taking the line length as the wrap point instead gives 132, which is
+    // wrong by a cycle.)
+    public override int DisplayWindowStartX => 124;
+
+    // Calibrated against VICE with the anchor above; see the base class. Differs from PAL's -11 by
+    // 15 pixels, close to the two cycles by which the two chips' line lengths differ, which is a
+    // hint about where the remaining model dependent difference lives.
+    public override int ColorChangePixelDelay => 4;
 
     public override int HBlankWidth => TotalWidth - MaxVisibleWidth;
     public override int VBlankHeight => TotalHeight - MaxVisibleHeight;
@@ -112,6 +129,14 @@ public class Vic2ModelPAL : Vic2ModelBase
     // MaxVisibleWidth (403) and MaxVisibleHeight (284) inherited from TvModel.Pal.
 
     public override int FirstRasterLineOfMainScreen => 51;
+
+    // The 6569's first cycle starts at X coordinate $194 (404) of the line's 504, and the 40 column
+    // display window is at X 24-343, so its first pixel is (24 - 404) mod 504 = 124 pixels into the
+    // line: four pixels into the line's 16th cycle.
+    public override int DisplayWindowStartX => 124;
+
+    // Calibrated against VICE with the anchor above; see the base class.
+    public override int ColorChangePixelDelay => -11;
 
     public override int HBlankWidth => TotalWidth - MaxVisibleWidth;
     // Should be 312 - 284 = 28  (or "around" 30 as stated in some docs)
@@ -190,6 +215,61 @@ public abstract class Vic2ModelBase
 
     public abstract int TotalWidth { get; }           // CyclesPerLine * PixelsPerCPUCycle;
     public abstract int TotalHeight { get; }
+
+    /// <summary>
+    /// Pixels from the start of a raster line's first cycle to the first pixel of the 40 column
+    /// display window.
+    ///
+    /// <para>On hardware this follows from the VIC-II's own (sprite) X coordinate system, whose
+    /// origin lies in the middle of a raster line rather than at its start. The display window is
+    /// at X 24-343 in 40 column mode on every chip variant, and X 0 falls 100 pixels after the
+    /// start of the line's first cycle on both the 6569 and the 6567R8, so the display window
+    /// starts 124 pixels into the line on both: four pixels into the line's 16th cycle. The two
+    /// chips differ in where their X counter wraps (after 504 on the 6569, which is its whole line;
+    /// after 512 on the 6567R8, whose 520 pixel line holds one X value for an extra 8 pixels later
+    /// in the line), which is why the naive "(24 - X at cycle 1) mod line length" gives the right
+    /// answer for PAL and 8 too many for NTSC.</para>
+    ///
+    /// <para>Everything the rasterizer derives from a cycle is placed relative to this, so a value
+    /// that does not match the chip shifts every raster timed effect sideways compared to hardware,
+    /// while leaving the picture itself looking the same. The default places the display window in
+    /// the middle of the line, which is what this emulator did before the per variant figures were
+    /// established, and which variants without a documented figure keep.</para>
+    /// </summary>
+    public virtual int DisplayWindowStartX => (int)Math.Floor((TotalWidth - DrawableAreaWidth) / 2.0d);
+
+    /// <summary>
+    /// Pixels between a colour register write taking effect and the pixel that first shows it.
+    ///
+    /// <para>On hardware the value a write leaves in a colour register reaches the pixel output
+    /// through a pipeline, so the change appears a few pixels later than the cycle boundary this
+    /// emulator would otherwise place it on. The delay is not in the chip documentation and is not
+    /// a whole number of cycles, so it cannot be derived the way <see cref="DisplayWindowStartX"/>
+    /// can; it has to be measured against hardware or an emulator that models it.</para>
+    ///
+    /// <para>The default of zero puts a colour change exactly on the cycle boundary, which is the
+    /// uncalibrated placement, and is what a variant keeps until it has been measured. The measured
+    /// variants override it with calibrations against VICE, made by eye, which should be treated as
+    /// provisional until a measurement replaces them. A pipeline delay cannot depend on the TV
+    /// standard, so the variants should end up with the same value; that they do not yet means
+    /// some other model dependent timing difference between this emulator and VICE is still being
+    /// absorbed there. A negative value says the same thing: the change shows up before the cycle
+    /// boundary this emulator counts from, so part of what is measured is a whole cycle of timing
+    /// rather than pixels of pipeline.</para>
+    ///
+    /// <para>How to settle it: the calibrations so far come from one program, the screen column
+    /// sample, which takes its whole timing from the bad line bus hold, the raster line register and
+    /// CIA timer A, so a whole-cycle disagreement with VICE in any of those is absorbed here. Compare
+    /// something that depends on none of them: the border column sample, which never meets a bad
+    /// line, or better a minimal program that polls the raster line register and stores a border
+    /// colour at once, run on both variants in both emulators. If the variants then agree on one
+    /// small positive value, that value is the pipeline and the whole cycle gets fixed where it
+    /// belongs, in the timing model. The 15 pixels between the current PAL and NTSC values is close
+    /// to the two cycles by which their line lengths differ, which points at something that scales
+    /// with line length, the raster counter's timing or a per-line loop, rather than at the hold.
+    /// </para>
+    /// </summary>
+    public virtual int ColorChangePixelDelay => 0;
 
     // Default to the shared TV model dimensions; chip variants with non-standard pixel timing
     // (e.g., Vic2ModelNTSC_old) can override to provide chip-specific values.

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/Rasterizer/Vic2RasterizerPixelGenerator.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Render/Rasterizer/Vic2RasterizerPixelGenerator.cs
@@ -87,6 +87,7 @@ public sealed class Vic2RasterizerUintPixelGenerator
     private int _drawableAreaHeight;
     private int _drawableAreaWidth;
     private ulong _cyclesPerLine;
+    private int _colorChangePixelDelay;
     private ushort _vic2VideoMatrixBaseAddress;
     private ushort _vic2BitmapBaseAddress;
     private ushort _vic2CharacterSetAddressInVIC2Bank;
@@ -324,6 +325,7 @@ public sealed class Vic2RasterizerUintPixelGenerator
         _drawableAreaHeight = _c64.Vic2.Vic2Screen.DrawableAreaHeight;
         _drawableAreaWidth = _c64.Vic2.Vic2Screen.DrawableAreaWidth;
         _cyclesPerLine = _c64.Vic2.Vic2Model.CyclesPerLine;
+        _colorChangePixelDelay = _c64.Vic2.Vic2Model.ColorChangePixelDelay;
 
         _lastScreenLineDataUpdate = -1;
 
@@ -450,9 +452,10 @@ public sealed class Vic2RasterizerUintPixelGenerator
                 _backgroundRunStartX = 0;
             }
 
-            // Register writes take effect from the cycle after the one they land in.
+            // Register writes take effect from the cycle after the one they land in, plus the
+            // pixels the chip's own pipeline takes to show the new value.
             while (_registerWriteNext < _registerWriteCount && _registerWrites[_registerWriteNext].FrameCycle < cycleCurrentVblank)
-                ApplyRegisterWrite(in _registerWrites[_registerWriteNext++], posX - _screenLayoutInclNonVisibleLeftBorderStartX);
+                ApplyRegisterWrite(in _registerWrites[_registerWriteNext++], posX - _screenLayoutInclNonVisibleLeftBorderStartX + _colorChangePixelDelay);
 
             // Skip if not within visible C64 border/text/bitmap area
             if (screenLine < _screenLayoutInclNonVisibleTopBorderStartY || screenLine > _screenLayoutInclNonVisibleBottomBorderEndY)

--- a/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2Screen.cs
+++ b/src/libraries/Highbyte.DotNet6502.Systems.Commodore64/Video/Vic2Screen.cs
@@ -31,6 +31,17 @@ public class Vic2Screen : ITextMode, IScreen
     public int VisibleLeftRightBorderWidth => (int)Math.Floor((double)((VisibleWidth - DrawableAreaWidth) / 2.0d));
     public int VisibleTopBottomBorderHeight => (int)Math.Floor((double)((VisibleHeight - DrawableAreaHeight) / 2.0d));
 
+    // Where the display window sits in a raster line, in pixels from the start of the line's first
+    // cycle. Taken from the chip variant rather than by centring the display window in the line,
+    // because everything derived from a cycle is placed relative to it.
+    public int DisplayWindowStartX => _vic2Model.DisplayWindowStartX;
+
+    // The first visible pixel of the line. Placed so the display window keeps the same position
+    // within the visible area as it would if that area were centred on it, which is how a TV set is
+    // adjusted: on the picture, not on the line's timing. How much border a set showed varied, so
+    // this is a presentation choice; where the display window falls within the line is not.
+    public int VisibleAreaStartX => DisplayWindowStartX - VisibleLeftRightBorderWidth;
+
 
     // 38 col mode border and screen differencies
     public const int COL_38_LEFT_BORDER_END_X_DELTA = 7;    // In first column, only the first 7 pixels are covered by the border
@@ -147,17 +158,14 @@ public class Vic2Screen : ITextMode, IScreen
 
         if (visible)
         {
-            if (normalizeToVisible)
-                leftBorderStartX = 0;
-            else
-                leftBorderStartX = (int)Math.Floor((double)((TotalWidth - VisibleWidth) / 2.0d));
+            leftBorderStartX = normalizeToVisible ? 0 : VisibleAreaStartX;
             borderWidth = VisibleLeftRightBorderWidth;
-            rightBorderEndX = TotalWidth - leftBorderStartX - 1;
+            rightBorderEndX = leftBorderStartX + VisibleWidth - 1;
         }
         else
         {
             leftBorderStartX = 0;
-            borderWidth = TotalLeftRightBorderWidth;
+            borderWidth = DisplayWindowStartX;
             rightBorderEndX = TotalWidth;
         }
 

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Render/Vic2RasterizerPixelGeneratorTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Render/Vic2RasterizerPixelGeneratorTests.cs
@@ -211,7 +211,7 @@ public class Vic2RasterizerPixelGeneratorTests
         var width = c64.Screen.VisibleWidth;
         var visibleLayout = c64.Vic2.ScreenLayouts.GetLayout(Vic2ScreenLayouts.LayoutType.Visible, for24RowMode: false, for38ColMode: false);
         var normalizedLayout = c64.Vic2.ScreenLayouts.GetLayout(Vic2ScreenLayouts.LayoutType.VisibleNormalized, for24RowMode: false, for38ColMode: false);
-        var changeX = (writeCycle + 1) * 8 - visibleLayout.LeftBorder.Start.X;   // first pixel of the cycle after the write
+        var changeX = (writeCycle + 1) * 8 - visibleLayout.LeftBorder.Start.X + c64.Vic2.Vic2Model.ColorChangePixelDelay;   // first pixel the change shows on
         var lineStart = normalizedLine * width;
         var oldColor = background[lineStart];
         var newColor = background[lineStart + width - 1];
@@ -247,7 +247,7 @@ public class Vic2RasterizerPixelGeneratorTests
 
         var width = c64.Screen.VisibleWidth;
         var visibleLayout = c64.Vic2.ScreenLayouts.GetLayout(Vic2ScreenLayouts.LayoutType.Visible, for24RowMode: false, for38ColMode: false);
-        var changeX = (writeCycle + 1) * 8 - visibleLayout.LeftBorder.Start.X;
+        var changeX = (writeCycle + 1) * 8 - visibleLayout.LeftBorder.Start.X + c64.Vic2.Vic2Model.ColorChangePixelDelay;
         Assert.True(changeX > normalizedLayout.Screen.Start.X && changeX < normalizedLayout.Screen.End.X);
         var lineStart = normalizedLine * width;
         var oldColor = background[lineStart + normalizedLayout.Screen.Start.X];
@@ -257,6 +257,35 @@ public class Vic2RasterizerPixelGeneratorTests
         Assert.Equal(newColor, background[lineStart + changeX]);
         // The line below, drawn entirely after the write, has the new colour throughout.
         Assert.Equal(newColor, background[(normalizedLine + 1) * width + normalizedLayout.Screen.Start.X]);
+    }
+
+    [Theory]
+    [InlineData("C64PAL", "PAL", 124)]
+    [InlineData("C64NTSC", "NTSC", 124)]
+    public void Border_colour_written_on_a_cycle_lands_where_the_chip_puts_that_cycle(string c64Model, string vic2Model, int displayWindowStartX)
+    {
+        // Pins the mapping from cycle to pixel against the chip figures rather than against the
+        // layout: a write completing on cycle c is shown from the start of cycle c + 1, which is
+        // (c + 1) * 8 pixels into the line, and the display window's first pixel is
+        // displayWindowStartX pixels into the line. So the change lands that far into the window.
+        var c64 = BuildC64(c64Model, vic2Model);
+        SetupRowBoundaryMarkerTextScreen(c64);
+        c64.Mem.Write(0xD011, 0x1B);
+        c64.Mem.Write(0xD020, 0);
+        const int writeCycle = 30;
+        var (generator, background, _) = CreateGenerator(c64);
+        var normalizedLayout = c64.Vic2.ScreenLayouts.GetLayout(Vic2ScreenLayouts.LayoutType.VisibleNormalized, for24RowMode: false, for38ColMode: false);
+        var normalizedLine = 5;   // a top border line, where the whole line carries the border colour
+
+        RenderFrameWithMidLineWrite(c64, generator, normalizedLine, writeCycle, () => c64.Mem.Write(0xD020, 2));
+
+        var width = c64.Screen.VisibleWidth;
+        var lineStart = normalizedLine * width;
+        // Pixels into the display window, which can be negative: the change falls in the left border.
+        var changeIntoDisplayWindow = (writeCycle + 1) * 8 - displayWindowStartX + c64.Vic2.Vic2Model.ColorChangePixelDelay;
+        var changeX = normalizedLayout.Screen.Start.X + changeIntoDisplayWindow;
+        Assert.NotEqual(background[lineStart + changeX - 1], background[lineStart + changeX]);
+        Assert.Equal(background[lineStart], background[lineStart + changeX - 1]);
     }
 
     [Fact]
@@ -284,7 +313,7 @@ public class Vic2RasterizerPixelGeneratorTests
 
         // Every line of the top border must show its own two colours, split at the write.
         var width = c64.Screen.VisibleWidth;
-        var changeX = (writeCycle + 1) * 8 - visibleLayout.LeftBorder.Start.X;
+        var changeX = (writeCycle + 1) * 8 - visibleLayout.LeftBorder.Start.X + c64.Vic2.Vic2Model.ColorChangePixelDelay;
         var checkedLines = 0;
         for (var line = 1; line < 30; line++)
         {

--- a/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Video/Vic2DisplayWindowPositionTests.cs
+++ b/tests/Highbyte.DotNet6502.Systems.Tests/Commodore64/Video/Vic2DisplayWindowPositionTests.cs
@@ -1,0 +1,73 @@
+using Highbyte.DotNet6502.Systems.Commodore64;
+using Highbyte.DotNet6502.Systems.Commodore64.Config;
+using Highbyte.DotNet6502.Systems.Commodore64.Video;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Highbyte.DotNet6502.Systems.Tests.Commodore64.Video;
+
+/// <summary>
+/// Where the display window sits in a raster line. The VIC-II's display window is at X 24-343 of its
+/// own coordinate system on every chip variant, and the X coordinate at the start of a line's first
+/// cycle differs per variant, but so does where the X counter wraps (504 on the 6569, 512 on the
+/// 6567R8 whose line is 520 pixels), and X 0 ends up 100 pixels after the first cycle's start on
+/// both, so the window sits 124 pixels into the line on both. Everything the rasterizer derives from
+/// a cycle is placed relative to this, so it decides where raster timed effects land.
+/// </summary>
+public class Vic2DisplayWindowPositionTests
+{
+    [Theory]
+    [InlineData("C64PAL", "PAL", 124)]
+    [InlineData("C64NTSC", "NTSC", 124)]
+    public void Display_window_starts_at_the_chip_variants_pixel_offset_into_the_raster_line(string c64Model, string vic2Model, int expectedStartX)
+    {
+        var c64 = BuildC64(c64Model, vic2Model);
+
+        var wholeLine = c64.Vic2.ScreenLayouts.GetLayout(Vic2ScreenLayouts.LayoutType.Normal, for24RowMode: false, for38ColMode: false);
+
+        Assert.Equal(expectedStartX, wholeLine.Screen.Start.X);
+        Assert.Equal(expectedStartX + c64.Vic2.Vic2Screen.DrawableAreaWidth - 1, wholeLine.Screen.End.X);
+    }
+
+    [Theory]
+    [InlineData("C64PAL", "PAL", 124)]
+    [InlineData("C64NTSC", "NTSC", 124)]
+    public void Visible_area_is_placed_so_the_display_window_keeps_its_offset_into_the_line(string c64Model, string vic2Model, int expectedStartX)
+    {
+        var c64 = BuildC64(c64Model, vic2Model);
+        var screen = c64.Vic2.Vic2Screen;
+
+        var visible = c64.Vic2.ScreenLayouts.GetLayout(Vic2ScreenLayouts.LayoutType.Visible, for24RowMode: false, for38ColMode: false);
+
+        Assert.Equal(expectedStartX, visible.Screen.Start.X);
+        Assert.Equal(expectedStartX - screen.VisibleLeftRightBorderWidth, visible.LeftBorder.Start.X);
+        Assert.Equal(screen.VisibleWidth, visible.RightBorder.End.X - visible.LeftBorder.Start.X + 1);
+    }
+
+    [Theory]
+    [InlineData("C64PAL", "PAL", 41, 42)]
+    [InlineData("C64NTSC", "NTSC", 49, 49)]
+    public void Border_widths_within_the_visible_area_are_unchanged_by_where_the_line_starts(string c64Model, string vic2Model, int expectedLeftBorderWidth, int expectedRightBorderWidth)
+    {
+        // The visible frame and the display window's place inside it are a presentation choice (real
+        // sets showed different amounts of border); only the offset into the line above is fixed by
+        // the chip. This pins the choice so the anchor cannot move the picture within the frame.
+        var c64 = BuildC64(c64Model, vic2Model);
+        var screen = c64.Vic2.Vic2Screen;
+
+        var normalized = c64.Vic2.ScreenLayouts.GetLayout(Vic2ScreenLayouts.LayoutType.VisibleNormalized, for24RowMode: false, for38ColMode: false);
+
+        Assert.Equal(0, normalized.LeftBorder.Start.X);
+        Assert.Equal(expectedLeftBorderWidth, normalized.Screen.Start.X);
+        Assert.Equal(expectedRightBorderWidth, screen.VisibleWidth - (normalized.Screen.End.X + 1));
+    }
+
+    private static C64 BuildC64(string c64Model, string vic2Model)
+    {
+        return C64.BuildC64(new C64Config
+        {
+            LoadROMs = false,
+            C64Model = c64Model,
+            Vic2Model = vic2Model
+        }, NullLoggerFactory.Instance);
+    }
+}


### PR DESCRIPTION
## Summary

- The rasterizer placed the 320-pixel display window by centring it in the raster line, which put its first pixel about four cycles earlier than the VIC-II does. Every position derived from a cycle was shifted sideways compared to hardware, while ordinary pictures looked the same because everything moved together. It only showed when comparing raster-timed effects against another emulator.
- Each chip variant now carries the offset of the display window into the line (`Vic2ModelBase.DisplayWindowStartX`): 124 pixels on both the 6569 and the 6567R8, taken from the display window at X 24 and where X 0 falls relative to the line's first cycle. The two chips differ in where their X counter wraps (after 504 on the 6569, after 511 on the 6567R8 whose 520-pixel line holds one X value for an extra 8 pixels later in the line), which is why a naive `(24 - X at cycle 1) mod line length` is right for PAL and 8 too many for NTSC; the derivation is in the source comments.
- The visible frame is placed so the display window keeps its position inside it, so static pictures are unchanged and only raster-timed effects move. Sprites are anchored to the display window (X 24) and are unaffected; the 38-column deltas already match hardware and are unaffected.
- Adds `ColorChangePixelDelay`, the offset between a colour register write and the pixel that first shows it, calibrated by eye against VICE: -11 on PAL, 4 on NTSC, default 0 for unmeasured variants. These are provisional: a pipeline delay cannot depend on the TV standard, so the two values differing means some other model-dependent timing difference is being absorbed there. The base-class comment states how to settle it (compare something that does not depend on the bad line hold or the CIA line clock, on both models, against VICE).

## Verification

- New tests pin the display window at 124 into the line on both models, the visible-area placement derived from it, the unchanged border widths inside the frame (41/42 PAL, 49/49 NTSC), and the cycle-to-pixel mapping of a colour write against the chip figures. Existing colour split tests derive their expected positions from the constants. Full solution: 2,851 tests pass.
- Rendered before and after headlessly: the plain BASIC screen is byte-identical on both models; a sample mixing static text with one raster-timed write differs on exactly the line with the write; the column samples move by the predicted amounts and remain stable across every program start cycle tested.
- Side-by-side against VICE on PAL and NTSC with the screen column sample: the colour edges now coincide with VICE's on both models at the calibrated values.
- Avalonia desktop and Blazor WASM apps build clean.

## Known open point

PAL at -11 and NTSC at 4 are 15 pixels apart, close to the two cycles by which the line lengths differ. That points at a remaining model-dependent timing difference against VICE, most plausibly in the raster counter's timing or the sample's per-line path rather than the bus hold. Being investigated separately; the source comments document the procedure.
